### PR TITLE
Ignore text block content in LineLengthCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -75,6 +75,12 @@ public class LineLengthCheck extends AbstractFileSetCheck {
     /** Default maximum number of columns in a line. */
     private static final int DEFAULT_MAX_COLUMNS = 80;
 
+    /** Java file extension. */
+    private static final String JAVA_FILE_EXTENSION = ".java";
+
+    /** Text block delimiter. */
+    private static final String TEXT_BLOCK_DELIMITER = "\"\"\"";
+
     /** Specify the maximum line length allowed. */
     private int max = DEFAULT_MAX_COLUMNS;
 
@@ -83,8 +89,30 @@ public class LineLengthCheck extends AbstractFileSetCheck {
 
     @Override
     protected void processFiltered(File file, FileText fileText) {
+        final boolean isJavaFile = file.getName().endsWith(JAVA_FILE_EXTENSION);
+        boolean insideTextBlock = false;
+
         for (int i = 0; i < fileText.size(); i++) {
             final String line = fileText.get(i);
+
+            if (isJavaFile) {
+                final int delimiterCount = getUnescapedTextBlockDelimiterCount(line);
+                if (insideTextBlock) {
+                    if (delimiterCount % 2 != 0) {
+                        insideTextBlock = false;
+                    }
+                    // Skip only pure content lines (no delimiters). Lines that carry a
+                    // closing (or close+reopen) delimiter are Java source code and must
+                    // still be checked for line length.
+                    if (delimiterCount == 0) {
+                        continue;
+                    }
+                }
+                else if (delimiterCount % 2 != 0) {
+                    insideTextBlock = true;
+                }
+            }
+
             final int realLength = CommonUtil.lengthExpandedTabs(
                 line, line.codePointCount(0, line.length()), getTabWidth());
 
@@ -92,6 +120,44 @@ public class LineLengthCheck extends AbstractFileSetCheck {
                 log(i + 1, MSG_KEY, max, realLength);
             }
         }
+    }
+
+    /**
+     * Returns the number of unescaped text block delimiters in a line.
+     *
+     * @param line the line to examine
+     * @return number of unescaped text block delimiters
+     */
+    private static int getUnescapedTextBlockDelimiterCount(String line) {
+        int count = 0;
+        int pos = 0;
+        while (pos <= line.length() - TEXT_BLOCK_DELIMITER.length()) {
+            if (line.startsWith(TEXT_BLOCK_DELIMITER, pos)
+                    && !isEscaped(line, pos)) {
+                count++;
+                pos += TEXT_BLOCK_DELIMITER.length();
+            }
+            else {
+                pos++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Checks whether the character at {@code index} is escaped by an odd number
+     * of preceding backslashes.
+     *
+     * @param line the line to examine
+     * @param index index of character to check
+     * @return true if escaped
+     */
+    private static boolean isEscaped(String line, int index) {
+        int backslashCount = 0;
+        for (int pos = index - 1; pos >= 0 && line.charAt(pos) == '\\'; pos--) {
+            backslashCount++;
+        }
+        return backslashCount % 2 != 0;
     }
 
     /**

--- a/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
@@ -462,9 +462,6 @@ public class Example9 {
           ST001,Station 001,ZONE1,Zone 1,CP1,Competitor 1,123 Street,Unit 2,Houston,TX,77033,US,29.761496813335178,-95.53049214204984
           ST002,Station 002,ZONE2,,CP2,,668 Street,Unit 23,San Jose,CA,95191,US,37.35102477242508,-121.9209934020318
           """;
-  // filtered violation 4 lines above 'Line is longer than 100 characters (found 147).'
-  // filtered violation 4 lines above 'Line is longer than 100 characters (found 133).'
-  // filtered violation 4 lines above 'Line is longer than 100 characters (found 116).'
 
   // violation below, 'Line is longer than 100 characters (found 183).'
   static final String SINGLE_LINE_SAMPLE = "locationId,label,regionId,regionLabel,vendorId,vendorLabel,address,address2,city,stateProvinceCode,zipCode,countryCode,latitude,longitude";

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
@@ -22,8 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
 
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -118,7 +122,6 @@ public class LineLengthCheckTest extends AbstractModuleTestSupport {
     public void testLineLengthIgnoringPackageStatements() throws Exception {
         final String[] expected = {
             "17: " + getCheckMessage(MSG_KEY, 75, 86),
-            "21: " + getCheckMessage(MSG_KEY, 75, 76),
             "29: " + getCheckMessage(MSG_KEY, 75, 77),
         };
 
@@ -130,7 +133,6 @@ public class LineLengthCheckTest extends AbstractModuleTestSupport {
     public void testLineLengthIgnoringImportStatements() throws Exception {
         final String[] expected = {
             "18: " + getCheckMessage(MSG_KEY, 75, 81),
-            "22: " + getCheckMessage(MSG_KEY, 75, 84),
             "30: " + getCheckMessage(MSG_KEY, 75, 77),
         };
 
@@ -160,5 +162,68 @@ public class LineLengthCheckTest extends AbstractModuleTestSupport {
         checkerConfig.addProperty("charset", "IBM1098");
 
         verify(checkerConfig, getPath("InputLineLengthUnmappableCharacters.java"), expected);
+    }
+
+    @Test
+    public void testTextBlockContentIsIgnored() throws Exception {
+        final String[] expected = {
+            "19: " + getCheckMessage(MSG_KEY, 80, 131),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputLineLengthTextBlock.java"), expected);
+    }
+
+    @Test
+    public void testEscapedTextBlockDelimiterDoesNotCloseBlock() throws Exception {
+        final String[] expected = {
+            "20: " + getCheckMessage(MSG_KEY, 80, 92),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputLineLengthEscapedDelimiter.java"), expected);
+    }
+
+    @Test
+    public void testEvenBackslashesBeforeDelimiterAtLineStart(@TempDir Path tempDir)
+            throws Exception {
+        final String[] expected = {
+            "14: " + getCheckMessage(MSG_KEY, 80, 88),
+        };
+
+        final Path inputFile = tempDir.resolve("InputLineLengthEscapedDelimiterAtLineStart.java");
+        final String input = String.join(System.lineSeparator(),
+                "/*",
+                "LineLength",
+                "fileExtensions = (default)null",
+                "ignorePattern = ^(package|import) .*$",
+                "max = (default)80",
+                "tabWidth = (default)0",
+                "",
+                "*/",
+                "package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;",
+                "",
+                "public class InputLineLengthEscapedDelimiterAtLineStart {",
+                "String text = \"\"\"",
+                "\\\\\"\"\"",
+                "String longLine = \"This is a regular string "
+                        + "that is long enough to trigger a violation\";",
+                "// violation above, 'Line is longer than 80 characters (found 88).'",
+                "}",
+                "");
+        Files.writeString(inputFile, input, StandardCharsets.UTF_8);
+        verifyWithInlineConfigParser(inputFile.toString(), expected);
+    }
+
+    @Test
+    public void testNonJavaFileStillCheckedForLineLength() throws Exception {
+        final String[] expected = {
+            "3: " + getCheckMessage(MSG_KEY, 80, 90),
+        };
+
+        verifyWithInlineConfigParserSeparateConfigAndTarget(
+                getPath("InputLineLengthNonJavaFileConfig.java"),
+                getPath("InputLineLengthNonJavaFile.txt"),
+                expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthEscapedDelimiter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthEscapedDelimiter.java
@@ -1,0 +1,21 @@
+/*
+LineLength
+fileExtensions = (default)null
+ignorePattern = ^(package|import) .*$
+max = (default)80
+tabWidth = (default)0
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
+
+public class InputLineLengthEscapedDelimiter {
+
+    // escaped triple-quote \""" does not close the text block
+    String text = """
+            line one
+            \"""still inside the block
+            """;
+
+    // violation below, 'Line is longer than 80 characters (found 92).'
+    String longLine = "This is a regular string that is long enough to trigger a violation";
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringImportStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringImportStatements.java
@@ -17,7 +17,7 @@ public class InputLineLengthIgnoringImportStatements {
         // violation below 'longer than 75 characters (found 81)'
         String s = "import java.security.interfaces.RSAMultiPrimePrivateCrtKey;";
 
-        // violation 2 lines below 'longer than 75 characters (found 84)'
+        // line below is inside text block and should be ignored
         String a = """
             import java.security.       interfaces.      RSAMultiPrimePrivateCrtKey;
             """;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringPackageStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringPackageStatements.java
@@ -16,7 +16,7 @@ public class InputLineLengthIgnoringPackageStatements {
         // violation below 'longer than 75 characters (found 86)'
         String s = "package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;";
 
-        // violation 2 lines below 'longer than 75 characters (found 76)'
+        // line below is inside text block and should be ignored
         String a = """
             package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
             """;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthNonJavaFile.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthNonJavaFile.txt
@@ -1,0 +1,4 @@
+First short line.
+Second short line.
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+// violation above, 'Line is longer than 80 characters (found 90).'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthNonJavaFileConfig.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthNonJavaFileConfig.java
@@ -1,0 +1,11 @@
+/*
+LineLength
+fileExtensions = txt
+ignorePattern = (default)^(package|import) .*
+max = (default)80
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
+
+public class InputLineLengthNonJavaFileConfig {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthTextBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthTextBlock.java
@@ -1,0 +1,20 @@
+/*
+LineLength
+fileExtensions = (default)null
+ignorePattern = ^(package|import) .*$
+max = (default)80
+tabWidth = (default)0
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
+
+public class InputLineLengthTextBlock {
+
+    String text = """
+            This is a very long line inside a text block that exceeds eighty characters and should not trigger a violation.
+            """;
+
+    // violation below, 'Line is longer than 80 characters (found 131).'
+    String longLine = "This is a very long regular Java string literal that should trigger a line length violation in this check.";
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterExamplesTest.java
@@ -188,14 +188,11 @@ public class SuppressWithPlainTextCommentFilterExamplesTest
     public void testExample9() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "23: Line is longer than 100 characters (found 147).",
-            "24: Line is longer than 100 characters (found 133).",
-            "25: Line is longer than 100 characters (found 116).",
-            "32: Line is longer than 100 characters (found 183).",
+            "29: Line is longer than 100 characters (found 183).",
         };
 
         final String[] expectedWithFilter = {
-            "32: Line is longer than 100 characters (found 183).",
+            "29: Line is longer than 100 characters (found 183).",
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example9.java"),

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example9.java
@@ -24,9 +24,6 @@ public class Example9 {
           ST001,Station 001,ZONE1,Zone 1,CP1,Competitor 1,123 Street,Unit 2,Houston,TX,77033,US,29.761496813335178,-95.53049214204984
           ST002,Station 002,ZONE2,,CP2,,668 Street,Unit 23,San Jose,CA,95191,US,37.35102477242508,-121.9209934020318
           """;
-  // filtered violation 4 lines above 'Line is longer than 100 characters (found 147).'
-  // filtered violation 4 lines above 'Line is longer than 100 characters (found 133).'
-  // filtered violation 4 lines above 'Line is longer than 100 characters (found 116).'
 
   // violation below, 'Line is longer than 100 characters (found 183).'
   static final String SINGLE_LINE_SAMPLE = "locationId,label,regionId,regionLabel,vendorId,vendorLabel,address,address2,city,stateProvinceCode,zipCode,countryCode,latitude,longitude";


### PR DESCRIPTION
Fixes issue #19554.

## Problem

`LineLengthCheck` currently flags lines inside Java text blocks (`""" ... """`) as line-length violations, even though those lines are string content and not actual source code. This produces false positives that are misleading and impossible to fix without restructuring the string content.

## Solution

Override `processFiltered` in `LineLengthCheck` to track when the file reader is inside a text block:

- When the opening `"""` delimiter is encountered (odd number of unescaped delimiters on a line), all subsequent lines are skipped until the closing `"""` is found.
- Lines before and after the text block continue to be validated normally.
- Only `.java` files are affected; all other file types continue unchanged.

## Files Changed

| File | Change |
|---|---|
| `src/main/java/.../sizes/LineLengthCheck.java` | Added text-block tracking logic in `processFiltered`, plus `getUnescapedTextBlockDelimiterCount` and `isEscaped` helpers |
| `src/test/java/.../sizes/LineLengthCheckTest.java` | Added `testTextBlockContentIsIgnored`; removed false-positive violations from existing text-block fixture tests |
| `src/test/resources/.../linelength/InputLineLengthTextBlock.java` | New regression input file demonstrating the fix |
| `src/test/resources/.../InputLineLengthIgnoringPackageStatements.java` | Updated to use a text block; removed the now-skipped expected violation |
| `src/test/resources/.../InputLineLengthIgnoringImportStatements.java` | Updated to use a text block; removed the now-skipped expected violation |

## Testing

Validated locally:

```bash
./mvnw -Dtest=LineLengthCheckTest,LineLengthCheckExamplesTest test -DskipITs -DskipIT=true -q
```

All tests pass.