### PR TITLE
Issue #16807: Update default properties for JavadocContentLocationCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -288,7 +288,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocation.java
@@ -1,6 +1,6 @@
 /*
 JavadocContentLocation
-
+location = (default)SECOND_LINE
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserHiddenComments4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserHiddenComments4.java
@@ -1,6 +1,6 @@
 /*
 com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck
-
+location = (default)SECOND_LINE
 
 */
 


### PR DESCRIPTION
## Summary
- Add missing `location` property with `(default)SECOND_LINE` tag to `InputJavadocContentLocation.java`
- Remove `JavadocContentLocationCheck` from `SUPPRESSED_MODULES` in `InlineConfigParser.java`

## Details
`JavadocContentLocationCheck` has only one configurable property (`location`, default: `SECOND_LINE`). 
Five of six input files already had the property specified. The remaining file (`InputJavadocContentLocation.java`) was missing it.

Closes #16807 (partial — one module of several)