### PR TITLE
Issue #11163: Trim OuterTypeNumber input files to enforce file size

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -287,10 +287,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]sizes[\\/]filelength[\\/]InputFileLength4\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]sizes[\\/]outertypenumber[\\/]InputOuterTypeNumberSimple1\.java"/>
-  <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]sizes[\\/]outertypenumber[\\/]InputOuterTypeNumberSimple\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]regexp[\\/]regexpsinglelinejava[\\/]InputRegexpSinglelineJavaSemantic7\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]regexp[\\/]regexpsinglelinejava[\\/]InputRegexpSinglelineJavaSemantic\.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberSimple.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberSimple.java
@@ -6,214 +6,46 @@ max = (default)1
 */
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber; // violation
-import java.io.*;
+                                                 // 'Outer type number is 3 (max allowed is 1).'
+
 /**
- * Contains simple mistakes:
- * - Long lines
- * - Tabs
- * - Format of variables and parameters
- * - Order of modifiers
- * @author Oliver Burn
+ * Test input with 3 outer types to trigger OuterTypeNumber violation.
  **/
 final class InputOuterTypeNumberSimple
 {
-    // Long line ----------------------------------------------------------------
-    // Contains a tab ->        <-
-    // Contains trailing whitespace ->
-
-    // Name format tests
-    //
-    /** Invalid format **/
-    public static final int badConstant = 2;
     /** Valid format **/
     public static final int MAX_ROWS = 2;
 
-    /** Invalid format **/
-    private static int badStatic = 2;
-    /** Valid format **/
-    private static int sNumCreated = 0;
-
-    /** Invalid format **/
-    private int badMember = 2;
     /** Valid format **/
     private int mNumCreated1 = 0;
-    /** Valid format **/
-    protected int mNumCreated2 = 0;
 
-    /** commas are wrong **/
-    private int[] mInts = new int[] {1,2, 3,
-                                     4};
-
-    //
-    // Accessor tests
-    //
-    /** should be private **/
-    public static int sTest1;
-    /** should be private **/
-    protected static int sTest3;
-    /** should be private **/
-    static int sTest2;
-
-    /** should be private **/
-    int mTest1;
-    /** should be private **/
-    public int mTest2;
-
-    //
-    // Parameter name format tests
-    //
-
-    /**
-     * @return hack
-     * @param badFormat1 bad format
-     * @param badFormat2 bad format
-     * @param badFormat3 bad format
-     * @throws java.lang.Exception abc
-     **/
-    int test1(int badFormat1,int badFormat2,
-              final int badFormat3)
-        throws java.lang.Exception
-    {
-        return 0;
-    }
-
-    /** method that is 20 lines long **/
-    private void longMethod()
-    {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-    }
-
-    /** constructor that is 10 lines long **/
+    /** constructor **/
     private InputOuterTypeNumberSimple()
     {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
+        // content
     }
 
-    /** test local variables */
-    private void localVariables()
+    /** method **/
+    private void method()
     {
-        // normal decl
-        int abc = 0;
-        int ABC = 0;
-
-        // final decls
-        final int cde = 0;
-        final int CDE = 0;
-
-        // decl in for loop init statement
-        for (int k = 0; k < 1; k++)
-        {
-            String innerBlockVariable = "";
-        }
-        for (int I = 0; I < 1; I++)
-        {
-            String InnerBlockVariable = "";
-        }
-    }
-
-    /** test method pattern */
-    void ALL_UPPERCASE_METHOD()
-    {
-    }
-
-    /** test illegal constant **/
-    private static final int BAD__NAME = 3;
-
-    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
-    // long line that has a tab ->        <- and would be OK if tab counted as 1 char
-    // tabs that count as one char because of their position ->        <-   ->        <-, OK
-
-    /** some lines to test the violation column after tabs */
-    void errorColumnAfterTabs()
-    {
-        // with tab-width 8 all statements below start at the same column,
-        // with different combinations of ' ' and '\t' before the statement
-                int tab0 =1;
-                int tab1 =1;
-                 int tab2 =1;
-                int tab3 =1;
-                    int tab4 =1;
-                  int tab5 =1;
-    }
-
-    // MEMME:
-    /* MEMME: a
-     * MEMME:
-     * OOOO
-     */
-    /* NOTHING */
-    /* YES */ /* MEMME: x */ /* YES!! */
-
-    /** test long comments **/
-    void veryLong()
-    {
-        /*
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          enough talk */
-    }
-
-    /**
-     * @see to lazy to document all args. Testing excessive # args
-     **/
-    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
-                    int aArg6, int aArg7, int aArg8, int aArg9)
-    {
+        int variable = 0;
     }
 }
 
-/** Test class for variable naming in for each clause. */
+/** Second outer type. */
 class InputOuterTypeNumberSimple2
 {
     /** Some more Javadoc. */
     public void doSomething()
     {
-        //"O" should be named "o"
-        for (Object O : new java.util.ArrayList())
+        for (Object obj : new java.util.ArrayList())
         {
-
+            // empty
         }
     }
 }
 
