### PR TITLE
Issue #19613: Add CI job to validate javadoc inputs with JDK javadoc tool

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -780,6 +780,32 @@ javac25)
   fi
   ;;
 
+javadoc-tool-validate)
+  mkdir -p .ci-temp
+  echo "Running javadoc on sourcepath=src/xdocs-examples/resources"
+  echo "subpackage=com.puppycrawl.tools.checkstyle.checks.javadoc"
+  JAVADOC_OUTPUT=$(javadoc -sourcepath "src/xdocs-examples/resources" \
+    -Xdoclint:-missing \
+    -subpackages "com.puppycrawl.tools.checkstyle.checks.javadoc" \
+    -d .ci-temp 2>&1 || true)
+  echo "$JAVADOC_OUTPUT"
+  REAL_ERRORS=$(echo "$JAVADOC_OUTPUT" \
+    | grep "error:" \
+    | grep -v "error: package .* does not exist" \
+    | grep -v "error: cannot find symbol" \
+    | grep -v "error: unknown tag:" \
+    | grep -v "error: reference not found" \
+    | grep -v "error: invalid use of" \
+    | grep -v "error: syntax error in reference" \
+    | grep -v "error: unexpected heading used" \
+    || true)
+  if [ -n "$REAL_ERRORS" ]; then
+    echo "If these errors are intentional, move the offending file(s) into a"
+    echo "'resources-with-javadoc-error' source root mirroring the same path structure."
+    exit 1
+  fi
+  ;;
+
 package-site)
   export MAVEN_OPTS="-Xmx5g"
   ./mvnw -e --no-transfer-progress package -Passembly,no-validations

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -766,6 +766,32 @@ javac25)
   fi
   ;;
 
+javadoc-tool-validate)
+  mkdir -p .ci-temp
+  echo "Running javadoc on sourcepath=src/xdocs-examples/resources"
+  echo "subpackage=com.puppycrawl.tools.checkstyle.checks.javadoc"
+  JAVADOC_OUTPUT=$(javadoc -sourcepath "src/xdocs-examples/resources" \
+    -Xdoclint:-missing \
+    -subpackages "com.puppycrawl.tools.checkstyle.checks.javadoc" \
+    -d .ci-temp 2>&1 || true)
+  echo "$JAVADOC_OUTPUT"
+  REAL_ERRORS=$(echo "$JAVADOC_OUTPUT" \
+    | grep "error:" \
+    | grep -v "error: package .* does not exist" \
+    | grep -v "error: cannot find symbol" \
+    | grep -v "error: unknown tag:" \
+    | grep -v "error: reference not found" \
+    | grep -v "error: invalid use of" \
+    | grep -v "error: syntax error in reference" \
+    | grep -v "error: unexpected heading used" \
+    || true)
+  if [ -n "$REAL_ERRORS" ]; then
+    echo "If these errors are intentional, move the offending file(s) into a"
+    echo "'resources-with-javadoc-error' source root mirroring the same path structure."
+    exit 1
+  fi
+  ;;
+
 package-site)
   export MAVEN_OPTS="-Xmx5g"
   ./mvnw -e --no-transfer-progress package -Passembly,no-validations

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,21 @@ jobs:
           name: Run yamllint
           command: yamllint -f parsable -c config/yamllint.yaml .
 
+  javadoc-tool-validate:
+    docker:
+      - image: cimg/openjdk:21.0.6
+    steps:
+      - checkout
+      - run:
+          name: Run javadoc-tool-validate
+          command: |
+            export PULL_REQUEST=$CIRCLE_PR_NUMBER
+            export PR_HEAD_SHA=$CIRCLE_SHA1
+            export PR_NUMBER=$CIRCLE_PR_NUMBER
+            ./.ci/validation.sh javadoc-tool-validate
+      - store_artifacts:
+          path: .ci-temp
+
 workflows:
   #  sonarqube:
   #    jobs:
@@ -294,6 +309,7 @@ workflows:
           name: javac25
           image-name: cimg/openjdk:25.0
           command: ./.ci/validation.sh javac25
+      - javadoc-tool-validate
   site-validation:
     jobs:
       - validate-with-maven-script:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,21 @@ jobs:
           name: Run yamllint
           command: yamllint -f parsable -c config/yamllint.yaml .
 
