### PR TITLE
Issue #19188: fix compilation comments to Java25 and add CI check for noncompilable inputs

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -694,7 +694,7 @@ javac17)
       mkdir -p target
       for file in "${files[@]}"
       do
-        javac --release 17 --enable-preview -d target "${file}"
+        javac --release 17 -d target "${file}"
       done
   fi
   ;;
@@ -710,7 +710,7 @@ javac19)
       mkdir -p target
       for file in "${files[@]}"
       do
-        javac --release 19 --enable-preview -d target "${file}"
+        javac --release 19 -d target "${file}"
       done
   fi
   ;;
@@ -726,11 +726,10 @@ javac20)
       mkdir -p target
       for file in "${files[@]}"
       do
-        javac --release 20 --enable-preview -d target "${file}"
+        javac --release 20 -d target "${file}"
       done
   fi
   ;;
-
 javac21)
   files=($(grep -Rli --include='*.java' ': Compilable with Java21' \
         src/test/resources-noncompilable \
@@ -742,7 +741,7 @@ javac21)
     mkdir -p target
     for file in "${files[@]}"
     do
-      javac --release 21 --enable-preview -d target "${file}"
+      javac --release 21 -d target "${file}"
     done
   fi
   ;;
@@ -758,7 +757,7 @@ javac22)
     mkdir -p target
     for file in "${files[@]}"
     do
-      javac --release 22 --enable-preview -d target "${file}"
+      javac --release 22 -d target "${file}"
     done
   fi
   ;;
@@ -774,7 +773,7 @@ javac25)
     mkdir -p target
     for file in "${files[@]}"
     do
-      javac --release 25 --enable-preview -d target "${file}"
+      javac --release 25 -d target "${file}"
     done
   fi
   ;;

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example1.java
@@ -5,7 +5,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 
 
 

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example2.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example2.java
@@ -7,7 +7,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 
 
 package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example3.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example3.java
@@ -8,7 +8,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 
 
 

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example4.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example4.java
@@ -8,7 +8,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 
 package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
 

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example5.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example5.java
@@ -8,7 +8,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 
 package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
 

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingnullcaseinswitch/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingnullcaseinswitch/Example1.java
@@ -5,7 +5,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 package com.puppycrawl.tools.checkstyle.checks.coding.missingnullcaseinswitch;
 
 import java.util.List;

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/patternvariableassignment/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/patternvariableassignment/Example1.java
@@ -5,7 +5,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 
 package com.puppycrawl.tools.checkstyle.checks.coding.patternvariableassignment;
 

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/Example1.java
@@ -5,7 +5,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedcatchparametershouldbeunnamed;
 

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlambdaparametershouldbeunnamed/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlambdaparametershouldbeunnamed/Example1.java
@@ -5,7 +5,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlambdaparametershouldbeunnamed;
 

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example1.java
@@ -6,7 +6,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
 import java.io.*;
 import java.util.function.Predicate;

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example2.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example2.java
@@ -7,7 +7,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
 import java.io.*;
 import java.util.function.Predicate;

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/Example1.java
@@ -5,7 +5,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 
 package com.puppycrawl.tools.checkstyle.checks.coding.whenshouldbeused;
 

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example1.java
@@ -5,7 +5,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 
 // xdoc section -- start

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example2.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example2.java
@@ -7,7 +7,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 
 // xdoc section -- start

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example3.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example3.java
@@ -7,7 +7,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 
 // xdoc section -- start

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example4.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example4.java
@@ -8,7 +8,7 @@
   </module>
 </module>
 */
-// non-compiled with javac: Compilable with Java21
+// non-compiled with javac: Compilable with Java25
 
 package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 


### PR DESCRIPTION
Follow-up to #19551, fixes #19188

-> changed `// non-compiled with javac: Compilable with Java21` to
   `// non-compiled with javac: Compilable with Java25` in 16 xdocs example files
-> removed `--enable-preview` flag from all javac jobs (17, 19, 20, 21, 22, 25)
   in `.ci/validation.sh`