### PR TITLE
Issue #15456: Define violation messages for NoWhitespaceBeforeCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -270,7 +270,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck",
             "com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck",
-            "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck",
             "com.puppycrawl.tools.checkstyle.api.AbstractCheckTest$ViolationAstCheck",
             "com.puppycrawl.tools.checkstyle.CheckerTest$VerifyPositionAfterTabFileSet"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheckTest.java
@@ -39,17 +39,17 @@ public class NoWhitespaceBeforeCheckTest
         final String[] expected = {
             "34:15: " + getCheckMessage(MSG_KEY, "++"),
             "34:22: " + getCheckMessage(MSG_KEY, "--"),
-            "180:19: " + getCheckMessage(MSG_KEY, ";"),
-            "182:24: " + getCheckMessage(MSG_KEY, ";"),
-            "189:19: " + getCheckMessage(MSG_KEY, ";"),
-            "191:28: " + getCheckMessage(MSG_KEY, ";"),
-            "199:27: " + getCheckMessage(MSG_KEY, ";"),
-            "215:16: " + getCheckMessage(MSG_KEY, ";"),
-            "270:1: " + getCheckMessage(MSG_KEY, ";"),
-            "274:16: " + getCheckMessage(MSG_KEY, ";"),
-            "288:1: " + getCheckMessage(MSG_KEY, ";"),
-            "291:62: " + getCheckMessage(MSG_KEY, "..."),
-            "295:16: " + getCheckMessage(MSG_KEY, ":"),
+            "183:19: " + getCheckMessage(MSG_KEY, ";"),
+            "185:24: " + getCheckMessage(MSG_KEY, ";"),
+            "192:19: " + getCheckMessage(MSG_KEY, ";"),
+            "194:28: " + getCheckMessage(MSG_KEY, ";"),
+            "202:27: " + getCheckMessage(MSG_KEY, ";"),
+            "218:16: " + getCheckMessage(MSG_KEY, ";"),
+            "273:1: " + getCheckMessage(MSG_KEY, ";"),
+            "277:16: " + getCheckMessage(MSG_KEY, ";"),
+            "291:1: " + getCheckMessage(MSG_KEY, ";"),
+            "294:62: " + getCheckMessage(MSG_KEY, "..."),
+            "299:16: " + getCheckMessage(MSG_KEY, ":"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputNoWhitespaceBeforeDefault.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeAtStartOfTheLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeAtStartOfTheLine.java
@@ -7,7 +7,7 @@ tokens = DOT
 */
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace
-.nowhitespacebefore; // violation
+.nowhitespacebefore; // violation ''.' is preceded with whitespace.'
 
 import java.util.function.Supplier;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeAtStartOfTheLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeAtStartOfTheLine2.java
@@ -19,6 +19,6 @@ public class InputNoWhitespaceBeforeAtStartOfTheLine2 {
 
     public <V> void methodName(V value) {
         Supplier<?> t =
-A ::new; // violation
+A ::new; // violation ''::' is preceded with whitespace.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeDefault.java
@@ -31,7 +31,10 @@ class InputNoWhitespaceBeforeDefault
         b=1; // Ignore 1
         b+=1; // Ignore 1
         b -=- 1 + (+ b); // Ignore 2
-        b = b ++ + b --; // 2 violations
+        b = b ++ + b --;
+        // 2 violations above:
+        //    ''\+\+' is preceded with whitespace.'
+        //    ''\-\-' is preceded with whitespace.'
         b = ++ b - -- b; // Ignore 1
     }
 
@@ -177,18 +180,18 @@ class InputNoWhitespaceBeforeDefault
     /** rfe 521323, detect whitespace before ';' */
     void rfe521323()
     {
-        doStuff() ; // violation
+        doStuff() ; // violation '';' is preceded with whitespace.'
         //       ^ whitespace
-        for (int i = 0 ; i < 5; i++) { // violation
+        for (int i = 0 ; i < 5; i++) { // violation '';' is preceded with whitespace.'
             //        ^ whitespace
         }
     }
 
 
     /** bug 806243 (NoWhitespaceBeforeCheck violation for anonymous inner class) */
-    private int i ; // violation
+    private int i ; // violation '';' is preceded with whitespace.'
     //           ^ whitespace
-    private int i1, i2, i3 ; // violation
+    private int i1, i2, i3 ; // violation '';' is preceded with whitespace.'
     //                    ^ whitespace
     private int i4, i5, i6;
 
@@ -196,7 +199,7 @@ class InputNoWhitespaceBeforeDefault
     void bug806243()
     {
         Object o = new InputNoWhitespaceBeforeDefault() {
-            private int j ; // violation
+            private int j ; // violation '';' is preceded with whitespace.'
             //           ^ whitespace
         };
     }
@@ -212,7 +215,7 @@ class InputNoWhitespaceBeforeDefault
  */
 interface IFoo_NoWhitespaceBeforeDefault
 {
-    void foo() ; // violation
+    void foo() ; // violation '';' is preceded with whitespace.'
     //        ^ whitespace
 }
 
@@ -267,11 +270,11 @@ class SpecialCasesInForLoop_NoWhitespaceBeforeDefault
         runs[0]
 .
  run()
-; // violation
+; // violation '';' is preceded with whitespace.'
     }
 
     public void testNullSemi() {
-        return ; // violation
+        return ; // violation '';' is preceded with whitespace.'
     }
 
     public void register(Object obj) { }
@@ -285,14 +288,15 @@ class SpecialCasesInForLoop_NoWhitespaceBeforeDefault
         testNullSemi
 (
 )
-; // violation
+; // violation '';' is preceded with whitespace.'
     }
 
-    public static void testNoWhitespaceBeforeEllipses(String ... args) { // violation
+    public static void testNoWhitespaceBeforeEllipses(String ... args) {
+        // violation above ''...' is preceded with whitespace.'
     }
 
     {
-        label1 : // violation
+        label1 : // violation '':' is preceded with whitespace.'
         for(int i = 0; i < 10; i++) {}
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeDot.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeDot.java
@@ -6,8 +6,8 @@ tokens = DOT
 
 */
 
-package com . puppycrawl // violation
-    .tools. // violation
+package com . puppycrawl // violation ''.' is preceded with whitespace.'
+    .tools. // violation ''.' is preceded with whitespace.'
     checkstyle.checks.whitespace.nowhitespacebefore;
 
 /**
@@ -130,14 +130,14 @@ class InputNoWhitespaceBeforeDot
     }
 
     /** @return dot test **/
-    private java .lang.  String dotTest() // violation
+    private java .lang.  String dotTest() // violation ''.' is preceded with whitespace.'
     {
         Object o = new java.lang.Object();
         o.
             toString();
         o
-            .toString(); // violation
-        o . toString(); // violation
+            .toString(); // violation ''.' is preceded with whitespace.'
+        o . toString(); // violation ''.' is preceded with whitespace.'
         return o.toString();
     }
 
@@ -265,7 +265,7 @@ class SpecialCasesInForLoop_NoWhitespaceBeforeDot
                 }
             }};
         runs[0]
-. // violation
+. // violation ''.' is preceded with whitespace.'
  run()
 ;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeDotAllowLineBreaks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeDotAllowLineBreaks.java
@@ -6,7 +6,7 @@ tokens = DOT
 
 */
 
-package com . puppycrawl // violation
+package com . puppycrawl // violation ''.' is preceded with whitespace.'
     .tools.
     checkstyle.checks.whitespace.nowhitespacebefore;
 
@@ -130,14 +130,14 @@ class InputNoWhitespaceBeforeDotAllowLineBreaks
     }
 
     /** @return dot test **/
