### PR TITLE
Issue #19619: Added checks for OpenJDK Style §3.7 - Indentation

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -154,6 +154,8 @@
   <suppress checks="FileTabCharacter"
     files="[\\/]InputCheckerTabCharacter\.txt"/>
   <suppress checks="FileTabCharacter"
+    files=".*[\\/]src[\\/]it[\\/]resources[\\/]com[\\/]openjdk[\\/]checkstyle[\\/]test[\\/]chapter3formatting[\\/]rule37indentation[\\/]InputFileTabCharacterInvalid\.java"/>
+  <suppress checks="FileTabCharacter"
     files="src[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]indentation[\\/]indentation[\\/]Input.*\.java"/>
   <suppress checks="FileTabCharacter"
     files="src[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]filters[\\/]suppresswithplaintextcommentfilter[\\/]Input.*"/>

--- a/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/IndentationTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/IndentationTest.java
@@ -1,0 +1,83 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapter3formatting.rule37indentation;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class IndentationTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapter3formatting/rule37indentation";
+    }
+
+    @Test
+    public void testIndentationValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputIndentationValid.java"));
+    }
+
+    @Test
+    public void testIndentationInvalid() throws Exception {
+        verifyWithWholeConfig(getPath("InputIndentationInvalid.java"));
+    }
+
+    @Test
+    public void testFileTabCharacterValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputFileTabCharacterValid.java"));
+    }
+
+    @Test
+    public void testFileTabCharacterInvalid() throws Exception {
+        verifyWithWholeConfig(getPath("InputFileTabCharacterInvalid.java"));
+    }
+
+    @Test
+    public void testThrowsIndentValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputThrowsIndentValid.java"));
+    }
+
+    @Test
+    public void testThrowsIndentInvalid() throws Exception {
+        verifyWithWholeConfig(getPath("InputThrowsIndentInvalid.java"));
+    }
+
+    @Test
+    public void testLineWrappingIndentationValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputLineWrappingIndentationValid.java"));
+    }
+
+    @Test
+    public void testLineWrappingIndentationInvalid() throws Exception {
+        verifyWithWholeConfig(getPath("InputLineWrappingIndentationInvalid.java"));
+    }
+
+    @Test
+    public void testArrayInitIndentValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputArrayInitIndentValid.java"));
+    }
+
+    @Test
+    public void testArrayInitIndentInvalid() throws Exception {
+        verifyWithWholeConfig(getPath("InputArrayInitIndentInvalid.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputArrayInitIndentInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputArrayInitIndentInvalid.java
@@ -1,0 +1,9 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule37indentation;
+
+public class InputArrayInitIndentInvalid {
+
+    int[] values = {
+    1, 2, 3
+    // violation above '.* incorrect indentation level 4, expected .* 8, 12.'
+    };
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputArrayInitIndentValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputArrayInitIndentValid.java
@@ -1,0 +1,8 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule37indentation;
+
+public class InputArrayInitIndentValid {
+
+    int[] values = {
+        1, 2, 3
+    };
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputFileTabCharacterInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputFileTabCharacterInvalid.java
@@ -1,0 +1,13 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule37indentation;
+
+/** Invalid tab-indented examples for OpenJDK style section 3.7. */
+public class InputFileTabCharacterInvalid {
+
+    //	has tab indentation
+    // violation above 'Line contains a tab character.'
+    private int value;
+
+    private void method() {
+        value++;
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputFileTabCharacterValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputFileTabCharacterValid.java
@@ -1,0 +1,11 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule37indentation;
+
+/** Valid spaces-only indentation examples for OpenJDK style section 3.7. */
+public class InputFileTabCharacterValid {
+
+    private int value;
+
+    private void method() {
+        value++;
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputIndentationInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputIndentationInvalid.java
@@ -1,0 +1,18 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule37indentation;
+
+/** Invalid indentation examples for OpenJDK style section 3.7. */
+public class InputIndentationInvalid {
+
+    private void method(int value) {
+        switch (value) {
+          case 1:
+          // violation above '.* incorrect indentation level 10, expected .* 12.'
+              value++;
+              // violation above '.* incorrect indentation level 14, expected .* 16.'
+                break;
+            default:
+                value--;
+                break;
+        }
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputIndentationValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputIndentationValid.java
@@ -1,0 +1,16 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule37indentation;
+
+/** Valid indentation examples for OpenJDK style section 3.7. */
+public class InputIndentationValid {
+
+    private void method(int value) {
+        switch (value) {
+            case 1:
+                value++;
+                break;
+            default:
+                value--;
+                break;
+        }
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputLineWrappingIndentationInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputLineWrappingIndentationInvalid.java
@@ -1,0 +1,10 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule37indentation;
+
+public class InputLineWrappingIndentationInvalid {
+
+    void method(int a,
+        int b) {
+    // violation above '.* incorrect indentation level 8, expected .* 12.'
+        int sum = a + b;
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputLineWrappingIndentationValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputLineWrappingIndentationValid.java
@@ -1,0 +1,9 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule37indentation;
+
+public class InputLineWrappingIndentationValid {
+
+    void method(int a,
+            int b) {
+        int sum = a + b;
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputThrowsIndentInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputThrowsIndentInvalid.java
@@ -1,0 +1,9 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule37indentation;
+
+public class InputThrowsIndentInvalid {
+
+    void method()
+        throws Exception {
+    // violation above '.* incorrect indentation level 8, expected .* 12.'
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputThrowsIndentValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation/InputThrowsIndentValid.java
@@ -1,0 +1,8 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule37indentation;
+
+public class InputThrowsIndentValid {
+
+    void method()
+            throws Exception {
+    }
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -35,8 +35,20 @@
 
   <!-- Add OpenJDK-specific checks here based on the style guide -->
 
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+
   <module name="TreeWalker">
     <!-- Add TreeWalker checks based on OpenJDK style guide -->
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+      <property name="caseIndent" value="4"/>
+      <property name="throwsIndent" value="8"/>
+      <property name="lineWrappingIndentation" value="8"/>
+      <property name="arrayInitIndent" value="4"/>
+    </module>
+
     <module name="OneStatementPerLine"/>
 
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->

--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -415,6 +415,10 @@ class Example9 {
       <subsection name="Example of Usage" id="Indentation_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
             Google Style</a>
           </li>

--- a/src/site/xdoc/checks/misc/indentation.xml.template
+++ b/src/site/xdoc/checks/misc/indentation.xml.template
@@ -178,6 +178,10 @@
       <subsection name="Example of Usage" id="Indentation_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
             Google Style</a>
           </li>

--- a/src/site/xdoc/checks/whitespace/filetabcharacter.xml
+++ b/src/site/xdoc/checks/whitespace/filetabcharacter.xml
@@ -143,6 +143,10 @@ class Example3 {
       <subsection name="Example of Usage" id="FileTabCharacter_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FileTabCharacter">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FileTabCharacter">
             Google Style</a>
           </li>

--- a/src/site/xdoc/checks/whitespace/filetabcharacter.xml.template
+++ b/src/site/xdoc/checks/whitespace/filetabcharacter.xml.template
@@ -92,6 +92,10 @@
       <subsection name="Example of Usage" id="FileTabCharacter_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FileTabCharacter">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FileTabCharacter">
             Google Style</a>
           </li>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -339,8 +339,28 @@
                     3.7 Indentation
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/whitespace/filetabcharacter.html#FileTabCharacter">
+                    FileTabCharacter</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FileTabCharacter">
+                  config</a>)
+                  <br/>
+                  <br/>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/misc/indentation.html#Indentation">Indentation</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule37indentation">
+                    samples
+                  </a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
Issue #19619 

- Added new checks to OpenJDK config: FileTabCharacter with eachLine=true
Indentation with: basicOffset=4, caseIndent=4, throwsIndent=8, lineWrappingIndentation=8, arrayInitIndent=4

- Updated OpenJDK coverage page: Marked 3.7 Indentation as covered, Added links for config and tests for FileTabCharacter and Indentation

- Added OpenJDK integration tests for rule 3.7: FileTabCharacter test class and inputs, Indentation test class and inputs

- Updated check documentation “Example of Usage” sections to include OpenJDK Style links: FileTabCharacter docs (.xml and .template), Indentation docs (.xml and .template)
