### PR TITLE
Issue #19617: Added checks for OpenJDK Style §2 - Java Source Files

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -661,6 +661,7 @@ javaparser
 javarevisited
 javascript
 javase
+javasourcefiles
 javax
 Jax
 jb

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule2javasourcefiles/InputJavaSourceFilesSection2.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule2javasourcefiles/InputJavaSourceFilesSection2.java
@@ -1,0 +1,9 @@
+package com.openjdk.checkstyle.test.chapter2javasourcefiles.rule2javasourcefiles;
+
+class InputJavaSourceFilesSection2 {
+    private final int value;
+
+    InputJavaSourceFilesSection2() {
+        value = 1;
+    }
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -17,6 +17,7 @@
 
 <module name="Checker">
   <property name="severity" value="error"/>
+  <property name="charset" value="US-ASCII"/>
 
   <property name="fileExtensions" value="java, properties, xml"/>
 
@@ -33,11 +34,24 @@
     <property name="optional" value="true"/>
   </module>
 
+  <module name="LineEnding">
+    <property name="lineEnding" value="lf"/>
+    <property name="fileExtensions" value="java"/>
+  </module>
+
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$"/>
+    <property name="minimum" value="0"/>
+    <property name="maximum" value="0"/>
+    <property name="message" value="Line has trailing spaces."/>
+  </module>
+
   <!-- Add OpenJDK-specific checks here based on the style guide -->
 
   <module name="TreeWalker">
     <!-- Add TreeWalker checks based on OpenJDK style guide -->
     <module name="OneStatementPerLine"/>
+    <module name="OuterTypeFilename"/>
 
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
     <module name="SuppressionXpathFilter">

--- a/src/site/xdoc/checks/misc/lineending.xml
+++ b/src/site/xdoc/checks/misc/lineending.xml
@@ -118,6 +118,10 @@ public class Example3 {  // ␊ // violation 'Expected line ending for file is C
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineEnding">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineEnding">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/lineending.xml.template
+++ b/src/site/xdoc/checks/misc/lineending.xml.template
@@ -87,6 +87,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineEnding">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineEnding">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/outertypefilename.xml
+++ b/src/site/xdoc/checks/misc/outertypefilename.xml
@@ -72,6 +72,10 @@ class Example5ButNotSameName {}
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OuterTypeFilename">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OuterTypeFilename">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/outertypefilename.xml.template
+++ b/src/site/xdoc/checks/misc/outertypefilename.xml.template
@@ -79,6 +79,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OuterTypeFilename">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OuterTypeFilename">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/regexp/regexpsingleline.xml
+++ b/src/site/xdoc/checks/regexp/regexpsingleline.xml
@@ -224,6 +224,10 @@ CREATE DATABASE MyDB;
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RegexpSingleline">
             Sun Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RegexpSingleline">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/regexp/regexpsingleline.xml.template
+++ b/src/site/xdoc/checks/regexp/regexpsingleline.xml.template
@@ -125,6 +125,10 @@
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RegexpSingleline">
             Sun Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RegexpSingleline">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -134,8 +134,27 @@
                     <strong>2 - Java Source Files</strong>
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/misc/lineending.html#LineEnding">LineEnding</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineEnding">
+                  config</a>),
+                  <a href="checks/regexp/regexpsingleline.html#RegexpSingleline">
+                    RegexpSingleline</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RegexpSingleline">
+                  config</a>),
+                  <a href="checks/misc/outertypefilename.html#OuterTypeFilename">
+                    OuterTypeFilename</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OuterTypeFilename">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule2javasourcefiles">
+                    samples
+                  </a>
+                </td>
               </tr>
               <tr>
                 <td>
@@ -151,8 +170,13 @@
                     2.1 Special Characters
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="https://checkstyle.org/config.html#Checker">charset=US-ASCII</a>
+                </td>
+                <td>--</td>
               </tr>
               <!-- 3 Formatting -->
               <tr>


### PR DESCRIPTION
fixes #19617 

#### Summary
Required OpenJDK §2 checks were added in [openjdk_checks.xml]:
[charset=US-ASCII]
LineEnding (lf, [java])
RegexpSingleline for trailing whitespace
OuterTypeFilename
Coverage/docs were aligned in [openjdk_style.xml], plus related check docs/templates were updated so internal xdoc consistency checks pass.
