### PR TITLE
Issue #16361: group last characters of testEscape

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -102,21 +102,19 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
 
     /**
      * This test cannot use verifyWithInlineConfigParserAndLogger because
-     * XML 1.0 forbids most control characters (&#x8;, &#xC;, &#xD;, etc.)
-     * even as numeric character references in attribute values. These characters
-     * require direct unit testing of the escape() method.
+     * XML 1.0 forbids control characters (U+0008, U+000C, U+0010, U+001E, U+001F)
+     * even as numeric character references or raw bytes in attribute values,
+     * making it impossible to pass these characters through the violation message
+     * into {@code escape()} via the inline config approach.
      */
     @Test
     public void testEscapeDirectly() {
         final String[][] encodings = {
             {"\b", "\\b"},
             {"\f", "\\f"},
-            {"\r", "\\r"},
-            {"/", "\\/"},
+            {"\u0010", "\\u0010"},
             {"\u001E", "\\u001E"},
             {"\u001F", "\\u001F"},
-            {" ", " "},
-            {"bar1234", "bar1234"},
         };
         for (String[] encoding : encodings) {
             final String encoded = SarifLogger.escape(encoding[0]);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerEscapeSelect.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerEscapeSelect.sarif
@@ -42,7 +42,7 @@
                 },
                 "region": {
                   "startColumn": 13,
-                  "startLine": 23
+                  "startLine": 36
                 }
               }
             }
@@ -62,7 +62,27 @@
                 },
                 "region": {
                   "startColumn": 13,
-                  "startLine": 23
+                  "startLine": 36
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "\r"
+          },
+          "ruleId": "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java"
+                },
+                "region": {
+                  "startColumn": 13,
+                  "startLine": 36
                 }
               }
             }
@@ -81,15 +101,57 @@
                   "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java"
                 },
                 "region": {
-                  "startColumn": 16,
-                  "startLine": 24
+                  "startColumn": 20,
+                  "startLine": 37
                 }
               }
             }
           ],
           "message": {
             "id": "illegal.token.text",
-            "text": "Token text matches the illegal pattern '[\\x10]'."
+            "text": "Token text matches the illegal pattern '\/'."
+          },
+          "ruleId": "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java"
+                },
+                "region": {
+                  "startColumn": 20,
+                  "startLine": 38
+                }
+              }
+            }
+          ],
+          "message": {
+            "id": "illegal.token.text",
+            "text": "Token text matches the illegal pattern ' '."
+          },
+          "ruleId": "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java"
+                },
+                "region": {
+                  "startColumn": 22,
+                  "startLine": 39
+                }
+              }
+            }
+          ],
+          "message": {
+            "id": "illegal.token.text",
+            "text": "Token text matches the illegal pattern 'bar1234'."
           },
           "ruleId": "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck"
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/InputSarifLoggerEscapeSelect.java
@@ -12,8 +12,21 @@
       <property name="message" value="&#9;"/>
     </module>
     <module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck">
+      <property name="tokens" value="NUM_INT"/>
+      <property name="format" value="1"/>
+      <property name="message" value="&#xD;"/>
+    </module>
+    <module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck">
       <property name="tokens" value="STRING_LITERAL"/>
-      <property name="format" value="[\x10]"/>
+      <property name="format" value="/"/>
+    </module>
+    <module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck">
+      <property name="tokens" value="STRING_LITERAL"/>
+      <property name="format" value=" "/>
+    </module>
+    <module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck">
+      <property name="tokens" value="STRING_LITERAL"/>
+      <property name="format" value="bar1234"/>
     </module>
   </module>
 </module>
@@ -21,5 +34,7 @@
 package com.puppycrawl.tools.checkstyle.sariflogger;
 public class InputSarifLoggerEscapeSelect {
     int x = 1; // violation '\t'
-    String s = ""; // violation .Token text matches the illegal pattern ..[\x10]...
+    String slash = "/"; // violation
+    String space = " "; // violation
+    String bar1234 = "bar1234"; // violation
 }


### PR DESCRIPTION
Issue #16361: 

Grouped characters that can be tested via verifyWithInlineConfigParserAndLogger into testEscape, and moved the remaining ones that cannot into testEscapeDirectly with an explanation.

The characters \b , \f , \u0010, \u001E, and \u001F stay in testEscapeDirectly because XML 1.0 forbids these control characters even as numeric character references or raw bytes in attribute values  making it impossible to pass them through a violation message into escape() via the inline config approach.

` \u0010`,` \u001E`, and` \u001F` CAN be injected as raw bytes into string literals and matched by IllegalTokenText, but the violation message contains the regex pattern text (like  [\x10]), not the actual character. So escape() is never called with the actual control character `escapeUnicode1F()`  jacoco is not genuinely covered that way it's just like cheating hence i putted back ` \u0010` from previous merged PR