### PR TITLE
Issue #18614: Fix false positive in IndentationCheck for new operator

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
@@ -121,7 +121,7 @@ public class NewHandler extends AbstractExpressionHandler {
         IndentLevel result;
         // if our expression isn't first on the line, just use the start
         // of the line
-        if (getLineStart(mainAst) == mainAst.getColumnNo()) {
+        if (isOnStartOfLine(mainAst)) {
             result = super.getIndentImpl();
 
             final boolean isLineWrappedNew = TokenUtil.isOfType(mainAst.getParent().getParent(),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4814,6 +4814,22 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         verifyWarns(checkConfig, fileName, expected);
     }
 
+    @Test
+    public void testNewWithTabsIndentation() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = {
+            "51:5: " + getCheckMessage(MSG_ERROR, "new", 4, 16),
+        };
+        verifyWarns(checkConfig, getPath("InputIndentationNewWithTabs.java"), expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4286,6 +4286,22 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         verifyWarns(checkConfig, fileName, expected);
     }
 
+    @Test
+    public void testNewWithTabsIndentation() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = {
+            "51:5: " + getCheckMessage(MSG_ERROR, "new", 4, 16),
+        };
+        verifyWarns(checkConfig, getPath("InputIndentationNewWithTabs.java"), expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTabs.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTabs.java
@@ -1,0 +1,55 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;        //indent:0 exp:0
+
+/**                                                                            //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:    //indent:1 exp:1
+ *                                                                             //indent:1 exp:1
+ * basicOffset = 4                                                             //indent:1 exp:1
+ * braceAdjustment = 0                                                         //indent:1 exp:1
+ * caseIndent = 4                                                              //indent:1 exp:1
+ * forceStrictCondition = false                                                //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                 //indent:1 exp:1
+ * tabWidth = 4                                                                //indent:1 exp:1
+ * throwsIndent = 4                                                            //indent:1 exp:1
+ *                                                                             //indent:1 exp:1
+ */                                                                            //indent:1 exp:1
+public class InputIndentationNewWithTabs {                                     //indent:0 exp:0
+
+	static class Inner {                                                       //indent:4 exp:4
+		Inner(String s) {                                                      //indent:8 exp:8
+		}                                                                      //indent:8 exp:8
+	}                                                                          //indent:4 exp:4
+
+	private Inner client;                                                      //indent:4 exp:4
+
+	public void testCorrectNewInTryCatch() {                                   //indent:4 exp:4
+		try {                                                                  //indent:8 exp:8
+			client = new Inner(                                                //indent:12 exp:12
+				null                                                           //indent:16 exp:16
+			);                                                                 //indent:12 exp:12
+		} catch (Exception e) {                                                //indent:8 exp:8
+		}                                                                      //indent:8 exp:8
+	}                                                                          //indent:4 exp:4
+
+	public void testCorrectNewSingleLineInTryCatch() {                         //indent:4 exp:4
+		try {                                                                  //indent:8 exp:8
+			client =                                                           //indent:12 exp:12
+				new Inner(null);                                               //indent:16 exp:16
+		} catch (Exception e) {                                                //indent:8 exp:8
+		}                                                                      //indent:8 exp:8
+	}                                                                          //indent:4 exp:4
+
+	public void testCorrectNewLineWrapped() {                                  //indent:4 exp:4
+		client =                                                               //indent:8 exp:8
+			new Inner(                                                         //indent:12 exp:12
+				null                                                           //indent:16 exp:16
+			);                                                                 //indent:12 exp:12
+	}                                                                          //indent:4 exp:4
+
+	public void testWrongNewIndent() {                                         //indent:4 exp:4
+		try {                                                                  //indent:8 exp:8
+			client =                                                           //indent:12 exp:12
+	new Inner(null);                                                           //indent:4 exp:16 warn
+		} catch (Exception e) {                                                //indent:8 exp:8
+		}                                                                      //indent:8 exp:8
+	}                                                                          //indent:4 exp:4
+}                                                                              //indent:0 exp:0


### PR DESCRIPTION
**Issue:** #18614

**Problem:**
IndentationCheck reported false positives for the new operator when tabs were used for indentation.
In NewHandler#getIndentImpl, the old condition compared values from different column systems 
(visual/tab expanded vs raw token column), which could mis-detect whether new starts the line.

**Fix:**
Updated NewHandler#getIndentImpl to use isOnStartOfLine(mainAst), so the check consistently uses tab-expanded visual columns.

**Testing:**
Added/updated regression coverage in InputIndentationNewWithTabs.java and IndentationCheckTest#testNewWithTabsIndentation, including a try-block case where line-wrapped new is at the start of the line to exercise the fixed path directly. Also reverted unrelated refactoring in testTryBlockConstructorParameters to keep this PR focused.