### PR TITLE
Issue #19394: Skip unnecessary plugins in no-error-pmd job

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -262,6 +262,10 @@ no-error-pmd)
                 -Dmaven.javadoc.skip=true \
                 -Dmaven.source.skip=true \
                 -Dpmd.skip=true \
+                -Dcpd.skip=true \
+                -Djapicmp.skip=true \
+                -Dcyclonedx.skip=true \
+                -Ddokka.skip=true \
                 -Dcheckstyle.skip=false \
                 -Dcheckstyle.version="${CS_POM_VERSION}"
   cd ..

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -255,10 +255,13 @@ davidwalsh
 DBFF
 Dcheckstyle
 dcm
+Dcpd
 Dconfig
 Dconnection
+Dcyclonedx
 ddd
 DDDL
+Ddokka
 Ddry
 DEADBEEF
 DECCHARS
@@ -295,6 +298,7 @@ Diachenko
 diffplug
 DIFFTOOL
 dirname
+Djapicmp
 Djacoco
 Djdepend
 Dlinkcheck


### PR DESCRIPTION
Issue #19394: Skip unnecessary plugins in no-error-pmd job

Added skip flags for plugins that consume memory but aren't needed for the no-error-pmd job:

- `-Dcpd.skip=true`
- `-Djapicmp.skip=true`
- `-Dcyclonedx.skip=true`
- `-Ddokka.skip=true`

The job only needs to compile PMD and run checkstyle on it. These plugins (japicmp, cyclonedx, dokka, cpd) are unnecessary and contribute to memory pressure causing OOM failures.