### PR TITLE
Issue #15456: Defined violation messages for SingleLineJavadocCheck.java

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -248,7 +248,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
@@ -56,10 +56,10 @@ public class SingleLineJavadocCheckTest extends AbstractModuleTestSupport {
     public void simpleTest() throws Exception {
         final String[] expected = {
             "22: " + getCheckMessage(MSG_KEY),
-            "38: " + getCheckMessage(MSG_KEY),
-            "50: " + getCheckMessage(MSG_KEY),
-            "53: " + getCheckMessage(MSG_KEY),
-            "59: " + getCheckMessage(MSG_KEY),
+            "40: " + getCheckMessage(MSG_KEY),
+            "52: " + getCheckMessage(MSG_KEY),
+            "55: " + getCheckMessage(MSG_KEY),
+            "61: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputSingleLineJavadoc.java"), expected);
@@ -69,11 +69,11 @@ public class SingleLineJavadocCheckTest extends AbstractModuleTestSupport {
     public void testIgnoredTags() throws Exception {
         final String[] expected = {
             "14: " + getCheckMessage(MSG_KEY),
-            "44: " + getCheckMessage(MSG_KEY),
-            "47: " + getCheckMessage(MSG_KEY),
-            "50: " + getCheckMessage(MSG_KEY),
+            "46: " + getCheckMessage(MSG_KEY),
+            "51: " + getCheckMessage(MSG_KEY),
             "56: " + getCheckMessage(MSG_KEY),
-            "59: " + getCheckMessage(MSG_KEY),
+            "62: " + getCheckMessage(MSG_KEY),
+            "67: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputSingleLineJavadocIgnoredTags.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/singlelinejavadoc/InputSingleLineJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/singlelinejavadoc/InputSingleLineJavadoc.java
@@ -19,8 +19,10 @@ class InputSingleLineJavadoc {
      */
     void foo1() {}
 
-    /** @throws CheckstyleException if a problem occurs */ // violation
-    void foo2() {}
+    /** @throws CheckstyleException if a problem occurs */
+    void foo2() {
+         // violation 2 lines above 'Single-line Javadoc comment should be multi-line.'
+    }
 
     /**
      * @throws CheckstyleException if a problem occurs
@@ -35,7 +37,7 @@ class InputSingleLineJavadoc {
      */
     void foo5() {}
 
-    /** @inheritDoc */ // violation
+    /** @inheritDoc */ // violation 'Single-line Javadoc comment should be multi-line.'
     void foo6() {}
 
     /** {@inheritDoc} */
@@ -47,15 +49,17 @@ class InputSingleLineJavadoc {
     /** {@inheritDoc}  {@link #bar} */
     void foo9() {}
 
-    /** @customTag */ // violation
+    /** @customTag */ // violation 'Single-line Javadoc comment should be multi-line.'
     void bar() {}
 
-    /** @ignoredCustomTag */ // violation
+    /** @ignoredCustomTag */ // violation 'Single-line Javadoc comment should be multi-line.'
     void bar1() {}
 
     /** <h1> Some header </h1> {@inheritDoc} {@code bar1} text*/
     void bar2() {}
 
-    /** @customTag <a> href="https://github.com/checkstyle/checkstyle/"</a> text*/ // violation
-    void bar3() {}
+    /** @customTag <a> href="https://github.com/checkstyle/checkstyle/"</a> text*/
+    void bar3() {
+         // violation 2 lines above 'Single-line Javadoc comment should be multi-line.'
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/singlelinejavadoc/InputSingleLineJavadocIgnoredTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/singlelinejavadoc/InputSingleLineJavadocIgnoredTags.java
@@ -11,8 +11,10 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.singlelinejavadoc;
 
 class InputSingleLineJavadocIgnoredTags {
 
-        /** As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)} */ // violation
-    void foo() {}
+        /** As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)} */
+    void foo() {
+         // violation 2 lines above 'Single-line Javadoc comment should be multi-line.'
+    }
 
     /**
      * As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}
@@ -41,21 +43,29 @@ class InputSingleLineJavadocIgnoredTags {
     /** {@inheritDoc} */
     void foo7() {}
 
-    /** {@inheritDoc}  {@code bar} */ // violation
-    void foo8() {}
+    /** {@inheritDoc}  {@code bar} */
+    void foo8() {
+         // violation 2 lines above 'Single-line Javadoc comment should be multi-line.'
+    }
 
-    /** {@inheritDoc}  {@link #bar} */ // violation
-    void foo9() {}
+    /** {@inheritDoc}  {@link #bar} */
+    void foo9() {
+         // violation 2 lines above 'Single-line Javadoc comment should be multi-line.'
+    }
 
-    /** @customTag */ // violation
+    /** @customTag */ // violation 'Single-line Javadoc comment should be multi-line.'
     void bar() {}
 
     /** @ignoredCustomTag */
     void bar1() {}
 
-    /** <h1> Some header </h1> {@inheritDoc} {@code bar1} text*/ // violation
-    void bar2() {}
+    /** <h1> Some header </h1> {@inheritDoc} {@code bar1} text*/
+    void bar2() {
+        // violation 2 lines above 'Single-line Javadoc comment should be multi-line.'
+    }
 
-    /** @customTag <a> href="https://github.com/checkstyle/checkstyle/"</a> text*/ // violation
-    void bar3() {}
+    /** @customTag <a> href="https://github.com/checkstyle/checkstyle/"</a> text*/
+    void bar3() {
+         // violation 2 lines above 'Single-line Javadoc comment should be multi-line.'
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/singlelinejavadoc/InputSingleLineJavadocLexerError.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/singlelinejavadoc/InputSingleLineJavadocLexerError.java
@@ -13,9 +13,11 @@ class InputSingleLineJavadocLexerError {
 
     /** @@{@return} */
     void foo() {
-        // violation 2 lines above
+        // violation 2 lines above 'Javadoc comment at column 4 has parse error.'
     }
 
-    /** @throws Exception if a problem occurs */ // violation
-    void foo2() {}
+    /** @throws Exception if a problem occurs */
+    void foo2() {
+         // violation 2 lines above 'Single-line Javadoc comment should be multi-line.'
+    }
 }


### PR DESCRIPTION
Issue #15456 :
Defined the violations message taken from message.properties , for `SingleLineJavadocCheck`.
Removed `SingleLineJavadocCheck.java` from `InlineConfigParser.java`
