### PR TITLE
Issue #5685: Fix false positive indentation for try/catch with body on same line

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -404,11 +404,22 @@ public abstract class AbstractExpressionHandler {
         for (DetailAST child = parentNode.getFirstChild();
                 child != null;
                 child = child.getNextSibling()) {
-            if (Arrays.binarySearch(tokenTypes, child.getType()) >= 0) {
+            if (Arrays.binarySearch(tokenTypes, child.getType()) >= 0
+                    && shouldCheckIndentationForChild(child)) {
                 checkExpressionSubtree(child, startIndent,
                     firstLineMatches, allowNesting);
             }
         }
+    }
+
+    /**
+     * Decide whether to check indentation for a specific child.
+     *
+     * @param child child AST node
+     * @return true if indentation should be checked
+     */
+    protected boolean shouldCheckIndentationForChild(DetailAST child) {
+        return true;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CatchHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CatchHandler.java
@@ -60,4 +60,10 @@ public class CatchHandler extends BlockParentHandler {
         checkCondExpr();
     }
 
+    @Override
+    protected boolean shouldCheckIndentationForChild(DetailAST child) {
+        final DetailAST leftCurly = getLeftCurly();
+        return getFirstAstNode(child).getLineNo() != leftCurly.getLineNo();
+    }
+
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/FinallyHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/FinallyHandler.java
@@ -40,4 +40,10 @@ public class FinallyHandler extends BlockParentHandler {
         super(indentCheck, "finally", ast, parent);
     }
 
+    @Override
+    protected boolean shouldCheckIndentationForChild(DetailAST child) {
+        final DetailAST leftCurly = getLeftCurly();
+        return getFirstAstNode(child).getLineNo() != leftCurly.getLineNo();
+    }
+
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
@@ -84,6 +84,12 @@ public class TryHandler extends BlockParentHandler {
         }
     }
 
+    @Override
+    protected boolean shouldCheckIndentationForChild(DetailAST child) {
+        final DetailAST leftCurly = getLeftCurly();
+        return getFirstAstNode(child).getLineNo() != leftCurly.getLineNo();
+    }
+
     /**
      * Method to check the indentation of left paren or right paren.
      * This method itself checks whether either of these are on start of line. This method

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4168,6 +4168,40 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testTryChildOnSameLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String fileName = getPath("InputIndentationTryChildOnSameLine.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testTryChildOnSameLineStrict() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "true");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String fileName = getPath("InputIndentationTryChildOnSameLineStrict.java");
+        final String[] expected = {
+            "11:44: " + getCheckMessage(MSG_ERROR, "@", 43, 12),
+        };
+        verify(checkConfig, fileName, expected);
+    }
+
+    @Test
     public void testSynchronizedWrapping() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("arrayInitIndent", "4");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryChildOnSameLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryChildOnSameLine.java
@@ -1,0 +1,63 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;         //indent:0 exp:0
+/**                                                                             //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:     //indent:1 exp:1
+ *                                                                              //indent:1 exp:1
+ * arrayInitIndent = 4                                                          //indent:1 exp:1
+ * basicOffset = 4                                                              //indent:1 exp:1
+ * braceAdjustment = 0                                                          //indent:1 exp:1
+ * caseIndent = 4                                                               //indent:1 exp:1
+ * forceStrictCondition = false                                                 //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                  //indent:1 exp:1
+ * tabWidth = 4                                                                 //indent:1 exp:1
+ * throwsIndent = 4                                                             //indent:1 exp:1
+ *                                                                              //indent:1 exp:1
+ */                                                                             //indent:1 exp:1
+public class InputIndentationTryChildOnSameLine {                               //indent:0 exp:0
+    void method() {                                                             //indent:4 exp:4
+        try { return;                                                           //indent:8 exp:8
+        }                                                                       //indent:8 exp:8
+        catch (Exception e) { return;                                           //indent:8 exp:8
+        }                                                                       //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+    void method2() {                                                            //indent:4 exp:4
+        try { doSomething();                                                    //indent:8 exp:8
+        }                                                                       //indent:8 exp:8
+        catch (RuntimeException e) { handle(e);                                 //indent:8 exp:8
+        }                                                                       //indent:8 exp:8
+        finally { cleanup();                                                    //indent:8 exp:8
+        }                                                                       //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+    void method3() {                                                            //indent:4 exp:4
+        try { invokeAndWait(new Runnable() { @Override                          //indent:8 exp:8
+            public void run() { doSomething(); }                                //indent:12 exp:12
+        }, c); } catch (Exception e) { e.printStackTrace(); }                   //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+    void method4() {                                                            //indent:4 exp:4
+        switch ("x") {                                                          //indent:8 exp:8
+            case "8": try { break;                                              //indent:12 exp:12
+                } catch (RuntimeException e) {                                  //indent:16 exp:16
+                    handle(e);                                                  //indent:20 exp:20
+                } finally {                                                     //indent:16 exp:16
+                    cleanup();                                                  //indent:20 exp:20
+                }                                                               //indent:16 exp:16
+                break;                                                          //indent:16 exp:16
+            default:                                                            //indent:12 exp:12
+                break;                                                          //indent:16 exp:16
+        }                                                                       //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+    void method5() {                                                            //indent:4 exp:4
+        label:                                                                  //indent:8 exp:8,12
+        try                                                                     //indent:8 exp:8,12
+        {                                                                       //indent:8 exp:8
+            return;                                                             //indent:12 exp:12
+        }                                                                       //indent:8 exp:8
+        catch (RuntimeException e) {                                            //indent:8 exp:8
+            handle(e);                                                          //indent:12 exp:12
+        }                                                                       //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+    private void doSomething() {}                                               //indent:4 exp:4
+    private void handle(Exception e) {}                                         //indent:4 exp:4
+    private void cleanup() {}                                                   //indent:4 exp:4
+    Object c;                                                                   //indent:4 exp:4
+    void invokeAndWait(Runnable r, Object o) {}                                 //indent:4 exp:4
+}                                                                               //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryChildOnSameLineStrict.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryChildOnSameLineStrict.java
@@ -1,0 +1,29 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;          //indent:0 exp:0
+
+import java.awt.Component;                                                       //indent:0 exp:0
+
+public class InputIndentationTryChildOnSameLineStrict {                          //indent:0 exp:0
+    public static boolean doEquals(final Object a, final Object b,               //indent:4 exp:4
+        Component c) {                                                           //indent:8 exp:8
+        if (a == b) return true;                                                 //indent:8 exp:8
+        final boolean[] ret = new boolean[1];                                    //indent:8 exp:8
+        try {                                                                    //indent:8 exp:8
+            invokeAndWait(new Runnable() { @Override                             //indent:12 exp:12
+                public void run() {                                              //indent:16 exp:16
+                    synchronized (ret) {                                         //indent:20 exp:20
+                        ret[0] = a.equals(b);                                    //indent:24 exp:24
+                    }                                                            //indent:20 exp:20
+                }                                                                //indent:16 exp:16
+            }, c);                                                               //indent:12 exp:12
+        }                                                                        //indent:8 exp:8
+        catch (Exception e) {                                                    //indent:8 exp:8
+            e.printStackTrace();                                                 //indent:12 exp:12
+        }                                                                        //indent:8 exp:8
+        synchronized (ret) {                                                     //indent:8 exp:8
+            return ret[0];                                                       //indent:12 exp:12
+        }                                                                        //indent:8 exp:8
+    }                                                                            //indent:4 exp:4
+
+    private static void invokeAndWait(Runnable r, Object o) {                    //indent:4 exp:4
+    }                                                                            //indent:4 exp:4
+}                                                                                //indent:0 exp:0


### PR DESCRIPTION
closes : #5685 

- Fixes a false positive in Indentation for inline statements on the same line as try, catch, and finally opening braces.
- Adds a targeted child-filter  in BlockParentHandler and applies it only in TryHandler, CatchHandler, and FinallyHandler so non-try/catch/finally behavior is unchanged.

Build Success with`mvn clean verify`