-/** Test enum for member naming check */
+/** Third outer type (enum). */
 enum MyEnum1
 {
     /** ABC constant */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberSimple1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberSimple1.java
@@ -8,212 +8,43 @@ max = 30
 package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber;
 
 /**
- * Contains simple mistakes:
- * - Long lines
- * - Tabs
- * - Format of variables and parameters
- * - Order of modifiers
- * @author Oliver Burn
+ * Test input with 3 outer types, max set to 30 so no violation expected.
  **/
 final class InputOuterTypeNumberSimple1
 {
-    // Long line ----------------------------------------------------------------
-    // Contains a tab ->        <-
-    // Contains trailing whitespace ->
-
-    // Name format tests
-    //
-    /** Invalid format **/
-    public static final int badConstant = 2;
     /** Valid format **/
     public static final int MAX_ROWS = 2;
 
-    /** Invalid format **/
-    private static int badStatic = 2;
-    /** Valid format **/
-    private static int sNumCreated = 0;
-
-    /** Invalid format **/
-    private int badMember = 2;
     /** Valid format **/
     private int mNumCreated1 = 0;
-    /** Valid format **/
-    protected int mNumCreated2 = 0;
 
-    /** commas are wrong **/
-    private int[] mInts = new int[] {1,2, 3,
-                                     4};
-
-    //
-    // Accessor tests
-    //
-    /** should be private **/
-    public static int sTest1;
-    /** should be private **/
-    protected static int sTest3;
-    /** should be private **/
-    static int sTest2;
-
-    /** should be private **/
-    int mTest1;
-    /** should be private **/
-    public int mTest2;
-
-    //
-    // Parameter name format tests
-    //
-
-    /**
-     * @return hack
-     * @param badFormat1 bad format
-     * @param badFormat2 bad format
-     * @param badFormat3 bad format
-     * @throws Exception abc
-     **/
-    int test1(int badFormat1,int badFormat2,
-              final int badFormat3)
-        throws Exception
-    {
-        return 0;
-    }
-
-    /** method that is 20 lines long **/
-    private void longMethod()
-    {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-    }
-
-    /** constructor that is 10 lines long **/
+    /** constructor **/
     private InputOuterTypeNumberSimple1()
     {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
+        // content
     }
 
-    /** test local variables */
-    private void localVariables()
+    /** method **/
+    private void method()
     {
-        // normal decl
-        int abc = 0;
-        int ABC = 0;
-
-        // final decls
-        final int cde = 0;
-        final int CDE = 0;
-
-        // decl in for loop init statement
-        for (int k = 0; k < 1; k++)
-        {
-            String innerBlockVariable = "";
-        }
-        for (int I = 0; I < 1; I++)
-        {
-            String InnerBlockVariable = "";
-        }
-    }
-
-    /** test method pattern */
-    void ALL_UPPERCASE_METHOD()
-    {
-    }
-
-    /** test illegal constant **/
-    private static final int BAD__NAME = 3;
-
-    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
-    // long line that has a tab ->        <- and would be OK if tab counted as 1 char
-    // tabs that count as one char because of their position ->        <-   ->        <-, OK
-
-    /** some lines to test the violation column after tabs */
-    void errorColumnAfterTabs()
-    {
-        // with tab-width 8 all statements below start at the same column,
-        // with different combinations of ' ' and '\t' before the statement
-                int tab0 =1;
-                int tab1 =1;
-                 int tab2 =1;
-                int tab3 =1;
-                    int tab4 =1;
-                  int tab5 =1;
-    }
-
-    // MEMME:
-    /* MEMME: a
-     * MEMME:
-     * OOOO
-     */
-    /* NOTHING */
-    /* YES */ /* MEMME: x */ /* YES!! */
-
-    /** test long comments **/
-    void veryLong()
-    {
-        /*
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          enough talk */
-    }
-
-    /**
-     * @see to lazy to document all args. Testing excessive # args
-     **/
-    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
-                    int aArg6, int aArg7, int aArg8, int aArg9)
-    {
+        int variable = 0;
     }
 }
 
-/** Test class for variable naming in for each clause. */
+/** Second outer type. */
 class InputOuterTypeNumberSimple3
 {
     /** Some more Javadoc. */
     public void doSomething()
     {
-        //"O" should be named "o"
-        for (Object O : new java.util.ArrayList())
+        for (Object obj : new java.util.ArrayList())
         {
-
+            // empty
         }
     }
 }
 
-/** Test enum for member naming check */
+/** Third outer type (enum). */
 enum MyEnum2
 {
     /** ABC constant */


### PR DESCRIPTION
Issue #11163

removing irrelevant filler content while keeping all 3 outer types per file (required for OuterTypeNumber violation testing).

Removed 2 FileLength suppressions from checkstyle-resources-suppressions.xml.

