### PR TITLE
Issue #15456: Define violation messages for MissingJavadocMethodCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -246,7 +246,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -138,11 +138,11 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
             "60:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "64:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "68:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "72:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "76:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "80:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "84:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "88:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "73:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "78:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "82:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "86:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "90:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodPublicOnly.java"), expected);
@@ -160,9 +160,9 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
     public void testRelaxedJavadoc() throws Exception {
         final String[] expected = {
             "65:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "69:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "81:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "85:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "70:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "83:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "87:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodPublicOnly3.java"), expected);
@@ -355,8 +355,8 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
             "76:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "80:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "82:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "87:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "89:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "88:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "90:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodSetterGetter.java"), expected);
@@ -377,8 +377,8 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
             "76:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "80:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "82:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "87:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "89:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "88:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "90:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodSetterGetter2.java"), expected);
@@ -462,10 +462,10 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
     public void testPublicMethods() throws Exception {
         final String[] expected = {
             "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "28:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "31:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "35:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "30:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "33:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodPublicMethods.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodConstructor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodConstructor.java
@@ -18,7 +18,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
  */
 public class InputMissingJavadocMethodConstructor {
     private int field;
-    public InputMissingJavadocMethodConstructor() {} // violation
+    public InputMissingJavadocMethodConstructor() {} // violation 'Missing a Javadoc comment.'
     public InputMissingJavadocMethodConstructor(Runnable p1) { this.field = 0; }
     /** */
     public InputMissingJavadocMethodConstructor(String p1) { this.field = 0; }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodEnumCtorScopeIsPrivate.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodEnumCtorScopeIsPrivate.java
@@ -23,7 +23,7 @@ public enum InputMissingJavadocMethodEnumCtorScopeIsPrivate {
         this.value = value;
     }
 
-    void packagePrivateMethod() { // violation
+    void packagePrivateMethod() { // violation 'Missing a Javadoc comment.'
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodExtendAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodExtendAnnotation.java
@@ -41,7 +41,7 @@ public abstract class InputMissingJavadocMethodExtendAnnotation<E>
   private static final String SUPPORTS_ADD = "";
   private static final String SUPPORTS_REMOVE = null;
 
-@CollectionFeature.Require // violation
+@CollectionFeature.Require // violation 'Missing a Javadoc comment.'
   public void testSetCount_zeroToZero_unsupported() {
     try {
       assertZeroToZero();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodIgnoreNameRegex2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodIgnoreNameRegex2.java
@@ -19,15 +19,15 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
  */
 public class InputMissingJavadocMethodIgnoreNameRegex2
 {
-    private void foo() { // violation
+    private void foo() { // violation 'Missing a Javadoc comment.'
 
     }
 
-    private void foo88() { // violation
+    private void foo88() { // violation 'Missing a Javadoc comment.'
 
     }
 
-    private void foo2() { // violation
+    private void foo2() { // violation 'Missing a Javadoc comment.'
         int x = 0;
         int k = x >> 2;
         String s = String.valueOf(k);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodInterfaceMemberScopeIsPublic.java
@@ -19,7 +19,7 @@ public interface InputMissingJavadocMethodInterfaceMemberScopeIsPublic {
 
         ;
 
-        public static void method() {} // violation
+        public static void method() {} // violation 'Missing a Javadoc comment.'
 
         void packagePrivateMethod() {}
 
@@ -27,7 +27,7 @@ public interface InputMissingJavadocMethodInterfaceMemberScopeIsPublic {
 
     class Class {
 
-        public void method() {} // violation
+        public void method() {} // violation 'Missing a Javadoc comment.'
 
         void packagePrivateMethod() {}
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodJavadocInMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodJavadocInMethod.java
@@ -17,16 +17,16 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
  * scope = "private"
  */
 public class InputMissingJavadocMethodJavadocInMethod {
-    public void foo1() { } // violation
+    public void foo1() { } // violation 'Missing a Javadoc comment.'
 
-    @Deprecated // violation
+    @Deprecated // violation 'Missing a Javadoc comment.'
     public void foo2() { }
 
-    @Deprecated // violation
+    @Deprecated // violation 'Missing a Javadoc comment.'
     /** */
     public void foo3() { }
 
-    public void foo4() { /** */ } // violation
+    public void foo4() { /** */ } // violation 'Missing a Javadoc comment.'
 
     @Deprecated
     public void foo5() { /** */ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNoJavadoc2A.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNoJavadoc2A.java
@@ -23,8 +23,8 @@ public class InputMissingJavadocMethodNoJavadoc2A //comment test
     int i3;
     private int i4;
 
-    public void foo1() {} // violation
-    protected void foo2() {} // violation
+    public void foo1() {} // violation 'Missing a Javadoc comment.'
+    protected void foo2() {} // violation 'Missing a Javadoc comment.'
     void foo3() {}
     private void foo4() {}
 
@@ -34,8 +34,8 @@ public class InputMissingJavadocMethodNoJavadoc2A //comment test
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
-        protected void foo2() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
+        protected void foo2() {} // violation 'Missing a Javadoc comment.'
         void foo3() {}
         private void foo4() {}
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNoJavadoc3A.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNoJavadoc3A.java
@@ -24,10 +24,10 @@ public class InputMissingJavadocMethodNoJavadoc3A //comment test
     int i3;
     private int i4;
 
-    public void foo1() {} // violation
+    public void foo1() {} // violation 'Missing a Javadoc comment.'
     protected void foo2() {}
-    void foo3() {} // violation
-    private void foo4() {} // violation
+    void foo3() {} // violation 'Missing a Javadoc comment.'
+    private void foo4() {} // violation 'Missing a Javadoc comment.'
 
     protected class ProtectedInner {
         public int i1;
@@ -47,10 +47,10 @@ public class InputMissingJavadocMethodNoJavadoc3A //comment test
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
         protected void foo2() {}
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 
     private class PrivateInner {
@@ -59,9 +59,9 @@ public class InputMissingJavadocMethodNoJavadoc3A //comment test
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
         protected void foo2() {}
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNoJavadoc3B.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNoJavadoc3B.java
@@ -23,10 +23,10 @@ class InputMissingJavadocMethodNoJavadoc3B {
     int i3;
     private int i4;
 
-    public void foo1() {} // violation
+    public void foo1() {} // violation 'Missing a Javadoc comment.'
     protected void foo2() {}
-    void foo3() {} // violation
-    private void foo4() {} // violation
+    void foo3() {} // violation 'Missing a Javadoc comment.'
+    private void foo4() {} // violation 'Missing a Javadoc comment.'
 
     public class PublicInner {
         public int i1;
@@ -34,10 +34,10 @@ class InputMissingJavadocMethodNoJavadoc3B {
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
         protected void foo2() {}
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 
     protected class ProtectedInner {
@@ -46,10 +46,10 @@ class InputMissingJavadocMethodNoJavadoc3B {
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
         protected void foo2() {}
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 
     class PackageInner {
@@ -58,10 +58,10 @@ class InputMissingJavadocMethodNoJavadoc3B {
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
         protected void foo2() {}
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 
     private class PrivateInner {
@@ -70,10 +70,10 @@ class InputMissingJavadocMethodNoJavadoc3B {
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
         protected void foo2() {}
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 
     class IgnoredName {
@@ -84,5 +84,5 @@ class InputMissingJavadocMethodNoJavadoc3B {
     }
 
     /**/
-    void methodWithTwoStarComment() {} // violation
+    void methodWithTwoStarComment() {} // violation 'Missing a Javadoc comment.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNoJavadocA.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNoJavadocA.java
@@ -23,10 +23,10 @@ public class InputMissingJavadocMethodNoJavadocA //comment test
     int i3;
     private int i4;
 
-    public void foo1() {} // violation
-    protected void foo2() {} // violation
-    void foo3() {} // violation
-    private void foo4() {} // violation
+    public void foo1() {} // violation 'Missing a Javadoc comment.'
+    protected void foo2() {} // violation 'Missing a Javadoc comment.'
+    void foo3() {} // violation 'Missing a Javadoc comment.'
+    private void foo4() {} // violation 'Missing a Javadoc comment.'
 
     protected class ProtectedInner {
         public int i1;
@@ -34,10 +34,10 @@ public class InputMissingJavadocMethodNoJavadocA //comment test
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
-        protected void foo2() {} // violation
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
+        protected void foo2() {} // violation 'Missing a Javadoc comment.'
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 
     class PackageInner {
@@ -46,10 +46,10 @@ public class InputMissingJavadocMethodNoJavadocA //comment test
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
-        protected void foo2() {} // violation
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
+        protected void foo2() {} // violation 'Missing a Javadoc comment.'
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 
     private class PrivateInner {
@@ -58,9 +58,9 @@ public class InputMissingJavadocMethodNoJavadocA //comment test
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
-        protected void foo2() {} // violation
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
+        protected void foo2() {} // violation 'Missing a Javadoc comment.'
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNoJavadocB.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNoJavadocB.java
@@ -22,10 +22,10 @@ class InputMissingJavadocMethodNoJavadocB {
     int i3;
     private int i4;
 
-    public void foo1() {} // violation
-    protected void foo2() {} // violation
-    void foo3() {} // violation
-    private void foo4() {} // violation
+    public void foo1() {} // violation 'Missing a Javadoc comment.'
+    protected void foo2() {} // violation 'Missing a Javadoc comment.'
+    void foo3() {} // violation 'Missing a Javadoc comment.'
+    private void foo4() {} // violation 'Missing a Javadoc comment.'
 
     public class PublicInner {
         public int i1;
@@ -33,10 +33,10 @@ class InputMissingJavadocMethodNoJavadocB {
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
-        protected void foo2() {} // violation
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
+        protected void foo2() {} // violation 'Missing a Javadoc comment.'
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 
     protected class ProtectedInner {
@@ -45,10 +45,10 @@ class InputMissingJavadocMethodNoJavadocB {
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
-        protected void foo2() {} // violation
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
+        protected void foo2() {} // violation 'Missing a Javadoc comment.'
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 
     class PackageInner {
@@ -57,10 +57,10 @@ class InputMissingJavadocMethodNoJavadocB {
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
-        protected void foo2() {} // violation
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
+        protected void foo2() {} // violation 'Missing a Javadoc comment.'
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 
     private class PrivateInner {
@@ -69,10 +69,10 @@ class InputMissingJavadocMethodNoJavadocB {
         int i3;
         private int i4;
 
-        public void foo1() {} // violation
-        protected void foo2() {} // violation
-        void foo3() {} // violation
-        private void foo4() {} // violation
+        public void foo1() {} // violation 'Missing a Javadoc comment.'
+        protected void foo2() {} // violation 'Missing a Javadoc comment.'
+        void foo3() {} // violation 'Missing a Javadoc comment.'
+        private void foo4() {} // violation 'Missing a Javadoc comment.'
     }
 
     class IgnoredName {
@@ -83,5 +83,5 @@ class InputMissingJavadocMethodNoJavadocB {
     }
 
     /**/
-    void methodWithTwoStarComment() {} // violation
+    void methodWithTwoStarComment() {} // violation 'Missing a Javadoc comment.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodPublicMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodPublicMethods.java
@@ -19,20 +19,24 @@ import java.lang.annotation.Target;
 /* Config = default */
 public class InputMissingJavadocMethodPublicMethods {
 
-    public void annotation(final char @SomeAnnotation [] arg) {} // violation
+    public void annotation(final char @SomeAnnotation [] arg) {}
+    // violation above 'Missing a Javadoc comment.'
 
-    public @SomeAnnotation String @SomeAnnotation [] annotationInSignature() { // violation
+    public @SomeAnnotation String @SomeAnnotation [] annotationInSignature() {
+    // violation above 'Missing a Javadoc comment.'
         return new String[]{};
     }
 
-    public static <T> T[] typeInSignature(T[] array) { // violation
+    public static <T> T[] typeInSignature(T[] array) { // violation 'Missing a Javadoc comment.'
         return null;
     }
-    public static <T> T[][] typeInSignature2(T[][] array) { // violation
+    public static <T> T[][] typeInSignature2(T[][] array) {
+    // violation above 'Missing a Javadoc comment.'
         return null;
     }
 
-    public static void main(String[] args) throws Exception {} // violation
+    public static void main(String[] args) throws Exception {}
+    // violation above 'Missing a Javadoc comment.'
 
     /**
      * Some javadoc

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodPublicOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodPublicOnly.java
@@ -21,20 +21,20 @@ public class InputMissingJavadocMethodPublicOnly
     private interface InnerInterface
     {
         String CONST = "InnerInterface";
-        void method(); // violation
+        void method(); // violation 'Missing a Javadoc comment.'
 
         class InnerInnerClass
         {
             private int mData;
 
-            private InnerInnerClass() // violation
+            private InnerInnerClass() // violation 'Missing a Javadoc comment.'
             {
                 final Runnable r = new Runnable() {
                         public void run() {};
                     };
             }
 
-            void method2() // violation
+            void method2() // violation 'Missing a Javadoc comment.'
             {
                 final Runnable r = new Runnable() {
                         public void run() {};
@@ -47,7 +47,7 @@ public class InputMissingJavadocMethodPublicOnly
     {
         private int mDiff;
 
-        void method() // violation
+        void method() // violation 'Missing a Javadoc comment.'
         {
         }
     }
@@ -57,35 +57,37 @@ public class InputMissingJavadocMethodPublicOnly
     protected int mDeer;
     public int aFreddo;
 
-    private InputMissingJavadocMethodPublicOnly(int aA) // violation
+    private InputMissingJavadocMethodPublicOnly(int aA) // violation 'Missing a Javadoc comment.'
     {
     }
 
-    InputMissingJavadocMethodPublicOnly(String aA) // violation
+    InputMissingJavadocMethodPublicOnly(String aA) // violation 'Missing a Javadoc comment.'
     {
     }
 
-    protected InputMissingJavadocMethodPublicOnly(Object aA) // violation
+    protected InputMissingJavadocMethodPublicOnly(Object aA)
+    // violation above 'Missing a Javadoc comment.'
     {
     }
 
-    public InputMissingJavadocMethodPublicOnly(Class<Object> aA) // violation
+    public InputMissingJavadocMethodPublicOnly(Class<Object> aA)
+    // violation above 'Missing a Javadoc comment.'
     {
     }
 
-    private void method(int aA) // violation
+    private void method(int aA) // violation 'Missing a Javadoc comment.'
     {
     }
 
-    void method(Long aA) // violation
+    void method(Long aA) // violation 'Missing a Javadoc comment.'
     {
     }
 
-    protected void method(Class<Object> aA) // violation
+    protected void method(Class<Object> aA) // violation 'Missing a Javadoc comment.'
     {
     }
 
-    public void method(StringBuffer aA) // violation
+    public void method(StringBuffer aA) // violation 'Missing a Javadoc comment.'
     {
     }
 
@@ -97,13 +99,11 @@ public class InputMissingJavadocMethodPublicOnly
     private void method(String aA)
     {
     }
-
     /**
      * This inner class has no author tag, which is OK.
      */
     public class InnerWithoutAuthor
     {
-
     }
 
     /** {@inheritDoc} */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodPublicOnly3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodPublicOnly3.java
@@ -62,11 +62,13 @@ public class InputMissingJavadocMethodPublicOnly3
     {
     }
 
-    protected InputMissingJavadocMethodPublicOnly3(Object aA) // violation
+    protected InputMissingJavadocMethodPublicOnly3(Object aA)
+    // violation above 'Missing a Javadoc comment.'
     {
     }
 
-    public InputMissingJavadocMethodPublicOnly3(Class<Object> aA) // violation
+    public InputMissingJavadocMethodPublicOnly3(Class<Object> aA)
+    // violation above 'Missing a Javadoc comment.'
     {
     }
 
@@ -78,11 +80,11 @@ public class InputMissingJavadocMethodPublicOnly3
     {
     }
 
-    protected void method(Class<Object> aA) // violation
+    protected void method(Class<Object> aA) // violation 'Missing a Javadoc comment.'
     {
     }
 
-    public void method(StringBuffer aA) // violation
+    public void method(StringBuffer aA) // violation 'Missing a Javadoc comment.'
     {
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodRecordsAndCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodRecordsAndCtors.java
@@ -19,33 +19,33 @@ public class InputMissingJavadocMethodRecordsAndCtors {
         private static int mNumber;
 
         // not javadoc
-        public void setNumber(final int number) { // violation
+        public void setNumber(final int number) { // violation 'Missing a Javadoc comment.'
             mNumber = number;
         }
 
         // not javadoc
-        public int getNumber() { // violation
+        public int getNumber() { // violation 'Missing a Javadoc comment.'
             return mNumber;
         }
 
-        public void setNumber1() { // violation
+        public void setNumber1() { // violation 'Missing a Javadoc comment.'
             mNumber = mNumber;
         }
     }
 
     public record MySecondRecord() {
         // not a javadoc comment on compact ctor
-        public MySecondRecord { // violation
+        public MySecondRecord { // violation 'Missing a Javadoc comment.'
         }
     }
 
     public record MyThirdRecord() {
         // not a javadoc comment on ctor
-        public MyThirdRecord() { // violation
+        public MyThirdRecord() { // violation 'Missing a Javadoc comment.'
         }
     }
 
-    public void setNumber1() // violation
+    public void setNumber1() // violation 'Missing a Javadoc comment.'
     {
 
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodScopeAnonInner2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodScopeAnonInner2.java
@@ -31,7 +31,7 @@ public class InputMissingJavadocMethodScopeAnonInner2
      * anon inner in member variable initialization.
      */
     private Runnable mRunnable = new Runnable() {
-        public void run() // violation
+        public void run() // violation 'Missing a Javadoc comment.'
         {
             System.identityHashCode("running");
         }
@@ -44,7 +44,7 @@ public class InputMissingJavadocMethodScopeAnonInner2
     {
         mButton.addMouseListener( new MouseAdapter()
         {
-            public void mouseClicked( MouseEvent aEv ) // violation
+            public void mouseClicked( MouseEvent aEv ) // violation 'Missing a Javadoc comment.'
             {
                 System.identityHashCode("click");
             }
@@ -58,7 +58,7 @@ public class InputMissingJavadocMethodScopeAnonInner2
     {
         mButton.addMouseListener( new MouseAdapter()
         {
-            public void mouseClicked( MouseEvent aEv ) // violation
+            public void mouseClicked( MouseEvent aEv ) // violation 'Missing a Javadoc comment.'
             {
                 System.identityHashCode("click");
             }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodScopeInnerInterfaces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodScopeInnerInterfaces.java
@@ -49,8 +49,8 @@ public class InputMissingJavadocMethodScopeInnerInterfaces
         public String CA = "CONST A";
         String CB = "CONST b";
 
-        public void ma(); // violation
-        void mb(); // violation
+        public void ma(); // violation 'Missing a Javadoc comment.'
+        void mb(); // violation 'Missing a Javadoc comment.'
     }
 
     private

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSetterGetter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSetterGetter.java
@@ -17,74 +17,75 @@ public class InputMissingJavadocMethodSetterGetter
 {
     private int mNumber;
 
-    public void setNumber(final int number) // violation
+    public void setNumber(final int number) // violation 'Missing a Javadoc comment.'
     {
         mNumber = number;
     }
 
-    public int getNumber() // violation
+    public int getNumber() // violation 'Missing a Javadoc comment.'
     {
         return mNumber;
     }
 
-    public void setNumber1() // violation
+    public void setNumber1() // violation 'Missing a Javadoc comment.'
     {
         mNumber = mNumber;
     }
 
-    public void setNumber2(int number) // violation
+    public void setNumber2(int number) // violation 'Missing a Javadoc comment.'
     {
         mNumber = number;
         firePropertyChanged();
     }
 
-    public void getNumber2() // violation
+    public void getNumber2() // violation 'Missing a Javadoc comment.'
     {
     }
 
-    public int getCost1(int forMe) // violation
+    public int getCost1(int forMe) // violation 'Missing a Javadoc comment.'
     {
         return 666;
     }
 
-    public int getCost2() // violation
+    public int getCost2() // violation 'Missing a Javadoc comment.'
     {
         mNumber = 4;
         return 666;
     }
 
-    public int getCost3() throws Exception // violation
+    public int getCost3() throws Exception // violation 'Missing a Javadoc comment.'
     {
         return 666;
     }
 
-    public boolean isSomething() // violation
+    public boolean isSomething() // violation 'Missing a Javadoc comment.'
     {
         return false;
     }
 
-    private void firePropertyChanged(){} // violation
+    private void firePropertyChanged(){} // violation 'Missing a Javadoc comment.'
 
-    Object setObject(Object object) { // violation
+    Object setObject(Object object) { // violation 'Missing a Javadoc comment.'
         return new Object();
     }
 
-    Object getNext() { // violation
+    Object getNext() { // violation 'Missing a Javadoc comment.'
         throw new UnsupportedOperationException();
     }
 
-    public void setWithoutAssignment(Object object) { // violation
+    public void setWithoutAssignment(Object object) { // violation 'Missing a Javadoc comment.'
         object.notify();
     }
 
-    InputMissingJavadocMethodSetterGetter() {} // violation
+    InputMissingJavadocMethodSetterGetter() {} // violation 'Missing a Javadoc comment.'
 
-    public InputMissingJavadocMethodSetterGetter(Object object) throws Exception {} // violation
+    public InputMissingJavadocMethodSetterGetter(Object object) throws Exception {}
+    // violation above 'Missing a Javadoc comment.'
 
 }
 
 interface TestInterface {
-    void setObject(Object object); // violation
+    void setObject(Object object); // violation 'Missing a Javadoc comment.'
 
-    Object getObject(); // violation
+    Object getObject(); // violation 'Missing a Javadoc comment.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSetterGetter2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSetterGetter2.java
@@ -27,33 +27,33 @@ public class InputMissingJavadocMethodSetterGetter2
         return mNumber;
     }
 
-    public void setNumber1() // violation
+    public void setNumber1() // violation 'Missing a Javadoc comment.'
     {
         mNumber = mNumber;
     }
 
-    public void setNumber2(int number) // violation
+    public void setNumber2(int number) // violation 'Missing a Javadoc comment.'
     {
         mNumber = number;
         firePropertyChanged();
     }
 
-    public void getNumber2() // violation
+    public void getNumber2() // violation 'Missing a Javadoc comment.'
     {
     }
 
-    public int getCost1(int forMe) // violation
+    public int getCost1(int forMe) // violation 'Missing a Javadoc comment.'
     {
         return 666;
     }
 
-    public int getCost2() // violation
+    public int getCost2() // violation 'Missing a Javadoc comment.'
     {
         mNumber = 4;
         return 666;
     }
 
-    public int getCost3() throws Exception // violation
+    public int getCost3() throws Exception // violation 'Missing a Javadoc comment.'
     {
         return 666;
     }
@@ -63,28 +63,29 @@ public class InputMissingJavadocMethodSetterGetter2
         return false;
     }
 
-    private void firePropertyChanged(){} // violation
+    private void firePropertyChanged(){} // violation 'Missing a Javadoc comment.'
 
-    Object setObject(Object object) { // violation
+    Object setObject(Object object) { // violation 'Missing a Javadoc comment.'
         return new Object();
     }
 
-    Object getNext() { // violation
+    Object getNext() { // violation 'Missing a Javadoc comment.'
         throw new UnsupportedOperationException();
     }
 
-    public void setWithoutAssignment(Object object) { // violation
+    public void setWithoutAssignment(Object object) { // violation 'Missing a Javadoc comment.'
         object.notify();
     }
 
-    InputMissingJavadocMethodSetterGetter2() {} // violation
+    InputMissingJavadocMethodSetterGetter2() {} // violation 'Missing a Javadoc comment.'
 
-    public InputMissingJavadocMethodSetterGetter2(Object object) throws Exception {} // violation
+    public InputMissingJavadocMethodSetterGetter2(Object object) throws Exception {}
+    // violation above 'Missing a Javadoc comment.'
 
 }
 
 interface TestInterface2 {
-    void setObject(Object object); // violation
+    void setObject(Object object); // violation 'Missing a Javadoc comment.'
 
-    Object getObject(); // violation
+    Object getObject(); // violation 'Missing a Javadoc comment.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSmallMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSmallMethods.java
@@ -67,7 +67,7 @@ public class InputMissingJavadocMethodSmallMethods extends Some
                 + "oooooooo";
     }
 
-    String foo7() // violation
+    String foo7() // violation 'Missing a Javadoc comment.'
     {
         return "Fooooooooooooooo"
                 + "ooooo"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodTags1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodTags1.java
@@ -20,7 +20,7 @@ class InputMissingJavadocMethodTags1
     private int mMissingJavadoc;
 
     // Invalid - should be Javadoc
-    void method1() // violation
+    void method1() // violation 'Missing a Javadoc comment.'
     {
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodTags5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodTags5.java
@@ -32,7 +32,7 @@ enum InputMissingJavadocMethodTagsEnum5
         {
         }
 
-        public void someOtherMethod() // violation
+        public void someOtherMethod() // violation 'Missing a Javadoc comment.'
         {
 
         }
@@ -41,7 +41,7 @@ enum InputMissingJavadocMethodTagsEnum5
 
 @interface InputMissingJavadocMethodTagsAnnotation
 {
-    String someField(); // violation
+    String someField(); // violation 'Missing a Javadoc comment.'
     int A_CONSTANT = 0;
     /** Some javadoc. */
     int B_CONSTANT = 1;


### PR DESCRIPTION
Issue : #15456

- Updated 22 input test files: replaced bare `// violation` comments with `// violation 'Missing a Javadoc comment.'`
