### PR TITLE
Issue #16979: suppress pitest mutation for SarifLogger.generateRules

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -865,6 +865,7 @@ multiplevariabledeclarations
 Multiset
 multithreading
 mutableexception
+mutationtest
 MVC
 mvn
 mvnrepository

--- a/config/pitest-suppressions/pitest-common-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-suppressions.xml
@@ -1,3 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>SarifLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.SarifLogger</mutatedClass>
+    <mutatedMethod>generateRules</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::size</description>
+    <lineContent>final List&lt;String&gt; result = new ArrayList&lt;&gt;(ruleMetadata.size());</lineContent>
+  </mutation>
 </suppressedMutations>


### PR DESCRIPTION
Part of #16979
     
->suppresses the pitest mutation in SarifLogger.generateRules
->introduced by pre-sizing the ArrayList with ruleMetadata.size().