### PR TITLE
Issue #18952: Document excluded OpenRewrite recipes (ReplaceStringBuilderWithString, CustomImportOrder)

### DIFF
--- a/config/rewrite.yml
+++ b/config/rewrite.yml
@@ -100,7 +100,7 @@ recipeList:
         - org.openrewrite.staticanalysis.OperatorWrap
         - org.openrewrite.staticanalysis.ReplaceThreadRunWithThreadStart
         - org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls
-        - org.openrewrite.staticanalysis.ReplaceStringBuilderWithString
+        # Kept excluded: to avoid conflicts with CustomImportOrderCheck
         - org.openrewrite.staticanalysis.CustomImportOrder
   - org.openrewrite.staticanalysis.CommonStaticAnalysis:
       exclude:


### PR DESCRIPTION
Issue: #18952
recipes documented

1. org.openrewrite.staticanalysis.ReplaceStringBuilderWithString
excluded because checkstyle has no matching check for this, and changing StringBuilder to string concatenation can be slower in loops.

2. org.openrewrite.staticanalysis.CustomImportOrder
excluded because checkstyle's CustomImportOrderCheck has many config options, and OpenRewrite uses a fixed order that would break projects with custom import setup.