### PR TITLE
Issue #16807: Update default properties for IllegalTypeCheck

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -865,6 +865,7 @@ multiplevariabledeclarations
 Multiset
 multithreading
 mutableexception
+mutationtest
 MVC
 mvn
 mvnrepository

--- a/config/pitest-suppressions/pitest-utils-suppressions.xml
+++ b/config/pitest-suppressions/pitest-utils-suppressions.xml
@@ -1,3 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>TokenUtil.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.utils.TokenUtil</mutatedClass>
+    <mutatedMethod>asBitSet</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/util/stream/Stream::filter with receiver</description>
+    <lineContent>.filter(Predicate.not(String::isEmpty))</lineContent>
+  </mutation>
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -285,7 +285,6 @@ public final class InlineConfigParser {
      *  Until <a href="https://github.com/checkstyle/checkstyle/issues/16807">#16807</a>.
      */
     private static final Set<String> SUPPRESSED_MODULES = Set.of(
-            "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -23,12 +23,11 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck.MSG_KEY;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
-import java.io.File;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -282,18 +281,14 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testClearDataBetweenFiles() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(IllegalTypeCheck.class);
-        final String violationFile = getPath("InputIllegalTypeTestClearDataBetweenFiles.java");
-        checkConfig.addProperty("illegalClassNames", "java.util.TreeSet");
-        final String[] expected = {
-            "21:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
-            "23:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
-        };
-
-        verify(createChecker(checkConfig), new File[] {
-            new File(violationFile),
-            new File(getPath("InputIllegalTypeSimilarClassName.java")),
-        }, violationFile, expected);
+        final String file1 = getPath("InputIllegalTypeTestClearDataBetweenFiles.java");
+        final String file2 = getPath("InputIllegalTypeSimilarClassName.java");
+        final List<String> expectedFirstInput = List.of(
+            "32:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
+            "34:13: " + getCheckMessage(MSG_KEY, "TreeSet")
+        );
+        final List<String> expectedSecondInput = List.of(CommonUtil.EMPTY_STRING_ARRAY);
+        verifyWithInlineConfigParser(file1, file2, expectedFirstInput, expectedSecondInput);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeEmptyStringMemberModifiers.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeEmptyStringMemberModifiers.java
@@ -7,7 +7,7 @@ illegalClassNames = (default)HashMap, HashSet, LinkedHashMap, LinkedHashSet, Tre
 legalAbstractClassNames = (default)
 ignoredMethodNames = (default)getEnvironment, getInitialContext
 illegalAbstractClassNameFormat = (default)^(.*[.])?Abstract.*$
-memberModifiers =
+memberModifiers = (default)
 tokens = (default)ANNOTATION_FIELD_DEF, CLASS_DEF, INTERFACE_DEF, METHOD_CALL, METHOD_DEF, \
          METHOD_REF, PARAMETER_DEF, VARIABLE_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF, \
          RECORD_COMPONENT_DEF

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestClearDataBetweenFiles.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestClearDataBetweenFiles.java
@@ -1,11 +1,22 @@
+/*
+IllegalType
+validateAbstractClassNames = (default)false
+illegalClassNames = java.util.TreeSet
+legalAbstractClassNames = (default)
+ignoredMethodNames = (default)getEnvironment, getInitialContext
+illegalAbstractClassNameFormat = (default)^(.*[.])?Abstract.*$
+memberModifiers = (default)
+tokens = (default)ANNOTATION_FIELD_DEF, CLASS_DEF, INTERFACE_DEF, METHOD_CALL, METHOD_DEF, \
+         METHOD_REF, PARAMETER_DEF, VARIABLE_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF, \
+         RECORD_COMPONENT_DEF
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 import java.util.HashMap;
 import java.util.TreeSet;
 
-/*
- * Config:
- * illegalClassNames = { java.util.TreeSet }
- */
 public class InputIllegalTypeTestClearDataBetweenFiles implements InputIllegalTypeSuper {
     private AbstractClass a = null;
     private NotAnAbstractClass b = null; /*another comment*/


### PR DESCRIPTION
Issue: #16807

Updates the input files for `IllegalTypeCheck` to mention all default properties with `(default)` tag, and removes `IllegalTypeCheck` from `SUPPRESSED_MODULES`.

Changes:
- Add inline config header to `InputIllegalTypeTestClearDataBetweenFiles.java`
- Add `(default)` tag to `memberModifiers` in `InputIllegalTypeEmptyStringMemberModifiers.java`
- Convert `testClearDataBetweenFiles` to use `verifyWithInlineConfigParser`
- Remove `IllegalTypeCheck` from `SUPPRESSED_MODULES` in `InlineConfigParser`