### PR TITLE
Issue #14084: Resolve CheckerFramework nullness return violation in LeftCurlyCheck

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1806,17 +1806,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return annotation;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable DetailAST
-      method return type: @Initialized @NonNull DetailAST
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter ast1 of TokenUtil.areOnSameLine.</message>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -229,23 +230,25 @@ public class LeftCurlyCheck
      * Skip all {@code TokenTypes.ANNOTATION}s to the first non-annotation.
      *
      * @param ast {@code DetailAST}.
-     * @return {@code DetailAST}.
+     * @return {@code DetailAST} or null if there are no annotations.
      */
     private static DetailAST skipModifierAnnotations(DetailAST ast) {
         DetailAST resultNode = ast;
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
 
         if (modifiers != null) {
-            final DetailAST lastAnnotation = findLastAnnotation(modifiers);
-
-            if (lastAnnotation != null) {
-                if (lastAnnotation.getNextSibling() == null) {
-                    resultNode = modifiers.getNextSibling();
-                }
-                else {
-                    resultNode = lastAnnotation.getNextSibling();
-                }
-            }
+            resultNode = findLastAnnotation(modifiers)
+                    .map(annotation -> {
+                        final DetailAST nextNode;
+                        if (annotation.getNextSibling() == null) {
+                            nextNode = modifiers.getNextSibling();
+                        }
+                        else {
+                            nextNode = annotation.getNextSibling();
+                        }
+                        return nextNode;
+                    })
+                    .orElse(resultNode);
         }
         return resultNode;
     }
@@ -255,15 +258,15 @@ public class LeftCurlyCheck
      * under the given set of modifiers.
      *
      * @param modifiers {@code DetailAST}.
-     * @return {@code DetailAST} or null if there are no annotations.
+     * @return Optional containing the last annotation, if found.
      */
-    private static DetailAST findLastAnnotation(DetailAST modifiers) {
+    private static Optional<DetailAST> findLastAnnotation(DetailAST modifiers) {
         DetailAST annotation = modifiers.findFirstToken(TokenTypes.ANNOTATION);
         while (annotation != null && annotation.getNextSibling() != null
                && annotation.getNextSibling().getType() == TokenTypes.ANNOTATION) {
             annotation = annotation.getNextSibling();
         }
-        return annotation;
+        return Optional.ofNullable(annotation);
     }
 
     /**


### PR DESCRIPTION
issue : #14084


## Summary
- annotated `findLastAnnotation` in `LeftCurlyCheck` with `@Nullable` to match its actual nullable return behavior
- removed the corresponding nullness suppression for `LeftCurlyCheck` from `checker-nullness-optional-interning-suppressions.xml`

## Details
- profile used: `checker-nullness-optional-interning`
- verification command:
  - `groovy .ci/checker-framework.groovy checker-nullness-optional-interning`
- result: build successful