### PR TITLE
Issue #14084: Remove CF prefer.map.and.orelse  suppression in NoWhitespaceAfterCheck

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -7129,17 +7129,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java</fileName>
-    <specifier>prefer.map.and.orelse</specifier>
-    <message>It is better style to use map and orElse.</message>
-    <lineContent>else if (objectArrayType.isPresent()) {</lineContent>
-    <details>
-      Consider changing to:
-      typeLastNode.map(java.util.Optional::orElseThrow).orElse(parent.getFirstChild())
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
     <lineContent>return result;</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -358,17 +358,14 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
         final DetailAST parent = ast.getParent();
         final boolean isPrecededByTypeArgs =
                 parent.findFirstToken(TokenTypes.TYPE_ARGUMENTS) != null;
-        final Optional<DetailAST> objectArrayType = Optional.ofNullable(getIdentLastToken(ast));
 
         if (isPrecededByTypeArgs) {
             typeLastNode = parent.findFirstToken(TokenTypes.TYPE_ARGUMENTS)
                     .findFirstToken(TokenTypes.GENERIC_END);
         }
-        else if (objectArrayType.isPresent()) {
-            typeLastNode = objectArrayType.orElseThrow();
-        }
         else {
-            typeLastNode = parent.getFirstChild();
+            final Optional<DetailAST> objectArrayType = Optional.ofNullable(getIdentLastToken(ast));
+            typeLastNode = objectArrayType.orElseGet(parent::getFirstChild);
         }
 
         return typeLastNode;


### PR DESCRIPTION
Issue : #14084 

 Refactor Optional handling in NoWhitespaceAfterCheck.getTypeLastNode to eliminate the `isPresent()+orElseThrow` pattern and use` Optional.orElseGet` for lazy fallback.
- Remove the corresponding `prefer.map.and.orelse` suppression entry from checker-nullness-optional-interning-suppressions.xml.


Why: this resolves the checker warning without readability loss, and keeps SpotBugs happy by avoiding eager Optional fallback computation.

just to not lose track of this 2  #19584 and  #19578 are both ready for review they both treat Checker Nullness entries as well and  i refactored them using `Optional` and exception free logic 