### PR TITLE
Issue #5741: Rename Smth abbreviation to Something in test inputs and whitelist

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1226,7 +1226,6 @@ SLo
 Slurper
 slurpersupport
 Sms
-Smth
 snyk
 socio
 Sohjiro

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -4885,7 +4885,7 @@ public final class TokenTypes {
      * <p>For example:</p>
      * <pre>
      * for (int value : values) {
-     *     doSmth();
+     *     doSomething();
      * }
      * </pre>
      *
@@ -4906,7 +4906,7 @@ public final class TokenTypes {
      *  `--SLIST -&gt; {
      *      |--EXPR -&gt; EXPR
      *      |   `--METHOD_CALL -&gt; (
-     *      |       |--IDENT -&gt; doSmth
+     *      |       |--IDENT -&gt; doSomething
      *      |       |--ELIST -&gt; ELIST
      *      |       `--RPAREN -&gt; )
      *      |--SEMI -&gt; ;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesSingleLineStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesSingleLineStatements.java
@@ -74,7 +74,7 @@ public class InputNeedBracesSingleLineStatements
         for (int i = 0; ; ) this.notify();
     }
 
-    private int getSmth(int num)
+    private int getSomething(int num)
     {
         int counter = 0;
         switch (num) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesTestSingleLineCaseDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesTestSingleLineCaseDefault.java
@@ -73,7 +73,7 @@ public class InputNeedBracesTestSingleLineCaseDefault
         for (int i = 0; ; ) this.notify();
     }
 
-    private int getSmth(int num)
+    private int getSomething(int num)
     {
         int counter = 0;
         switch (num) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidForIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationInvalidForIndent.java
@@ -84,7 +84,7 @@ public class InputIndentationInvalidForIndent {                           //inde
         }                                                                 //indent:8 exp:8
     }                                                                     //indent:4 exp:4
 
-  public void doSmth() {                                                  //indent:2 exp:4 warn
+  public void doSomething() {                                             //indent:2 exp:4 warn
     for (int h                                                            //indent:4 exp:8 warn
         : new int[] {}) {                                                 //indent:8 exp:12 warn
       System.getProperty(                                                 //indent:6 exp:12 warn

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSResolveMutation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSResolveMutation.java
@@ -77,7 +77,7 @@ public class InputJavaNCSSResolveMutation {
             for (int i = 0; ; ) this.notify();
         }
 
-        private int getSmth(int num) {
+        private int getSomething(int num) {
             int counter = 0;
             switch (num) {
                 case 1:

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityDefault.java
@@ -118,7 +118,7 @@ public class InputNPathComplexityDefault {
     }
 
     public void InputNestedTernaryCheck() { // violation
-        double x = (getSmth() || Math.random() == 5) ? null : (int) Math
+        double x = (getSomething() || Math.random() == 5) ? null : (int) Math
                 .cos(400 * (10 + 40)); // good
         double y = (0.2 == Math.random()) ? (0.3 == Math.random()) ? null : (int) Math
                 .cos(400 * (10 + 40)) : 6; // bad (nested in first position)
@@ -127,7 +127,7 @@ public class InputNPathComplexityDefault {
                         .sin(300 * (12 + 30))); // bad (nested in second
                                                 // position)
     }
-    public boolean getSmth() { return true; }; // violation
+    public boolean getSomething() { return true; }; // violation
     public int apply(Object o) { return 0; } // violation
 
     public void inClass(int type, Short s, int color) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityDefault2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityDefault2.java
@@ -118,7 +118,7 @@ public class InputNPathComplexityDefault2 {
     }
 
     public void InputNestedTernaryCheck() {
-        double x = (getSmth() || Math.random() == 5) ? null : (int) Math
+        double x = (getSomething() || Math.random() == 5) ? null : (int) Math
                 .cos(400 * (10 + 40)); // good
         double y = (0.2 == Math.random()) ? (0.3 == Math.random()) ? null : (int) Math
                 .cos(400 * (10 + 40)) : 6; // bad (nested in first position)
@@ -127,7 +127,7 @@ public class InputNPathComplexityDefault2 {
                         .sin(300 * (12 + 30))); // bad (nested in second
                                                 // position)
     }
-    public boolean getSmth() { return true; };
+    public boolean getSomething() { return true; };
     public int apply(Object o) { return 0; }
 
     public void inClass(int type, Short s, int color) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadStartOfTheLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/InputParenPadStartOfTheLine.java
@@ -12,7 +12,7 @@ tokens = (default)ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, \
 package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
 
 public class InputParenPadStartOfTheLine {
-public String checkSmth( String
+public String checkSomething( String
 a) { // violation, '')' is not preceded with whitespace.'
     return a + 1;
    }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundStartOfTheLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundStartOfTheLine.java
@@ -22,7 +22,7 @@ tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, B
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 public class InputWhitespaceAroundStartOfTheLine {
- public void checkSmth(
+ public void checkSomething(
 ){ // violation ''{' is not preceded with whitespace'
   final int SOMETHING = 1;
  }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda10.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda10.java
@@ -20,7 +20,7 @@ public class InputLambda10 {
 
     public static void testVoidLambda(TestOfVoidLambdas test) {
         LOG.info("Method called");
-        test.doSmth("fef");
+        test.doSomething("fef");
     }
 
 
@@ -31,6 +31,6 @@ public class InputLambda10 {
 
     private interface TestOfVoidLambdas {
 
-        public void doSmth(String first);
+        public void doSomething(String first);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda11.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda11.java
@@ -20,7 +20,7 @@ public class InputLambda11 {
 
     public static void testVoidLambda(TestOfVoidLambdas test) {
         LOG.info("Method called");
-        test.doSmth("fef");
+        test.doSomething("fef");
     }
 
 
@@ -31,6 +31,6 @@ public class InputLambda11 {
 
     private interface TestOfVoidLambdas {
 
-        public void doSmth(String first);
+        public void doSomething(String first);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda12.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda12.java
@@ -20,7 +20,7 @@ public class InputLambda12 {
 
     public static void testVoidLambda(TestOfVoidLambdas test) {
         LOG.info("Method called");
-        test.doSmth("fef", 5);
+        test.doSomething("fef", 5);
     }
 
 
@@ -31,6 +31,6 @@ public class InputLambda12 {
 
     private interface TestOfVoidLambdas {
 
-        public void doSmth(String first, Integer second);
+        public void doSomething(String first, Integer second);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda13.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda13.java
@@ -20,7 +20,7 @@ public class InputLambda13 {
 
     public static void testVoidLambda(TestOfVoidLambdas test) {
         LOG.info("Method called");
-        test.doSmth("fef", 5);
+        test.doSomething("fef", 5);
     }
 
 
@@ -33,6 +33,6 @@ public class InputLambda13 {
 
     private interface TestOfVoidLambdas {
 
-        public void doSmth(String first, Integer second);
+        public void doSomething(String first, Integer second);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda2.java
@@ -20,7 +20,7 @@ public class InputLambda2 {
 
     public static void testVoidLambda(TestOfVoidLambdas test) {
         LOG.info("Method called");
-        test.doSmth();
+        test.doSomething();
     }
 
 
@@ -30,6 +30,6 @@ public class InputLambda2 {
 
     private interface TestOfVoidLambdas {
 
-        public void doSmth();
+        public void doSomething();
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda3.java
@@ -20,7 +20,7 @@ public class InputLambda3 {
 
     public static void testVoidLambda(TestOfVoidLambdas test) {
         LOG.info("Method called");
-        test.doSmth();
+        test.doSomething();
     }
 
 
@@ -32,6 +32,6 @@ public class InputLambda3 {
 
     private interface TestOfVoidLambdas {
 
-        public void doSmth();
+        public void doSomething();
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda8.java
@@ -20,7 +20,7 @@ public class InputLambda8 {
 
     public static void testVoidLambda(TestOfVoidLambdas test) {
         LOG.info("Method called");
-        test.doSmth("fef", 2);
+        test.doSomething("fef", 2);
     }
 
 
@@ -31,6 +31,6 @@ public class InputLambda8 {
 
     private interface TestOfVoidLambdas {
 
-        public void doSmth(String first, Integer second);
+        public void doSomething(String first, Integer second);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java8/InputLambda9.java
@@ -20,7 +20,7 @@ public class InputLambda9 {
 
     public static void testVoidLambda(TestOfVoidLambdas test) {
         LOG.info("Method called");
-        test.doSmth("fef", 2);
+        test.doSomething("fef", 2);
     }
 
 
@@ -31,6 +31,6 @@ public class InputLambda9 {
 
     private interface TestOfVoidLambdas {
 
-        public void doSmth(String first, Integer second);
+        public void doSomething(String first, Integer second);
     }
 }


### PR DESCRIPTION
Issue #5741: Rename Smth abbreviation to Something in test inputs and remove from whitelist.
Fixed doSmth, getSmth, checkSmth across 17 test input files and TokenTypes.java Javadoc example.