### PR TITLE
Issue #19682: Add RECORD_DEF and COMPACT_CTOR_DEF to AtclauseOrder ta…

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/BlockTagsTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/BlockTagsTest.java
@@ -71,6 +71,17 @@ public class BlockTagsTest extends AbstractGoogleModuleTestSupport {
     }
 
     @Test
+    public void testCorrectAtClauseOrderOnRecordAndCompactCtor() throws Exception {
+        verifyWithWholeConfig(getPath("InputCorrectAtClauseOrderCheckOnRecordAndCompactCtor.java"));
+    }
+
+    @Test
+    public void testIncorrectAtClauseOrderOnRecordAndCompactCtor() throws Exception {
+        verifyWithWholeConfig(
+            getPath("InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor.java"));
+    }
+
+    @Test
     public void testNonEmptyAtclauseDescription() throws Exception {
         verifyWithWholeConfig(getPath("InputNonEmptyAtclauseDescription.java"));
     }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheckOnRecordAndCompactCtor.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheckOnRecordAndCompactCtor.java
@@ -1,0 +1,53 @@
+package com.google.checkstyle.test.chapter7javadoc.rule713atclauses;
+
+/**
+ * Record with correct tag order.
+ *
+ * @param x the x coordinate
+ * @param y the y coordinate
+ * @deprecated use NewPoint
+ */
+record InputCorrectAtClauseOrderCheckOnRecordAndCompactCtor(int x, int y) {
+
+  /**
+   * Some text.
+   *
+   * @param val some text
+   * @return some text
+   * @deprecated old method
+   */
+  static String method(String val) {
+    return val;
+  }
+
+  /**
+   * Generic record with correct tag order.
+   *
+   * @param <T> the type
+   * @param name the name
+   * @deprecated use other record
+   */
+  record InnerGenericRecord<T>(String name) {}
+
+  /**
+   * Record with compact ctor that has correct tag order.
+   *
+   * @param lo the lower bound
+   * @param hi the upper bound
+   */
+  record InnerRecordWithCompactCtor(int lo, int hi) {
+    /**
+     * Validates range.
+     *
+     * @param lo the lower bound
+     * @param hi the upper bound
+     * @throws Exception if error
+     * @deprecated use factory method
+     */
+    InnerRecordWithCompactCtor {
+      if (lo > hi) {
+        throw new IllegalArgumentException();
+      }
+    }
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor.java
@@ -1,0 +1,53 @@
+package com.google.checkstyle.test.chapter7javadoc.rule713atclauses;
+
+/**
+ * Record with wrong tag order.
+ *
+ * @deprecated use NewPoint
+ * @param x the x coordinate // violation 'Block tags have to appear in the order'
+ * @param y the y coordinate // violation 'Block tags have to appear in the order'
+ */
+record InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor(int x, int y) {
+
+  /**
+   * Some text.
+   *
+   * @deprecated old method
+   * @param val some text // violation 'Block tags have to appear in the order'
+   * @return some text // violation 'Block tags have to appear in the order'
+   */
+  static String method(String val) {
+    return val;
+  }
+
+  /**
+   * Generic record with wrong tag order.
+   *
+   * @deprecated use other record
+   * @param <T> the type // violation 'Block tags have to appear in the order'
+   * @param name the name // violation 'Block tags have to appear in the order'
+   */
+  record InnerGenericRecord<T>(String name) {}
+
+  /**
+   * Record with compact ctor that has wrong tag order.
+   *
+   * @param lo the lower bound
+   * @param hi the upper bound
+   */
+  record InnerRecordWithCompactCtor(int lo, int hi) {
+    /**
+     * Validates range.
+     *
+     * @deprecated use factory method
+     * @param lo the lower bound // violation 'Block tags have to appear in the order'
+     * @param hi the upper bound // violation 'Block tags have to appear in the order'
+     * @throws Exception if error // violation 'Block tags have to appear in the order'
+     */
+    InnerRecordWithCompactCtor {
+      if (lo > hi) {
+        throw new IllegalArgumentException();
+      }
+    }
+  }
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -402,8 +402,8 @@
     <module name="RequireEmptyLineBeforeBlockTagGroup"/>
     <module name="AtclauseOrder">
       <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
-      <property name="target"
-               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+      <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+                                  VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF"/>
     </module>
     <module name="JavadocMethod">
       <property name="accessModifiers" value="public"/>


### PR DESCRIPTION
Issue #19682:

Add `RECORD_DEF` and `COMPACT_CTOR_DEF` to the `target` property of `AtclauseOrder` in `google_checks.xml`.
Google Java Style Guide Section 7.1.3 (Block tags) defines the tag ordering rule universally and does not exclude records.

Diff Regression config: https://gist.githubusercontent.com/vivek-0509/882c358cc5bbf17bec304c66512bd595/raw/f8c56f08ff616484457e341b92e5d72d5a9e6c61/base_config.xml

Diff Regression patch config: https://gist.githubusercontent.com/vivek-0509/d082f1038eebeebae5896ffb64140b02/raw/aeb38bb635f9dc9ef23871117337fef611258ec2/patch_config.xml