### PR TITLE
Issue #19559: Fix false negative in google_checks.xml for same-line t…

### DIFF
--- a/config/google-java-format/excluded/compilable-input-paths.txt
+++ b/config/google-java-format/excluded/compilable-input-paths.txt
@@ -63,6 +63,7 @@ src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentati
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLineBreakAfterLeftCurlyOfBlockInSwitch.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputClassAnnotations.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputClassAnnotation2.java
+src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputAnnotationOnTypes.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4853methodsandconstructorsannotations/InputMethodsAndConstructorsAnnotations.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4854fieldannotations/InputFieldAnnotations.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputCommentsIndentationCommentIsAtTheEndOfBlock.java

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/ClassAnnotationsTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/ClassAnnotationsTest.java
@@ -55,6 +55,18 @@ public class ClassAnnotationsTest extends AbstractGoogleModuleTestSupport {
     }
 
     @Test
+    public void testAnnotationOnTypes() throws Exception {
+        final String filePath = getPath("InputAnnotationOnTypes.java");
+        verifyWithWholeConfig(filePath);
+    }
+
+    @Test
+    public void testAnnotationOnTypesFormatted() throws Exception {
+        final String filePath = getPath("InputFormattedAnnotationOnTypes.java");
+        verifyWithWholeConfig(filePath);
+    }
+
+    @Test
     public void testPackageAnnotation() throws Exception {
         final String filePath = getPath("package-info.java");
         verifyWithWholeConfig(filePath);

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputAnnotationOnTypes.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputAnnotationOnTypes.java
@@ -1,0 +1,25 @@
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;
+
+/** Somejavadoc data. */
+public final class InputAnnotationOnTypes {
+
+  /** Somejavadoc data. */
+  @Deprecated static class Foo {}
+  // violation above 'Annotation 'Deprecated' should be alone on line.'
+
+  /** Somejavadoc data. */
+  @Deprecated interface Bar {}
+  // violation above 'Annotation 'Deprecated' should be alone on line.'
+
+  // violation 2 lines below 'Annotation 'Deprecated' should be alone on line.'
+  /** Somejavadoc data. */
+  @Deprecated enum Size {
+    S,
+    M,
+    L
+  }
+
+  /** Somejavadoc data. */
+  @Deprecated record Point(int x) {}
+  // violation above 'Annotation 'Deprecated' should be alone on line.'
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputClassAnnotation2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputClassAnnotation2.java
@@ -8,19 +8,23 @@ import javax.annotation.CheckReturnValue;
 public final class InputClassAnnotation2 {
   void test1() {}
 
+  // 2 violations 4 lines below:
+  //    'Annotation 'Deprecated' should be alone on line.'
+  //    'Annotation 'CheckReturnValue' should be alone on line.'
   /** Somejavadoc data. */
   @Deprecated @CheckReturnValue
   public class Inner {
-    // violation 2 lines above 'Annotation 'CheckReturnValue' should be alone on line'
     void test2() {}
   }
 }
 
-// violation 2 lines below 'Top-level class InputClassAnnotation3 has to reside'
+// violation 5 lines below 'Top-level class InputClassAnnotation3 has to reside'
+// 2 violations 4 lines below:
+//    'Annotation 'Deprecated' should be alone on line.'
+//    'Annotation 'CheckReturnValue' should be alone on line.'
 /** Somejavadoc data. */
 @Deprecated @CheckReturnValue
 final class InputClassAnnotation3 {
-  // violation 2 lines above 'Annotation 'CheckReturnValue' should be alone on line'
   void test2() {}
 }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputClassAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputClassAnnotations.java
@@ -30,15 +30,19 @@ public class InputClassAnnotations {
    */
   class Inner2 {}
 
+  // 2 violations 6 lines below:
+  //    'Annotation 'SomeAnnotation1' should be alone on line.'
+  //    'Annotation 'SomeAnnotation2' should be alone on line.'
   /**
    * Inner class 3.
    */
   @SomeAnnotation1 @SomeAnnotation2
-  // violation above 'Annotation 'SomeAnnotation2' should be alone on line.'
   class Inner3 {}
 
+  // 2 violations 3 lines below:
+  //    'Annotation 'SomeAnnotation1' should be alone on line.'
+  //    'Annotation 'SomeAnnotation2' should be alone on line.'
   @SomeAnnotation1 @SomeAnnotation2
-  // violation above 'Annotation 'SomeAnnotation2' should be alone on line.'
   /** // violation 'Javadoc comment is placed in the wrong location.'
    * Inner class 4.
    */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputFormattedAnnotationOnTypes.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/InputFormattedAnnotationOnTypes.java
@@ -1,0 +1,25 @@
+package com.google.checkstyle.test.chapter4formatting.rule4852classannotations;
+
+/** Somejavadoc data. */
+public final class InputFormattedAnnotationOnTypes {
+
+  /** Somejavadoc data. */
+  @Deprecated
+  static class Foo {}
+
+  /** Somejavadoc data. */
+  @Deprecated
+  interface Bar {}
+
+  /** Somejavadoc data. */
+  @Deprecated
+  enum Size {
+    S,
+    M,
+    L
+  }
+
+  /** Somejavadoc data. */
+  @Deprecated
+  record Point(int x) {}
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/sample1/package-info.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4852classannotations/sample1/package-info.java
@@ -1,4 +1,6 @@
-// violation 2 lines below 'Annotation 'SuppressWarnings' should be alone on line'
+// 2 violations 4 lines below:
+//    'Annotation 'Deprecated' should be alone on line.'
+//    'Annotation 'SuppressWarnings' should be alone on line.'
 /** This is a package. */
 @Deprecated @SuppressWarnings("...")
 package com.google.checkstyle.test.chapter4formatting.rule4852classannotations.sample1;

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -378,10 +378,15 @@
                     TYPE_EXTENSION_AND "/>
     </module>
     <module name="AnnotationLocation">
-      <property name="id" value="AnnotationLocationMostCases"/>
+      <property name="id" value="AnnotationLocationTypeAndPackage"/>
       <property name="tokens"
-               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
-                      RECORD_DEF, COMPACT_CTOR_DEF, PACKAGE_DEF"/>
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, RECORD_DEF, PACKAGE_DEF"/>
+      <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationMethodsAndCtors"/>
+      <property name="tokens"
+               value="METHOD_DEF, CTOR_DEF, COMPACT_CTOR_DEF"/>
     </module>
     <module name="AnnotationLocation">
       <property name="id" value="AnnotationLocationVariables"/>


### PR DESCRIPTION
Issue #19559:

### Changes

- Split `AnnotationLocationMostCases` module in `google_checks.xml` into two modules  to correctly enforce Google Style section [4.8.5.2](https://google.github.io/styleguide/javaguide.html#s4.8.5-annotations) (type/package annotations) and [ section 4.8.5.3](https://google.github.io/styleguide/javaguide.html#s4.8.5-annotations)  (method/constructor annotations) separately
- Section [4.8.5.2](https://google.github.io/styleguide/javaguide.html#s4.8.5-annotations) requires each annotation on its own line, no same-line exception
- section 4.8.5.3 allows a single parameterless annotation on the same line
- Previously both rules shared the same config, causing false negatives for  `@Deprecated class Foo {}` style code
- Updated existing test violation comments to reflect newly caught violations
- Added integration tests for single parameterless annotation on type declarations

Diff Regression config: https://gist.githubusercontent.com/vivek-0509/8290a310ad14130d43b58f3d71b0de0e/raw/84dbcaa2e54fb7b270875d9e239871dae5c17d8b/base_config.xml

Diff Regression patch config: https://gist.githubusercontent.com/vivek-0509/7379aeff1f5d02ce6974a372847c2583/raw/2fd6e25c70ad261174ec3b9878ab59b2d17d8944/patch_config.xml