### PR TITLE
Issue #16807: Specify all default properties for JavadocParagraphCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -151,7 +151,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     @Test
     public void testConditionRequiredWithoutOrdinaryChecks() throws Exception {
         final String[] expected = {
-            "7:5: " + getCheckMessage(JavadocParagraphCheck.class,
+            "10:5: " + getCheckMessage(JavadocParagraphCheck.class,
                     JavadocParagraphCheck.MSG_REDUNDANT_PARAGRAPH),
         };
         final String path = getPath("InputTreeWalkerJavadoc.java");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -284,7 +284,6 @@ public final class InlineConfigParser {
      */
     private static final Set<String> SUPPRESSED_MODULES = Set.of(
             "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck",
             "com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder",
             "com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter",
             "com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
@@ -176,12 +176,12 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testJavadocParagraph() throws Exception {
         final String[] expected = {
-            "19:4: " + getCheckMessage(MSG_LINE_BEFORE),
-            "28:7: " + getCheckMessage(MSG_REDUNDANT_PARAGRAPH),
-            "31:7: " + getCheckMessage(MSG_LINE_BEFORE),
-            "50:7: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
-            "76:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "table"),
-            "87:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "pre"),
+            "22:4: " + getCheckMessage(MSG_LINE_BEFORE),
+            "31:7: " + getCheckMessage(MSG_REDUNDANT_PARAGRAPH),
+            "34:7: " + getCheckMessage(MSG_LINE_BEFORE),
+            "53:7: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "ul"),
+            "79:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "table"),
+            "90:8: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "pre"),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphBlockTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphBlockTag.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = (default)true
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphCheck1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphCheck1.java
@@ -1,5 +1,8 @@
 /*
 JavadocParagraph
+allowNewlineParagraph = (default)true
+violateExecutionOnNonTightHtml = (default)false
+
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphCorrect.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = (default)true
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = (default)true
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect2.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = false
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect3.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = false
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect4.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = (default)true
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect5.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = false
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrect6.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = (default)true
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = (default)true
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag2.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = false
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphIncorrectOpenClosedTag3.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = (default)true
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphNested.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/InputJavadocParagraphNested.java
@@ -1,7 +1,7 @@
 /*
 JavadocParagraph
-violateExecutionOnNonTightHtml = (default)false
 allowNewlineParagraph = (default)true
+violateExecutionOnNonTightHtml = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerJavadoc.java
@@ -1,5 +1,8 @@
 /*
 com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck
+allowNewlineParagraph = (default)true
+violateExecutionOnNonTightHtml = (default)false
+
 
 */
 package com.puppycrawl.tools.checkstyle.treewalker;


### PR DESCRIPTION
Issue: #16807 

Summary
---
- Add missing default properties for `javadocparagraph/InputJavadocParagraphCheck1.java` and `treewalker/InputTreeWalkerJavadoc.java`. Adjust violation line numbers in their associated tests.
- Sort properties alphabetically.
- Remove suppression from `InlineConfigParser#SUPPRESSED_MODULES`