### PR TITLE
Issue #15456: Define violation messages for InvalidJavadocPositionCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -244,7 +244,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc."
                     + "AbstractJavadocCheckTest$TokenIsNotInAcceptablesCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/invalidjavadocposition/comment/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/invalidjavadocposition/comment/package-info.java
@@ -4,7 +4,7 @@ InvalidJavadocPosition
 
 */
 
-/** violation */ // violation
+/** violation */ // violation 'Javadoc .* placed in the wrong location.'
 /** valid */
 // comment
 package com.puppycrawl.tools.checkstyle.checks.javadoc.invalidjavadocposition.comment;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/invalidjavadocposition/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/invalidjavadocposition/package-info.java
@@ -4,7 +4,7 @@ InvalidJavadocPosition
 
 */
 
-/** violation */ // violation
+/** violation */ // violation 'Javadoc .* placed in the wrong location.'
 /** valid */
 @Example
 package com.puppycrawl.tools.checkstyle.checks.javadoc.invalidjavadocposition;


### PR DESCRIPTION
Issue #15456

Violation messages are added to all `// violation` comments in InvalidJavadocPositionCheck input files, and the check is removed from `SUPPRESSED_CHECKS` in `InlineConfigParser