### PR TITLE
Issue #19144: updated JavadocMethod to use AST of javadoc

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -910,7 +910,6 @@ nlow
 NMCS
 NMTOKEN
 noarch
-noarg
 noarraytrailingcomma
 noblank
 nobr

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -129,8 +129,6 @@
   <suppress id="noConsecutiveLines" files="[\\/]emptylineseparator.xml"/>
   <suppress id="noConsecutiveLines" files="[\\/]javadocparagraph.xml"/>
 
-  <!-- until #19144 -->
-  <suppress id="noUsageOfGetFileContentsMethod" files="JavadocMethodCheck.java"/>
   <!-- until #19145 -->
   <suppress id="noUsageOfGetFileContentsMethod" files="JavadocStyleCheck.java"/>
   <!-- until #19146 -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -27,21 +27,18 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.MatchResult;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
-import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
-import com.puppycrawl.tools.checkstyle.api.TextBlock;
+import com.puppycrawl.tools.checkstyle.api.JavadocCommentsTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
 import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 
 /**
@@ -112,7 +109,7 @@ import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
  * @since 3.0
  */
 @StatelessCheck
-public class JavadocMethodCheck extends AbstractCheck {
+public class JavadocMethodCheck extends AbstractJavadocCheck {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -161,36 +158,6 @@ public class JavadocMethodCheck extends AbstractCheck {
 
     /** Html element end symbol. */
     private static final String ELEMENT_END = ">";
-
-    /** Compiled regexp to match Javadoc tags that take an argument. */
-    private static final Pattern MATCH_JAVADOC_ARG = CommonUtil.createPattern(
-            "^\\s*(?>\\*|\\/\\*\\*)?\\s*@(throws|exception|param)\\s+(\\S+)\\s+\\S*");
-    /** Compiled regexp to match Javadoc tags with argument but with missing description. */
-    private static final Pattern MATCH_JAVADOC_ARG_MISSING_DESCRIPTION =
-        CommonUtil.createPattern("^\\s*(?>\\*|\\/\\*\\*)?\\s*@(throws|exception|param)\\s+"
-            + "(\\S[^*]*)(?:(\\s+|\\*\\/))?");
-
-    /** Compiled regexp to look for a continuation of the comment. */
-    private static final Pattern MATCH_JAVADOC_MULTILINE_CONT =
-            CommonUtil.createPattern("(\\*\\/|@|[^\\s\\*])");
-
-    /** Multiline finished at end of comment. */
-    private static final String END_JAVADOC = "*/";
-    /** Multiline finished at next Javadoc. */
-    private static final String NEXT_TAG = "@";
-
-    /** Compiled regexp to match Javadoc tags with no argument. */
-    private static final Pattern MATCH_JAVADOC_NOARG =
-            CommonUtil.createPattern("^\\s*(?>\\*|\\/\\*\\*)?\\s*@(return|see)\\s+\\S");
-    /** Compiled regexp to match Javadoc tags with no argument allowing inline return tag. */
-    private static final Pattern MATCH_JAVADOC_NOARG_INLINE_RETURN =
-            CommonUtil.createPattern("^\\s*(?>\\*|\\/\\*\\*)?\\s*\\{?@(return|see)\\s+\\S");
-    /** Compiled regexp to match first part of multilineJavadoc tags. */
-    private static final Pattern MATCH_JAVADOC_NOARG_MULTILINE_START =
-            CommonUtil.createPattern("^\\s*(?>\\*|\\/\\*\\*)?\\s*@(return|see)\\s*$");
-    /** Compiled regexp to match Javadoc tags with no argument and {}. */
-    private static final Pattern MATCH_JAVADOC_NOARG_CURLY =
-            CommonUtil.createPattern("\\{\\s*@(inheritDoc)\\s*\\}");
 
     /**
      * Control whether to allow inline return tags.
@@ -289,13 +256,21 @@ public class JavadocMethodCheck extends AbstractCheck {
     }
 
     @Override
-    public final int[] getRequiredTokens() {
-        return CommonUtil.EMPTY_INT_ARRAY;
+    public int[] getDefaultJavadocTokens() {
+        return new int[] {
+            JavadocCommentsTokenTypes.JAVADOC_CONTENT,
+        };
     }
 
     @Override
     public int[] getDefaultTokens() {
-        return getAcceptableTokens();
+        return new int[] {
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.BLOCK_COMMENT_BEGIN,
+        };
     }
 
     @Override
@@ -305,31 +280,39 @@ public class JavadocMethodCheck extends AbstractCheck {
             TokenTypes.CTOR_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.BLOCK_COMMENT_BEGIN,
         };
     }
 
     @Override
-    public final void visitToken(DetailAST ast) {
-        processAST(ast);
+    public int[] getRequiredJavadocTokens() {
+        return getAcceptableJavadocTokens();
+    }
+
+    @Override
+    public int[] getAcceptableJavadocTokens() {
+        return getDefaultJavadocTokens();
+    }
+
+    @Override
+    public void visitJavadocToken(DetailNode ast) {
+        final DetailAST targetAst = getTargetAst(getBlockCommentAst());
+        if (targetAst != null
+                && isTargetTokenConfigured(targetAst.getType())
+                && shouldCheck(targetAst)) {
+            checkComment(targetAst, ast);
+        }
     }
 
     /**
-     * Called to process an AST when visiting it.
+     * Checks whether declaration type should be validated according to configured tokens.
      *
-     * @param ast the AST to process. Guaranteed to not be PACKAGE_DEF or
-     *             IMPORT tokens.
+     * @param tokenType declaration token type
+     * @return true when check should validate the declaration
      */
-    // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/19144
-    @SuppressWarnings("deprecation")
-    private void processAST(DetailAST ast) {
-        if (shouldCheck(ast)) {
-            final FileContents contents = getFileContents();
-            final TextBlock textBlock = contents.getJavadocBefore(ast.getLineNo());
-
-            if (textBlock != null) {
-                checkComment(ast, textBlock);
-            }
-        }
+    private boolean isTargetTokenConfigured(int tokenType) {
+        final Set<String> tokenNames = getTokenNames();
+        return tokenNames.isEmpty() || tokenNames.contains(TokenUtil.getTokenName(tokenType));
     }
 
     /**
@@ -344,18 +327,18 @@ public class JavadocMethodCheck extends AbstractCheck {
         final AccessModifierOption accessModifier = CheckUtil
                 .getAccessModifierFromModifiersToken(ast);
         return surroundingAccessModifier.isPresent() && Arrays.stream(accessModifiers)
-                        .anyMatch(modifier -> modifier == surroundingAccessModifier.get())
-                && Arrays.stream(accessModifiers).anyMatch(modifier -> modifier == accessModifier);
+                .anyMatch(modifier -> modifier == surroundingAccessModifier.get())
+            && Arrays.stream(accessModifiers).anyMatch(modifier -> modifier == accessModifier);
     }
 
     /**
      * Checks the Javadoc for a method.
      *
      * @param ast the token for the method
-     * @param comment the Javadoc comment
+     * @param javadocRoot the Javadoc tree root
      */
-    private void checkComment(DetailAST ast, TextBlock comment) {
-        final List<JavadocTag> tags = getMethodTags(comment);
+    private void checkComment(DetailAST ast, DetailNode javadocRoot) {
+        final List<JavadocTag> tags = getMethodTags(javadocRoot);
 
         if (!hasShortCircuitTag(ast, tags)) {
             if (ast.getType() == TokenTypes.ANNOTATION_FIELD_DEF) {
@@ -449,108 +432,191 @@ public class JavadocMethodCheck extends AbstractCheck {
     }
 
     /**
-     * Returns the tags in a javadoc comment. Only finds throws, exception,
-     * param, return and see tags.
+     * Returns supported tags from javadoc AST. It finds throws, exception,
+     * param, return, see and inheritDoc tags.
      *
-     * @param comment the Javadoc comment
+     * @param javadocRoot the javadoc tree root
      * @return the tags found
      */
-    private List<JavadocTag> getMethodTags(TextBlock comment) {
-        Pattern matchJavadocNoArg = MATCH_JAVADOC_NOARG;
-        if (allowInlineReturn) {
-            matchJavadocNoArg = MATCH_JAVADOC_NOARG_INLINE_RETURN;
-        }
-        final String[] lines = comment.getText();
+    private List<JavadocTag> getMethodTags(DetailNode javadocRoot) {
         final List<JavadocTag> tags = new ArrayList<>();
-        int currentLine = comment.getStartLineNo() - 1;
-        final int startColumnNumber = comment.getStartColNo();
 
-        for (int i = 0; i < lines.length; i++) {
-            currentLine++;
-            final Matcher javadocArgMatcher =
-                MATCH_JAVADOC_ARG.matcher(lines[i]);
-            final Matcher javadocArgMissingDescriptionMatcher =
-                MATCH_JAVADOC_ARG_MISSING_DESCRIPTION.matcher(lines[i]);
-            final Matcher javadocNoargMatcher =
-                matchJavadocNoArg.matcher(lines[i]);
-            final Matcher noargCurlyMatcher =
-                MATCH_JAVADOC_NOARG_CURLY.matcher(lines[i]);
-            final Matcher noargMultilineStart =
-                MATCH_JAVADOC_NOARG_MULTILINE_START.matcher(lines[i]);
+        DetailNode current = javadocRoot.getFirstChild();
+        while (current != null) {
+            if (current.getType() == JavadocCommentsTokenTypes.JAVADOC_BLOCK_TAG) {
+                final DetailNode blockTag = current.getFirstChild();
+                final int blockTagType = blockTag.getType();
 
-            if (javadocArgMatcher.find()) {
-                final int col = calculateTagColumn(javadocArgMatcher, i, startColumnNumber);
-                tags.add(new JavadocTag(currentLine, col, javadocArgMatcher.group(1),
-                        javadocArgMatcher.group(2)));
+                if (blockTagType == JavadocCommentsTokenTypes.PARAM_BLOCK_TAG) {
+                    final String parameterName = getTagArgument(
+                            blockTag, JavadocCommentsTokenTypes.PARAMETER_NAME);
+                    if (parameterName != null) {
+                        tags.add(new JavadocTag(current.getLineNumber(), current.getColumnNumber(),
+                                JavadocTagInfo.PARAM.getName(), parameterName));
+                    }
+                }
+                else if (blockTagType == JavadocCommentsTokenTypes.THROWS_BLOCK_TAG
+                        || blockTagType == JavadocCommentsTokenTypes.EXCEPTION_BLOCK_TAG) {
+                    final String throwsName = getTagArgument(
+                            blockTag, JavadocCommentsTokenTypes.IDENTIFIER);
+                    if (throwsName != null) {
+                        tags.add(new JavadocTag(current.getLineNumber(), current.getColumnNumber(),
+                                JavadocUtil.getTagName(current), throwsName));
+                    }
+                }
+                else if ((blockTagType == JavadocCommentsTokenTypes.RETURN_BLOCK_TAG
+                    || blockTagType == JavadocCommentsTokenTypes.SEE_BLOCK_TAG)
+                    && hasDescriptionContent(blockTag)) {
+                    tags.add(new JavadocTag(current.getLineNumber(), current.getColumnNumber(),
+                            JavadocUtil.getTagName(current)));
+                }
             }
-            else if (javadocArgMissingDescriptionMatcher.find()) {
-                final int col = calculateTagColumn(javadocArgMissingDescriptionMatcher, i,
-                    startColumnNumber);
-                tags.add(new JavadocTag(currentLine, col,
-                    javadocArgMissingDescriptionMatcher.group(1),
-                    javadocArgMissingDescriptionMatcher.group(2)));
-            }
-            else if (javadocNoargMatcher.find()) {
-                final int col = calculateTagColumn(javadocNoargMatcher, i, startColumnNumber);
-                tags.add(new JavadocTag(currentLine, col, javadocNoargMatcher.group(1)));
-            }
-            else if (noargCurlyMatcher.find()) {
-                tags.add(new JavadocTag(currentLine, 0, noargCurlyMatcher.group(1)));
-            }
-            else if (noargMultilineStart.find()) {
-                tags.addAll(getMultilineNoArgTags(noargMultilineStart, lines, i, currentLine));
-            }
+
+            current = current.getNextSibling();
         }
+
+        collectInlineTags(javadocRoot, tags);
         return tags;
     }
 
     /**
-     * Calculates column number using Javadoc tag matcher.
+     * Traverses javadoc tree and collects relevant inline tags.
      *
-     * @param javadocTagMatchResult found javadoc tag match result
-     * @param lineNumber line number of Javadoc tag in comment
-     * @param startColumnNumber column number of Javadoc comment beginning
-     * @return column number
+     * @param root root node to traverse
+     * @param tags destination for collected tags
      */
-    private static int calculateTagColumn(MatchResult javadocTagMatchResult,
-            int lineNumber, int startColumnNumber) {
-        int col = javadocTagMatchResult.start(1) - 1;
-        if (lineNumber == 0) {
-            col += startColumnNumber;
+    private void collectInlineTags(DetailNode root, List<JavadocTag> tags) {
+        DetailNode current = root;
+        while (current != null) {
+            if (current.getType() == JavadocCommentsTokenTypes.JAVADOC_INLINE_TAG) {
+                final DetailNode inlineTag = current.getFirstChild();
+                if (inlineTag.getType() == JavadocCommentsTokenTypes.INHERIT_DOC_INLINE_TAG) {
+                    tags.add(new JavadocTag(current.getLineNumber(), current.getColumnNumber(),
+                            JavadocTagInfo.INHERIT_DOC.getName()));
+                }
+                else if (allowInlineReturn
+                        && inlineTag.getType() == JavadocCommentsTokenTypes.RETURN_INLINE_TAG
+                        && hasDescriptionContent(inlineTag)) {
+                    tags.add(new JavadocTag(current.getLineNumber(), current.getColumnNumber(),
+                            JavadocTagInfo.RETURN.getName()));
+                }
+            }
+
+            DetailNode toVisit = current.getFirstChild();
+            while (current != root && toVisit == null) {
+                toVisit = current.getNextSibling();
+                current = current.getParent();
+            }
+            current = toVisit;
         }
-        return col;
     }
 
     /**
-     * Gets multiline Javadoc tags with no arguments.
+     * Gets argument of block tag.
      *
-     * @param noargMultilineStart javadoc tag Matcher
-     * @param lines comment text lines
-     * @param lineIndex line number that contains the javadoc tag
-     * @param tagLine javadoc tag line number in file
-     * @return javadoc tags with no arguments
+     * @param blockTag block tag node
+     * @param argumentType type of argument token
+     * @return argument text or null if not present
      */
-    private static List<JavadocTag> getMultilineNoArgTags(final Matcher noargMultilineStart,
-            final String[] lines, final int lineIndex, final int tagLine) {
-        int remIndex = lineIndex;
-        Matcher multilineCont;
+    private static String getTagArgument(DetailNode blockTag, int argumentType) {
+        final DetailNode argumentNode = JavadocUtil.findFirstToken(blockTag, argumentType);
+        final String result;
+        if (argumentNode == null) {
+            result = null;
+        }
+        else {
+            result = argumentNode.getText();
+        }
+        return result;
+    }
 
-        do {
-            remIndex++;
-            multilineCont = MATCH_JAVADOC_MULTILINE_CONT.matcher(lines[remIndex]);
-        } while (!multilineCont.find());
+    /**
+     * Checks if the block tag has non-empty description.
+     *
+     * @param blockTag tag to check
+     * @return true if description contains visible content
+     */
+    private static boolean hasDescriptionContent(DetailNode blockTag) {
+        final DetailNode description = JavadocUtil.findFirstToken(
+                blockTag, JavadocCommentsTokenTypes.DESCRIPTION);
+        boolean result = false;
+        if (description != null) {
+            DetailNode current = description;
+            while (current != null) {
+                if (current.getFirstChild() == null
+                        && current.getType() != JavadocCommentsTokenTypes.LEADING_ASTERISK
+                        && !current.getText().isBlank()) {
+                    result = true;
+                    break;
+                }
 
-        final List<JavadocTag> tags = new ArrayList<>();
-        final String lFin = multilineCont.group(1);
-        if (!NEXT_TAG.equals(lFin)
-            && !END_JAVADOC.equals(lFin)) {
-            final String param1 = noargMultilineStart.group(1);
-            final int col = noargMultilineStart.start(1) - 1;
+                DetailNode toVisit = current.getFirstChild();
+                while (current != description && toVisit == null) {
+                    toVisit = current.getNextSibling();
+                    current = current.getParent();
+                }
+                current = toVisit;
+            }
+        }
+        return result;
+    }
 
-            tags.add(new JavadocTag(tagLine, col, param1));
+    /**
+     * Finds declaration token that javadoc belongs to.
+     *
+     * @param blockCommentAst block comment AST node
+     * @return declaration AST node or null if unsupported parent type
+     */
+    private static DetailAST getTargetAst(DetailAST blockCommentAst) {
+        DetailAST result = adjustTargetFromContext(blockCommentAst.getParent());
+
+        if (!isTargetType(result)) {
+            result = adjustTargetFromContext(blockCommentAst.getNextSibling());
+            while (result != null && !isTargetType(result)
+                    && (result.getType() == TokenTypes.SINGLE_LINE_COMMENT
+                    || result.getType() == TokenTypes.BLOCK_COMMENT_BEGIN)) {
+                result = adjustTargetFromContext(result.getNextSibling());
+            }
         }
 
-        return tags;
+        if (!isTargetType(result)) {
+            result = null;
+        }
+        return result;
+    }
+
+    /**
+     * Adjusts candidate AST node to declaration token for checks.
+     *
+     * @param candidate candidate AST node
+     * @return adjusted declaration token candidate
+     */
+    private static DetailAST adjustTargetFromContext(DetailAST candidate) {
+        DetailAST result = candidate;
+        if (result != null) {
+            if (result.getType() == TokenTypes.TYPE || result.getType() == TokenTypes.MODIFIERS) {
+                result = result.getParent();
+            }
+            else if (result.getParent() != null
+                    && result.getParent().getType() == TokenTypes.MODIFIERS) {
+                result = result.getParent().getParent();
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Checks whether AST node type is supported by this check.
+     *
+     * @param ast declaration candidate
+     * @return true if declaration is supported
+     */
+    private static boolean isTargetType(DetailAST ast) {
+        return ast != null
+                && (ast.getType() == TokenTypes.METHOD_DEF
+                || ast.getType() == TokenTypes.CTOR_DEF
+                || ast.getType() == TokenTypes.ANNOTATION_FIELD_DEF
+                || ast.getType() == TokenTypes.COMPACT_CTOR_DEF);
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMethodCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMethodCheck.xml
@@ -98,13 +98,23 @@
             <property default-value="false" name="validateThrows" type="boolean">
                <description>Control whether to validate &lt;code&gt;throws&lt;/code&gt; tags.</description>
             </property>
+            <property default-value="false"
+                      name="violateExecutionOnNonTightHtml"
+                      type="boolean">
+               <description>Control when to print violations if the Javadoc being examined by this check
+ violates the tight html rules defined at
+ &lt;a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules"&gt;
+     Tight-HTML Rules&lt;/a&gt;.</description>
+            </property>
          </properties>
          <message-keys>
             <message-key key="javadoc.classInfo"/>
             <message-key key="javadoc.duplicateTag"/>
             <message-key key="javadoc.expectedTag"/>
             <message-key key="javadoc.invalidInheritDoc"/>
+            <message-key key="javadoc.parse.rule.error"/>
             <message-key key="javadoc.return.expected"/>
+            <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.unusedTag"/>
             <message-key key="javadoc.unusedTagGeneral"/>
          </message-keys>

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml
@@ -128,6 +128,14 @@ public int checkReturnTag(final int aTagIndex,
               <td>6.0</td>
             </tr>
             <tr>
+              <td><a id="violateExecutionOnNonTightHtml"/><a href="#violateExecutionOnNonTightHtml">violateExecutionOnNonTightHtml</a></td>
+              <td>Control when to print violations if the Javadoc being examined by this check violates the tight html rules defined at <a href="../../writingjavadocchecks.html#Tight-HTML_rules">
+     Tight-HTML Rules</a>.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.3</td>
+            </tr>
+            <tr>
               <td><a id="tokens"/><a href="#tokens">tokens</a></td>
               <td>tokens to check</td>
               <td>subset of tokens
@@ -552,8 +560,18 @@ public class Example8 {
             </a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.parse.rule.error%22">
+              javadoc.parse.rule.error
+            </a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.return.expected%22">
               javadoc.return.expected
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
             </a>
           </li>
           <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -30,6 +30,10 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DetailAstImpl;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
+import com.puppycrawl.tools.checkstyle.api.JavadocCommentsTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -50,6 +54,7 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             TokenTypes.CTOR_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.BLOCK_COMMENT_BEGIN,
         };
 
         assertWithMessage("Default acceptable tokens are invalid")
@@ -469,10 +474,26 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testGetRequiredTokens() {
-        final int[] expected = CommonUtil.EMPTY_INT_ARRAY;
+        final int[] expected = {
+            TokenTypes.BLOCK_COMMENT_BEGIN,
+        };
         final JavadocMethodCheck check = new JavadocMethodCheck();
         final int[] actual = check.getRequiredTokens();
         assertWithMessage("Required tokens differ from expected")
+            .that(actual)
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void testGetDefaultJavadocTokens() {
+        final JavadocMethodCheck check = new JavadocMethodCheck();
+
+        final int[] actual = check.getDefaultJavadocTokens();
+        final int[] expected = {
+            JavadocCommentsTokenTypes.JAVADOC_CONTENT,
+        };
+
+        assertWithMessage("Default javadoc tokens are invalid")
             .that(actual)
             .isEqualTo(expected);
     }
@@ -610,5 +631,187 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocMethodDoNotAllowInlineReturn.java"), expected);
+    }
+
+    @Test
+    public void testIsTargetTokenConfigured() throws Exception {
+        final JavadocMethodCheck check = new JavadocMethodCheck();
+        final var method = JavadocMethodCheck.class
+                .getDeclaredMethod("isTargetTokenConfigured", int.class);
+        method.setAccessible(true);
+
+        // Empty configured tokens means default-token behavior: do not filter by token set.
+        final boolean defaultTokenBehavior = (boolean) method.invoke(check, TokenTypes.METHOD_DEF);
+
+        check.setTokens("CTOR_DEF");
+        final boolean methodTokenIncluded = (boolean) method.invoke(check, TokenTypes.METHOD_DEF);
+        final boolean ctorTokenIncluded = (boolean) method.invoke(check, TokenTypes.CTOR_DEF);
+
+        assertWithMessage("Expected METHOD_DEF to be accepted when configured tokens are empty")
+            .that(defaultTokenBehavior)
+            .isTrue();
+        assertWithMessage("Expected METHOD_DEF to be rejected when only CTOR_DEF is configured")
+            .that(methodTokenIncluded)
+            .isFalse();
+        assertWithMessage("Expected CTOR_DEF to be accepted when only CTOR_DEF is configured")
+            .that(ctorTokenIncluded)
+            .isTrue();
+    }
+
+    @Test
+        public void testGetTagArgument() throws Exception {
+        final var getTagArgumentMethod = JavadocMethodCheck.class
+            .getDeclaredMethod(
+                "getTagArgument",
+                DetailNode.class,
+                int.class);
+        getTagArgumentMethod.setAccessible(true);
+
+        final JavadocNodeImpl blockTag = new JavadocNodeImpl();
+        blockTag.setType(JavadocCommentsTokenTypes.PARAM_BLOCK_TAG);
+
+        final JavadocNodeImpl parameterName = new JavadocNodeImpl();
+        parameterName.setType(JavadocCommentsTokenTypes.PARAMETER_NAME);
+        parameterName.setText("value");
+        blockTag.addChild(parameterName);
+
+        final String argument = (String) getTagArgumentMethod.invoke(
+                null, blockTag, JavadocCommentsTokenTypes.PARAMETER_NAME);
+        final String missingArgument = (String) getTagArgumentMethod.invoke(
+                null, blockTag, JavadocCommentsTokenTypes.IDENTIFIER);
+
+        assertWithMessage("Expected to resolve existing tag argument")
+            .that(argument)
+            .isEqualTo("value");
+        assertWithMessage("Expected null when tag argument token is absent")
+            .that(missingArgument)
+            .isNull();
+    }
+
+    @Test
+    public void testHasDescriptionContent() throws Exception {
+        final var descriptionContentMethod = JavadocMethodCheck.class
+                .getDeclaredMethod(
+                        "hasDescriptionContent",
+                DetailNode.class);
+        descriptionContentMethod.setAccessible(true);
+
+        final JavadocNodeImpl blockTag = new JavadocNodeImpl();
+        blockTag.setType(JavadocCommentsTokenTypes.PARAM_BLOCK_TAG);
+
+        final JavadocNodeImpl returnTag = new JavadocNodeImpl();
+        returnTag.setType(JavadocCommentsTokenTypes.RETURN_BLOCK_TAG);
+
+        final JavadocNodeImpl description = new JavadocNodeImpl();
+        description.setType(JavadocCommentsTokenTypes.DESCRIPTION);
+        returnTag.addChild(description);
+
+        final JavadocNodeImpl leadingAsterisk = new JavadocNodeImpl();
+        leadingAsterisk.setType(JavadocCommentsTokenTypes.LEADING_ASTERISK);
+        leadingAsterisk.setText("*");
+        description.addChild(leadingAsterisk);
+
+        final JavadocNodeImpl blankText = new JavadocNodeImpl();
+        blankText.setType(JavadocCommentsTokenTypes.TEXT);
+        blankText.setText("   ");
+        description.addChild(blankText);
+
+        final JavadocNodeImpl contentText = new JavadocNodeImpl();
+        contentText.setType(JavadocCommentsTokenTypes.TEXT);
+        contentText.setText("description");
+        description.addChild(contentText);
+
+        final boolean hasDescription = (boolean) descriptionContentMethod
+            .invoke(null, returnTag);
+        final boolean hasDescriptionInTagWithoutDescriptionNode =
+            (boolean) descriptionContentMethod.invoke(null, blockTag);
+
+        assertWithMessage("Expected visible description content to be detected")
+            .that(hasDescription)
+            .isTrue();
+        assertWithMessage("Expected false when DESCRIPTION node is absent")
+            .that(hasDescriptionInTagWithoutDescriptionNode)
+            .isFalse();
+    }
+
+    @Test
+        public void testTargetAstFromTypeContext() throws Exception {
+        final var getTargetAstMethod = JavadocMethodCheck.class
+            .getDeclaredMethod(
+                "getTargetAst",
+            DetailAST.class);
+        final var adjustTargetMethod = JavadocMethodCheck.class
+            .getDeclaredMethod(
+                "adjustTargetFromContext",
+            DetailAST.class);
+        getTargetAstMethod.setAccessible(true);
+        adjustTargetMethod.setAccessible(true);
+
+        final DetailAstImpl methodDef = new DetailAstImpl();
+        methodDef.setType(TokenTypes.METHOD_DEF);
+        final DetailAstImpl typeNode = new DetailAstImpl();
+        typeNode.setType(TokenTypes.TYPE);
+        final DetailAstImpl blockCommentInType = new DetailAstImpl();
+        blockCommentInType.setType(TokenTypes.BLOCK_COMMENT_BEGIN);
+        methodDef.addChild(typeNode);
+        typeNode.addChild(blockCommentInType);
+
+        final Object adjustedFromType = adjustTargetMethod.invoke(null, typeNode);
+        final Object targetFromTypeParent = getTargetAstMethod.invoke(null, blockCommentInType);
+
+        assertWithMessage("Expected TYPE context to adjust to enclosing declaration")
+            .that(((DetailAST) adjustedFromType).getType())
+            .isEqualTo(TokenTypes.METHOD_DEF);
+        assertWithMessage("Expected block comment under TYPE to resolve METHOD_DEF target")
+            .that(((DetailAST) targetFromTypeParent).getType())
+            .isEqualTo(TokenTypes.METHOD_DEF);
+    }
+
+    @Test
+    public void testTargetAstSkipsCommentSiblings() throws Exception {
+        final var getTargetAstMethod = JavadocMethodCheck.class
+                .getDeclaredMethod(
+                        "getTargetAst",
+                DetailAST.class);
+        final var targetTypeMethod = JavadocMethodCheck.class
+                .getDeclaredMethod(
+                        "isTargetType",
+                DetailAST.class);
+        getTargetAstMethod.setAccessible(true);
+        targetTypeMethod.setAccessible(true);
+
+        final DetailAstImpl root = new DetailAstImpl();
+        root.setType(TokenTypes.CLASS_DEF);
+        final DetailAstImpl blockComment = new DetailAstImpl();
+        blockComment.setType(TokenTypes.BLOCK_COMMENT_BEGIN);
+        final DetailAstImpl singleLineComment = new DetailAstImpl();
+        singleLineComment.setType(TokenTypes.SINGLE_LINE_COMMENT);
+        final DetailAstImpl ctorDef = new DetailAstImpl();
+        ctorDef.setType(TokenTypes.CTOR_DEF);
+        root.addChild(blockComment);
+        root.addChild(singleLineComment);
+        root.addChild(ctorDef);
+
+        final Object targetAfterCommentSiblings = getTargetAstMethod.invoke(null, blockComment);
+        final boolean compactCtorSupported =
+            (boolean) targetTypeMethod.invoke(null, createAst(TokenTypes.COMPACT_CTOR_DEF));
+        final boolean nullTargetUnsupported =
+            (boolean) targetTypeMethod.invoke(null, (Object) null);
+
+        assertWithMessage("Expected target resolution to skip comment siblings")
+            .that(((DetailAST) targetAfterCommentSiblings).getType())
+            .isEqualTo(TokenTypes.CTOR_DEF);
+        assertWithMessage("Expected COMPACT_CTOR_DEF to be treated as supported target")
+            .that(compactCtorSupported)
+            .isTrue();
+        assertWithMessage("Expected null AST to be rejected as target")
+            .that(nullTargetUnsupported)
+            .isFalse();
+    }
+
+    private static DetailAstImpl createAst(int tokenType) {
+        final DetailAstImpl ast = new DetailAstImpl();
+        ast.setType(tokenType);
+        return ast;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
@@ -579,18 +579,18 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
     @Test
     public void testSuppressedByIdJavadocCheck() throws Exception {
         final String[] suppressedViolationMessages = {
-            "29: " + getCheckMessage(JavadocMethodCheck.class, MSG_RETURN_EXPECTED),
-            "33:9: " + getCheckMessage(JavadocMethodCheck.class,
+            "30: " + getCheckMessage(JavadocMethodCheck.class, MSG_RETURN_EXPECTED),
+            "34:9: " + getCheckMessage(JavadocMethodCheck.class,
                                        MSG_UNUSED_TAG, "@param", "unused"),
-            "40:22: " + getCheckMessage(JavadocMethodCheck.class,
+            "41:22: " + getCheckMessage(JavadocMethodCheck.class,
                                         MSG_EXPECTED_TAG, "@param", "a"),
         };
 
         final String[] expectedViolationMessages = {
-            "29: " + getCheckMessage(JavadocMethodCheck.class, MSG_RETURN_EXPECTED),
-            "33:9: " + getCheckMessage(JavadocMethodCheck.class,
+            "30: " + getCheckMessage(JavadocMethodCheck.class, MSG_RETURN_EXPECTED),
+            "34:9: " + getCheckMessage(JavadocMethodCheck.class,
                                        MSG_UNUSED_TAG, "@param", "unused"),
-            "40:22: " + getCheckMessage(JavadocMethodCheck.class,
+            "41:22: " + getCheckMessage(JavadocMethodCheck.class,
                                         MSG_EXPECTED_TAG, "@param", "a"),
         };
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -391,7 +391,7 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
     @Test
     public void testJavaDocMethod2() throws Exception {
         final String[] expected = {
-            "20:25: " + getCheckMessage(JavadocMethodCheck.class,
+            "21:25: " + getCheckMessage(JavadocMethodCheck.class,
                   MSG_EXPECTED_TAG, "@param", "i"),
         };
         verifyWithInlineConfigParser(
@@ -401,7 +401,7 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
     @Test
     public void testJavadoc() throws Exception {
         final String[] expected = {
-            "26:39: " + getCheckMessage(JavadocMethodCheck.class,
+            "27:39: " + getCheckMessage(JavadocMethodCheck.class,
                   MSG_EXPECTED_TAG, "@param", "i"),
         };
         verifyWithInlineConfigParser(
@@ -452,6 +452,18 @@ public class CheckUtilTest extends AbstractModuleTestSupport {
         assertWithMessage("Expected isPackageInfo() to return false for ('/')")
                 .that(result)
                 .isFalse();
+    }
+
+    @Test
+    public void testGetSurroundingAccessModifierOnRootNode() throws Exception {
+        final DetailAST compilationUnit = getNodeFromFile(TokenTypes.COMPILATION_UNIT);
+
+        final Optional<AccessModifierOption> result =
+                CheckUtil.getSurroundingAccessModifier(compilationUnit);
+
+        assertWithMessage("Expected empty result for COMPILATION_UNIT root node")
+            .that(result.isPresent())
+            .isFalse();
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod1.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod2.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod3.java
@@ -6,7 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAboveComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAboveComments.java
@@ -6,10 +6,10 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodAboveComments {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAllowInlineReturn.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAllowInlineReturn.java
@@ -6,8 +6,8 @@ validateThrows = (default)false
 accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAllowedAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAllowedAnnotations.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompilationUnit.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompilationUnit.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 // Java17

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodConstructor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodConstructor.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCustomMessage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCustomMessage.java
@@ -6,13 +6,13 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 message.javadoc.return.expected = @return tag should be present and have description :)
 message.javadoc.expectedTag = Expected {0} tag for ''{1}'' :)
 message.javadoc.unusedTag = Unused {0} tag for ''{1}'' :)
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodCustomMessage {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDefaultAccessModifier.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDefaultAccessModifier.java
@@ -6,8 +6,8 @@ accessModifiers = public
 allowMissingParamTags = (default)false
 allowMissingReturnTag = true
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDoNotAllowInlineReturn.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDoNotAllowInlineReturn.java
@@ -1,13 +1,13 @@
 /*
 JavadocMethod
 allowInlineReturn = (default)false
+violateExecutionOnNonTightHtml = (default)false
 allowedAnnotations = (default)Override
 validateThrows = (default)false
 accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodEnum.java
@@ -6,8 +6,8 @@ accessModifiers = private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtendAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtendAnnotation.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtraThrowsOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtraThrowsOne.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtraThrowsTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtraThrowsTwo.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodGenerics.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodGenerics.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsOne.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsTwo.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodInheritDoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodInheritDoc.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodJavadocInMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodJavadocInMethod.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodLoadErrors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodLoadErrors.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodMissingJavadocNoMissingTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodMissingJavadocNoMissingTags.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = true
 allowMissingReturnTag = true
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodMissingJavadocTagsDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodMissingJavadocTagsDefault.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocDefault.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocOnlyPrivateScope.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocOnlyPrivateScope.java
@@ -6,8 +6,8 @@ accessModifiers = private, package, public
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocOnlyPrivateScopePackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocOnlyPrivateScopePackage.java
@@ -6,8 +6,8 @@ accessModifiers = private, package, public
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocProtectedScope.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocProtectedScope.java
@@ -6,8 +6,8 @@ accessModifiers = public, protected
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocProtectedScopePackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocProtectedScopePackage.java
@@ -6,8 +6,8 @@ accessModifiers = public, protected
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPackageClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPackageClass.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPackageClass2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPackageClass2.java
@@ -6,7 +6,8 @@ accessModifiers = private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodParamsTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodParamsTags.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodProtectedScopeJavadocOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodProtectedScopeJavadocOne.java
@@ -6,8 +6,8 @@ accessModifiers = public, protected
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodProtectedScopeJavadocTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodProtectedScopeJavadocTwo.java
@@ -6,8 +6,8 @@ accessModifiers = public, protected
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly1One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly1One.java
@@ -6,8 +6,8 @@ accessModifiers =
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly1Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly1Two.java
@@ -6,8 +6,8 @@ accessModifiers =
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnlyOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnlyOne.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnlyTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnlyTwo.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodReceiverParameter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodReceiverParameter.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords2.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = true
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords3.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodScopeAnonInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodScopeAnonInner.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodScopeInnerInterfaces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodScopeInnerInterfaces.java
@@ -6,8 +6,8 @@ accessModifiers = public
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodSetterGetter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodSetterGetter.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodSurroundingAccessModifier.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodSurroundingAccessModifier.java
@@ -6,8 +6,8 @@ accessModifiers = private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1One.java
@@ -6,10 +6,10 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1Three.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1Three.java
@@ -6,10 +6,10 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 import java.io.IOException;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1Two.java
@@ -6,7 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionOne.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionTwo.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTypeParamsTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTypeParamsTags.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_01.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_01.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_02.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_02.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_03.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_03.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_1379666.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_1379666.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodsNotSkipWritten.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodsNotSkipWritten.java
@@ -6,8 +6,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
-
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressByIdJavadocCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressByIdJavadocCheck.java
@@ -14,7 +14,8 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 id = foo
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil4.java
@@ -6,7 +6,8 @@ validateThrows = (default)false
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil5.java
@@ -6,7 +6,8 @@ validateThrows = (default)false
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil7.java
@@ -6,7 +6,8 @@ accessModifiers = public
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
-tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, BLOCK_COMMENT_BEGIN
 
 
 */


### PR DESCRIPTION
fixes #19144 

This PR completes the migration of JavadocMethodCheck from line/regex-based Javadoc parsing to AST-based Javadoc parsing using AbstractJavadocCheck, and removes the temporary suppression for issue #19144.

It also updates inline-config test inputs and expectations affected by the new token/property model, and addresses follow-up coverage gaps introduced by the migration.

Core check migration:
Converted [JavadocMethodCheck.java] to extend AbstractJavadocCheck.
Replaced old regex/text-block tag parsing with DetailNode/Javadoc AST traversal.
Added/updated token handling to include BLOCK_COMMENT_BEGIN registration and AST token flow.
Restored configured-token semantics by filtering target declarations against configured tokens (for cases like tokens=CTOR_DEF).