### PR TITLE
Issue #10015: fix false positive for method definition parenthesis on new lines

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -231,6 +231,27 @@ public class BlockParentHandler extends AbstractExpressionHandler {
     }
 
     /**
+     * Determines whether left parenthesis should be checked.
+     *
+     * @param leftParen left parenthesis token
+     * @return true if left parenthesis should be checked
+     */
+    protected boolean shouldCheckLeftParen(DetailAST leftParen) {
+        return true;
+    }
+
+    /**
+     * Determines whether right parenthesis should be checked.
+     *
+     * @param leftParen left parenthesis token
+     * @param rightParen right parenthesis token
+     * @return true if right parenthesis should be checked
+     */
+    protected boolean shouldCheckRightParen(DetailAST leftParen, DetailAST rightParen) {
+        return true;
+    }
+
+    /**
      * Get the right parenthesis portion of the expression we are handling.
      *
      * @return the right parenthesis expression
@@ -252,8 +273,14 @@ public class BlockParentHandler extends AbstractExpressionHandler {
     public void checkIndentation() {
         checkTopLevelToken();
         // separate to allow for eventual configuration
-        checkLeftParen(getLeftParen());
-        checkRightParen(getLeftParen(), getRightParen());
+        final DetailAST leftParen = getLeftParen();
+        if (shouldCheckLeftParen(leftParen)) {
+            checkLeftParen(leftParen);
+        }
+        final DetailAST rightParen = getRightParen();
+        if (shouldCheckRightParen(leftParen, rightParen)) {
+            checkRightParen(leftParen, rightParen);
+        }
         if (hasCurlies()) {
             checkLeftCurly();
             checkRightCurly();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.indentation;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * Handler for method definitions.
@@ -115,6 +116,33 @@ public class MethodDefHandler extends BlockParentHandler {
         if (getLeftCurly() != null) {
             super.checkIndentation();
         }
+    }
+
+    @Override
+    protected boolean shouldCheckLeftParen(DetailAST leftParen) {
+        return !isMethodParenOnItsOwnLineWithMatchingRightParen(leftParen,
+                getMethodDefParamRightParen(getMainAst()));
+    }
+
+    @Override
+    protected boolean shouldCheckRightParen(DetailAST leftParen, DetailAST rightParen) {
+        return !isMethodParenOnItsOwnLineWithMatchingRightParen(leftParen, rightParen);
+    }
+
+    /**
+     * Checks if method definition parenthesis are wrapped on separate lines and aligned.
+     *
+     * @param leftParen left parenthesis of method definition
+     * @param rightParen right parenthesis of method definition
+     * @return true if both parenthesis start their own lines and are aligned
+     */
+    private boolean isMethodParenOnItsOwnLineWithMatchingRightParen(DetailAST leftParen,
+            DetailAST rightParen) {
+        return rightParen != null
+                && !TokenUtil.areOnSameLine(leftParen, rightParen)
+                && isOnStartOfLine(leftParen)
+                && isOnStartOfLine(rightParen)
+                && expandedTabsColumnNo(leftParen) == expandedTabsColumnNo(rightParen);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -3730,8 +3730,8 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("tabWidth", "4");
         final String[] expected = {
-            "13:9: " + getCheckMessage(MSG_ERROR, "method def rparen", 8, 4),
-            "18:9: " + getCheckMessage(MSG_ERROR, "method def rparen", 8, 4),
+            "22:9: " + getCheckMessage(MSG_ERROR, "method def rparen", 8, 4),
+            "27:9: " + getCheckMessage(MSG_ERROR, "method def rparen", 8, 4),
         };
 
         verifyWarns(checkConfig,
@@ -3744,13 +3744,48 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("tabWidth", "4");
         final String[] expected = {
-            "11:10: " + getCheckMessage(MSG_ERROR, "2", 9, 12),
-            "17:8: " + getCheckMessage(MSG_ERROR, "int", 7, 8),
-            "18:9: " + getCheckMessage(MSG_ERROR, "method def rparen", 8, 4),
+            "20:10: " + getCheckMessage(MSG_ERROR, "2", 9, 12),
+            "26:8: " + getCheckMessage(MSG_ERROR, "int", 7, 8),
+            "27:9: " + getCheckMessage(MSG_ERROR, "method def rparen", 8, 4),
         };
 
         verifyWarns(checkConfig,
                 getPath("InputIndentationCheckMethodParenOnNewLine1.java"),
+                expected);
+    }
+
+    @Test
+    public void testIndentationMethodParenthesisOnNewLine2() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWarns(checkConfig,
+                getPath("InputIndentationCheckMethodParenOnNewLine2.java"),
+                expected);
+    }
+
+    @Test
+    public void testIndentationMethodParenthesisOnNewLine3() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        final String[] expected = {
+            "17:13: " + getCheckMessage(MSG_ERROR, "method def lparen", 12, 4),
+        };
+
+        verifyWarns(checkConfig,
+                getPath("InputIndentationCheckMethodParenOnNewLine3.java"),
+                expected);
+    }
+
+    @Test
+    public void testIndentationMethodParenthesisOnNewLine4() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWarns(checkConfig,
+                getPath("InputIndentationCheckMethodParenOnNewLine4.java"),
                 expected);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckMethodParenOnNewLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckMethodParenOnNewLine.java