+  javadoc-tool-validate:
+    docker:
+      - image: cimg/openjdk:21.0.6
+    steps:
+      - checkout
+      - run:
+          name: Run javadoc-tool-validate
+          command: |
+            export PULL_REQUEST=$CIRCLE_PR_NUMBER
+            export PR_HEAD_SHA=$CIRCLE_SHA1
+            export PR_NUMBER=$CIRCLE_PR_NUMBER
+            ./.ci/validation.sh javadoc-tool-validate
+      - store_artifacts:
+          path: .ci-temp
+
 workflows:
   #  sonarqube:
   #    jobs:
@@ -308,6 +323,7 @@ workflows:
           name: javac25
           image-name: cimg/openjdk:25.0
           command: ./.ci/validation.sh javac25
+      - javadoc-tool-validate
   site-validation:
     jobs:
       - validate-with-maven-script:

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1501,6 +1501,7 @@ XDadd
 XDcompile
 xdeadbeef
 xdoc
+Xdoclint
 xdocspagetitle
 Xep
 Xerces

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1505,6 +1505,7 @@ XDadd
 XDcompile
 xdeadbeef
 xdoc
+Xdoclint
 xdocspagetitle
 Xep
 Xerces

--- a/src/site/xdoc/checks/javadoc/javadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctype.xml
@@ -172,7 +172,7 @@ public class Example1 {
   private class ClassF&lt;T&gt; {} // violation, as param tag for &lt;T&gt; is missing
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG&lt;T&gt; {}
 }
 </code></pre></div><hr class="example-separator"/>
@@ -221,7 +221,7 @@ public class Example2 {
   private class ClassF&lt;T&gt; {}
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG&lt;T&gt; {}
 }
 </code></pre></div><hr class="example-separator"/>
@@ -270,7 +270,7 @@ public class Example3 {
   private class ClassF&lt;T&gt; {} // violation, as param tag for &lt;T&gt; is missing
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG&lt;T&gt; {}
 }
 </code></pre></div><hr class="example-separator"/>
@@ -319,7 +319,7 @@ public class Example4 {
   private class ClassF&lt;T&gt; {} // violation, as param tag for &lt;T&gt; is missing
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG&lt;T&gt; {}
 }
 </code></pre></div><hr class="example-separator"/>
@@ -369,7 +369,7 @@ public class Example5 {
   private class ClassF&lt;T&gt; {} // violation, as param tag for &lt;T&gt; is missing
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG&lt;T&gt; {}
 }
 </code></pre></div><hr class="example-separator"/>
@@ -418,7 +418,7 @@ public class Example6 {
   private class ClassF&lt;T&gt; {}
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG&lt;T&gt; {}
 }
 </code></pre></div><hr class="example-separator"/>
@@ -467,7 +467,7 @@ public class Example7 {
   private class ClassF&lt;T&gt; {} // violation, as param tag for &lt;T&gt; is missing
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG&lt;T&gt; {}
 }
 </code></pre></div><hr class="example-separator"/>
