### PR TITLE
Issue #14482: remove UnmodifiableCollectionUtil of unmodifiableList (unmodifiableList and singleton)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5238,6 +5238,9 @@
                 <mutator>NULL_RETURNS</mutator>
                 <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
+              <features>
+                <feature>+funmodifiablecollection</feature>
+              </features>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.utils.*</param>
               </targetClasses>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
@@ -74,21 +74,6 @@ public final class UnmodifiableCollectionUtil {
     }
 
     /**
-     * Returns an unmodifiable view of a List containing elements of a specific type.
-     *
-     * @param items The List of items to make unmodifiable.
-     * @param elementType The Class object representing the type of elements in the list.
-     * @param <S> The generic type of elements in the input Collection.
-     * @param <T> The type of elements in the resulting unmodifiable List.
-     * @return An unmodifiable List containing elements of the specified type.
-     */
-    public static <S, T> List<T> unmodifiableList(Collection<S> items, Class<T> elementType) {
-        return items.stream()
-                .map(elementType::cast)
-                .toList();
-    }
-
-    /**
      * Creates a copy of array.
      *
      * @param array Array to create a copy of
@@ -122,4 +107,5 @@ public final class UnmodifiableCollectionUtil {
     public static <T> Set<T> singleton(T obj) {
         return Collections.singleton(obj);
     }
+
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
@@ -214,6 +214,8 @@ public final class XpathUtil {
         final XPathDynamicContext xpathDynamicContext = xpathExpression
                 .createDynamicContext(rootNode);
         final List<Item> items = xpathExpression.evaluate(xpathDynamicContext);
-        return UnmodifiableCollectionUtil.unmodifiableList(items, NodeInfo.class);
+        return items.stream()
+                .map(NodeInfo.class::cast)
+                .toList();
     }
 }


### PR DESCRIPTION
Issue #14482

This PR removes `UnmodifiableCollectionUtil` where possible. only in returns and no assignements 