### PR TITLE
Issue #19548: Fix IllegalTokenText in google_checks.xml to detect 2-d…

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
@@ -59,6 +59,18 @@ public class InputSpecialEscapeSequences {
     String r9 = "\\134"; // violation 'Consider using special escape sequence .*'
   }
 
+  /** Some javadoc. */
+  public void specialCharsWithWarn2DigitOctal() {
+    String r1 = "\\10"; // violation 'Consider using special escape sequence'
+    String r2 = "\\11"; // violation 'Consider using special escape sequence'
+    String r3 = "\\12"; // violation 'Consider using special escape sequence'
+    String r4 = "\\14"; // violation 'Consider using special escape sequence'
+    String r5 = "\\15"; // violation 'Consider using special escape sequence'
+    String r6 = "\\40"; // violation 'Consider using special escape sequence'
+    String r7 = "\\42"; // violation 'Consider using special escape sequence'
+    String r8 = "\\47"; // violation 'Consider using special escape sequence'
+  }
+
   class Inner {
     public String wrongEscapeSequences() {
       final String r1 = "\u0008"; // violation 'Consider using special escape sequence'
@@ -105,6 +117,18 @@ public class InputSpecialEscapeSequences {
       String r7 = "\\042"; // violation 'Consider using special escape sequence .*'
       String r8 = "\\047"; // violation 'Consider using special escape sequence .*'
       String r9 = "\\134"; // violation 'Consider using special escape sequence .*'
+    }
+
+    /** Some javadoc. */
+    public void specialCharsWithWarn2DigitOctal() {
+      String r1 = "\\10"; // violation 'Consider using special escape sequence'
+      String r2 = "\\11"; // violation 'Consider using special escape sequence'
+      String r3 = "\\12"; // violation 'Consider using special escape sequence'
+      String r4 = "\\14"; // violation 'Consider using special escape sequence'
+      String r5 = "\\15"; // violation 'Consider using special escape sequence'
+      String r6 = "\\40"; // violation 'Consider using special escape sequence'
+      String r7 = "\\42"; // violation 'Consider using special escape sequence'
+      String r8 = "\\47"; // violation 'Consider using special escape sequence'
     }
 
     Inner anoInner =
@@ -154,6 +178,17 @@ public class InputSpecialEscapeSequences {
             String r7 = "\\042"; // violation 'Consider using special escape sequence .*'
             String r8 = "\\047"; // violation 'Consider using special escape sequence .*'
             String r9 = "\\134"; // violation 'Consider using special escape sequence .*'
+          }
+
+          public void specialCharsWithWarn2DigitOctal() {
+            String r1 = "\\10"; // violation 'Consider using special escape sequence'
+            String r2 = "\\11"; // violation 'Consider using special escape sequence'
+            String r3 = "\\12"; // violation 'Consider using special escape sequence'
+            String r4 = "\\14"; // violation 'Consider using special escape sequence'
+            String r5 = "\\15"; // violation 'Consider using special escape sequence'
+            String r6 = "\\40"; // violation 'Consider using special escape sequence'
+            String r7 = "\\42"; // violation 'Consider using special escape sequence'
+            String r8 = "\\47"; // violation 'Consider using special escape sequence'
           }
         };
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesForEscapedS.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesForEscapedS.java
@@ -27,5 +27,13 @@ class InputSpecialEscapeSequencesForEscapedS {
     final String r2 = "\011"; // violation 'Consider using special escape sequence'
     final String r3 = "\012"; // violation 'Consider using special escape sequence'
     final String r4 = "\010"; // violation 'Consider using special escape sequence'
+    final String r5 = "\10"; // violation 'Consider using special escape sequence'
+    final String r6 = "\11"; // violation 'Consider using special escape sequence'
+    final String r7 = "\12"; // violation 'Consider using special escape sequence'
+    final String r8 = "\14"; // violation 'Consider using special escape sequence'
+    final String r9 = "\15"; // violation 'Consider using special escape sequence'
+    final String r10 = "\40"; // violation 'Consider using special escape sequence'
+    final String r11 = "\42"; // violation 'Consider using special escape sequence'
+    final String r12 = "\47"; // violation 'Consider using special escape sequence'
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForOctalValues.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForOctalValues.java
@@ -129,6 +129,38 @@ public class InputSpecialEscapeSequencesInTextBlockForOctalValues {
         """
         \\040
         """;
+    String r10 = // violation below 'Consider using special escape sequence'
+        """
+        \\10
+        """;
+    String r11 = // violation below 'Consider using special escape sequence'
+        """
+        \\11
+        """;
+    String r12 = // violation below 'Consider using special escape sequence'
+        """
+        \\12
+        """;
+    String r13 = // violation below 'Consider using special escape sequence'
+        """
+        \\14
+        """;
+    String r14 = // violation below 'Consider using special escape sequence'
+        """
+        \\15
+        """;
+    String r15 = // violation below 'Consider using special escape sequence'
+        """
+        \\40
+        """;
+    String r16 = // violation below 'Consider using special escape sequence'
+        """
+        \\42
+        """;
+    String r17 = // violation below 'Consider using special escape sequence'
+        """
+        \\47
+        """;
   }
 
   private static void specialCharsWithWarn3() {
@@ -167,6 +199,38 @@ public class InputSpecialEscapeSequencesInTextBlockForOctalValues {
     String r9 = // violation below 'Consider using special escape sequence'
         """
         \\134
+        """;
+    String r10 = // violation below 'Consider using special escape sequence'
+        """
+        \\10
+        """;
+    String r11 = // violation below 'Consider using special escape sequence'
+        """
+        \\11
+        """;
+    String r12 = // violation below 'Consider using special escape sequence'
+        """
+        \\12
+        """;
+    String r13 = // violation below 'Consider using special escape sequence'
+        """
+        \\14
+        """;
+    String r14 = // violation below 'Consider using special escape sequence'
+        """
+        \\15
+        """;
+    String r15 = // violation below 'Consider using special escape sequence'
+        """
+        \\40
+        """;
+    String r16 = // violation below 'Consider using special escape sequence'
+        """
+        \\42
+        """;
+    String r17 = // violation below 'Consider using special escape sequence'
+        """
+        \\47
         """;
   }
 
@@ -247,6 +311,38 @@ public class InputSpecialEscapeSequencesInTextBlockForOctalValues {
           String r9 = // violation below 'Consider using special escape sequence'
               """
               \\134
+              """;
+          String r10 = // violation below 'Consider using special escape sequence'
+              """
+              \\10
+              """;
+          String r11 = // violation below 'Consider using special escape sequence'
+              """
+              \\11
+              """;
+          String r12 = // violation below 'Consider using special escape sequence'
+              """
+              \\12
+              """;
+          String r13 = // violation below 'Consider using special escape sequence'
+              """
+              \\14
+              """;
+          String r14 = // violation below 'Consider using special escape sequence'
+              """
+              \\15
+              """;
+          String r15 = // violation below 'Consider using special escape sequence'
+              """
+              \\40
+              """;
+          String r16 = // violation below 'Consider using special escape sequence'
+              """
+              \\42
+              """;
+          String r17 = // violation below 'Consider using special escape sequence'
+              """
+              \\47
               """;
         }
       };

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -82,7 +82,7 @@
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL, TEXT_BLOCK_CONTENT"/>
       <property name="format"
-          value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|20|22|27|5(C|c))|\\(0(10|11|12|14|15|40|42|47)|134)"/>
+          value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|20|22|27|5(C|c))|\\(0?(10|11|12|14|15|40|42|47)|134)"/>
       <property name="message"
                value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
     </module>


### PR DESCRIPTION
Issue #19548:

The regex only detected 3-digit octal forms (e.g. `\012`) but missed equivalent 2-digit forms (e.g. `\12`) for characters with special escape sequences per [Google Java Style Guide §2.3.2](https://google.github.io/styleguide/javaguide.html#s2.3.2-special-escape-sequences), and [JLS §3.10.7](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-3.10.7)

Fix: changed `0(10|11|...)` to `0?(10|11|...)` making the leading zero optional. Added integration test coverage for all 8 two-digit octal escapes.

Diff Regression config: https://gist.githubusercontent.com/vivek-0509/26f7dc0977fa0ecaf66e127eb4245194/raw/171fc84ff7037cad652da44dbd135f994a03e163/base_config.xml

Diff Regression patch config: https://gist.githubusercontent.com/vivek-0509/4076379193a16479693fc871ec0f1cd8/raw/e0cc1597cde728943ee64faec406b5310e512628/patch_config.xml