### PR TITLE
Issue #11163: Trim JavaNCSS input files to enforce file size

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -235,8 +235,6 @@
 
   <!-- intentional problem for testing -->
   <suppress checks="FileLength"
-    files="[\\/]InputJavaNCSSRecordsMax\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/].*[\\/].*[\\/].*\.java"/>
   <suppress checks="FileLength"
     files="[\\/]it[\\/]resources-noncompilable[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/].*[\\/].*[\\/].*\.java"/>
@@ -501,8 +499,7 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]xpath[\\/]xpathmapper[\\/]InputXpathMapperStringConcat\.java"/>
   <suppress checks="FileLength"
-
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]metrics[\\/]javancss[\\/]InputJavaNCSSRecordsAndCompactCtors\.java"/>
+    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]main[\\/]InputMainComplexityOverflow\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]grammar[\\/]java14[\\/]InputJava14TextBlocks\.java"/>
   <suppress checks="FileLength"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckTest.java
@@ -86,19 +86,15 @@ public class JavaNCSSCheckTest extends AbstractModuleTestSupport {
     public void testRecordsAndCompactCtors() throws Exception {
 
         final String[] expected = {
-            "12:1: " + getCheckMessage(MSG_FILE, 89, 2),
-            "16:1: " + getCheckMessage(MSG_CLASS, 87, 3),
-            "18:3: " + getCheckMessage(MSG_CLASS, 7, 3),
-            "36:3: " + getCheckMessage(MSG_RECORD, 6, 4),
-            "45:3: " + getCheckMessage(MSG_RECORD, 15, 4),
-            "56:5: " + getCheckMessage(MSG_METHOD, 8, 7),
-            "75:3: " + getCheckMessage(MSG_RECORD, 6, 4),
-            "109:3: " + getCheckMessage(MSG_RECORD, 8, 4),
-            "130:3: " + getCheckMessage(MSG_CLASS, 11, 3),
-            "151:3: " + getCheckMessage(MSG_RECORD, 12, 4),
-            "152:5: " + getCheckMessage(MSG_METHOD, 11, 7),
-            "166:3: " + getCheckMessage(MSG_CLASS, 12, 3),
-            "167:5: " + getCheckMessage(MSG_METHOD, 11, 7),
+            "12:1: " + getCheckMessage(MSG_FILE, 55, 2),
+            "14:1: " + getCheckMessage(MSG_CLASS, 54, 3),
+            "16:3: " + getCheckMessage(MSG_CLASS, 7, 3),
+            "34:3: " + getCheckMessage(MSG_RECORD, 6, 4),
+            "43:3: " + getCheckMessage(MSG_RECORD, 15, 4),
+            "54:5: " + getCheckMessage(MSG_METHOD, 8, 7),
+            "73:3: " + getCheckMessage(MSG_RECORD, 6, 4),
+            "106:3: " + getCheckMessage(MSG_RECORD, 10, 4),
+            "107:5: " + getCheckMessage(MSG_METHOD, 9, 7),
         };
 
         verifyWithInlineConfigParser(
@@ -120,8 +116,8 @@ public class JavaNCSSCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testRecordMax() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_CLASS, 152, 80),
-            "15:5: " + getCheckMessage(MSG_RECORD, 151, 150),
+            "14:1: " + getCheckMessage(MSG_CLASS, 105, 80),
+            "15:5: " + getCheckMessage(MSG_RECORD, 104, 100),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSRecordsAndCompactCtors.java
@@ -9,11 +9,9 @@ recordMaximum = 4
 */
 
 // Java17
-package com.puppycrawl.tools.checkstyle.checks.metrics.javancss;  // violation 'NCSS for this file is 89 (max allowed is 2).'
+package com.puppycrawl.tools.checkstyle.checks.metrics.javancss;  // violation 'NCSS for this file is 55 (max allowed is 2).'
 
-import java.time.LocalDateTime;
-
-public class InputJavaNCSSRecordsAndCompactCtors {  // violation '.* is 87 (max allowed is 3).'
+public class InputJavaNCSSRecordsAndCompactCtors {  // violation '.* is 54 (max allowed is 3).'
 
   class TestClass {  // violation 'NCSS for this class is 7 (max allowed is 3).'
     //should count as 2
@@ -101,72 +99,12 @@ public class InputJavaNCSSRecordsAndCompactCtors {  // violation '.* is 87 (max 
   }
 
   record MyRecord6(int x, int y) {
-    //should give an ncss of 2
     public MyRecord6{
     }
   }
 
-  public record FXOrder(int units,  // violation 'NCSS for this record is 8 (max allowed is 4).'
-                        String side,
-                        double price,
-                        LocalDateTime sentAt,
-                        int ttl) {
-    public FXOrder {
-      if (units < 1) {
-        throw new IllegalArgumentException(
-                "FXOrder units must be positive");
-      }
-      if (ttl < 0) {
-        throw new IllegalArgumentException(
-                "FXOrder TTL must be positive, or 0 for market orders");
-      }
-      if (price <= 0.0) {
-        throw new IllegalArgumentException(
-                "FXOrder price must be positive");
-      }
-    } // 8
-  }
-
-  public class FXOrderClass {  // violation 'NCSS for this class is 11 (max allowed is 3).'
-    private int units;
-    private int ttl;
-    private double price; // 3
-
-    public FXOrderClass(int units, int ttl, double price) {
-      if (units < 1) {
-        throw new IllegalArgumentException(
-                "FXOrder units must be positive");
-      }
-      if (ttl < 0) {
-        throw new IllegalArgumentException(
-                "FXOrder TTL must be positive, or 0 for market orders");
-      }
-      if (price <= 0.0) {
-        throw new IllegalArgumentException(
-                "FXOrder price must be positive");
-      }
-    } // 8
-  }
-
-  record MyRecord7(int x, int y) {  // violation 'NCSS for this record is 12 (max allowed is 4).'
-    public MyRecord7{ // violation 'NCSS for this method is 11 (max allowed is 7).'
-      System.out.println("test");
-      System.out.println("test");
-      System.out.println("test");
-      System.out.println("test");
-      System.out.println("test");
-      System.out.println("test");
-      System.out.println("test");
-      System.out.println("test");
-      System.out.println("test");
-      System.out.println("test");
-    }
-  }
-
-  class MyClass {  // violation 'NCSS for this class is 12 (max allowed is 3).'
-    MyClass(int x) {  // violation 'NCSS for this method is 11 (max allowed is 7).'
-      System.out.println("test");
-      System.out.println("test");
+  record MyRecord7(int x, int y) {  // violation 'NCSS for this record is 10 (max allowed is 4).'
+    public MyRecord7{ // violation 'NCSS for this method is 9 (max allowed is 7).'
       System.out.println("test");
       System.out.println("test");
       System.out.println("test");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSRecordsMax.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSRecordsMax.java
@@ -3,7 +3,7 @@ JavaNCSS
 methodMaximum = (default)50
 classMaximum = 80
 fileMaximum = (default)2000
-recordMaximum = (default)150
+recordMaximum = 100
 
 
 */
@@ -11,8 +11,8 @@ recordMaximum = (default)150
 // Java17
 package com.puppycrawl.tools.checkstyle.checks.metrics.javancss;
 
-public class InputJavaNCSSRecordsMax {// violation 'NCSS for this class is 152 (max allowed is 80)'
-    record MyRecord() { // violation 'NCSS for this record is 151 (max allowed is 150)'
+public class InputJavaNCSSRecordsMax {// violation 'NCSS for this class is 105 (max allowed is 80)'
+    record MyRecord() { // violation 'NCSS for this record is 104 (max allowed is 100)'
         static int myRecordField1 = 0;
         static int myRecordField2 = 0;
         static int myRecordField3 = 0;
@@ -116,52 +116,5 @@ public class InputJavaNCSSRecordsMax {// violation 'NCSS for this class is 152 (
         static int myRecordField101 = 0;
         static int myRecordField102 = 0;
         static int myRecordField103 = 0;
-        static int myRecordField104 = 0;
-        static int myRecordField105 = 0;
-        static int myRecordField106 = 0;
-        static int myRecordField107 = 0;
-        static int myRecordField108 = 0;
-        static int myRecordField109 = 0;
-        static int myRecordField110 = 0;
-        static int myRecordField111 = 0;
-        static int myRecordField112 = 0;
-        static int myRecordField113 = 0;
-        static int myRecordField114 = 0;
-        static int myRecordField115 = 0;
-        static int myRecordField116 = 0;
-        static int myRecordField117 = 0;
-        static int myRecordField118 = 0;
-        static int myRecordField119 = 0;
-        static int myRecordField120 = 0;
-        static int myRecordField121 = 0;
-        static int myRecordField122 = 0;
-        static int myRecordField123 = 0;
-        static int myRecordField124 = 0;
-        static int myRecordField125 = 0;
-        static int myRecordField126 = 0;
-        static int myRecordField127 = 0;
-        static int myRecordField128 = 0;
-        static int myRecordField129 = 0;
-        static int myRecordField130 = 0;
-        static int myRecordField131 = 0;
-        static int myRecordField132 = 0;
-        static int myRecordField133 = 0;
-        static int myRecordField134 = 0;
-        static int myRecordField135 = 0;
-        static int myRecordField136 = 0;
-        static int myRecordField137 = 0;
-        static int myRecordField138 = 0;
-        static int myRecordField139 = 0;
-        static int myRecordField140 = 0;
-        static int myRecordField141 = 0;
-        static int myRecordField142 = 0;
-        static int myRecordField143 = 0;
-        static int myRecordField144 = 0;
-        static int myRecordField145 = 0;
-        static int myRecordField146 = 0;
-        static int myRecordField147 = 0;
-        static int myRecordField148 = 0;
-        static int myRecordField149 = 0;
-        static int myRecordField150 = 0;
     }
 }


### PR DESCRIPTION
Issue #11163: 

Trimmed 2 JavaNCSS test input files to meet the 120-line limit and removed their FileLength suppressions.

* Reduced size of both files by removing extra records and unused code
* Updated `JavaNCSSCheckTest.java` with correct violation lines and counts
* Removed 2 suppression entries from `checkstyle-resources-suppressions.xml`