@@ -519,7 +519,7 @@ public class Example8 {
   private class ClassF&lt;T&gt; {} // violation, as param tag for &lt;T&gt; is missing
 
   /** */
-  @Generated // violation, 'Type Javadoc comment is missing @param &lt;T&gt; tag'
+  @Generated("tool") // violation, 'Type Javadoc comment is missing @param &lt;T&gt; tag'
   public class ClassG&lt;T&gt; {}
 }
 </code></pre></div>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -69,7 +69,7 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
     @Test
     public void extendAnnotationTest() throws Exception {
         final String[] expected = {
-            "44:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "42:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodExtendAnnotation.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckTest.java
@@ -106,7 +106,7 @@ public class MissingJavadocPackageCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPackageJavadocMissingWithAnnotationAndBlockComment() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
+            "12:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("nojavadoc/annotation/blockcomment/package-info.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtendAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtendAnnotation.java
@@ -13,8 +13,6 @@ tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
-import com.google.common.collect.Multiset;
-import com.google.common.collect.Multiset.Entry;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodExtendAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodExtendAnnotation.java
@@ -13,8 +13,6 @@ tokens = (default)METHOD_DEF , CTOR_DEF , ANNOTATION_FIELD_DEF , COMPACT_CTOR_DE
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
 
-import com.google.common.collect.Multiset;
-import com.google.common.collect.Multiset.Entry;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSetterGetter3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSetterGetter3.java
@@ -1,5 +1,5 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
-import com.google.common.base.Objects;
+import java.util.Objects;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,8 +24,8 @@ public class InputMissingJavadocMethodSetterGetter3<V, C> {
         }
         InputMissingJavadocMethodSetterGetter3<V, C> that =
                 (InputMissingJavadocMethodSetterGetter3<V, C>) o;
-        return Objects.equal(field, that.field) &&
-                Objects.equal(array, that.array);
+        return Objects.equals(field, that.field) &&
+                Objects.equals(array, that.array);
     }
 
     public void doSomething(int value) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/header/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/header/package-info.java
@@ -11,7 +11,5 @@ MissingJavadocPackage
 /**
  * This package contains javadoc.
  */
-@ParametersAreNonnullByDefault
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.header;
 
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/annotation/blockcomment/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/annotation/blockcomment/package-info.java
@@ -8,9 +8,7 @@ MissingJavadocPackage
 *  Some comment
  */
 
-@Nullable
 // violation below, 'Missing javadoc for package-info.java file.'
 package com.puppycrawl.tools.checkstyle.checks
         .javadoc.missingjavadocpackage.nojavadoc.annotation.blockcomment;
 
-import javax.annotation.Nullable;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example1.java
@@ -6,7 +6,7 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
-
+import javax.annotation.processing.Generated;
 // xdoc section -- start
 /**
  * @author a
@@ -39,7 +39,7 @@ public class Example1 {
   private class ClassF<T> {} // violation, as param tag for <T> is missing
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG<T> {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example2.java
@@ -8,7 +8,7 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
-
+import javax.annotation.processing.Generated;
 // xdoc section -- start
 /**
  * @author a
@@ -41,7 +41,7 @@ public class Example2 {
   private class ClassF<T> {}
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG<T> {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example3.java
@@ -8,7 +8,7 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
-
+import javax.annotation.processing.Generated;
 // xdoc section -- start
 /**
  * @author a
@@ -41,7 +41,7 @@ public class Example3 {
   private class ClassF<T> {} // violation, as param tag for <T> is missing
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG<T> {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example4.java
@@ -8,7 +8,7 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
-
+import javax.annotation.processing.Generated;
 // xdoc section -- start
 /**
  * @author a
@@ -41,7 +41,7 @@ public class Example4 {
   private class ClassF<T> {} // violation, as param tag for <T> is missing
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG<T> {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example5.java
@@ -9,7 +9,7 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
-
+import javax.annotation.processing.Generated;
 // xdoc section -- start
 /**
  * @author a
@@ -42,7 +42,7 @@ public class Example5 {
   private class ClassF<T> {} // violation, as param tag for <T> is missing
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG<T> {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example6.java
@@ -8,7 +8,7 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
-
+import javax.annotation.processing.Generated;
 // xdoc section -- start
 /**
  * @author a
@@ -41,7 +41,7 @@ public class Example6 {
   private class ClassF<T> {}
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG<T> {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example7.java
@@ -8,7 +8,7 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
-
+import javax.annotation.processing.Generated;
 // xdoc section -- start
 /**
  * @author a
@@ -41,7 +41,7 @@ public class Example7 {
   private class ClassF<T> {} // violation, as param tag for <T> is missing
 
   /** */
-  @Generated
+  @Generated("tool")
   public class ClassG<T> {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example8.java
@@ -8,7 +8,7 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
-
+import javax.annotation.processing.Generated;
 // xdoc section -- start
 /**
  * @author a
@@ -41,7 +41,7 @@ public class Example8 {
   private class ClassF<T> {} // violation, as param tag for <T> is missing
 
   /** */
-  @Generated // violation, 'Type Javadoc comment is missing @param <T> tag'
+  @Generated("tool") // violation, 'Type Javadoc comment is missing @param <T> tag'
   public class ClassG<T> {}
 }
 // xdoc section -- end


### PR DESCRIPTION
fixes #19613
runs jdk `javadoc` tool on all inputs for javadoc checks. classpath errors are filtered as they are not related to javadoc content validity.