### PR TITLE
Issue #19608: Fix false negative in VariableDeclarationUsageDistance …

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedTryCatchIfElse.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputFormattedTryCatchIfElse.java
@@ -7,7 +7,7 @@ public class InputFormattedTryCatchIfElse {
 
   void foo() throws Exception {
     int a = 90;
-    boolean test = true;
+    boolean test = true; // violation 'Distance .* is .*, but allowed 3.'
 
     if (a == 1) {
     } else {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputTryCatchIfElse.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputTryCatchIfElse.java
@@ -7,7 +7,7 @@ public class InputTryCatchIfElse {
 
   void foo() throws Exception {
     int a = 90;
-    boolean test = true;
+    boolean test = true; // violation 'Distance .* is .*, but allowed 3.'
 
     if (a == 1) {
     } else {}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -310,7 +310,8 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
             case TokenTypes.LITERAL_FOR,
                  TokenTypes.LITERAL_WHILE,
                  TokenTypes.LITERAL_DO,
-                 TokenTypes.LITERAL_IF -> currentDistToVarUsage + 1;
+                 TokenTypes.LITERAL_IF,
+                 TokenTypes.LITERAL_TRY -> currentDistToVarUsage + 1;
             default -> {
                 if (childNode.findFirstToken(TokenTypes.SLIST) == null) {
                     yield currentDistToVarUsage + 1;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
@@ -192,6 +192,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
             "913:9: " + getCheckMessage(MSG_KEY, "a", 5, 1),
             "924:9: " + getCheckMessage(MSG_KEY, "a", 2, 1),
             "945:9: " + getCheckMessage(MSG_KEY, "a", 5, 1),
+            "979:9: " + getCheckMessage(MSG_KEY, "a", 4, 1),
             "990:9: " + getCheckMessage(MSG_KEY, "a", 2, 1),
             "1001:9: " + getCheckMessage(MSG_KEY, "a", 4, 1),
             "1036:9: " + getCheckMessage(MSG_KEY, "c", 4, 1),
@@ -275,6 +276,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
             "913:9: " + getCheckMessage(MSG_KEY_EXT, "a", 5, 3),
             "945:9: " + getCheckMessage(MSG_KEY_EXT, "a", 5, 3),
             "1036:9: " + getCheckMessage(MSG_KEY_EXT, "c", 4, 3),
+            "979:9: " + getCheckMessage(MSG_KEY_EXT, "a", 4, 3),
             "1001:9: " + getCheckMessage(MSG_KEY_EXT, "a", 4, 3),
             "1066:9: " + getCheckMessage(MSG_KEY_EXT, "a", 4, 3),
         };
@@ -367,6 +369,20 @@ public class VariableDeclarationUsageDistanceCheckTest extends
 
         verifyWithInlineConfigParser(
                 getPath("InputVariableDeclarationUsageDistanceTryResources.java"), expected);
+    }
+
+    @Test
+    public void testVariableDeclarationUsageDistanceTryBlock() throws Exception {
+        final String[] expected = {
+            "16:9: " + getCheckMessage(MSG_KEY_EXT, "a", 4, 3),
+            "28:9: " + getCheckMessage(MSG_KEY_EXT, "a", 4, 3),
+            "40:9: " + getCheckMessage(MSG_KEY_EXT, "a", 4, 3),
+            "76:9: " + getCheckMessage(MSG_KEY_EXT, "a", 4, 3),
+            "88:9: " + getCheckMessage(MSG_KEY_EXT, "a", 4, 3),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputVariableDeclarationUsageDistanceTryBlock.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceDefault.java
@@ -976,7 +976,7 @@ class New6 {
     }
 
     void tryWithoutFinally() {
-        int a = 1;
+        int a = 1; // violation 'Distance .* is 4.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceScopes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceScopes.java
@@ -976,7 +976,7 @@ class New4 {
     }
 
     void tryWithoutFinally() {
-        int a = 1;
+        int a = 1; // violation 'Distance between .* declaration and its first usage is 4.'
         System.lineSeparator();
         System.lineSeparator();
         System.lineSeparator();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceTryBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceTryBlock.java
@@ -1,0 +1,108 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = (default)3
+ignoreVariablePattern = (default)
+validateBetweenScopes = (default)false
+ignoreFinal = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+public class InputVariableDeclarationUsageDistanceTryBlock {
+
+    void tryWithUsageInTryBody() {
+        int a = 1; // violation 'Distance .* is 4.'
+        System.lineSeparator();
+        System.lineSeparator();
+        System.lineSeparator();
+        try {
+            System.out.println(a);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    void tryWithUsageInCatch() {
+        int a = 1; // violation 'Distance .* is 4.'
+        System.lineSeparator();
+        System.lineSeparator();
+        System.lineSeparator();
+        try {
+            System.lineSeparator();
+        } catch (Exception e) {
+            System.out.println(a);
+        }
+    }
+
+    void tryWithUsageInFinally() {
+        int a = 1; // violation 'Distance .* is 4.'
+        System.lineSeparator();
+        System.lineSeparator();
+        System.lineSeparator();
+        try {
+            System.lineSeparator();
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            System.out.println(a);
+        }
+    }
+
+    // no violation - distance is within allowed limit
+    void tryWithinAllowedDistance() {
+        int a = 1;
+        System.lineSeparator();
+        System.lineSeparator();
+        try {
+            System.out.println(a);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    // no violation - usage immediately in try
+    void tryImmediateUsage() {
+        int a = 1;
+        try {
+            System.out.println(a);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    void tryWithoutFinally() {
+        int a = 1; // violation 'Distance .* is 4.'
+        System.lineSeparator();
+        System.lineSeparator();
+        System.lineSeparator();
+        try {
+            a = 2;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    void tryFinallyWithoutCatch() {
+        int a = 1; // violation 'Distance .* is 4.'
+        System.lineSeparator();
+        System.lineSeparator();
+        System.lineSeparator();
+        try {
+            a = 2;
+        } finally {
+            System.lineSeparator();
+        }
+    }
+
+    void synchronizedBlock() {
+        int a = 1;
+        System.lineSeparator();
+        System.lineSeparator();
+        System.lineSeparator();
+        synchronized (this) {
+            System.out.println(a);
+        }
+    }
+}


### PR DESCRIPTION
Issue #19608:
### Summary
- Add `LITERAL_TRY` to explicit switch cases in `getDistToVariableUsageInChildNode()` to prevent distance reset to 0
- Add dedicated test input `InputVariableDeclarationUsageDistanceTryBlock.java` with try-body, catch, finally, try-without-catch, and edge case scenarios
- Update existing test expectations for newly detected true positives

### Root Cause
In `getDistToVariableUsageInChildNode()`, `LITERAL_FOR`, `LITERAL_WHILE`, `LITERAL_DO`, and `LITERAL_IF` were handled explicitly, returning `currentDistToVarUsage + 1`. `LITERAL_TRY` was not listed and fell into the `default` branch. Since `LITERAL_TRY` has `SLIST` as a direct child, `findFirstToken(TokenTypes.SLIST)` returned non-null, causing `yield 0`, resetting the accumulated distance entirely. 