### PR TITLE
Issue #13040: convert all wget to curls

### DIFF
--- a/.ci/eclipse-compiler-javac.sh
+++ b/.ci/eclipse-compiler-javac.sh
@@ -18,13 +18,14 @@ ECJ_MAVEN_VERSION="R-4.37-202509050730"
 
 echo "Using pinned eclipse release: $ECJ_MAVEN_VERSION"
 
-ECJ_JAR=$(wget --quiet -O- "$ECLIPSE_URL/$ECJ_MAVEN_VERSION/" | grep -o "ecj-[^\"]*" | head -n1)
+ECJ_JAR=$(curl --fail-with-body -s "$ECLIPSE_URL/$ECJ_MAVEN_VERSION/" \
+    | grep -o "ecj-[^\"]*" | head -n1)
 ECJ_PATH=~/.m2/repository/$ECJ_MAVEN_VERSION/$ECJ_JAR
 
 if [ ! -f "$ECJ_PATH" ]; then
     echo "$ECJ_PATH is not found, downloading ..."
     cd target
-    wget $ECLIPSE_URL/"$ECJ_MAVEN_VERSION"/"$ECJ_JAR"
+    curl --fail-with-body -O "$ECLIPSE_URL/$ECJ_MAVEN_VERSION/$ECJ_JAR"
     echo "test jar after download:"
     jar -tvf "$ECJ_JAR" > /dev/null
     echo "check compiler options"

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -33,7 +33,7 @@ all-sevntu-checks)
     | sed "s/com\.github\.sevntu\.checkstyle\.checks\..*\.//" \
     | sort | uniq | sed "s/Check$//" > $working_dir/file.txt
 
-  wget -q http://sevntu-checkstyle.github.io/sevntu.checkstyle/apidocs/allclasses-frame.html -O - \
+  curl --fail-with-body -s http://sevntu-checkstyle.github.io/sevntu.checkstyle/apidocs/allclasses-frame.html \
     | grep "<li>" | cut -d '>' -f 3 | sed "s/<\/a//" \
     | grep -E "Check$" \
     | sort | uniq | sed "s/Check$//" > $working_dir/web.txt
@@ -415,13 +415,11 @@ verify-no-exception-configs)
 
   mkdir -p .ci-temp/verify-no-exception-configs
   working_dir=.ci-temp/verify-no-exception-configs
-  wget -q \
-    --directory-prefix $working_dir \
-    --no-clobber \
+  curl -s --fail-with-body -o "$working_dir/checks-nonjavadoc-error.xml" \
+    -H "Authorization: token $GITHUB_TOKEN" \
     https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/checks-nonjavadoc-error.xml
-  wget -q \
-    --directory-prefix $working_dir \
-    --no-clobber \
+  curl -s --fail-with-body -o "$working_dir/checks-only-javadoc-error.xml" \
+    -H "Authorization: token $GITHUB_TOKEN" \
     https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/checks-only-javadoc-error.xml
   MODULES_WITH_EXTERNAL_FILES="Filter|ImportControl"
   xmlstarlet fo -D \

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -255,9 +255,9 @@ davidwalsh
 DBFF
 Dcheckstyle
 dcm
-Dcpd
 Dconfig
 Dconnection
+Dcpd
 Dcyclonedx
 ddd
 DDDL
@@ -298,8 +298,8 @@ Diachenko
 diffplug
 DIFFTOOL
 dirname
-Djapicmp
 Djacoco
+Djapicmp
 Djdepend
 Dlinkcheck
 DMail
@@ -1462,7 +1462,6 @@ Webp
 website
 webtoolkit
 Wellformedness
-wget
 whenshouldbeused
 wherejavadocrequired
 wheretobreak


### PR DESCRIPTION
Issue : #13040


### .ci/validation.sh
- Line 36: Replaced `wget -q URL -O -` with `curl -s URL` for sevntu-checkstyle apidocs
- Lines 418-425: Replaced `wget --directory-prefix --no-clobber URL` with `curl -s --fail-with-body -o -H "Authorization: token $GITHUB_TOKEN" URL` for GitHub raw content downloads
### .ci/eclipse-compiler-javac.sh
- Line 21: Replaced `wget --quiet -O- URL` with `curl -s URL` for ECJ JAR filename lookup
- Line 27: Replaced `wget URL` with `curl -O URL` for ECJ JAR download