@@ -1,20 +1,29 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;  //indent:0 exp:0
 
-/* Config: default */                                                    //indent:0 exp:0
+/* Config:                                                                 //indent:0 exp:0
+ * basicOffset = 4                                                         //indent:1 exp:1
+ * braceAdjustment = 0                                                     //indent:1 exp:1
+ * caseIndent = 4                                                          //indent:1 exp:1
+ * throwsIndent = 4                                                        //indent:1 exp:1
+ * arrayInitIndent = 4                                                     //indent:1 exp:1
+ * lineWrappingIndentation = 4                                             //indent:1 exp:1
+ * tabWidth = 4                                                            //indent:1 exp:1
+ * forceStrictCondition = false                                            //indent:1 exp:1
+ */                                                                        //indent:1 exp:1
 
-public class InputIndentationCheckMethodParenOnNewLine {                 //indent:0 exp:0
-    void                                                                 //indent:4 exp:4
-        method (                                                         //indent:8 exp:8
-    )                                                                    //indent:4 exp:4
-    {                                                                    //indent:4 exp:4
-    }                                                                    //indent:4 exp:4
-    void                                                                 //indent:4 exp:4
-        methodTest (                                                     //indent:8 exp:8
-        )                                                                //indent:8 exp:4 warn
-    {}                                                                   //indent:4 exp:4
-    void                                                                 //indent:4 exp:4
-        methodTest2                                                      //indent:8 exp:8
-    (                                                                    //indent:4 exp:4
-        )                                                                //indent:8 exp:4 warn
-    {}                                                                   //indent:4 exp:4
-}                                                                        //indent:0 exp:0
+public class InputIndentationCheckMethodParenOnNewLine {                   //indent:0 exp:0
+    void                                                                   //indent:4 exp:4
+        method (                                                           //indent:8 exp:8
+    )                                                                      //indent:4 exp:4
+    {                                                                      //indent:4 exp:4
+    }                                                                      //indent:4 exp:4
+    void                                                                   //indent:4 exp:4
+        methodTest (                                                       //indent:8 exp:8
+        )                                                                  //indent:8 exp:4 warn
+    {}                                                                     //indent:4 exp:4
+    void                                                                   //indent:4 exp:4
+        methodTest2                                                        //indent:8 exp:8
+    (                                                                      //indent:4 exp:4
+        )                                                                  //indent:8 exp:4 warn
+    {}                                                                     //indent:4 exp:4
+}                                                                          //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckMethodParenOnNewLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckMethodParenOnNewLine2.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;  //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
 
 /* Config:                                                                 //indent:0 exp:0
  * basicOffset = 4                                                         //indent:1 exp:1
@@ -11,19 +11,11 @@ package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;  //inden
  * forceStrictCondition = false                                            //indent:1 exp:1
  */                                                                        //indent:1 exp:1
 
