### PR TITLE
Issue #14482: Replace UnmodifiableCollectionUtil in XmlLoader and kil according pitest mutation

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -9144,29 +9144,6 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java</fileName>
     <specifier>type.arguments.not.inferred</specifier>
-    <message>Could not infer type arguments for Map.copyOf</message>
-    <lineContent>return Map.copyOf(map);</lineContent>
-    <details>
-      unsatisfiable constraint: K extends @Initialized @Nullable Object &lt;: @Initialized @NonNull Object
-      capture extends K extends @Initialized @Nullable Object &lt;: use of K from Map.copyOf(map)
-      From complementary bound.: capture extends K extends @Initialized @Nullable Object &lt;= inference type: ? extends K
-      @Initialized @NonNull Map&lt;capture extends K extends @Initialized @Nullable Object, capture extends V extends @Initialized @Nullable Object&gt; &lt;: inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      @Initialized @NonNull Map&lt;capture extends K extends @Initialized @Nullable Object, capture extends V extends @Initialized @Nullable Object&gt; -&gt; inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      map -&gt; inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      From: Argument constraint
-      V extends @Initialized @Nullable Object &lt;: @Initialized @NonNull Object
-      capture extends V extends @Initialized @Nullable Object &lt;: use of V from Map.copyOf(map)
-      From complementary bound.: capture extends V extends @Initialized @Nullable Object &lt;= inference type: ? extends V
-      @Initialized @NonNull Map&lt;capture extends K extends @Initialized @Nullable Object, capture extends V extends @Initialized @Nullable Object&gt; &lt;: inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      @Initialized @NonNull Map&lt;capture extends K extends @Initialized @Nullable Object, capture extends V extends @Initialized @Nullable Object&gt; -&gt; inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      map -&gt; inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      From: Argument constraint
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java</fileName>
-    <specifier>type.arguments.not.inferred</specifier>
     <message>Could not infer type arguments for Stream.map</message>
     <lineContent>.map(elementType::cast)</lineContent>
     <details>

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -9133,29 +9133,6 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java</fileName>
     <specifier>type.arguments.not.inferred</specifier>
-    <message>Could not infer type arguments for Map.copyOf</message>
-    <lineContent>return Map.copyOf(map);</lineContent>
-    <details>
-      unsatisfiable constraint: K extends @Initialized @Nullable Object &lt;: @Initialized @NonNull Object
-      capture extends K extends @Initialized @Nullable Object &lt;: use of K from Map.copyOf(map)
-      From complementary bound.: capture extends K extends @Initialized @Nullable Object &lt;= inference type: ? extends K
-      @Initialized @NonNull Map&lt;capture extends K extends @Initialized @Nullable Object, capture extends V extends @Initialized @Nullable Object&gt; &lt;: inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      @Initialized @NonNull Map&lt;capture extends K extends @Initialized @Nullable Object, capture extends V extends @Initialized @Nullable Object&gt; -&gt; inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      map -&gt; inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      From: Argument constraint
-      V extends @Initialized @Nullable Object &lt;: @Initialized @NonNull Object
-      capture extends V extends @Initialized @Nullable Object &lt;: use of V from Map.copyOf(map)
-      From complementary bound.: capture extends V extends @Initialized @Nullable Object &lt;= inference type: ? extends V
-      @Initialized @NonNull Map&lt;capture extends K extends @Initialized @Nullable Object, capture extends V extends @Initialized @Nullable Object&gt; &lt;: inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      @Initialized @NonNull Map&lt;capture extends K extends @Initialized @Nullable Object, capture extends V extends @Initialized @Nullable Object&gt; -&gt; inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      map -&gt; inference type: java.util.Map&lt;? extends K,? extends V&gt;
-      From: Argument constraint
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java</fileName>
-    <specifier>type.arguments.not.inferred</specifier>
     <message>Could not infer type arguments for Stream.map</message>
     <lineContent>.map(elementType::cast)</lineContent>
     <details>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
@@ -32,8 +32,6 @@ import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 
-import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
-
 /**
  * Contains the common implementation of a loader, for loading a configuration
  * from an XML file.
@@ -68,8 +66,7 @@ public class XmlLoader
      */
     protected XmlLoader(Map<String, String> publicIdToResourceNameMap)
             throws SAXException, ParserConfigurationException {
-        this.publicIdToResourceNameMap =
-                UnmodifiableCollectionUtil.copyOfMap(publicIdToResourceNameMap);
+        this.publicIdToResourceNameMap = Map.copyOf(publicIdToResourceNameMap);
         parser = createXmlReader(this);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -98,18 +97,6 @@ public final class UnmodifiableCollectionUtil {
      */
     public static <T> T[] copyOfArray(T[] array, int length) {
         return Arrays.copyOf(array, length);
-    }
-
-    /**
-     * Creates a copy of Map.
-     *
-     * @param map map to create a copy of
-     * @param <K> the type of keys in the map
-     * @param <V> the type of values in the map
-     * @return an immutable copy of the input map
-     */
-    public static <K, V> Map<K, V> copyOfMap(Map<? extends K, ? extends V> map) {
-        return Map.copyOf(map);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
@@ -72,6 +72,20 @@ public class XmlLoaderTest {
             .isNotNull();
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPublicIdToResourceNameMapIsCopied() throws Exception {
+        final Map<String, String> mutableMap = new HashMap<>();
+        mutableMap.put("id", "resource");
+        final DummyLoader loader = new DummyLoader(mutableMap);
+        mutableMap.put("newId", "newResource");
+        final Map<String, String> internalMap = (Map<String, String>) TestUtil.getInternalState(
+                loader, "publicIdToResourceNameMap", Map.class);
+        assertWithMessage("Internal map should not reflect external changes")
+                .that(internalMap.containsKey("newId"))
+                .isFalse();
+    }
+
     private static final class DummyLoader extends XmlLoader {
 
         private DummyLoader(Map<String, String> publicIdToResourceNameMap)


### PR DESCRIPTION
Issue #14482

### changes 
replaced `nmodifiableCollectionUtil.copyOfMap` with ` Map.copyOf` , the same mutation as other prs (Pitest replace y defensive copy (Map.copyOf) with a direct reference to the input map) 
we  kill it in a test  by passing a mutable map to the constructor and modifying it immediately after,because the test asserts that the internal state remains unchanged, it forces a failure if the defensive copy is removed, successfully proving the code's immutability and killing the mutation.

this will be 5th pr in this issue (half of the files that needs to be refactored ) so i will wait until  some get reviewed to see if this a valid update and to avoid conflicts  then i will continue with the second half to close this issue with no need to wait for pitest :)