### PR TITLE
Issue #10858: Add Checkstyle from PR to Github's Diff Report

### DIFF
--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -176,6 +176,8 @@ jobs:
           REPO="../../../../checkstyle"
           BASE_BRANCH="upstream/master"
           export MAVEN_OPTS="-Xmx5g"
+          sed -i 's/#local-checkstyle/local-checkstyle/' projects.properties
+          grep local-checkstyle projects.properties
           if [ -f new_module_config.xml ]; then
             groovy diff.groovy -r "$REPO" -p "$REF" -pc new_module_config.xml -m single\
               -l projects.properties -xm "-Dcheckstyle.failsOnError=false"\


### PR DESCRIPTION
#10858 


###  Problem
The diff report currently uses the released Checkstyle version instead of the PR build, which can result in **false clean reports** (no differences shown even when behavior changes).

###  Fix
Enable the local Checkstyle build by uncommenting `local-checkstyle` in `projects.properties` before running `diff.groovy`:
```bash
sed -i 's/#local-checkstyle/local-checkstyle/' projects.properties
```
