### PR TITLE
Issue #3301: Enable IntelliJ IDEA inspection ThrowFromFinallyBlock

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -4713,9 +4713,8 @@
                    enabled_by_default="true">
     <option name="ignoreRethrownExceptions" value="false"/>
   </inspection_tool>
-  <!-- disabled till we switch to jacoco that support try-with-resources -->
-  <inspection_tool class="ThrowFromFinallyBlock" enabled="false" level="ERROR"
-                   enabled_by_default="false"/>
+  <inspection_tool class="ThrowFromFinallyBlock" enabled="true" level="ERROR"
+                   enabled_by_default="true"/>
   <inspection_tool class="ThrowFromFinallyBlockJS" enabled="true" level="ERROR"
                    enabled_by_default="true"/>
   <inspection_tool class="ThrowableInstanceNeverThrown" enabled="true" level="ERROR"


### PR DESCRIPTION
Issue : #3301

Enable Intellij IDEA inspection `ThrowFromFinallyBlock` As we are now using `Jacco`.