### PR TITLE
Issue #16361: testEscape \t and \u0010

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -102,7 +102,7 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
 
     /**
      * This test cannot use verifyWithInlineConfigParserAndLogger because
-     * XML 1.0 forbids most control characters (&#x8;, &#xC;, &#xD;, &#x9;, etc.)
+     * XML 1.0 forbids most control characters (&#x8;, &#xC;, &#xD;, etc.)
      * even as numeric character references in attribute values. These characters
      * require direct unit testing of the escape() method.
      */
@@ -111,10 +111,8 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
         final String[][] encodings = {
             {"\b", "\\b"},
             {"\f", "\\f"},
-            {"\t", "\\t"},
             {"\r", "\\r"},
             {"/", "\\/"},
-            {"\u0010", "\\u0010"},
             {"\u001E", "\\u001E"},
             {"\u001F", "\\u001F"},
             {" ", " "},

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerEscapeSelect.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerEscapeSelect.sarif
@@ -42,13 +42,54 @@
                 },
                 "region": {
                   "startColumn": 13,
-                  "startLine": 15
+                  "startLine": 23
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "\t"
+          },
+          "ruleId": "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java"
+                },
+                "region": {
+                  "startColumn": 13,
+                  "startLine": 23
                 }
               }
             }
           ],
           "message": {
             "text": "\"\\\\ \\n"
+          },
+          "ruleId": "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java"
+                },
+                "region": {
+                  "startColumn": 16,
+                  "startLine": 24
+                }
+              }
+            }
+          ],
+          "message": {
+            "id": "illegal.token.text",
+            "text": "Token text matches the illegal pattern '[\\x10]'."
           },
           "ruleId": "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck"
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java
@@ -6,11 +6,20 @@
       <property name="format" value="1"/>
       <property name="message" value="&quot;\\ \n"/>
     </module>
+    <module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck">
+      <property name="tokens" value="NUM_INT"/>
+      <property name="format" value="1"/>
+      <property name="message" value="&#9;"/>
+    </module>
+    <module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck">
+      <property name="tokens" value="STRING_LITERAL"/>
+      <property name="format" value="[\x10]"/>
+    </module>
   </module>
 </module>
 */
 package com.puppycrawl.tools.checkstyle.sariflogger;
-
 public class InputSarifLoggerEscapeSelect {
-    int x = 1;
+    int x = 1; // violation '\t'
+    String s = ""; // violation .Token text matches the illegal pattern ..[\x10]...
 }


### PR DESCRIPTION
Issue : #16361 

following https://github.com/checkstyle/checkstyle/pull/19479#discussion_r3064391035

### changes 
for the \t it was pretty easy the `&#9;` was enough 
for the `'\u0010`  i tried the `&#x10;` but it is breaks xml , tried the  litteral "\u0010"  but `IllegalTokenText` sees it  as a literal 6 character, finally i tried raw byte 0x10 in Java string literal and it worked :)

