### PR TITLE
Issue #14482: Replace UnmodifiableCollectionUtil in LocalizedMessage.

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java
@@ -26,13 +26,12 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.ResourceBundle.Control;
-
-import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 
 /**
  * Represents a message that can be localised. The translations come from
@@ -81,7 +80,7 @@ public class LocalizedMessage {
             this.args = null;
         }
         else {
-            this.args = UnmodifiableCollectionUtil.copyOfArray(args, args.length);
+            this.args = Arrays.copyOf(args, args.length);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/LocalizedMessageTest.java
@@ -288,6 +288,22 @@ public class LocalizedMessageTest {
                 .isNull();
     }
 
+    @Test
+    public void testArgsAreCopiedToEnsureImmutability() {
+        final Object[] originalArgs = {"InitialValue"};
+        final LocalizedMessage message = new LocalizedMessage(
+                Definitions.CHECKSTYLE_BUNDLE,
+                DefaultLogger.class,
+                "DefaultLogger.addException",
+                originalArgs);
+
+        originalArgs[0] = "MutatedValue";
+
+        assertWithMessage("LocalizedMessage args must be a copy to ensure immutability")
+                .that(message.getMessage())
+                .contains("InitialValue");
+    }
+
     @AfterEach
     public void tearDown() {
         LocalizedMessage.setLocale(DEFAULT_LOCALE);


### PR DESCRIPTION
Issue #14482

the exact same pattern as #19695

Pitest's `ArgumentPropagationMutator` tries to prove that the  defensive copy (Arrays.copyOf) is unnecessary, It does this by making the class point directly to the original array we passed in. this is why we add a test  that modifies the array after construction and checks the message to killl the mutation