### PR TITLE
Issue #19148: migrate MissingJavadocMethodCheck to javadoc AST

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -137,8 +137,6 @@
   <suppress id="noUsageOfGetFileContentsMethod" files="JavadocTypeCheck.java"/>
   <!-- until #19147 -->
   <suppress id="noUsageOfGetFileContentsMethod" files="JavadocVariableCheck.java"/>
-  <!-- until #19148 -->
-  <suppress id="noUsageOfGetFileContentsMethod" files="MissingJavadocMethodCheck.java"/>
   <!-- until #19149 -->
   <suppress id="noUsageOfGetFileContentsMethod" files="MissingJavadocTypeCheck.java"/>
   <!-- permanent suppression to allow regexp on content of the line -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
@@ -19,20 +19,26 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
-import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.Scope;
-import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <div>
@@ -73,7 +79,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * @since 8.21
  */
 @FileStatefulCheck
-public class MissingJavadocMethodCheck extends AbstractCheck {
+public class MissingJavadocMethodCheck extends AbstractJavadocCheck {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -89,6 +95,9 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
 
     /** Pattern matching names of setter methods. */
     private static final Pattern SETTER_PATTERN = Pattern.compile("^set[A-Z].*");
+
+    /** Pattern matching a comment-only single-line comment. */
+    private static final Pattern SINGLE_LINE_COMMENT_PATTERN = Pattern.compile("^\\s*//.*$");
 
     /** Maximum nodes allowed in a body of setter. */
     private static final int SETTER_BODY_SIZE = 3;
@@ -116,6 +125,15 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
 
     /** Configure annotations that allow missed documentation. */
     private Set<String> allowedAnnotations = Set.of("Override");
+
+    /** Parser used to recognize Javadoc comments through the Javadoc AST pipeline. */
+    private final JavadocDetailNodeParser javadocParser = new JavadocDetailNodeParser();
+
+    /** Line numbers keyed the same way as FileContents#getJavadocBefore(int). */
+    private final Set<Integer> javadocCommentEndLines = new HashSet<>();
+
+    /** Block comments used to skip comment-only lines when searching for nearby Javadocs. */
+    private final List<BlockCommentPosition> blockComments = new ArrayList<>();
 
     /**
      * Setter to configure annotations that allow missed documentation.
@@ -179,7 +197,7 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
     }
 
     @Override
-    public final int[] getRequiredTokens() {
+    public int[] getRequiredTokens() {
         return CommonUtil.EMPTY_INT_ARRAY;
     }
 
@@ -198,19 +216,160 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
         };
     }
 
-    // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/19148
     @Override
-    @SuppressWarnings("deprecation")
-    public final void visitToken(DetailAST ast) {
-        final Scope theScope = ScopeUtil.getScope(ast);
-        if (shouldCheck(ast, theScope)) {
-            final FileContents contents = getFileContents();
-            final TextBlock textBlock = contents.getJavadocBefore(ast.getLineNo());
+    public int[] getDefaultJavadocTokens() {
+        return CommonUtil.EMPTY_INT_ARRAY;
+    }
 
-            if (textBlock == null && !isMissingJavadocAllowed(ast)) {
-                log(ast, MSG_JAVADOC_MISSING);
-            }
+    @Override
+    public void beginTree(DetailAST rootAST) {
+        super.beginTree(rootAST);
+        javadocCommentEndLines.clear();
+        blockComments.clear();
+        collectComments(rootAST);
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        final Scope theScope = ScopeUtil.getScope(ast);
+        if (shouldCheck(ast, theScope)
+                && !hasJavadocBefore(ast.getLineNo())
+                && !isMissingJavadocAllowed(ast)) {
+            log(ast, MSG_JAVADOC_MISSING);
         }
+    }
+
+    /**
+     * Collects all block comments in the file.
+     *
+     * @param ast the current node.
+     */
+    private void collectComments(DetailAST ast) {
+        final Deque<DetailAST> nodes = new ArrayDeque<>();
+        DetailAST node = ast;
+
+        while (node != null || !nodes.isEmpty()) {
+            while (node != null) {
+                nodes.push(node);
+                node = node.getNextSibling();
+            }
+
+            node = nodes.pop();
+            if (node.getType() == TokenTypes.BLOCK_COMMENT_BEGIN) {
+                collectBlockComment(node);
+            }
+            node = node.getFirstChild();
+        }
+    }
+
+    @Override
+    public void visitJavadocToken(DetailNode ast) {
+        // No token-level Javadoc traversal is required for presence-only checks.
+    }
+
+    /**
+     * Collects information about a block comment.
+     *
+     * @param blockComment the block comment to collect.
+     */
+    private void collectBlockComment(DetailAST blockComment) {
+        final int startLineNo = blockComment.getLineNo();
+        final int endLineNo = blockComment.getLastChild().getLineNo();
+        final boolean javadocComment = isJavadocComment(blockComment);
+
+        blockComments.add(new BlockCommentPosition(startLineNo, endLineNo, javadocComment));
+        if (javadocComment) {
+            javadocCommentEndLines.add(endLineNo - 1);
+        }
+    }
+
+    /**
+     * Checks whether a block comment is recognized as a Javadoc comment by the Javadoc parser.
+     *
+     * @param blockComment the block comment to inspect
+     * @return {@code true} if the block comment is recognized as a Javadoc comment
+     */
+    private boolean isJavadocComment(DetailAST blockComment) {
+        boolean result = false;
+        if (JavadocUtil.isJavadocComment(JavadocUtil.getBlockCommentContent(blockComment))) {
+            final JavadocDetailNodeParser.ParseStatus parseStatus =
+                    javadocParser.parseJavadocComment(blockComment);
+            result = parseStatus.getTree() != null
+                    || parseStatus.getParseErrorMessage() != null;
+        }
+        return result;
+    }
+
+    /**
+     * Checks whether there is a Javadoc comment before the specified line.
+     *
+     * @param lineNoBefore the line number to check before.
+     * @return {@code true} if there is a Javadoc comment before the line.
+     */
+    private boolean hasJavadocBefore(int lineNoBefore) {
+        int lineNo = lineNoBefore - 2;
+
+        while (lineNo > 0 && (lineIsBlank(lineNo) || lineIsComment(lineNo)
+                || lineInsideBlockComment(lineNo + 1))) {
+            lineNo--;
+        }
+        return javadocCommentEndLines.contains(lineNo);
+    }
+
+    /**
+     * Checks if the specified line is blank.
+     *
+     * @param lineNo the zero-based line number.
+     * @return {@code true} if the specified line is blank.
+     */
+    private boolean lineIsBlank(int lineNo) {
+        return CommonUtil.isBlank(getLines()[lineNo]);
+    }
+
+    /**
+     * Checks if the specified line is a single-line comment without code.
+     *
+     * @param lineNo the zero-based line number.
+     * @return {@code true} if the specified line is a single-line comment without code.
+     */
+    private boolean lineIsComment(int lineNo) {
+        return SINGLE_LINE_COMMENT_PATTERN.matcher(getLines()[lineNo]).matches();
+    }
+
+    /**
+     * Checks if the specified line number is inside a non-Javadoc block comment.
+     *
+     * @param lineNo the one-based line number to check.
+     * @return {@code true} if the line is inside a non-Javadoc block comment.
+     */
+    private boolean lineInsideBlockComment(int lineNo) {
+        return blockComments.stream()
+            .filter(comment -> !comment.javadocComment)
+            .anyMatch(comment -> isLineBlockComment(lineNo, comment));
+    }
+
+    /**
+     * Checks if the given line is inside a block comment and the comment occupies
+     * both the start and end lines.
+     *
+     * @param lineNo the one-based line number to check.
+     * @param comment the block comment to inspect.
+     * @return {@code true} if the line is inside the block comment.
+     */
+    private boolean isLineBlockComment(int lineNo, BlockCommentPosition comment) {
+        final boolean lineInsideBlockComment = lineNo >= comment.startLineNo
+                && lineNo <= comment.endLineNo;
+        boolean lineHasOnlyBlockComment = true;
+        final String startLine = getLines()[comment.startLineNo - 1].trim();
+        if (!startLine.startsWith("/*")) {
+            lineHasOnlyBlockComment = false;
+        }
+
+        final String endLine = getLines()[comment.endLineNo - 1].trim();
+        if (!endLine.endsWith("*/")) {
+            lineHasOnlyBlockComment = false;
+        }
+        return lineInsideBlockComment && lineHasOnlyBlockComment;
     }
 
     /**
@@ -223,8 +382,9 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
         final int numberOfLines;
         final DetailAST lcurly = methodDef.getLastChild();
         final DetailAST rcurly = lcurly.getLastChild();
+        final DetailAST firstChild = getFirstChildSkipComments(lcurly);
 
-        if (lcurly.getFirstChild() == rcurly) {
+        if (firstChild == rcurly) {
             numberOfLines = 1;
         }
         else {
@@ -299,6 +459,38 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
     }
 
     /**
+     * Gets the first non-comment child of the given node.
+     *
+     * @param ast the node to inspect.
+     * @return the first non-comment child, or {@code null} if none exist.
+     */
+    private static DetailAST getFirstChildSkipComments(DetailAST ast) {
+        DetailAST child = ast.getFirstChild();
+        while (child != null && TokenUtil.isCommentType(child.getType())) {
+            child = child.getNextSibling();
+        }
+        return child;
+    }
+
+    /**
+     * Gets the number of non-comment children of the given node.
+     *
+     * @param ast the node to inspect.
+     * @return the number of non-comment children.
+     */
+    private static int getChildCountSkipComments(DetailAST ast) {
+        int count = 0;
+        DetailAST child = ast.getFirstChild();
+        while (child != null) {
+            if (!TokenUtil.isCommentType(child.getType())) {
+                count++;
+            }
+            child = child.getNextSibling();
+        }
+        return count;
+    }
+
+    /**
      * Returns whether an AST represents a getter method.
      *
      * @param ast the AST to check with
@@ -326,7 +518,7 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
                 final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
 
                 if (slist != null) {
-                    final DetailAST expr = slist.getFirstChild();
+                    final DetailAST expr = getFirstChildSkipComments(slist);
                     getterMethod = expr.getType() == TokenTypes.LITERAL_RETURN;
                 }
             }
@@ -362,12 +554,38 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
                 // RCURLY
                 final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
 
-                if (slist != null && slist.getChildCount() == SETTER_BODY_SIZE) {
-                    final DetailAST expr = slist.getFirstChild();
+                if (slist != null && getChildCountSkipComments(slist) == SETTER_BODY_SIZE) {
+                    final DetailAST expr = getFirstChildSkipComments(slist);
                     setterMethod = expr.getFirstChild().getType() == TokenTypes.ASSIGN;
                 }
             }
         }
         return setterMethod;
+    }
+
+    /** Line range information for a block comment. */
+    private static final class BlockCommentPosition {
+
+        /** The one-based start line number. */
+        private final int startLineNo;
+
+        /** The one-based end line number. */
+        private final int endLineNo;
+
+        /** Whether the block comment is Javadoc. */
+        private final boolean javadocComment;
+
+        /**
+         * Creates a block comment position.
+         *
+         * @param startLineNo the start line number
+         * @param endLineNo the end line number
+         * @param javadocComment whether the block comment is Javadoc
+         */
+        private BlockCommentPosition(int startLineNo, int endLineNo, boolean javadocComment) {
+            this.startLineNo = startLineNo;
+            this.endLineNo = endLineNo;
+            this.javadocComment = javadocComment;
+        }
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckBeanInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckBeanInfo.java
@@ -1,0 +1,53 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import java.util.Arrays;
+
+/**
+ * Bean info for {@link MissingJavadocMethodCheck}.
+ */
+public class MissingJavadocMethodCheckBeanInfo extends java.beans.SimpleBeanInfo {
+
+    /**
+     * Creates a bean info instance.
+     */
+    public MissingJavadocMethodCheckBeanInfo() {
+        // no code by design
+    }
+
+    @Override
+    public java.beans.PropertyDescriptor[] getPropertyDescriptors() {
+        try {
+            final java.beans.BeanInfo beanInfo = java.beans.Introspector.getBeanInfo(
+                    MissingJavadocMethodCheck.class, Object.class,
+                    java.beans.Introspector.IGNORE_IMMEDIATE_BEANINFO);
+            return Arrays.stream(beanInfo.getPropertyDescriptors())
+                    .filter(property -> {
+                        return !"violateExecutionOnNonTightHtml".equals(property.getName());
+                    })
+                    .toArray(java.beans.PropertyDescriptor[]::new);
+        }
+        catch (java.beans.IntrospectionException exception) {
+            throw new IllegalStateException("Failed to load bean info for "
+                    + MissingJavadocMethodCheck.class.getName(), exception);
+        }
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -220,12 +220,39 @@ public final class SiteUtil {
     public static Set<String> getMessageKeys(Class<?> module)
             throws MacroExecutionException {
         final Set<Field> messageKeyFields = getCheckMessageKeysFields(module);
+        if (AbstractJavadocCheck.class.isAssignableFrom(module)
+                && !hasJavadocTokens(module)) {
+            messageKeyFields.removeIf(field -> {
+                return field.getDeclaringClass() == AbstractJavadocCheck.class;
+            });
+        }
         // We use a TreeSet to sort the message keys alphabetically
         final Set<String> messageKeys = new TreeSet<>();
         for (Field field : messageKeyFields) {
             messageKeys.add(getFieldValue(field, module).toString());
         }
         return messageKeys;
+    }
+
+    /**
+     * Checks whether the module has any Javadoc tokens.
+     *
+     * @param module the module to inspect
+     * @return {@code true} if the module has Javadoc tokens
+     * @throws MacroExecutionException if the module instance cannot be created
+     */
+    private static boolean hasJavadocTokens(Class<?> module) throws MacroExecutionException {
+        try {
+            final AbstractJavadocCheck check = (AbstractJavadocCheck) module
+                    .getDeclaredConstructor()
+                    .newInstance();
+            return check.getAcceptableJavadocTokens().length != 0;
+        }
+        catch (ReflectiveOperationException exception) {
+            final String message = String.format(Locale.ROOT,
+                    "Couldn't instantiate class: %s", module.getName());
+            throw new MacroExecutionException(message, exception);
+        }
     }
 
     /**
@@ -667,14 +694,16 @@ public final class SiteUtil {
 
         if (AbstractJavadocCheck.class.isAssignableFrom(clss)) {
             final AbstractJavadocCheck check = (AbstractJavadocCheck) instance;
-            result.add("violateExecutionOnNonTightHtml");
-
             final int[] acceptableJavadocTokens = check.getAcceptableJavadocTokens();
             Arrays.sort(acceptableJavadocTokens);
             final int[] defaultJavadocTokens = check.getDefaultJavadocTokens();
             Arrays.sort(defaultJavadocTokens);
             final int[] requiredJavadocTokens = check.getRequiredJavadocTokens();
             Arrays.sort(requiredJavadocTokens);
+
+            if (acceptableJavadocTokens.length != 0) {
+                result.add("violateExecutionOnNonTightHtml");
+            }
 
             if (!Arrays.equals(acceptableJavadocTokens, defaultJavadocTokens)
                     || !Arrays.equals(acceptableJavadocTokens, requiredJavadocTokens)) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -21,14 +21,26 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck.MSG_JAVADOC_MISSING;
+import static org.mockito.Mockito.mockStatic;
 
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 
+import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.JavaParser;
+import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtilTest;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -64,6 +76,50 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("Required tokens are invalid")
             .that(actual)
             .isEqualTo(expected);
+    }
+
+    @Test
+    public void testViolateExecutionOnNonTightHtmlPropertyIsHidden() throws Exception {
+        final MissingJavadocMethodCheck check = new MissingJavadocMethodCheck();
+
+        assertWithMessage("Unexpected inherited property was exposed")
+                .that(PropertyUtils.getPropertyDescriptor(check, "violateExecutionOnNonTightHtml"))
+                .isNull();
+    }
+
+    @Test
+    public void testBeanInfoPropertyDescriptors() {
+        final PropertyDescriptor[] descriptors =
+                new MissingJavadocMethodCheckBeanInfo().getPropertyDescriptors();
+
+        assertWithMessage("Unexpected inherited property was exposed by bean info")
+                .that(Arrays.stream(descriptors)
+                        .noneMatch(property -> {
+                            return "violateExecutionOnNonTightHtml".equals(property.getName());
+                        }))
+                .isTrue();
+    }
+
+    @Test
+    public void testBeanInfoPropertyDescriptorsOnIntrospectionException() throws Exception {
+        final MissingJavadocMethodCheckBeanInfo beanInfo = new MissingJavadocMethodCheckBeanInfo();
+
+        try (MockedStatic<Introspector> introspector = mockStatic(Introspector.class)) {
+            introspector.when(() -> {
+                Introspector.getBeanInfo(MissingJavadocMethodCheck.class,
+                        Object.class, Introspector.IGNORE_IMMEDIATE_BEANINFO);
+            })
+                    .thenThrow(new IntrospectionException("mock exception"));
+
+            final IllegalStateException exception = TestUtil.getExpectedThrowable(
+                    IllegalStateException.class, beanInfo::getPropertyDescriptors,
+                    "Expected IllegalStateException");
+
+            assertWithMessage("Expected IntrospectionException as cause")
+                    .that(exception)
+                    .hasCauseThat()
+                    .isInstanceOf(IntrospectionException.class);
+        }
     }
 
     @Test
@@ -524,12 +580,26 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
         final DetailAST notGetterMethod = CheckUtilTest.getNode(testFile, TokenTypes.METHOD_DEF);
 
         final DetailAST getterMethod = notGetterMethod.getNextSibling().getNextSibling();
+        final Path coverageTestFile = Path.of(getPath("InputMissingJavadocMethodCoverage.java"));
+        final DetailAST topMethod = CheckUtilTest.getNode(coverageTestFile, TokenTypes.METHOD_DEF);
+        final DetailAST commentMethod = topMethod.getNextSibling();
+        final DetailAST noArgNonGetterMethod = commentMethod.getNextSibling();
+        final DetailAST getterWithParameterMethod = noArgNonGetterMethod.getNextSibling();
 
         assertWithMessage("Invalid result: AST provided is getter method")
                 .that(MissingJavadocMethodCheck.isGetterMethod(getterMethod))
                 .isTrue();
         assertWithMessage("Invalid result: AST provided is not getter method")
                 .that(MissingJavadocMethodCheck.isGetterMethod(notGetterMethod))
+                .isFalse();
+        assertWithMessage("Invalid result: AST provided is not getter method")
+                .that(MissingJavadocMethodCheck.isGetterMethod(commentMethod))
+                .isFalse();
+        assertWithMessage("Invalid result: AST provided is not getter method")
+                .that(MissingJavadocMethodCheck.isGetterMethod(noArgNonGetterMethod))
+                .isFalse();
+        assertWithMessage("Invalid result: AST provided is not getter method")
+                .that(MissingJavadocMethodCheck.isGetterMethod(getterWithParameterMethod))
                 .isFalse();
     }
 
@@ -582,5 +652,67 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodAboveComments.java"),
                 expected);
+    }
+
+    @Test
+    public void testMissingJavadocMethodNearTopComment() throws Exception {
+        final String[] expected = {
+            "2:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "4:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "6:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "10:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParserSeparateConfigAndTarget(
+                getPath("InputMissingJavadocMethodCoverageConfig.java"),
+                getPath("InputMissingJavadocMethodCoverage.java"), expected);
+    }
+
+    @Test
+    public void testJavadocAstBranches(@TempDir Path tempDir) throws Exception {
+        final Path file = tempDir.resolve("InputMissingJavadocMethod.java");
+
+        Files.writeString(file,
+                """
+                class InputMissingJavadocMethod {
+                    /** Ok. */
+                    void method() {}
+                }
+                """);
+        final DetailAST root =
+                JavaParser.parseFile(file.toFile(), JavaParser.Options.WITH_COMMENTS);
+        final DetailAST blockComment = TestUtil.findTokenInAstByPredicate(root,
+                ast -> ast.getType() == TokenTypes.BLOCK_COMMENT_BEGIN)
+                .orElseThrow();
+        final MissingJavadocMethodCheck check = new MissingJavadocMethodCheck();
+        final JavadocDetailNodeParser.ParseStatus parseStatusWithoutTree =
+                new JavadocDetailNodeParser.ParseStatus();
+
+        TestUtil.setInternalState(check, "javadocParser", new JavadocDetailNodeParser() {
+            @Override
+            public ParseStatus parseJavadocComment(DetailAST javadocCommentAst) {
+                return parseStatusWithoutTree;
+            }
+        });
+        assertWithMessage("Invalid result: Javadoc without parser tree or error accepted")
+                .that(TestUtil.invokeMethod(check, "isJavadocComment", Boolean.class,
+                        blockComment))
+                .isFalse();
+
+        final JavadocDetailNodeParser.ParseStatus parseStatusWithError =
+                new JavadocDetailNodeParser.ParseStatus();
+        parseStatusWithError.setParseErrorMessage(TestUtil.instantiate(
+                JavadocDetailNodeParser.ParseErrorMessage.class, 1, "key", new Object[0]));
+        TestUtil.setInternalState(check, "javadocParser", new JavadocDetailNodeParser() {
+            @Override
+            public ParseStatus parseJavadocComment(DetailAST javadocCommentAst) {
+                return parseStatusWithError;
+            }
+        });
+        assertWithMessage("Invalid result: Javadoc with parser error rejected")
+                .that(TestUtil.invokeMethod(check, "isJavadocComment", Boolean.class,
+                        blockComment))
+                .isTrue();
+
+        check.visitJavadocToken(null);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1101,8 +1101,10 @@ public class XdocsPagesTest {
             if (AbstractJavadocCheck.class.isAssignableFrom(clss)) {
                 properties.removeAll(JAVADOC_CHECK_PROPERTIES);
 
-                // override
-                properties.add("violateExecutionOnNonTightHtml");
+                final AbstractJavadocCheck check = (AbstractJavadocCheck) instance;
+                if (check.getAcceptableJavadocTokens().length != 0) {
+                    properties.add("violateExecutionOnNonTightHtml");
+                }
             }
             else if (AbstractCheck.class.isAssignableFrom(clss)) {
                 properties.removeAll(CHECK_PROPERTIES);
@@ -1678,15 +1680,7 @@ public class XdocsPagesTest {
                                                  Node subSection,
                                                  Object instance) throws Exception {
         final Class<?> clss = instance.getClass();
-        final Set<Field> fields = CheckUtil.getCheckMessages(clss, true);
-        final Set<String> list = new TreeSet<>();
-
-        for (Field field : fields) {
-            // below is required for package/private classes
-            field.trySetAccessible();
-
-            list.add(field.get(null).toString());
-        }
+        final Set<String> list = SiteUtil.getMessageKeys(clss);
 
         final StringBuilder expectedText = new StringBuilder(120);
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodCoverage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodCoverage.java
@@ -1,0 +1,13 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod; class InputMissingJavadocMethodCoverage {
+    public void topMethod() {} // violation 'Missing a Javadoc comment.'
+    // comment
+    public void method() {} // violation 'Missing a Javadoc comment.'
+
+    public int Cost1() { // violation 'Missing a Javadoc comment.'
+        return 1;
+    }
+
+    public int getCost1(int value) { // violation 'Missing a Javadoc comment.'
+        return value;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodCoverageConfig.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodCoverageConfig.java
@@ -1,0 +1,16 @@
+/*
+MissingJavadocMethod
+minLineCount = (default)-1
+allowedAnnotations = (default)Override
+scope = package
+excludeScope = (default)null
+allowMissingPropertyJavadoc = (default)false
+ignoreMethodNamesRegex = (default)null
+tokens = (default)METHOD_DEF , CTOR_DEF , ANNOTATION_FIELD_DEF , COMPACT_CTOR_DEF
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
+
+class InputMissingJavadocMethodCoverageConfig {
+}


### PR DESCRIPTION
Issue: #19148

This PR migrates MissingJavadocMethodCheck to AbstractJavadocCheck and replaces
the deprecated FileContents#getJavadocBefore(...) usage with parser-backed
Javadoc detection.

Key points:
- Extends AbstractJavadocCheck
- Uses Javadoc parser to recognize Javadoc comments
- Preserves existing behavior, properties, and violation semantics
- Keeps adjacency semantics unchanged
- Removes the obsolete suppression for this check

Validation:
- ./mvnw clean -Dtest=MissingJavadocMethodCheckTest,XdocsPagesTest test
- ./mvnw clean verify