### PR TITLE
Issue #1525: Add ignoreUniformChains property to BooleanExpressionComplexityCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -70,6 +70,8 @@ public final class BooleanExpressionComplexityCheck extends AbstractCheck {
     private final Deque<Context> contextStack = new ArrayDeque<>();
     /** Specify the maximum number of boolean operations allowed in one expression. */
     private int max;
+    /** Control whether to ignore uniform chains of the same boolean operator. */
+    private boolean ignoreUniformChains;
     /** Current context. */
     private Context context = new Context(false);
 
@@ -128,6 +130,18 @@ public final class BooleanExpressionComplexityCheck extends AbstractCheck {
         this.max = max;
     }
 
+    /**
+     * Setter to control whether to ignore uniform chains of the same boolean operator.
+     * When enabled, a sequence like {@code a || b || c || d} counts as complexity 1
+     * instead of the number of operators present.
+     *
+     * @param ignoreUniformChains whether to ignore uniform operator chains.
+     * @since 13.4.1
+     */
+    public void setIgnoreUniformChains(boolean ignoreUniformChains) {
+        this.ignoreUniformChains = ignoreUniformChains;
+    }
+
     @Override
     public void visitToken(DetailAST ast) {
         switch (ast.getType()) {
@@ -138,20 +152,26 @@ public final class BooleanExpressionComplexityCheck extends AbstractCheck {
             case TokenTypes.EXPR -> visitExpr();
 
             case TokenTypes.BOR -> {
-                if (!isPipeOperator(ast) && !isPassedInParameter(ast)) {
+                if (!isPipeOperator(ast) && !isPassedInParameter(ast)
+                        && (!ignoreUniformChains || ast.getParent().getType() != ast.getType())) {
                     context.visitBooleanOperator();
                 }
             }
 
             case TokenTypes.BAND,
                  TokenTypes.BXOR -> {
-                if (!isPassedInParameter(ast)) {
+                if (!isPassedInParameter(ast)
+                        && (!ignoreUniformChains || ast.getParent().getType() != ast.getType())) {
                     context.visitBooleanOperator();
                 }
             }
 
             case TokenTypes.LAND,
-                 TokenTypes.LOR -> context.visitBooleanOperator();
+                 TokenTypes.LOR -> {
+                if (!ignoreUniformChains || ast.getParent().getType() != ast.getType()) {
+                    context.visitBooleanOperator();
+                }
+            }
 
             default -> throw new IllegalArgumentException("Unknown type: " + ast);
         }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/metrics/BooleanExpressionComplexityCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/metrics/BooleanExpressionComplexityCheck.xml
@@ -27,6 +27,11 @@
  variables and Checkstyle does not know types of methods from different classes.
  &lt;/p&gt;</description>
          <properties>
+            <property default-value="false" name="ignoreUniformChains" type="boolean">
+               <description>Control whether to ignore uniform chains of the same boolean operator.
+ When enabled, a sequence like &lt;code&gt;a || b || c || d&lt;/code&gt; counts as complexity 1
+ instead of the number of operators present.</description>
+            </property>
             <property default-value="3" name="max" type="int">
                <description>Specify the maximum number of boolean operations allowed in one expression.</description>
             </property>

--- a/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml
+++ b/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml
@@ -44,6 +44,13 @@
               <th>since</th>
             </tr>
             <tr>
+              <td><a id="ignoreUniformChains"/><a href="#ignoreUniformChains">ignoreUniformChains</a></td>
+              <td>Control whether to ignore uniform chains of the same boolean operator. When enabled, a sequence like <code>a || b || c || d</code> counts as complexity 1 instead of the number of operators present.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>13.4.1</td>
+            </tr>
+            <tr>
               <td><a id="max"/><a href="#max">max</a></td>
               <td>Specify the maximum number of boolean operations allowed in one expression.</td>
               <td><a href="../../property_types.html#int">int</a></td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckTest.java
@@ -42,11 +42,11 @@ public class BooleanExpressionComplexityCheckTest extends AbstractModuleTestSupp
     public void test() throws Exception {
 
         final String[] expected = {
-            "21:9: " + getCheckMessage(MSG_KEY, 4, 3),
-            "39:46: " + getCheckMessage(MSG_KEY, 4, 3),
-            "50:9: " + getCheckMessage(MSG_KEY, 6, 3),
-            "57:34: " + getCheckMessage(MSG_KEY, 4, 3),
-            "60:34: " + getCheckMessage(MSG_KEY, 4, 3),
+            "22:9: " + getCheckMessage(MSG_KEY, 4, 3),
+            "40:46: " + getCheckMessage(MSG_KEY, 4, 3),
+            "51:9: " + getCheckMessage(MSG_KEY, 6, 3),
+            "58:34: " + getCheckMessage(MSG_KEY, 4, 3),
+            "61:34: " + getCheckMessage(MSG_KEY, 4, 3),
         };
 
         verifyWithInlineConfigParser(
@@ -100,10 +100,10 @@ public class BooleanExpressionComplexityCheckTest extends AbstractModuleTestSupp
         final int max = 3;
 
         final String[] expected = {
-            "16:12: " + getCheckMessage(MSG_KEY, 4, max),
-            "25:23: " + getCheckMessage(MSG_KEY, 4, max),
-            "37:23: " + getCheckMessage(MSG_KEY, 4, max),
-            "48:27: " + getCheckMessage(MSG_KEY, 4, max),
+            "17:12: " + getCheckMessage(MSG_KEY, 4, max),
+            "26:23: " + getCheckMessage(MSG_KEY, 4, max),
+            "38:23: " + getCheckMessage(MSG_KEY, 4, max),
+            "49:27: " + getCheckMessage(MSG_KEY, 4, max),
         };
 
         verifyWithInlineConfigParser(
@@ -137,15 +137,27 @@ public class BooleanExpressionComplexityCheckTest extends AbstractModuleTestSupp
         final int max = 0;
 
         final String[] expected = {
-            "17:21: " + getCheckMessage(MSG_KEY, 6, max),
-            "21:17: " + getCheckMessage(MSG_KEY, 6, max),
-            "25:27: " + getCheckMessage(MSG_KEY, 6, max),
-            "29:48: " + getCheckMessage(MSG_KEY, 1, max),
+            "18:21: " + getCheckMessage(MSG_KEY, 6, max),
+            "22:17: " + getCheckMessage(MSG_KEY, 6, max),
+            "26:27: " + getCheckMessage(MSG_KEY, 6, max),
+            "30:48: " + getCheckMessage(MSG_KEY, 1, max),
         };
 
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputBooleanExpressionComplexityWhenExpression.java"),
                 expected);
+    }
+
+    @Test
+    public void testIgnoreUniformChains() throws Exception {
+
+        final String[] expected = {
+            "34:9: " + getCheckMessage(MSG_KEY, 4, 3),
+            "60:9: " + getCheckMessage(MSG_KEY, 4, 3),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputBooleanExpressionComplexityUniformChain.java"), expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -87,6 +87,7 @@ public class XdocsExamplesAstConsistencyTest {
      * <p>Until: <a href="https://github.com/checkstyle/checkstyle/issues/18435">...</a>
      */
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
+            "checks/metrics/booleanexpressioncomplexity/Example4",
             "checks/annotation/annotationonsameline/Example2",
             "checks/annotation/missingoverride/Example2",
             "checks/annotation/suppresswarningsholder/Example1",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityWhenExpression.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityWhenExpression.java
@@ -1,5 +1,6 @@
 /*
 BooleanExpressionComplexity
+ignoreUniformChains = (default)false
 max = 0
 tokens = (default)LAND, BAND, LOR, BOR, BXOR
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexity.java
@@ -1,5 +1,6 @@
 /*
 BooleanExpressionComplexity
+ignoreUniformChains = (default)false
 max = (default)3
 tokens = (default)LAND, BAND, LOR, BOR, BXOR
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexity2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexity2.java
@@ -1,5 +1,6 @@
 /*
 BooleanExpressionComplexity
+ignoreUniformChains = (default)false
 max = 5
 tokens = BXOR,LAND,LOR
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityLeaves.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityLeaves.java
@@ -1,5 +1,6 @@
 /*
 BooleanExpressionComplexity
+ignoreUniformChains = (default)false
 max = (default)3
 tokens = (default)LAND, BAND, LOR, BOR, BXOR
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityNPE.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityNPE.java
@@ -1,5 +1,6 @@
 /*
 BooleanExpressionComplexity
+ignoreUniformChains = (default)false
 max = (default)3
 tokens = (default)LAND, BAND, LOR, BOR, BXOR
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordLeaves.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordLeaves.java
@@ -1,5 +1,6 @@
 /*
 BooleanExpressionComplexity
+ignoreUniformChains = (default)false
 max = (default)3
 tokens = (default)LAND, BAND, LOR, BOR, BXOR
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordsAndCompactCtors.java
@@ -1,5 +1,6 @@
 /*
 BooleanExpressionComplexity
+ignoreUniformChains = (default)false
 max = (default)3
 tokens = (default)LAND, BAND, LOR, BOR, BXOR
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexitySmall.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexitySmall.java
@@ -1,5 +1,6 @@
 /*
 BooleanExpressionComplexity
+ignoreUniformChains = (default)false
 max = 1
 tokens = (default)LAND, BAND, LOR, BOR, BXOR
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityUniformChain.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityUniformChain.java
@@ -1,0 +1,69 @@
+/*
+BooleanExpressionComplexity
+max = (default)3
+ignoreUniformChains = true
+tokens = (default)LAND, BAND, LOR, BOR, BXOR
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.metrics.booleanexpressioncomplexity;
+
+public class InputBooleanExpressionComplexityUniformChain {
+
+    private int type;
+
+    public boolean isDefinitionToken() {
+        return type == 1
+            || type == 2
+            || type == 3
+            || type == 4
+            || type == 5
+            || type == 6
+            || type == 7
+            || type == 8;
+    }
+
+    public boolean allConditionsMet(boolean a, boolean b, boolean c,
+                                    boolean d, boolean e, boolean f) {
+        return a && b && c && d && e && f;
+    }
+
+    public boolean mixed(boolean a, boolean b, boolean c,
+                         boolean d, boolean e, boolean f) {
+        return a && b || c && d || e && f;
+        // violation above 'Boolean expression complexity is 4 (max allowed is 3).'
+    }
+
+    public boolean twoChains(boolean a, boolean b, boolean c,
+                              boolean d, boolean e, boolean f) {
+        return (a || b || c) && (d || e || f);
+    }
+
+    public boolean uniformBand(boolean a, boolean b, boolean c,
+                               boolean d, boolean e, boolean f) {
+        return a & b & c & d & e;
+    }
+
+    public boolean uniformBxor(boolean a, boolean b, boolean c,
+                               boolean d, boolean e, boolean f) {
+        return a ^ b ^ c ^ d ^ e;
+    }
+
+    public boolean uniformBor(boolean a, boolean b, boolean c,
+                              boolean d, boolean e, boolean f) {
+        return a | b | c | d | e;
+    }
+
+    public boolean mixedBor(boolean a, boolean b, boolean c,
+                            boolean d, boolean e, boolean f) {
+        return (a & b) | (c & d) | (e & f);
+        // violation above 'Boolean expression complexity is 4 (max allowed is 3).'
+    }
+
+    public boolean longUniformBor(boolean a, boolean b, boolean c,
+                                  boolean d, boolean e, boolean f) {
+        return a | b | c | d | e | f;
+    }
+
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckExamplesTest.java
@@ -59,4 +59,14 @@ public class BooleanExpressionComplexityCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "19:5: " + getCheckMessage(MSG_KEY, 4, 3),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/Example4.java
@@ -1,0 +1,23 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="BooleanExpressionComplexity">
+      <property name="ignoreUniformChains" value="true"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.metrics.booleanexpressioncomplexity;
+// xdoc section -- start
+public class Example4
+{
+  int type;
+  boolean isDefToken() {
+    return type == 1 || type == 2 || type == 3 || type == 4 || type == 5;
+  }
+  boolean mixed(boolean a, boolean b, boolean c, boolean d, boolean e, boolean f) {
+    return a && b || c && d || e && f;
+    // violation above, 'Boolean expression complexity is 4 (max allowed is 3)'
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
fixes #1525

added `ignoreUniformChains` property to `BooleanExpressionComplexityCheck`.

Diff Regression config: https://gist.githubusercontent.com/ayushactiveat/8312311ce27ba0a23505fe8905a73572/raw/0618c41191fd385608ee7bb7bbfa1f7fffc675f6/base_config.xml

Diff Regression patch config: https://gist.githubusercontent.com/ayushactiveat/0c28d717c40cbe221eca0ffb10a3da7d/raw/7c1324be2037d5c29a7d5b5acf7fefcdbef54c29/patch_config.xml