### PR TITLE
Issue #15456: violation messages for BooleanExpressionComplexityCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -251,7 +251,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck",
-            "com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
@@ -43,10 +43,10 @@ public class BooleanExpressionComplexityCheckTest extends AbstractModuleTestSupp
 
         final String[] expected = {
             "21:9: " + getCheckMessage(MSG_KEY, 4, 3),
-            "38:46: " + getCheckMessage(MSG_KEY, 4, 3),
-            "48:9: " + getCheckMessage(MSG_KEY, 6, 3),
-            "54:34: " + getCheckMessage(MSG_KEY, 4, 3),
-            "56:34: " + getCheckMessage(MSG_KEY, 4, 3),
+            "39:46: " + getCheckMessage(MSG_KEY, 4, 3),
+            "50:9: " + getCheckMessage(MSG_KEY, 6, 3),
+            "57:34: " + getCheckMessage(MSG_KEY, 4, 3),
+            "60:34: " + getCheckMessage(MSG_KEY, 4, 3),
         };
 
         verifyWithInlineConfigParser(
@@ -101,9 +101,9 @@ public class BooleanExpressionComplexityCheckTest extends AbstractModuleTestSupp
 
         final String[] expected = {
             "16:12: " + getCheckMessage(MSG_KEY, 4, max),
-            "24:23: " + getCheckMessage(MSG_KEY, 4, max),
-            "35:23: " + getCheckMessage(MSG_KEY, 4, max),
-            "45:27: " + getCheckMessage(MSG_KEY, 4, max),
+            "25:23: " + getCheckMessage(MSG_KEY, 4, max),
+            "37:23: " + getCheckMessage(MSG_KEY, 4, max),
+            "48:27: " + getCheckMessage(MSG_KEY, 4, max),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexity.java
@@ -18,7 +18,8 @@ public class InputBooleanExpressionComplexity {
         if (_a && _b || _c ^ _d) {
         }
 
-        if (((_a && (_b & _c)) || (_c ^ _d))) { // violation
+        if (((_a && (_b & _c)) || (_c ^ _d))) {
+            // violation above 'Boolean expression complexity is 4 (max allowed is 3).'
         }
 
         if (_a && _b && _c) {
@@ -35,7 +36,8 @@ public class InputBooleanExpressionComplexity {
         new NestedClass() {
             public void method() {
                 new Settings(Settings.FALSE || Settings.FALSE ||
-                        Settings.FALSE || _a || _b); // violation
+                        Settings.FALSE || _a || _b);
+                // violation above 'Boolean expression complexity is 4 (max allowed is 3).'
             }
             public void method2() {
             }
@@ -45,15 +47,18 @@ public class InputBooleanExpressionComplexity {
 
     public boolean bitwise()
     {
-        return (((_a & (_b & _c)) | (_c ^ _d) | (_a & _d))); // violation
+        return (((_a & (_b & _c)) | (_c ^ _d) | (_a & _d)));
+        // violation above 'Boolean expression complexity is 6 (max allowed is 3).'
     }
 
     public void notIgnoredMethodParameters()
     {
         new Settings(Settings.FALSE && Settings.FALSE && Settings.FALSE
-                && Settings.TRUE && Settings.TRUE); // violation
+                && Settings.TRUE && Settings.TRUE);
+        // violation above 'Boolean expression complexity is 4 (max allowed is 3).'
         new Settings(Settings.FALSE || Settings.FALSE || Settings.FALSE
-                || Settings.TRUE || Settings.TRUE); // violation
+                || Settings.TRUE || Settings.TRUE);
+        // violation above 'Boolean expression complexity is 4 (max allowed is 3).'
     }
 
     public void ignoredMethodParameters()

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordsAndCompactCtors.java
@@ -13,7 +13,8 @@ public class InputBooleanExpressionComplexityRecordsAndCompactCtors {
 
     record MyRecord1(boolean a, boolean b) {
         private boolean myBool() {
-           return  (a & b) ^ (a || b) | a; // violation
+           return  (a & b) ^ (a || b) | a;
+           // violation above 'Boolean expression complexity is 4 (max allowed is 3).'
         }
     }
 
@@ -21,7 +22,8 @@ public class InputBooleanExpressionComplexityRecordsAndCompactCtors {
 
         // in compact ctor
         public MyRecord2{
-            boolean d = (a & b) ^ (a || b) | a; // violation
+            boolean d = (a & b) ^ (a || b) | a;
+            // violation above 'Boolean expression complexity is 4 (max allowed is 3).'
         }
     }
 
@@ -32,7 +34,8 @@ public class InputBooleanExpressionComplexityRecordsAndCompactCtors {
             this(3);
             boolean b = true;
             boolean a = true;
-            boolean d = (a & b) ^ (a || b) | a; // violation
+            boolean d = (a & b) ^ (a || b) | a;
+            // violation above 'Boolean expression complexity is 4 (max allowed is 3).'
         }
     }
 
@@ -42,7 +45,8 @@ public class InputBooleanExpressionComplexityRecordsAndCompactCtors {
             public MyRecord5{
                 boolean b = false;
                 boolean a = true;
-                boolean d = (a & b) ^ (a || b) | a; // violation
+                boolean d = (a & b) ^ (a || b) | a;
+                // violation above 'Boolean expression complexity is 4 (max allowed is 3).'
             }
         }
     }


### PR DESCRIPTION
Issue #15456

Violation messages are added to all `// violation` comments in BooleanExpressionComplexityCheck input files, and the check is removed from `SUPPRESSED_CHECKS` in `InlineConfigParser.java`