### PR TITLE
Issue #16361: proposal to refactor testNullInfoStreamOptions and testNullErrorStreamOptions

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -255,9 +255,9 @@ davidwalsh
 DBFF
 Dcheckstyle
 dcm
-Dcpd
 Dconfig
 Dconnection
+Dcpd
 Dcyclonedx
 ddd
 DDDL
@@ -298,8 +298,8 @@ Diachenko
 diffplug
 DIFFTOOL
 dirname
-Djapicmp
 Djacoco
+Djapicmp
 Djdepend
 Dlinkcheck
 DMail

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -168,6 +168,12 @@ public class DefaultLoggerTest extends AbstractModuleTestSupport {
                 .isFalse();
     }
 
+    /**
+     * This test cannot use verifyWithInlineConfigParserAndLogger as it does not
+     * involve an input file, configuration or audit process. It only verifies that
+     * constructing a DefaultLogger with null stream options throws an
+     * IllegalArgumentException with the correct message.
+     */
     @Test
     public void testNullInfoStreamOptions() {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -181,6 +187,12 @@ public class DefaultLoggerTest extends AbstractModuleTestSupport {
                         .isEqualTo("Parameter infoStreamOptions can not be null");
     }
 
+    /**
+     * This test cannot use verifyWithInlineConfigParserAndLogger as it does not
+     * involve an input file, configuration or audit process. It only verifies that
+     * constructing a DefaultLogger with null stream options throws an
+     * IllegalArgumentException with the correct message.
+     */
     @Test
     public void testNullErrorStreamOptions() {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();


### PR DESCRIPTION
issue : #16361 

These two tests cannot use `verifyWithInlineConfigParserAndLogger` directly because they do not involve an input file, configuration or an audit process they only verify that constructing a `DefaultLogger` with null stream options throws an `IllegalArgumentException` with the correct message. 

### changes 

(since the issue description says "or similar method ")i tried  refactor `testNullInfoStreamOptions` and `testNullErrorStreamOptions` by introducing a new `verifyLoggerConstructionException` helper method in `AbstractModuleTestSupport`, this results in that the repeated boilerplatecode of calling `TestUtil.getExpectedThrowable`, capturing the exception, and asserting on its message is now in one place .


f this approach isn't accepted, the alternative would be to add comments on these two tests explaining why they cannot be refactored further.
For `testEscape`, PR #19479 was already approved but seems to have stalled , this 3 are the only ones left to fully close this issue :)