### PR TITLE
Issue #14482: refactor api/violation and kill according pitest mutation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import com.puppycrawl.tools.checkstyle.LocalizedMessage;
-import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 
 /**
  * Represents a violation that can be localised. The translations come from
@@ -115,7 +114,7 @@ public final class Violation
             this.args = null;
         }
         else {
-            this.args = UnmodifiableCollectionUtil.copyOfArray(args, args.length);
+            this.args = Arrays.copyOf(args, args.length);
         }
         this.bundle = bundle;
         this.severityLevel = severityLevel;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
@@ -211,4 +211,19 @@ public class ViolationTest {
                 EMPTY_OBJECT_ARRAY, "module", Violation.class, null);
     }
 
+    @Test
+    public void testArgsAreCopiedToEnsureImmutability() {
+        final Object[] originalArgs = {"InitialValue"};
+        final Violation violation = new Violation(1,
+                "com.puppycrawl.tools.checkstyle.messages",
+                "general.exception",
+                originalArgs, null, getClass(), null);
+
+        originalArgs[0] = "MutatedValue";
+
+        assertWithMessage("Violation args must be a copy")
+            .that(violation.getViolation())
+            .contains("InitialValue");
+    }
+
 }


### PR DESCRIPTION
Issue #14482

same pattern  as #19688 just needs to add test .

Pitest replaced  defensive copy (Arrays.copyOf) with a direct reference to the original array since no existing test tried to modify the input array after creating a Violation,Pitest assumed the copy was useless code because the program's behavior didn't appear to change.