### PR TITLE
Issue #19641: Add New OpenJDK Style 3.10 Variable Declaration Rule 1

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1432,6 +1432,7 @@ uxxxx
 validator
 VALUELONG
 vararg
+variabledeclarations
 variabledeclarationusagedistance
 Veach
 Verdana

--- a/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule310variabledeclarations/OneVariablePerDeclarationTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule310variabledeclarations/OneVariablePerDeclarationTest.java
@@ -1,0 +1,44 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapter3formatting.rule310variabledeclarations;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class OneVariablePerDeclarationTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapter3formatting/"
+            + "rule310variabledeclarations/onevariableperline";
+    }
+
+    @Test
+    public void testMultipleVariableDeclarations() throws Exception {
+        verifyWithWholeConfig(getPath("InputOneVariablePerDeclaration.java"));
+    }
+
+    @Test
+    public void testMultipleVariableDeclarationsReformatted() throws Exception {
+        verifyWithWholeConfig(getPath("InputOneVariablePerDeclarationReformatted.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule310variabledeclarations/onevariableperline/InputOneVariablePerDeclaration.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule310variabledeclarations/onevariableperline/InputOneVariablePerDeclaration.java
@@ -1,0 +1,118 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule310variabledeclarations.onevariableperline;
+
+/** Some javadoc. */
+public class InputOneVariablePerDeclaration {
+    int mnp, efg; // violation 'Each variable declaration must be in its own statement.'
+    int i1; int j1;
+    // 2 violations above:
+    //  'Only one variable definition per line allowed.'
+    //  'Only one statement per line allowed.'
+
+    void method1() {
+        String str, str1; // violation 'Each variable declaration must be in its own statement.'
+        java.lang.Object obj; Object obj1;
+        // 2 violations above:
+        //  'Only one variable definition per line allowed.'
+        //  'Only one statement per line allowed.'
+    }
+
+    // second definition is wrapped
+    // line of VARIABLE_DEF is not the same as first line of the definition
+    // violation below 'Only one variable definition per line allowed.'
+    java.lang.String string; java.lang.String[]
+            strings;
+    // both definitions are wrapped
+    // violation below 'Only one variable definition per line allowed.'
+    java.lang
+            .String string1; java.lang.String[]
+                    strings1;
+
+    void method2() {
+        for (int i = 0, j = 0; i < 10; i++, j--) { // ok, in for loop initializer
+        }
+
+        for (int i = 0; i < 4; i++) {}
+    }
+
+    class Inner {
+        int xyz, qwe; // violation 'Each variable declaration must be in its own statement.'
+        int i1; int j1;
+        // 2 violations above:
+        //  'Only one variable definition per line allowed.'
+        //  'Only one statement per line allowed.'
+
+        void method1() {
+            String str, str1;
+            // violation above 'Each variable declaration must be in its own statement.'
+            java.lang.Object obj; Object obj1;
+            // 2 violations above:
+            //  'Only one variable definition per line allowed.'
+            //  'Only one statement per line allowed.'
+        }
+
+        // second definition is wrapped
+        // line of VARIABLE_DEF is not the same as first line of the definition
+        // violation below 'Only one variable definition per line allowed.'
+        java.lang.String string; java.lang.String[]
+                strings;
+        // both definitions are wrapped
+        // violation below 'Only one variable definition per line allowed.'
+        java.lang
+                .String string1; java.lang.String[]
+                        strings1;
+
+        void method2() {
+            for (int i = 0, j = 0; i < 10; i++, j--) { // ok, in for loop initializer
+            }
+
+            for (int i = 0; i < 4; i++) {}
+        }
+
+        Inner anon =
+                new Inner() {
+                    int abc, pqr;
+                    // violation above 'Each variable declaration must be in its own statement.'
+                    int i1; int j1;
+                    // 2 violations above:
+                    //  'Only one variable definition per line allowed.'
+                    //  'Only one statement per line allowed.'
+
+                    void method1() {
+                        String str, str1;
+                        // violation above 'Each variable declaration must be in its own statement.'
+                        java.lang.Object obj; Object obj1;
+                        // 2 violations above:
+                        //  'Only one variable definition per line allowed.'
+                        //  'Only one statement per line allowed.'
+                    }
+
+                    // second definition is wrapped
+                    // line of VARIABLE_DEF is not the same as first line of the definition
+                    // violation below 'Only one variable definition per line allowed.'
+                    java.lang.String string; java.lang.String[]
+                            strings;
+                    // both definitions are wrapped
+                    // violation below 'Only one variable definition per line allowed.'
+                    java.lang
+                            .String string1; java.lang.String[]
+                                    strings1;
+
+
+                    void method2() {
+                        for (int i = 0, j = 0; i < 10; i++, j--) { // ok, in for loop initializer
+                        }
+
+                        for (int i = 0; i < 4; i++) {}
+                    }
+                };
+    }
+
+    class Suppress {
+        // violation below 'Each variable declaration must be in its own statement.'
+        @SuppressWarnings("unused")
+        long q1, q2, q3;
+
+        @SuppressWarnings("unused") long q4, q5, q6;
+        // violation above 'Each variable declaration must be in its own statement.'
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule310variabledeclarations/onevariableperline/InputOneVariablePerDeclarationReformatted.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule310variabledeclarations/onevariableperline/InputOneVariablePerDeclarationReformatted.java
@@ -1,0 +1,96 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule310variabledeclarations.onevariableperline;
+
+/** Some javadoc. */
+public class InputOneVariablePerDeclarationReformatted {
+    int mnp, efg; // violation 'Each variable declaration must be in its own statement.'
+    int i1;
+    int j1;
+
+    void method1() {
+        String str, str1; // violation 'Each variable declaration must be in its own statement.'
+        java.lang.Object obj;
+        Object obj1;
+    }
+
+    // second definition is wrapped
+    // line of VARIABLE_DEF is not the same as first line of the definition
+    java.lang.String string;
+    java.lang.String[] strings;
+    // both definitions are wrapped
+    java.lang.String string1;
+    java.lang.String[] strings1;
+
+    void method2() {
+        for (int i = 0, j = 0; i < 10; i++, j--) { // ok, in for loop initializer
+        }
+
+        for (int i = 0; i < 4; i++) {}
+    }
+
+    class Inner {
+        int xyz, qwe; // violation 'Each variable declaration must be in its own statement.'
+        int i1;
+        int j1;
+
+        void method1() {
+            String str, str1;
+            // violation above 'Each variable declaration must be in its own statement.'
+            java.lang.Object obj;
+            Object obj1;
+        }
+
+        // second definition is wrapped
+        // line of VARIABLE_DEF is not the same as first line of the definition
+        java.lang.String string;
+        java.lang.String[] strings;
+        // both definitions are wrapped
+        java.lang.String string1;
+        java.lang.String[] strings1;
+
+        void method2() {
+            for (int i = 0, j = 0; i < 10; i++, j--) { // ok, in for loop initializer
+            }
+
+            for (int i = 0; i < 4; i++) {}
+        }
+
+        Inner anon =
+                new Inner() {
+                    int abc, pqr;
+                    // violation above 'Each variable declaration must be in its own statement.'
+                    int i1;
+                    int j1;
+
+                    void method1() {
+                        String str, str1;
+                        // violation above 'Each variable declaration must be in its own statement.'
+                        java.lang.Object obj;
+                        Object obj1;
+                    }
+
+                    // second definition is wrapped
+                    // line of VARIABLE_DEF is not the same as first line of the definition
+                    java.lang.String string;
+                    java.lang.String[] strings;
+                    // both definitions are wrapped
+                    java.lang.String string1;
+                    java.lang.String[] strings1;
+
+                    void method2() {
+                        for (int i = 0, j = 0; i < 10; i++, j--) { // ok, in for loop initializer
+                        }
+
+                        for (int i = 0; i < 4; i++) {}
+                    }
+                };
+    }
+
+    class Suppress {
+        // violation below 'Each variable declaration must be in its own statement.'
+        @SuppressWarnings("unused")
+        long q1, q2, q3;
+        @SuppressWarnings("unused")
+        long q4, q5, q6;
+        // violation 2 lines above 'Each variable declaration must be in its own statement.'
+    }
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -72,6 +72,8 @@
     <module name="HexLiteralCase"/>
     <module name="NumericalPrefixesInfixesSuffixesCharacterCase"/>
 
+    <module name="MultipleVariableDeclarations"/>
+
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.openjdk.suppressionxpathfilter.config}"

--- a/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml
+++ b/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml
@@ -65,6 +65,10 @@ public class Example1 {
             Sun Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml.template
+++ b/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml.template
@@ -48,6 +48,10 @@
             Sun Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -531,8 +531,19 @@
                     3.10 Variable Declarations
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/coding/multiplevariabledeclarations.html#MultipleVariableDeclarations">
+                    MultipleVariableDeclarations</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule310variabledeclarations/onevariableperline">
+                    samples</a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
Part 1 of issue: #19641 

Summary
---
1. Add integration test for rule: one variable per declaration and one declaration per line.
2. Update `openjdk_style.xml`
3. Update config in `openjdk_checks.xml`
4. Add reference to OpenJDK example usage in `MultipleVariableDeclarations` check page.