### PR TITLE
Issue #18200: update Maven cache after every successful master build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,3 +170,21 @@ steps:
                  eq(variables['Build.Reason'], 'Schedule')
                )
            )
+
+  - task: Cache@2
+    inputs:
+      key: 'maven | "$(Agent.OS)" | **/pom.xml | "$(Build.BuildId)"'
+      restoreKeys: |
+        maven | "$(Agent.OS)" | **/pom.xml
+        maven | "$(Agent.OS)"
+        maven
+      path: |
+        $(MAVEN_CACHE_FOLDER)
+        .mvn/wrapper
+    displayName: Save Maven cache after master build
+    condition: |
+      and(
+        succeeded(),
+        ne(variables.SKIP_CACHE, 'true'),
+        eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      )


### PR DESCRIPTION
Issue: #18200
issues faced ->  maven cache was never being updated, in the main issue, in the main issue, @stoyanK7 found that ``` cache is always restored but never uploaded  ```- cache stuck in a stale state while dependabot constantly updated dependencies, which causes maven to download 