### PR TITLE
Issue #19622: Added checks for OpenJDK Style §3.2 - Package declaration

### DIFF
--- a/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule32packagedeclaration/PackageDeclarationTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule32packagedeclaration/PackageDeclarationTest.java
@@ -1,0 +1,48 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapter3formatting.rule32packagedeclaration;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class PackageDeclarationTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapter3formatting/rule32packagedeclaration";
+    }
+
+    @Test
+    public void testPackageDeclaration() throws Exception {
+        verifyWithWholeConfig(getPath("InputPackageDeclaration.java"));
+    }
+
+    @Test
+    public void testPackageDeclarationWrapAfterDot() throws Exception {
+        verifyWithWholeConfig(getPath("InputPackageDeclarationWrapAfterDot.java"));
+    }
+
+    @Test
+    public void testPackageDeclarationWrapAfterPackage() throws Exception {
+        verifyWithWholeConfig(getPath("InputPackageDeclarationWrapAfterPackage.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule32packagedeclaration/InputPackageDeclaration.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule32packagedeclaration/InputPackageDeclaration.java
@@ -1,0 +1,9 @@
+package com.openjdk.checkstyle.test
+        .chapter3formatting.rule32packagedeclaration;
+// violation 2 lines above 'package statement should not be line-wrapped.'
+
+/**
+ * Test input for the package declaration rule.
+ */
+public final class InputPackageDeclaration {
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule32packagedeclaration/InputPackageDeclarationWrapAfterDot.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule32packagedeclaration/InputPackageDeclarationWrapAfterDot.java
@@ -1,0 +1,9 @@
+package com.openjdk.checkstyle.test.
+        chapter3formatting.rule32packagedeclaration;
+// violation 2 lines above 'package statement should not be line-wrapped.'
+
+/**
+ * Test input for the package declaration rule with line-wrap after dot.
+ */
+public final class InputPackageDeclarationWrapAfterDot {
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule32packagedeclaration/InputPackageDeclarationWrapAfterPackage.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule32packagedeclaration/InputPackageDeclarationWrapAfterPackage.java
@@ -1,0 +1,9 @@
+package
+        com.openjdk.checkstyle.test.chapter3formatting.rule32packagedeclaration;
+// violation 2 lines above 'package statement should not be line-wrapped.'
+
+/**
+ * Test input for the package declaration rule with line-wrap after package.
+ */
+public final class InputPackageDeclarationWrapAfterPackage {
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -67,6 +67,9 @@
 
     <!-- §3.12: Expression lambda body length check based on OpenJDK style guide -->
     <module name="LambdaBodyLength"/>
+    <module name="NoLineWrap">
+      <property name="tokens" value="PACKAGE_DEF"/>
+    </module>
 
     <module name="UpperEll"/>
     <module name="HexLiteralCase"/>

--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml
@@ -191,6 +191,10 @@ class // violation 'should not be line-wrapped'
             Google Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
@@ -102,6 +102,10 @@
             Google Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -237,8 +237,20 @@
                     3.2 Package declaration
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/whitespace/nolinewrap.html#NoLineWrap">
+                    NoLineWrap</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule32packagedeclaration">
+                    samples
+                  </a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
Issue #19622 

Adds OpenJDK Style §3.2 package-declaration coverage to Checkstyle. The OpenJDK config now enforces NoLineWrap for `PACKAGE_DEF`, the OpenJDK coverage page marks the subsection as covered, and a new integration test verifies that a wrapped package declaration is reported.