### PR TITLE
Issue #14084: Remove entries from checker purity value returns

### DIFF
--- a/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
@@ -1532,34 +1532,6 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
     <specifier>type.arguments.not.inferred</specifier>
-    <message>Could not infer type arguments for IntStream.collect</message>
-    <lineContent>.collect(BitSet::new, BitSet::set, BitSet::or);</lineContent>
-    <details>
-      unsatisfiable constraint: @GuardedBy BitSet &lt;: @GuardSatisfied BitSet
-      @GuardedBy BitSet &lt;: use of R from Arrays.stream(tokens).map(String::trim).filter(Predicate.not(String::isEmpty)).mapToInt(TokenUtil::getTokenId).collect(BitSet::new, BitSet::set, BitSet::or)
-      From complementary bound.: @GuardedBy BitSet -&gt; use of R from Arrays.stream(tokens).map(String::trim).filter(Predicate.not(String::isEmpty)).mapToInt(TokenUtil::getTokenId).collect(BitSet::new, BitSet::set, BitSet::or)
-      BitSet::new -&gt; inference type: java.util.function.Supplier&lt;R&gt;
-      From: Argument constraint
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
-    <specifier>type.arguments.not.inferred</specifier>
-    <message>Could not infer type arguments for IntStream.collect</message>
-    <lineContent>.collect(BitSet::new, BitSet::set, BitSet::or);</lineContent>
-    <details>
-      unsatisfiable constraint: @GuardedBy BitSet &lt;: @GuardSatisfied BitSet
-      @GuardedBy BitSet &lt;: use of R from IntStream.of(tokens).collect(BitSet::new, BitSet::set, BitSet::or)
-      From complementary bound.: @GuardedBy BitSet -&gt; use of R from IntStream.of(tokens).collect(BitSet::new, BitSet::set, BitSet::or)
-      BitSet::new -&gt; inference type: java.util.function.Supplier&lt;R&gt;
-      From: Argument constraint
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
-    <specifier>type.arguments.not.inferred</specifier>
     <message>Could not infer type arguments for Stream.collect</message>
     <lineContent>.collect(Collectors.toUnmodifiableMap(</lineContent>
     <details>

--- a/config/checker-framework-suppressions/checker-purity-value-returns-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-purity-value-returns-suppressions.xml
@@ -98,34 +98,4 @@
       required: @IntRange(from=2, to=36) int
     </details>
   </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
-    <specifier>methodref.param</specifier>
-    <message>Incompatible parameter type for bitIndex</message>
-    <lineContent>.collect(BitSet::new, BitSet::set, BitSet::or);</lineContent>
-    <details>
-      found   : @IntRangeFromNonNegative int
-      required: int
-      Consequence: method in BitSet
-      void set(BitSet this, @IntRangeFromNonNegative int p0)
-      is not a valid method reference for method in ObjIntConsumer&lt;BitSet&gt;
-      void accept(ObjIntConsumer&lt;BitSet&gt; this, BitSet p0, int p1)
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
-    <specifier>methodref.param</specifier>
-    <message>Incompatible parameter type for bitIndex</message>
-    <lineContent>.collect(BitSet::new, BitSet::set, BitSet::or);</lineContent>
-    <details>
-      found   : @IntRangeFromNonNegative int
-      required: int
-      Consequence: method in BitSet
-      void set(BitSet this, @IntRangeFromNonNegative int p0)
-      is not a valid method reference for method in ObjIntConsumer&lt;BitSet&gt;
-      void accept(ObjIntConsumer&lt;BitSet&gt; this, BitSet p0, int p1)
-    </details>
-  </checkerFrameworkError>
 </suppressedErrors>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -372,8 +371,11 @@ public final class TokenUtil {
      * @return tokens as BitSet
      */
     public static BitSet asBitSet(int... tokens) {
-        return IntStream.of(tokens)
-                .collect(BitSet::new, BitSet::set, BitSet::or);
+        final BitSet bitSet = new BitSet();
+        for (int token : tokens) {
+            bitSet.set(token);
+        }
+        return bitSet;
     }
 
     /**
@@ -383,11 +385,14 @@ public final class TokenUtil {
      * @return tokens as BitSet
      */
     public static BitSet asBitSet(String... tokens) {
-        return Arrays.stream(tokens)
-                .map(String::trim)
-                .filter(Predicate.not(String::isEmpty))
-                .mapToInt(TokenUtil::getTokenId)
-                .collect(BitSet::new, BitSet::set, BitSet::or);
+        final BitSet bitSet = new BitSet();
+        for (String token : tokens) {
+            final String trimmed = token.trim();
+            if (!trimmed.isEmpty()) {
+                bitSet.set(getTokenId(trimmed));
+            }
+        }
+        return bitSet;
     }
 
 }


### PR DESCRIPTION
issue : #14084 

Summary
- Remove two checker-purity-value-returns suppressions in TokenUtil related to BitSet construction.
- Refactor TokenUtil.asBitSet(int... tokens) and TokenUtil.asBitSet(String... tokens) to use explicit loops.
- Keep behavior unchanged while satisfying Checker Framework and static analysis constraints.

i tried `collect(BitSet::new, BitSet::set, BitSet::or)` and lambda accumulators but they triggered  `PMD`.

@romani  this will be my 14th open PR, can i send more or should i wait until some get reviewed ?