### PR TITLE
Issue #14482: remove UnmodifiableCollectionUtil singleton

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import java.util.Collections;
 import java.util.Set;
 
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean;
@@ -28,7 +29,6 @@ import com.puppycrawl.tools.checkstyle.api.ExternalResourceHolder;
 import com.puppycrawl.tools.checkstyle.api.Filter;
 import com.puppycrawl.tools.checkstyle.api.FilterSet;
 import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
-import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 
 /**
  * <div>
@@ -177,7 +177,7 @@ public class SuppressionFilter
 
     @Override
     public Set<String> getExternalResourceLocations() {
-        return UnmodifiableCollectionUtil.singleton(file);
+        return Collections.singleton(file);
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * <div>Note: it simply wraps the existing JDK methods to provide a workaround
@@ -110,16 +109,5 @@ public final class UnmodifiableCollectionUtil {
      */
     public static <K, V> Map<K, V> copyOfMap(Map<? extends K, ? extends V> map) {
         return Map.copyOf(map);
-    }
-
-    /**
-     * Returns an immutable set containing only the specified object.
-     *
-     * @param obj the type of object in the set
-     * @param <T> the type of object
-     * @return immutable set
-     */
-    public static <T> Set<T> singleton(T obj) {
-        return Collections.singleton(obj);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -221,6 +222,22 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
         secondCheckerConfig.addProperty("cacheFile", cacheFile.getPath());
 
         execute(secondCheckerConfig, pathToEmptyFile.toString());
+    }
+
+    @Test
+    public void testGetExternalResourceLocations() throws Exception {
+        final SuppressionFilter filter = new SuppressionFilter();
+        final String fileName = getPath("InputSuppressionFilterNone.xml");
+        filter.setFile(fileName);
+
+        final Set<String> actual = filter.getExternalResourceLocations();
+
+        assertWithMessage("Should contain exactly one resource")
+            .that(actual)
+            .hasSize(1);
+        assertWithMessage("Should contain the configured suppression file")
+            .that(actual)
+            .containsExactly(fileName);
     }
 
     private static boolean isConnectionAvailableAndStable(String url) throws Exception {


### PR DESCRIPTION
part of #14482

for this specific case , i believe pitest change it to `return Collections.emptySet();` and test still passed even tho they shouldn't this is why asserting `hasSize(1);` kills it 