### PR TITLE
Issue #15456: Define violation messages for InvalidJavadocPositionCheck

### DIFF
--- a/src/site/xdoc/checks/misc/todocomment.xml
+++ b/src/site/xdoc/checks/misc/todocomment.xml
@@ -64,7 +64,8 @@ public class Example1 {
   int i;
   int x;
   public void test() {
-    i++;   // TODO: do differently in future    // violation
+    // violation below 'matches to-do format'
+    i++;   // TODO: do differently in future
     i++;   // todo: do differently in future
     i=i/x; // FIXME: handle x = 0 case
     i=i/x; // FIX :  handle x = 0 case
@@ -92,9 +93,12 @@ public class Example2 {
   int i;
   int x;
   public void test() {
-    i++;   // TODO: do differently in future    // violation
-    i++;   // todo: do differently in future    // violation
-    i=i/x; // FIXME: handle x = 0 case          // violation
+    // violation below 'matches to-do format'
+    i++;   // TODO: do differently in future
+    // violation below 'matches to-do format'
+    i++;   // todo: do differently in future
+    // violation below 'matches to-do format'
+    i=i/x; // FIXME: handle x = 0 case
     i=i/x; // FIX :  handle x = 0 case
   }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -265,7 +265,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck",
-            "com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck",
             "com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck",
             "com.puppycrawl.tools.checkstyle.api.AbstractCheckTest$ViolationAstCheck",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/InputTodoCommentDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/InputTodoCommentDefault.java
@@ -9,7 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.todocomment;
 
 public class InputTodoCommentDefault {
     int i;
-    public void method() { // violation below 'Comment matches .*'
+    public void method() { // violation below 'matches to-do format'
         i++; // TODO: do differently in future
         i++;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/InputTodoCommentSimpleOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/InputTodoCommentSimpleOne.java
@@ -1,4 +1,4 @@
-/* // violation
+/* // violation 'matches to-do format'
 TodoComment
 format = FIXME:
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/InputTodoCommentSimpleTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/InputTodoCommentSimpleTwo.java
@@ -1,4 +1,4 @@
-/* // violation
+/* // violation 'matches to-do format'
 TodoComment
 format = FIXME:
 
@@ -65,13 +65,13 @@ public class InputTodoCommentSimpleTwo {
   	        int tab5 =1;
     }
 
-    // FIXME: // violation
-    /* FIXME: a // violation
+    // FIXME: // violation 'matches to-do format'
+    /* FIXME: a // violation 'matches to-do format'
      * FIXME:
      * TODO
      */
     /* NOTHING */
-    /* YES */ /* FIXME: x */ /* YES!! */ // violation
+    /* YES */ /* FIXME: x */ /* YES!! */ // violation 'matches to-do format'
 
     /** test long comments **/
     void veryLong()
@@ -117,4 +117,3 @@ class InputTodoCommentSimple2
         }
     }
 }
-

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckExamplesTest.java
@@ -34,7 +34,7 @@ public class TodoCommentCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "15:14: " + getCheckMessage(MSG_KEY, "TODO:"),
+            "16:14: " + getCheckMessage(MSG_KEY, "TODO:"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -44,9 +44,9 @@ public class TodoCommentCheckExamplesTest extends AbstractExamplesModuleTestSupp
     public void testExample2() throws Exception {
         final String[] expected = {
             "1:3: " + getCheckMessage(MSG_KEY, "(?i)(TODO)|(FIXME)"),
-            "18:14: " + getCheckMessage(MSG_KEY, "(?i)(TODO)|(FIXME)"),
             "19:14: " + getCheckMessage(MSG_KEY, "(?i)(TODO)|(FIXME)"),
-            "20:14: " + getCheckMessage(MSG_KEY, "(?i)(TODO)|(FIXME)"),
+            "21:14: " + getCheckMessage(MSG_KEY, "(?i)(TODO)|(FIXME)"),
+            "23:14: " + getCheckMessage(MSG_KEY, "(?i)(TODO)|(FIXME)"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example1.java
@@ -12,7 +12,8 @@ public class Example1 {
   int i;
   int x;
   public void test() {
-    i++;   // TODO: do differently in future    // violation
+    // violation below 'matches to-do format'
+    i++;   // TODO: do differently in future
     i++;   // todo: do differently in future
     i=i/x; // FIXME: handle x = 0 case
     i=i/x; // FIX :  handle x = 0 case

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example2.java
@@ -7,7 +7,7 @@
   </module>
 </module>
 */
-// violation 9 lines above
+// violation 9 lines above 'matches to-do format'
 package com.puppycrawl.tools.checkstyle.checks.todocomment;
 
 // xdoc section -- start
@@ -15,9 +15,12 @@ public class Example2 {
   int i;
   int x;
   public void test() {
-    i++;   // TODO: do differently in future    // violation
-    i++;   // todo: do differently in future    // violation
-    i=i/x; // FIXME: handle x = 0 case          // violation
+    // violation below 'matches to-do format'
+    i++;   // TODO: do differently in future
+    // violation below 'matches to-do format'
+    i++;   // todo: do differently in future
+    // violation below 'matches to-do format'
+    i=i/x; // FIXME: handle x = 0 case
     i=i/x; // FIX :  handle x = 0 case
   }
 }


### PR DESCRIPTION
Issue: https://github.com/checkstyle/checkstyle/issues/15456

Adds explicit violation messages to the remaining InvalidJavadocPositionCheck package-info inputs and removes this check from SUPPRESSED_CHECKS.

Verification:

mvn -q clean "-Dexec.skip=true" "-Dtest=com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheckTest,com.puppycrawl.tools.checkstyle.bdd.InlineConfigParserTest" test
mvn -q clean verify