### PR TITLE
Issue #15456: Define violation messages for NoWhitespaceBeforeCaseDefaultColonCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -271,8 +271,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck",
             "com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck",
-            "com.puppycrawl.tools.checkstyle.checks.whitespace."
-                    + "NoWhitespaceBeforeCaseDefaultColonCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck",
             "com.puppycrawl.tools.checkstyle.api.AbstractCheckTest$ViolationAstCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCaseDefaultColonCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCaseDefaultColonCheckTest.java
@@ -91,12 +91,12 @@ public class NoWhitespaceBeforeCaseDefaultColonCheckTest
     @Test
     public void testPatternMatchingForSwitch() throws Exception {
         final String[] expected = {
-            "14:62: " + getCheckMessage(MSG_KEY, ":"),
-            "16:21: " + getCheckMessage(MSG_KEY, ":"),
-            "18:21: " + getCheckMessage(MSG_KEY, ":"),
-            "20:67: " + getCheckMessage(MSG_KEY, ":"),
-            "23:36: " + getCheckMessage(MSG_KEY, ":"),
-            "25:21: " + getCheckMessage(MSG_KEY, ":"),
+            "15:62: " + getCheckMessage(MSG_KEY, ":"),
+            "17:21: " + getCheckMessage(MSG_KEY, ":"),
+            "19:21: " + getCheckMessage(MSG_KEY, ":"),
+            "22:67: " + getCheckMessage(MSG_KEY, ":"),
+            "25:36: " + getCheckMessage(MSG_KEY, ":"),
+            "27:21: " + getCheckMessage(MSG_KEY, ":"),
         };
         verifyWithInlineConfigParser(
                 getPath(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebeforecasedefaultcolon/InputNoWhitespaceBeforeCaseDefaultColon.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebeforecasedefaultcolon/InputNoWhitespaceBeforeCaseDefaultColon.java
@@ -12,11 +12,11 @@ import java.util.Calendar;
 public class InputNoWhitespaceBeforeCaseDefaultColon {
     {
         switch(1) {
-            case 1 : // violation
+            case 1 : // violation '':' is preceded with whitespace.'
                 break;
             case 2:
                 break;
-            default : // violation
+            default : // violation '':' is preceded with whitespace.'
                 break;
         }
 
@@ -29,7 +29,7 @@ public class InputNoWhitespaceBeforeCaseDefaultColon {
         }
 
         switch(3) {
-            case 3/* space after */ : // violation
+            case 3/* space after */ : // violation '':' is preceded with whitespace.'
                 break;
             default/* no space after */:
                 break;
@@ -37,17 +37,17 @@ public class InputNoWhitespaceBeforeCaseDefaultColon {
 
         switch(4) {
             case 4
-                    : // violation
+                    : // violation '':' is preceded with whitespace.'
                 break;
             default:
                 switch(5) {
-                    case 5 : // violation
+                    case 5 : // violation '':' is preceded with whitespace.'
                         break;
                     case 6
-: // violation
+: // violation '':' is preceded with whitespace.'
                         break;
                     case 7
-                          : // violation
+                          : // violation '':' is preceded with whitespace.'
                         break;
                     default:
                         break;
@@ -58,12 +58,12 @@ public class InputNoWhitespaceBeforeCaseDefaultColon {
         switch(8) {
             case 8/* no space after */:
                 break;
-            default/* space after */ : // violation
+            default/* space after */ : // violation '':' is preceded with whitespace.'
                 break;
         }
 
         switch (Calendar.MONDAY) {
-            case Calendar.TUESDAY    : // violation
+            case Calendar.TUESDAY    : // violation '':' is preceded with whitespace.'
                 break;
             case Calendar.WEDNESDAY:
                 break;
@@ -76,20 +76,20 @@ public class InputNoWhitespaceBeforeCaseDefaultColon {
                     9:
                 break;
             case
-                    10 : // violation
+                    10 : // violation '':' is preceded with whitespace.'
                 break;
             default
-                    : // violation
+                    : // violation '':' is preceded with whitespace.'
                 break;
 
         }
 
         switch(11) {
             case
-                    /* comment */ 11 : // violation
+                    /* comment */ 11 : // violation '':' is preceded with whitespace.'
                 break;
             default
-                    /* comment */ : // violation
+                    /* comment */ : // violation '':' is preceded with whitespace.'
                 break;
 
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebeforecasedefaultcolon/InputNoWhitespaceBeforeCaseDefaultColonEnumAndStrings.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebeforecasedefaultcolon/InputNoWhitespaceBeforeCaseDefaultColonEnumAndStrings.java
@@ -33,13 +33,13 @@ class InputNoWhitespaceBeforeCaseDefaultColonEnumAndStrings {
             case MON,
                     FRI: numLetters = 6;
                             break;
-            case TUE : numLetters = 7; // violation
+            case TUE : numLetters = 7; // violation '':' is preceded with whitespace.'
                        break;
             case THU, SAT
-                    : numLetters = 8; // violation
+                    : numLetters = 8; // violation '':' is preceded with whitespace.'
                          break;
             case WED,
-                    SUN : numLetters = 9; // violation
+                    SUN : numLetters = 9; // violation '':' is preceded with whitespace.'
                           break;
         };
         return numLetters;
@@ -58,7 +58,7 @@ class InputNoWhitespaceBeforeCaseDefaultColonEnumAndStrings {
                 yield l + someInt * 2;
             }
             default
-                   : { // violation
+                   : { // violation '':' is preceded with whitespace.'
                 int l = day.toString().length();
                 yield l;
             }
@@ -71,7 +71,7 @@ class InputNoWhitespaceBeforeCaseDefaultColonEnumAndStrings {
             case "FEB": days = 28;
                         break;
             case "JAN", "MAR"
-                       , "MAY" : days = 31; break; // violation
+                       , "MAY" : days = 31; break; // violation '':' is preceded with whitespace.'
             case "APR", "JUN": days = 30;
                                 break;
         };
@@ -88,13 +88,13 @@ class InputNoWhitespaceBeforeCaseDefaultColonEnumAndStrings {
 
         boolean t8 = (switch (e) {
             case A
-                : // violation
+                : // violation '':' is preceded with whitespace.'
                 x = 1;
                 yield true;
-            case B : // violation
+            case B : // violation '':' is preceded with whitespace.'
                 yield (x = 1) == 1 || true;
             default
-                    :yield false; // violation
+                    :yield false; // violation '':' is preceded with whitespace.'
         }) && x == 1;
 
         if (!t8) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebeforecasedefaultcolon/InputNoWhitespaceBeforeCaseDefaultColonPatternMatchingForSwitch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebeforecasedefaultcolon/InputNoWhitespaceBeforeCaseDefaultColonPatternMatchingForSwitch.java
@@ -11,18 +11,20 @@ public class InputNoWhitespaceBeforeCaseDefaultColonPatternMatchingForSwitch {
 
     void test(Object obj) {
         switch (obj) {
-            case ColoredPoint(int a, int b, _) when (a >= b) : {} break; // violation
+            // violation below '':' is preceded with whitespace.'
+            case ColoredPoint(int a, int b, _) when (a >= b) : {} break;
             case ColoredPoint(int a, int b, _) when (b > 100)
-                    : {} break; // violation
+                    : {} break; // violation '':' is preceded with whitespace.'
             case ColoredPoint(int a, int b, _) when (b != 1000)
-                    :  // violation
+                    :  // violation '':' is preceded with whitespace.'
             {} break;
-            case ColoredPoint(int a, int b, _) when (b != 100000) : // violation
+            // violation below '':' is preceded with whitespace.'
+            case ColoredPoint(int a, int b, _) when (b != 100000) :
             {} break;
             case
-                    Rectangle(_,_) :  // violation
+                    Rectangle(_,_) :  // violation '':' is preceded with whitespace.'
             {}
-            default : System.out.println("none"); // violation
+            default : System.out.println("none"); // violation '':' is preceded with whitespace.'
         }
     }
 


### PR DESCRIPTION
issue #15456

Replaced all bare `// violation` comments with `// violation '':' is preceded with whitespace.'` in 3 input test files for `NoWhitespaceBeforeCaseDefaultColonCheck`. Removed check from `SUPPRESSED_CHECKS` in `InlineConfigParser.java`.
