### PR TITLE
Issue #16807: update MultipleStringLiterals inline config inputs

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -236,7 +236,7 @@ public final class InlineConfigParser {
      *  Until <a href="https://github.com/checkstyle/checkstyle/issues/15456">#15456</a>.
      */
     private static final Set<String> SUPPRESSED_CHECKS = Set.of(
-            "com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck",
+
             "com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck",
 
             "com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckTest.java
@@ -44,9 +44,9 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     public void testIt() throws Exception {
 
         final String[] expected = {
-            "14:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
-            "17:17: " + getCheckMessage(MSG_KEY, "\"\"", 4),
-            "19:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
+            "19:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
+            "22:17: " + getCheckMessage(MSG_KEY, "\"\"", 4),
+            "24:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
         };
 
         verifyWithInlineConfigParser(
@@ -58,8 +58,8 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     public void testItIgnoreEmpty() throws Exception {
 
         final String[] expected = {
-            "14:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
-            "19:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
+            "18:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
+            "23:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
         };
 
         verifyWithInlineConfigParser(
@@ -79,8 +79,8 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
         final File[] inputs = {new File(firstInput), new File(secondInput)};
 
         final List<String> expectedFirstInput = Arrays.asList(
-            "14:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
-            "19:23: " + getCheckMessage(MSG_KEY, "\", \"", 3)
+            "18:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
+            "23:23: " + getCheckMessage(MSG_KEY, "\", \"", 3)
         );
         final List<String> expectedSecondInput = Arrays.asList(CommonUtil.EMPTY_STRING_ARRAY);
 
@@ -93,7 +93,7 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     public void testItIgnoreEmptyAndComspace() throws Exception {
 
         final String[] expected = {
-            "14:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
+            "18:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
         };
 
         verifyWithInlineConfigParser(
@@ -105,7 +105,7 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     public void testItWithoutIgnoringAnnotations() throws Exception {
 
         final String[] expected = {
-            "28:23: " + getCheckMessage(MSG_KEY, "\"unchecked\"", 4),
+            "32:23: " + getCheckMessage(MSG_KEY, "\"unchecked\"", 4),
         };
 
         verifyWithInlineConfigParser(
@@ -130,9 +130,9 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDefaultConfiguration() throws Exception {
         final String[] expected = {
-            "14:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
-            "16:17: " + getCheckMessage(MSG_KEY, "\"DoubleString\"", 2),
-            "19:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
+            "18:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
+            "20:17: " + getCheckMessage(MSG_KEY, "\"DoubleString\"", 2),
+            "23:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
         };
 
         verifyWithInlineConfigParser(
@@ -143,7 +143,7 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIgnores() throws Exception {
         final String[] expected = {
-            "28:23: " + getCheckMessage(MSG_KEY, "\"unchecked\"", 4),
+            "32:23: " + getCheckMessage(MSG_KEY, "\"unchecked\"", 4),
         };
 
         verifyWithInlineConfigParser(
@@ -154,19 +154,19 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMultipleStringLiteralsTextBlocks1() throws Exception {
         final String[] expected = {
-            "14:22: " + getCheckMessage(MSG_KEY, "\"string\"", 3),
-            "19:25: " + getCheckMessage(MSG_KEY, "\"other string\"", 2),
-            "23:25: " + getCheckMessage(MSG_KEY, "\"other string\\n\"", 2),
-            "30:25: " + getCheckMessage(MSG_KEY, "\"<html>\\u000D\\u000A\\n\\u2000\\n "
+            "18:22: " + getCheckMessage(MSG_KEY, "\"string\"", 3),
+            "23:25: " + getCheckMessage(MSG_KEY, "\"other string\"", 2),
+            "27:25: " + getCheckMessage(MSG_KEY, "\"other string\\n\"", 2),
+            "34:25: " + getCheckMessage(MSG_KEY, "\"<html>\\u000D\\u000A\\n\\u2000\\n "
                 + "   <body>\\u000D\\u000A\\n\\u2000\\n        <p>Hello, world</p>\\u000D\\"
                 + "u000A\\n\\u2000\\n    </body>\\u000D\\u000A\\n\\u2000\\n</html>\\u000D\\"
                 + "u000A\\u2000\\n\"", 2),
-            "37:34: " + getCheckMessage(MSG_KEY, "\"fun with\\n\\n whitespace\\t"
+            "41:34: " + getCheckMessage(MSG_KEY, "\"fun with\\n\\n whitespace\\t"
                 + "\\r\\n and other escapes \\\"\"\"\\n\"", 2),
-            "42:34: " + getCheckMessage(MSG_KEY, "\"\\b \\f \\\\ \\0 \\1 \\2 "
+            "46:34: " + getCheckMessage(MSG_KEY, "\"\\b \\f \\\\ \\0 \\1 \\2 "
                 + "\\r \\r\\n \\\\r\\\\n \\\\''\\n\\\\11 \\\\57 \\n\\\\n\\n\\\\\\n\\n \\\\ \"\"a "
                 + "\"a\\n\\\\' \\\\\\' \\'\\n\"", 2),
-            "65:20: " + getCheckMessage(MSG_KEY, "\"foo\"", 4),
+            "69:20: " + getCheckMessage(MSG_KEY, "\"foo\"", 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMultipleStringLiteralsTextBlocks1.java"),
@@ -176,10 +176,10 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMultipleStringLiteralsTextBlocks2() throws Exception {
         final String[] expected = {
-            "14:19: " + getCheckMessage(MSG_KEY, "\"another test\"", 2),
-            "18:20: " + getCheckMessage(MSG_KEY, "\"\"", 6),
-            "29:23: " + getCheckMessage(MSG_KEY, "\"        .\\n         .\\n.\\n\"", 2),
-            "45:24: " + getCheckMessage(MSG_KEY, "\"             foo\\n\\n\\n "
+            "18:19: " + getCheckMessage(MSG_KEY, "\"another test\"", 2),
+            "22:20: " + getCheckMessage(MSG_KEY, "\"\"", 6),
+            "33:23: " + getCheckMessage(MSG_KEY, "\"        .\\n         .\\n.\\n\"", 2),
+            "49:24: " + getCheckMessage(MSG_KEY, "\"             foo\\n\\n\\n "
                 + "       bar\"", 2),
         };
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals.java
@@ -1,7 +1,7 @@
 /*
 MultipleStringLiterals
 allowedDuplicates = 2
-ignoreStringsRegexp =
+ignoreStringsRegexp = (default)^""$
 ignoreOccurrenceContext = (default)ANNOTATION
 
 
@@ -11,12 +11,12 @@ package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiterals
 {   /*string literals*/
-    String m = "StringContents"; // violation
+    String m = "StringContents"; // violation, 'The String "StringContents" appears 3 times in the file.'
     String m1 = "SingleString";
     String m2 = "DoubleString" + "DoubleString";
-    String m3 = "" + ""; // violation
+    String m3 = "" + ""; // violation, 'The String "" appears 4 times in the file.'
     String m4 = "" + "";
-    String debugStr = ", " + ", " + ", "; // violation
+    String debugStr = ", " + ", " + ", "; // violation, 'The String ", " appears 3 times in the file.'
 
     void method1() {
         String a1 = "StringContents";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals2.java
@@ -11,12 +11,12 @@ package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiterals2
 {   /*string literals*/
-    String m = "StringContents"; // violation
+    String m = "StringContents"; // violation, 'The String "StringContents" appears 3 times in the file.'
     String m1 = "SingleString";
     String m2 = "DoubleString" + "DoubleString";
     String m3 = "" + "";
     String m4 = "" + "";
-    String debugStr = ", " + ", " + ", "; // violation
+    String debugStr = ", " + ", " + ", "; // violation, 'The String ", " appears 3 times in the file.'
 
     void method1() {
         String a1 = "StringContents";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals4.java
@@ -11,7 +11,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiterals4
 {   /*string literals*/
-    String m = "StringContents"; // violation
+    String m = "StringContents"; // violation, 'The String "StringContents" appears 3 times in the file.'
     String m1 = "SingleString";
     String m2 = "DoubleString" + "DoubleString";
     String m3 = "" + "";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals5.java
@@ -2,7 +2,7 @@
 MultipleStringLiterals
 allowedDuplicates = 3
 ignoreStringsRegexp = (default)^""$
-ignoreOccurrenceContext =
+ignoreOccurrenceContext = (default)ANNOTATION
 
 
 */
@@ -25,7 +25,7 @@ public class InputMultipleStringLiterals5
         String a2 = "String" + "Contents";
     }
 
-    @SuppressWarnings("unchecked") // violation
+    @SuppressWarnings("unchecked") // violation, 'The String "unchecked" appears 4 times in the file.'
     void method2(){}
 
     @SuppressWarnings("unchecked")

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals6.java
@@ -11,12 +11,12 @@ package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiterals6
 {   /*string literals*/
-    String m = "StringContents"; // violation
+    String m = "StringContents"; // violation, 'The String "StringContents" appears 3 times in the file.'
     String m1 = "SingleString";
-    String m2 = "DoubleString" + "DoubleString"; // violation
+    String m2 = "DoubleString" + "DoubleString"; // violation, 'The String "DoubleString" appears 2 times in the file.'
     String m3 = "" + "";
     String m4 = "" + "";
-    String debugStr = ", " + ", " + ", "; // violation
+    String debugStr = ", " + ", " + ", "; // violation, 'The String ", " appears 3 times in the file.'
 
     void method1() {
         String a1 = "StringContents";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals7.java
@@ -25,7 +25,7 @@ public class InputMultipleStringLiterals7
         String a2 = "String" + "Contents";
     }
 
-    @SuppressWarnings("unchecked") // violation
+    @SuppressWarnings("unchecked") // violation, 'The String "unchecked" appears 4 times in the file.'
     void method2(){}
 
     @SuppressWarnings("unchecked")

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
@@ -9,34 +9,40 @@ ignoreOccurrenceContext = (default)ANNOTATION
 package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiteralsTextBlocks1 {
-    String string1 = "string"; // violation, 'The String "string" appears 3 times in the file.'
+    String string1 = "string";
+    // violation, 'The String "string" appears 3 times in the file.'
     String string2a = "string";
     String string2b = """
              string""";
 
     String string3 = """
-            other string"""; // violation above, 'The String "other string" appears 2 times in the file.'
+            other string""";
+    // violation above, 'The String "other string" appears 2 times in the file.'
     String string4 = """
-            other string"""; // violation below, 'The String "other string.*" appears 2 times in the file.'
+            other string""";
+    // violation below, 'The String "other string.*" appears 2 times in the file.'
     String string5 = """
             other string
             """; // occurrence #1
     String string6 = """
             other string
             """;
-     // violation 6 lines above, 'The String "other string.*" appears 2 times in the file.'
+      // violation 6 lines above, 'The String "other string.*" appears 2 times in the file.'
+    // violation below
     String escape1 = """
             <html>\u000D\u000A\n\u2000
                 <body>\u000D\u000A\n\u2000
                     <p>Hello, world</p>\u000D\u000A\n\u2000
                 </body>\u000D\u000A\n\u2000
             </html>\u000D\u000A\u2000
-            """; // violation below, 'The String "<html>\u000D\u000A\n\u2000\n    <body>\u000D\u000A\n\u2000\n        <p>Hello, world</p>\u000D\u000A\n\u2000\n    </body>\u000D\u000A\n\u2000\n</html>\u000D\u000A\u2000\n" appears 2 times in the file.'
+            """;
     String testMoreEscapes1 = """
             fun with\n
              whitespace\t\r
              and other escapes \"""
-            """; // violation below, 'The String "fun with\n\n whitespace\t\r\n and other escapes \"""\n" appears 2 times in the file.'
+            """; // violation below,
+    // 'The String "fun with\n\n whitespace\t\r\n and other escapes \"""\n
+    // " appears 2 times in the file.'
     String evenMoreEscapes1 = """
             \b \f \\ \0 \1 \2 \r \r\n \\r\\n \\''
             \\11 \\57 \n\\n\n\\\n\n \\ ""a "a

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
@@ -4,41 +4,39 @@ allowedDuplicates = (default)1
 ignoreStringsRegexp = (null)
 ignoreOccurrenceContext = (default)ANNOTATION
 
-
 */
-
 // Java17
 package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiteralsTextBlocks1 {
-    String string1 = "string"; // occurance #1 // violation
-    String string2a = "string"; // violation #1
+    String string1 = "string"; // violation, 'The String "string" appears 3 times in the file.'
+    String string2a = "string";
     String string2b = """
-            string"""; // violation #2
+             string""";
 
     String string3 = """
-            other string"""; // occurance #1 // violation above
+            other string"""; // violation above, 'The String "other string" appears 2 times in the file.'
     String string4 = """
-            other string"""; // violation below
+            other string"""; // violation below, 'The String "other string.*" appears 2 times in the file.'
     String string5 = """
             other string
             """; // occurrence #1
     String string6 = """
             other string
             """;
-     // violation below
+     // violation 6 lines above, 'The String "other string.*" appears 2 times in the file.'
     String escape1 = """
             <html>\u000D\u000A\n\u2000
                 <body>\u000D\u000A\n\u2000
                     <p>Hello, world</p>\u000D\u000A\n\u2000
                 </body>\u000D\u000A\n\u2000
             </html>\u000D\u000A\u2000
-            """; // occurrence #1 // violation below
+            """; // violation below, 'The String "<html>\u000D\u000A\n\u2000\n    <body>\u000D\u000A\n\u2000\n        <p>Hello, world</p>\u000D\u000A\n\u2000\n    </body>\u000D\u000A\n\u2000\n</html>\u000D\u000A\u2000\n" appears 2 times in the file.'
     String testMoreEscapes1 = """
             fun with\n
              whitespace\t\r
              and other escapes \"""
-            """; // occurrence #1 // violation below
+            """; // violation below, 'The String "fun with\n\n whitespace\t\r\n and other escapes \"""\n" appears 2 times in the file.'
     String evenMoreEscapes1 = """
             \b \f \\ \0 \1 \2 \r \r\n \\r\\n \\''
             \\11 \\57 \n\\n\n\\\n\n \\ ""a "a
@@ -50,22 +48,22 @@ public class InputMultipleStringLiteralsTextBlocks1 {
                     <p>Hello, world</p>\u000D\u000A\n\u2000
                 </body>\u000D\u000A\n\u2000
             </html>\u000D\u000A\u2000
-            """; // violation #1
+            """;
     String testMoreEscapes2 = """
             fun with\n
              whitespace\t\r
              and other escapes \"""
-            """; // violation #1
+            """;
     String evenMoreEscapes2 = """
             \b \f \\ \0 \1 \2 \r \r\n \\r\\n \\''
             \\11 \\57 \n\\n\n\\\n\n \\ ""a "a
             \\' \\\' \'
-            """; // violation #1
+            """;
 
-    String str1a = "foo"; // occurrence #1 // violation
-    String str1b = "foo"; // violation #1
+    String str1a = "foo"; // violation, 'The String "foo" appears 4 times in the file.'
+    String str1b = "foo";
     String str2a = """
-            foo"""; // violation #2
+            foo""";
     String str2b = """
-            foo"""; // violation #3
+            foo""";
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks2.java
@@ -11,21 +11,21 @@ ignoreOccurrenceContext = (default)ANNOTATION
 package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiteralsTextBlocks2 {
-    String str3 = "another test"; // occurrence #1 // violation
+    String str3 = "another test"; // violation, 'The String "another test" appears 2 times in the file.'
     String str4 = """
-            another test"""; // violation #1
+            another test""";
 
-    String str5a = ""; // occurrence #1 // violation
+    String str5a = ""; // violation, 'The String "" appears 6 times in the file.'
     String str5b = """
-            """; // violation #1
+            """;
     String str6 = """
-                        """; // violation #2
+                        """;
     String str7 = """
-"""; // violation #3
+""";
 
     String str8 = """
-                             """; // violation #4
-     // violation below
+                             """;
+     // violation below, 'The String ".*" appears 2 times in the file.'
     String str8b = """
         .
          .
@@ -41,7 +41,7 @@ public class InputMultipleStringLiteralsTextBlocks2 {
     String str9a = """
             test    """; // trailing whitespace removed per javac result
     String str9b = "test    "; // trailing whitespace not removed, strings are not equal!
-     // violation below
+     // violation below, 'The String ".*bar" appears 2 times in the file.'
     String str10a = """
              foo
 


### PR DESCRIPTION
Issue: #16807

Updated MultipleStringLiterals input files to explicitly mention all default properties
and use the default tag for default-valued properties.

Changes:
- updated inline config comments in MultipleStringLiterals input files
- added missing violation messages in input files
- updated expected line numbers in MultipleStringLiteralsCheckTest
- removed MultipleStringLiteralsCheck from SUPPRESSED_CHECKS in InlineConfigParser