-public class InputIndentationCheckMethodParenOnNewLine1 {                  //indent:0 exp:0
+public class InputIndentationCheckMethodParenOnNewLine2 {                  //indent:0 exp:0
     void                                                                   //indent:4 exp:4
-        method (                                                           //indent:8 exp:8
-    )                                                                      //indent:4 exp:4
+        method                                                             //indent:8 exp:8
+            (                                                              //indent:12 exp:12
+            )                                                              //indent:12 exp:12
     {                                                                      //indent:4 exp:4
-        int b =                                                            //indent:8 exp:8
-         2                                                                 //indent:9 exp:12 warn
-            *                                                              //indent:12 exp:12
-            3;                                                             //indent:12 exp:12
     }                                                                      //indent:4 exp:4
-    void                                                                   //indent:4 exp:4
-        methodTest (                                                       //indent:8 exp:8
-       int a                                                               //indent:7 exp:8 warn
-        )                                                                  //indent:8 exp:4 warn
-    {}                                                                     //indent:4 exp:4
 }                                                                          //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckMethodParenOnNewLine3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckMethodParenOnNewLine3.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;  //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
 
 /* Config:                                                                 //indent:0 exp:0
  * basicOffset = 4                                                         //indent:1 exp:1
@@ -11,19 +11,11 @@ package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;  //inden
  * forceStrictCondition = false                                            //indent:1 exp:1
  */                                                                        //indent:1 exp:1
 
-public class InputIndentationCheckMethodParenOnNewLine1 {                  //indent:0 exp:0
+public class InputIndentationCheckMethodParenOnNewLine3 {                  //indent:0 exp:0
     void                                                                   //indent:4 exp:4
-        method (                                                           //indent:8 exp:8
-    )                                                                      //indent:4 exp:4
+        method                                                             //indent:8 exp:8
+            (                                                              //indent:12 exp:4 warn
+            int a)                                                         //indent:12 exp:12
     {                                                                      //indent:4 exp:4
-        int b =                                                            //indent:8 exp:8
-         2                                                                 //indent:9 exp:12 warn
-            *                                                              //indent:12 exp:12
-            3;                                                             //indent:12 exp:12
     }                                                                      //indent:4 exp:4
-    void                                                                   //indent:4 exp:4
-        methodTest (                                                       //indent:8 exp:8
-       int a                                                               //indent:7 exp:8 warn
-        )                                                                  //indent:8 exp:4 warn
-    {}                                                                     //indent:4 exp:4
 }                                                                          //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckMethodParenOnNewLine4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckMethodParenOnNewLine4.java
@@ -1,4 +1,4 @@
-package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;  //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
 
 /* Config:                                                                 //indent:0 exp:0
  * basicOffset = 4                                                         //indent:1 exp:1
@@ -11,19 +11,11 @@ package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;  //inden
  * forceStrictCondition = false                                            //indent:1 exp:1
  */                                                                        //indent:1 exp:1
 
-public class InputIndentationCheckMethodParenOnNewLine1 {                  //indent:0 exp:0
+public class InputIndentationCheckMethodParenOnNewLine4 {                  //indent:0 exp:0
     void                                                                   //indent:4 exp:4
-        method (                                                           //indent:8 exp:8
-    )                                                                      //indent:4 exp:4
+        method                                                             //indent:8 exp:8
+    (                                                                      //indent:4 exp:4
+        int a)                                                             //indent:8 exp:8
     {                                                                      //indent:4 exp:4
-        int b =                                                            //indent:8 exp:8
-         2                                                                 //indent:9 exp:12 warn
-            *                                                              //indent:12 exp:12
-            3;                                                             //indent:12 exp:12
     }                                                                      //indent:4 exp:4
-    void                                                                   //indent:4 exp:4
-        methodTest (                                                       //indent:8 exp:8
-       int a                                                               //indent:7 exp:8 warn
-        )                                                                  //indent:8 exp:4 warn
-    {}                                                                     //indent:4 exp:4
 }                                                                          //indent:0 exp:0


### PR DESCRIPTION
closes : #10015 

## Summary
- fixes false positives in `IndentationCheck` for method definitions where parentheses are on separate lines
- updates method-definition parenthesis handling so checks are skipped only for the valid wrapped/aligned form
- adds tests that cover the newline parenthesis forms involved in this issue
## Problem
`IndentationCheck` reported violations for valid method-definition formatting when `(` and `)` were placed on separate lines in a wrapped signature.
## Solution
`MethodDefHandler` now treats this layout as a special valid case and avoids running the normal parenthesis indentation checks for that specific wrapped/aligned pattern, while keeping existing behavior for other method formats.
## Testing
- added/updated indentation inputs and `IndentationCheckTest` cases for method parenthesis-on-newline scenarios
- verified the issue format is accepted and invalid layouts still report violations