### PR TITLE
Issue #14482: Refactors DetailAstImpl to use Collections.unmodifiableList() replacing UnmodifiableCollectionUtil

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
@@ -19,7 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -28,7 +31,6 @@ import org.antlr.v4.runtime.Token;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
-import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 
 /**
  * The implementation of {@link DetailAST}. This should only be directly used to
@@ -502,7 +504,7 @@ public final class DetailAstImpl implements DetailAST {
     public List<Token> getHiddenBefore() {
         List<Token> returnList = null;
         if (hiddenBefore != null) {
-            returnList = UnmodifiableCollectionUtil.unmodifiableList(hiddenBefore);
+            returnList = Collections.unmodifiableList(hiddenBefore);
         }
         return returnList;
     }
@@ -516,7 +518,7 @@ public final class DetailAstImpl implements DetailAST {
     public List<Token> getHiddenAfter() {
         List<Token> returnList = null;
         if (hiddenAfter != null) {
-            returnList = UnmodifiableCollectionUtil.unmodifiableList(hiddenAfter);
+            returnList = Collections.unmodifiableList(hiddenAfter);
         }
         return returnList;
     }
@@ -526,8 +528,8 @@ public final class DetailAstImpl implements DetailAST {
      *
      * @param hiddenBefore comment token preceding this DetailAstImpl
      */
-    public void setHiddenBefore(List<Token> hiddenBefore) {
-        this.hiddenBefore = UnmodifiableCollectionUtil.unmodifiableList(hiddenBefore);
+    public void setHiddenBefore(Collection<Token> hiddenBefore) {
+        this.hiddenBefore = new ArrayList<>(hiddenBefore);
     }
 
     /**
@@ -535,7 +537,7 @@ public final class DetailAstImpl implements DetailAST {
      *
      * @param hiddenAfter comment token following this DetailAstImpl
      */
-    public void setHiddenAfter(List<Token> hiddenAfter) {
-        this.hiddenAfter = UnmodifiableCollectionUtil.unmodifiableList(hiddenAfter);
+    public void setHiddenAfter(Collection<Token> hiddenAfter) {
+        this.hiddenAfter = new ArrayList<>(hiddenAfter);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
@@ -43,17 +43,6 @@ public final class UnmodifiableCollectionUtil {
     }
 
     /**
-     * Creates an unmodifiable list based on the provided collection.
-     *
-     * @param collection the collection to create an unmodifiable list from
-     * @param <T> the type of elements in the set
-     * @return an unmodifiable list containing the elements from the provided collection
-     */
-    public static <T> List<T> unmodifiableList(List<T> collection) {
-        return Collections.unmodifiableList(collection);
-    }
-
-    /**
      * Creates an unmodifiable list from the provided collection.
      * If the collection is null, returns an empty unmodifiable list.
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
@@ -43,6 +43,9 @@ public final class UnmodifiableCollectionUtil {
 
     /**
      * Creates an unmodifiable list based on the provided collection.
+     * This does NOT handle null — if called with null it will throw NPE.
+     * This is intentional: see
+     * <a href="https://github.com/hcoles/pitest/issues/1462">pitest issue #1462</a>.
      *
      * @param collection the collection to create an unmodifiable list from
      * @param <T> the type of elements in the set

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import java.io.File;
 import java.io.Writer;
@@ -35,6 +36,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.Token;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -836,6 +838,72 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         assertWithMessage(badPrevMsg)
             .that(node.getPreviousSibling())
             .isEqualTo(prev);
+    }
+
+    @Test
+    public void testGetHiddenBeforeIsUnmodifiable() {
+        final DetailAstImpl detailAst = new DetailAstImpl();
+        final List<Token> tokens = new ArrayList<>();
+        tokens.add(new CommonToken(1, "before"));
+        detailAst.setHiddenBefore(tokens);
+
+        final List<Token> actual = detailAst.getHiddenBefore();
+
+        final Throwable thrown = getExpectedThrowable(UnsupportedOperationException.class, () -> {
+            actual.add(new CommonToken(2, "fail"));
+        });
+
+        assertWithMessage("Should throw exception when modifying unmodifiable list")
+            .that(thrown)
+            .isNotNull();
+    }
+
+    @Test
+    public void testGetHiddenAfterIsUnmodifiable() {
+        final DetailAstImpl detailAst = new DetailAstImpl();
+        final List<Token> tokens = new ArrayList<>();
+        tokens.add(new CommonToken(1, "after"));
+        detailAst.setHiddenAfter(tokens);
+
+        final List<Token> actual = detailAst.getHiddenAfter();
+
+        final Throwable thrown = getExpectedThrowable(UnsupportedOperationException.class, () -> {
+            actual.add(new CommonToken(2, "fail"));
+        });
+
+        assertWithMessage("Should throw exception when modifying unmodifiable list")
+            .that(thrown)
+            .isNotNull();
+    }
+
+    @Test
+    public void testSetHiddenBeforeIsDefensive() {
+        final DetailAstImpl detailAst = new DetailAstImpl();
+        final List<Token> tokens = new ArrayList<>();
+        tokens.add(new CommonToken(1, "original"));
+
+        detailAst.setHiddenBefore(tokens);
+
+        tokens.add(new CommonToken(2, "external-change"));
+
+        assertWithMessage("Internal list should not be affected by external changes")
+            .that(detailAst.getHiddenBefore())
+            .hasSize(1);
+    }
+
+    @Test
+    public void testSetHiddenAfterIsDefensive() {
+        final DetailAstImpl detailAst = new DetailAstImpl();
+        final List<Token> tokens = new ArrayList<>();
+        tokens.add(new CommonToken(1, "original"));
+
+        detailAst.setHiddenAfter(tokens);
+
+        tokens.add(new CommonToken(2, "external-change"));
+
+        assertWithMessage("Internal list should not be affected by external changes")
+            .that(detailAst.getHiddenAfter())
+            .hasSize(1);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -840,5 +840,4 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
             .that(node.getPreviousSibling())
             .isEqualTo(prev);
     }
-
 }


### PR DESCRIPTION
issue #14482

## Description:
Migrated DetailAstImpl from `UnmodifiableCollectionUtil` to standard `java.util.Collections.unmodifiableList`.


## changes
Previously, both the setter and getter wrapped the list, making the getter's unmodifiableList call redundant from Pitest's perspective, siince the list was already unmodifiable when stored Pitest's `ArgumentPropagationMutator` could remove the getter's wrapper without any test failing ,causing a surviving mutation.
To resolve this, the setters now perform a defensive copy via new `ArrayList<>()`, storing a mutable list internally. The getter then wraps it with` Collections.unmodifiableList`, making that call functionally necessary and killable by Pitest.
Setter parameters were also changed from List to Collection to satisfy SpotBugs `(OCP_OVERLY_CONCRETE_COLLECTION_PARAMETER)`.
Tests added:

`testGetHiddenBeforeIsUnmodifiable` / `testGetHiddenAfterIsUnmodifiable` —> verify the getter returns an unmodifiable view
`testSetHiddenBeforeIsDefensive` /` testSetHiddenAfterIsDefensive` —> verify the setter performs a defensive copy