### PR TITLE
Issue #354: allow nested line wrapping indent with forceStrictCondition

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -871,6 +871,7 @@ multiplevariabledeclarations
 Multiset
 multithreading
 mutableexception
+mutationtest
 MVC
 mvn
 mvnrepository

--- a/config/pitest-suppressions/pitest-indentation-suppressions.xml
+++ b/config/pitest-suppressions/pitest-indentation-suppressions.xml
@@ -1,3 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>LineWrappingHandler.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.indentation.LineWrappingHandler</mutatedClass>
+    <mutatedMethod>checkNestedWrappingIndent</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.ConditionalsBoundaryMutator</mutator>
+    <description>changed conditional boundary</description>
+    <lineContent>if (previousLineIndent &gt; firstNodeIndent</lineContent>
+  </mutation>
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -163,6 +163,7 @@ public class LineWrappingHandler {
         }
         final int currentIndent = firstNodeIndent + indentLevel;
 
+        int previousLineIndent = firstNodeIndent;
         for (DetailAST node : firstNodesOnLines.values()) {
             final int currentType = node.getType();
             if (checkForNullParameterChild(node) || checkForMethodLparenNewLine(node)
@@ -173,9 +174,51 @@ public class LineWrappingHandler {
                 logWarningMessage(node, firstNodeIndent);
             }
             else if (!TokenUtil.isOfType(currentType, IGNORED_LIST)) {
-                logWarningMessage(node, currentIndent);
+                previousLineIndent = checkNestedWrappingIndent(node,
+                        currentIndent, firstNodeIndent, indentLevel, previousLineIndent);
             }
         }
+    }
+
+    /**
+     * Checks indentation of a node that is not an RPAREN and not in the ignored list,
+     * accounting for legitimate nested continuation lines when forceStrictCondition is true.
+     *
+     * @param node the node to check.
+     * @param currentIndent expected indent for a single-level wrapped line.
+     * @param firstNodeIndent indent of the first node on the first wrapped line.
+     * @param indentLevel the line wrapping indentation increment.
+     * @param previousLineIndent the indent of the last validly-positioned node.
+     * @return updated previousLineIndent value.
+     */
+    private int checkNestedWrappingIndent(DetailAST node, int currentIndent,
+            int firstNodeIndent, int indentLevel, int previousLineIndent) {
+        final int actualCol = expandedTabsColumnNo(node);
+        final int result;
+        if (previousLineIndent > firstNodeIndent
+                && indentCheck.isForceStrictCondition()) {
+            // allow nested continuation, e.g. && inside a wrapped method arg
+            final int nestedIndent = previousLineIndent + indentLevel;
+            if (actualCol == currentIndent || actualCol == nestedIndent) {
+                result = actualCol;
+            }
+            else {
+                indentCheck.indentationLog(node,
+                        IndentationCheck.MSG_ERROR, node.getText(),
+                        actualCol, currentIndent);
+                result = previousLineIndent;
+            }
+        }
+        else {
+            logWarningMessage(node, currentIndent);
+            if (actualCol == currentIndent) {
+                result = actualCol;
+            }
+            else {
+                result = previousLineIndent;
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -294,6 +294,24 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testForceStrictConditionNestedContinuation() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "true");
+        checkConfig.addProperty("lineWrappingIndentation", "8");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "8");
+        final String[] expected = {
+            "35:15: " + getCheckMessage(MSG_ERROR_MULTI, "new", 14, "12, 16"),
+        };
+        verifyWarns(checkConfig,
+            getPath("InputIndentationForceStrictConditionNested.java"), expected);
+    }
+
+    @Test
     public void testZeroCaseLevel() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("arrayInitIndent", "4");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationForceStrictConditionNested.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationForceStrictConditionNested.java
@@ -1,0 +1,45 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;         //indent:0 exp:0
+
+/**                                                                              //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:      //indent:1 exp:1
+ *                                                                               //indent:1 exp:1
+ * basicOffset = 4                                                               //indent:1 exp:1
+ * braceAdjustment = 0                                                           //indent:1 exp:1
+ * caseIndent = 4                                                                //indent:1 exp:1
+ * forceStrictCondition = true                                                   //indent:1 exp:1
+ * lineWrappingIndentation = 8                                                   //indent:1 exp:1
+ * tabWidth = 4                                                                  //indent:1 exp:1
+ * throwsIndent = 8                                                              //indent:1 exp:1
+ *                                                                               //indent:1 exp:1
+ */                                                                              //indent:1 exp:1
+public class InputIndentationForceStrictConditionNested {                        //indent:0 exp:0
+
+    boolean b1 = false;                                                          //indent:4 exp:4
+    boolean b2 = false;                                                          //indent:4 exp:4
+    boolean b3 = false;                                                          //indent:4 exp:4
+
+    void test1(Object a, boolean b) {                                            //indent:4 exp:4
+        test1(new Object(),                                                      //indent:8 exp:8
+                b1                                                               //indent:16 exp:16
+                        && b2);                                                  //indent:24 exp:24
+    }                                                                            //indent:4 exp:4
+
+    void test2(Object a, boolean b) {                                            //indent:4 exp:4
+        test2(new Object(),                                                      //indent:8 exp:8
+                b1                                                               //indent:16 exp:16
+                        || b2);                                                  //indent:24 exp:24
+    }                                                                            //indent:4 exp:4
+
+    void test3(Object a, Object b) {                                             //indent:4 exp:4
+        test3(new Object(),                                                      //indent:8 exp:8
+              new Object());                                                     //indent:14 exp:12,16 warn
+    }                                                                            //indent:4 exp:4
+
+    void test4(Object a, boolean b) {                                            //indent:4 exp:4
+        test1(new Object(),                                                      //indent:8 exp:8
+                b1                                                               //indent:16 exp:16
+                        && b2                                                    //indent:24 exp:24
+                                && b3);                                          //indent:32 exp:32
+    }                                                                            //indent:4 exp:4
+
+}                                                                                //indent:0 exp:0


### PR DESCRIPTION
fixes #354 
fixes false positives in #354 when `forceStrictCondition=true`.

this valid code was incorrectly flagged:
```java
callMe(LongName.variableA,
        LongName.variableB
                && LongName.variableC); // false flagged
```

this -> `&&` ,sits on a line that is already wrapped, so needs double the wrapping indent.