### PR TITLE
Issue #19640:Add new OPENJDK style 4.1-PackageName rule 1

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -81,6 +81,14 @@
     files="uncommentedmain[\\/]InputUncommentedMainBeginTreePackage2\.java"/>
 
   <!-- intentional problem for testing -->
+  <suppress checks="PackageDeclarationCheck"
+    files="rule41packagenames[\\/]InputBadPackageName2\.java"/>
+  <suppress checks="PackageDeclarationCheck"
+    files="rule41packagenames[\\/]InputPackageBadName3\.java"/>
+  <suppress checks="PackageDeclarationCheck"
+    files="rule41packagenames[\\/]InputPackageNameBad\.java"/>
+
+  <!-- intentional problem for testing -->
   <suppress checks="RegexpSingleline"
     files="javadoctype[\\/]InputJavadocTypeWithBlockComment\.java"/>
 

--- a/src/it/java/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/PackageNamesTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/PackageNamesTest.java
@@ -1,0 +1,53 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapter4naming.rule41packagenames;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class PackageNamesTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapter4naming/rule41packagenames";
+    }
+
+    @Test
+    public void testGoodPackageName() throws Exception {
+        verifyWithWholeConfig(getPath("InputPackageNameGood.java"));
+    }
+
+    @Test
+    public void testBadPackageNameCamelCase() throws Exception {
+        verifyWithWholeConfig(getPath("InputPackageNameBad.java"));
+    }
+
+    @Test
+    public void testBadPackageNameUnderscore() throws Exception {
+        verifyWithWholeConfig(getPath("InputBadPackageName2.java"));
+    }
+
+    @Test
+    public void testBadPackageNameSpecialSymbols() throws Exception {
+        verifyWithWholeConfig(getPath("InputPackageBadName3.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputBadPackageName2.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputBadPackageName2.java
@@ -1,0 +1,8 @@
+package com.openjdk.checkstyle.test.chapter4naming.rule_41_packagenames;
+
+// violation 2 lines above 'Name .* must match pattern .*'
+
+/**
+ * Input package name with underscore in the middle of the name.
+ */
+final class InputBadPackageName2 {}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputBadPackageName2.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputBadPackageName2.java
@@ -1,0 +1,9 @@
+package com.openjdk.checkstyle.test.chapter4naming.rule_41_packagenames;
+
+// violation 2 lines above """Package names should be all lower
+// case without underscores or other special characters."""
+
+/**
+ * Input package name with underscore in the middle of the name.
+ */
+final class InputBadPackageName2 {}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputPackageBadName3.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputPackageBadName3.java
@@ -1,0 +1,8 @@
+package com.openjdk.checkstyle.test.chapte$r4naming.rul$e41pac$kageNamess;
+
+// violation 2 lines above 'Name .* must match pattern .*'
+
+/**
+ * Input package name with special symbols in the middle of the name.
+ */
+final class InputPackageBadName3 {}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputPackageBadName3.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputPackageBadName3.java
@@ -1,0 +1,9 @@
+package com.openjdk.checkstyle.test.chapte$r4naming.rul$e41pac$kagenames;
+
+// violation 2 lines above """Package names should be all lower
+// case without underscores or other special characters."""
+
+/**
+ * Input package name with special symbols in the middle of the name.
+ */
+final class InputPackageBadName3 {}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputPackageNameBad.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputPackageNameBad.java
@@ -1,0 +1,6 @@
+package com.openjdk.checkstyle.test.chapter4naming.rule41PackageNames; // violation 'Name .* must match pattern .*'
+
+/**
+ * Input package name with uppercase letter in the middle of the name.
+ */
+final class InputPackageNameBad {}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputPackageNameBad.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputPackageNameBad.java
@@ -1,0 +1,9 @@
+package com.openjdk.checkstyle.test.chapter4naming.rule41PackageNamesCamelCase;
+
+// violation 2 lines above """Package names should be all lower
+// case without underscores or other special characters."""
+
+/**
+ * Input package name with uppercase letter in the middle of the name.
+ */
+final class InputPackageNameBad {}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputPackageNameGood.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames/InputPackageNameGood.java
@@ -1,0 +1,6 @@
+package com.openjdk.checkstyle.test.chapter4naming.rule41packagenames;
+
+/**
+ * Input package name with correct format.
+ */
+final class InputPackageNameGood {}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -46,6 +46,10 @@
       <property name="optional" value="true"/>
     </module>
 
+    <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+    </module>
+
   </module>
 
 </module>

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -106,6 +106,10 @@
       <property name="optional" value="true"/>
     </module>
 
+    <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+    </module>
+
   </module>
 
 </module>

--- a/src/site/xdoc/checks/naming/packagename.xml
+++ b/src/site/xdoc/checks/naming/packagename.xml
@@ -94,6 +94,10 @@ public class Example2 {
             Google Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageName">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageName">
             Sun Style</a>
           </li>

--- a/src/site/xdoc/checks/naming/packagename.xml.template
+++ b/src/site/xdoc/checks/naming/packagename.xml.template
@@ -66,6 +66,10 @@
             Google Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageName">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageName">
             Sun Style</a>
           </li>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -607,7 +607,18 @@
                     4.1 Package Names
                   </a>
                 </td>
-                <td>???</td>
+                <td>
+                    <span class="wrapper inline">
+                        <img src="images/ok_blue.png" alt=""/>
+                    </span>
+                    <a href="checks/naming/packagename.html#PackageName">PackageName</a>
+                    (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageName">config</a>)
+                </td>
+                <td>
+                    <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames">
+                       samples
+                    </a>
+                </td>
                 <td/>
               </tr>
               <tr>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -762,7 +762,23 @@
                     4.1 Package Names
                   </a>
                 </td>
-                <td>???</td>
+                <td>
+                    <p>
+                        Note: Detection of plural forms or
+                      semantic word variations is not supported,
+                        as there is no valid method to do it.
+                    </p>
+                    <span class="wrapper inline">
+                        <img src="images/ok_blue.png" alt=""/>
+                    </span>
+                    <a href="checks/naming/packagename.html#PackageName">PackageName</a>
+                    (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageName">config</a>)
+                </td>
+                <td>
+                    <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule41packagenames">
+                       samples
+                    </a>
+                </td>
                 <td/>
               </tr>
               <tr>


### PR DESCRIPTION
Issue #19640
## New OpenJDK check  :
- Added PackageNameCheck to OpenJDK  
-  Added PackageNameTest.java in `src/it/java/com/openjdk/checkstyle/test/chapter4naming/rule41packagename/`
- Created `chapter4naming` directory in `src/it/java/com/openjdk/checkstyle/test/` and in `resource/**/**/test/`
- Put PackageDeclarationCheck suppression on inputfiles as the violations are intented.
- The input files contain , `correct format` ,`invalid underscore` , `invalid special symbols`, `invalid CamelCase`
