### PR TITLE
 Issue #14084: Remove Checker Framework unnecessary.equals suppression in SiteUtil

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -8792,13 +8792,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java</fileName>
-    <specifier>unnecessary.equals</specifier>
-    <message>use of .equals can be safely replaced by ==/!=</message>
-    <lineContent>while (!Object.class.equals(currentClass)) {</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/ViolationMessagesMacro.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference clss.getPackage()</message>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SiteUtil.java
@@ -1213,7 +1213,7 @@ public final class SiteUtil {
         Field result = null;
         Class<?> currentClass = fieldClass;
 
-        while (!Object.class.equals(currentClass)) {
+        while (currentClass != Object.class) {
             try {
                 result = currentClass.getDeclaredField(propertyName);
                 result.trySetAccessible();


### PR DESCRIPTION
Issue: #14084

- Replace class identity check in `SiteUtil.getField` from` Object.class.equals(currentClass)` to `currentClass != Object.class`.
- Remove the corresponding `checker-nullness-optional-interning` suppression entry .

