### PR TITLE
Issue #14084: Remove lock-tainting suppressions for enum toString methods

### DIFF
--- a/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
@@ -314,13 +314,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/api/Scope.java</fileName>
-    <specifier>method.guarantee.violated</specifier>
-    <message>method toString is @SideEffectFree but calls getName which is @ReleasesNoLocks (weaker side effect guarantee)</message>
-    <lineContent>return getName();</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/api/Scope.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
     <lineContent>public String toString() {</lineContent>
@@ -332,13 +325,6 @@
       cannot override method in @GuardedBy Object
       @GuardedBy String toString(@GuardSatisfied Object this)
     </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevel.java</fileName>
-    <specifier>method.guarantee.violated</specifier>
-    <message>method toString is @SideEffectFree but calls getName which is @ReleasesNoLocks (weaker side effect guarantee)</message>
-    <lineContent>return getName();</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
@@ -708,13 +694,6 @@
       cannot override method in @GuardedBy Object
       @GuardedBy String toString(@GuardSatisfied Object this)
     </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AccessModifierOption.java</fileName>
-    <specifier>method.guarantee.violated</specifier>
-    <message>method toString is @SideEffectFree but calls getName which is @ReleasesNoLocks (weaker side effect guarantee)</message>
-    <lineContent>return getName();</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Scope.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Scope.java
@@ -42,7 +42,7 @@ public enum Scope {
 
     @Override
     public String toString() {
-        return getName();
+        return name().toLowerCase(Locale.ENGLISH);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevel.java
@@ -43,7 +43,7 @@ public enum SeverityLevel {
 
     @Override
     public String toString() {
-        return getName();
+        return name().toLowerCase(Locale.ENGLISH);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AccessModifierOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AccessModifierOption.java
@@ -40,15 +40,6 @@ public enum AccessModifierOption {
 
     @Override
     public String toString() {
-        return getName();
-    }
-
-    /**
-     * Returns the access modifier name.
-     *
-     * @return the access modifier name
-     */
-    private String getName() {
         return name().toLowerCase(Locale.ENGLISH);
     }
 


### PR DESCRIPTION
Issue: #14084

Refactor enum toString implementations to avoid method.guarantee.violated in checker-lock-tainting:

### changes 

Changes:
- Inline `toString` return expression to `name().toLowerCase(Locale.ENGLISH)` instead of delegating through `getName()`

is this a valid update , or  it  hurts code readbilty / cleanliness?