-    private java .lang.  String dotTest() // violation
+    private java .lang.  String dotTest() // violation ''.' is preceded with whitespace.'
     {
         Object o = new java.lang.Object();
         o.
             toString();
         o
             .toString();
-        o . toString(); // violation
+        o . toString(); // violation ''.' is preceded with whitespace.'
         return o.toString();
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeEmptyForLoop.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeEmptyForLoop.java
@@ -17,13 +17,13 @@ public class InputNoWhitespaceBeforeEmptyForLoop {
         for (int x = 0; ; ) {
             break;
         }
-        for (int x = 0 ; ; ) { // violation
+        for (int x = 0 ; ; ) { // violation '';' is preceded with whitespace.'
             break;
         }
         for (int x = 0; x < 10; ) {
             break;
         }
-        for (int x = 0; x < 10 ; ) { // violation
+        for (int x = 0; x < 10 ; ) { // violation '';' is preceded with whitespace.'
             break;
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeMethodRef.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeMethodRef.java
@@ -22,8 +22,9 @@ public class InputNoWhitespaceBeforeMethodRef {
   }
 
   public <V> void methodName(V value) {
-    Supplier<?> t = Nested2<V> ::new; // violation
-    Supplier<SomeClass.Nested<V>> passes = SomeClass.Nested ::new; // violation
+    Supplier<?> t = Nested2<V> ::new; // violation ''::' is preceded with whitespace.'
+    Supplier<SomeClass.Nested<V>> passes = SomeClass.Nested ::new;
+    // violation above ''::' is preceded with whitespace.'
     Supplier<SomeClass.Nested<V>> fails = SomeClass.Nested<V>::new;
   }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeWithEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeWithEmoji.java
@@ -10,13 +10,13 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebefore;
 
 public class InputNoWhitespaceBeforeWithEmoji {
     private String[] _mVar0 = {
-        "😃😉🙈" ,  // violation
-        "😃 😉 🙈" ,  // violation
+        "😃😉🙈" ,  // violation '',' is preceded with whitespace.'
+        "😃 😉 🙈" ,  // violation '',' is preceded with whitespace.'
         "😃 😉 🙈",
         "😃😉🙈"
     };
     private String _mVar1 = "😃😉🙈";
     private String _mVar2 = "😃 😉 🙈";
-    private String _mVar3 = "😃 😉 🙈" ; // violation
-    private String _mVar4 = "a b c" ; // violation
+    private String _mVar3 = "😃 😉 🙈" ; // violation '';' is preceded with whitespace.'
+    private String _mVar4 = "a b c" ; // violation '';' is preceded with whitespace.'
 }


### PR DESCRIPTION
Issue #15456

Violation messages are added to all `// violation` comments in NoWhitespaceBeforeCheck input files, and the check is removed from `SUPPRESSED_CHECKS` in `InlineConfigParser.java`.

Additionally, `+` is now escaped in `TestInputViolation.toRegex()` to prevent `++` token text from being interpreted as a regex quantifier.