### PR TITLE
Issue #16979: resolve PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS spotbugs suppressions in JavaAstVisitor

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -260,13 +260,6 @@
     <Bug pattern="BAS_BLOATED_ASSIGNMENT_SCOPE"/>
   </Match>
 
-  <!-- Suppress PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS -->
-  <!-- false positive: NakedReceiverMutator causes unkillable mutations -->
-  <!-- until https://github.com/checkstyle/checkstyle/issues/16979 -->
-  <Match>
-    <Class name="com.puppycrawl.tools.checkstyle.JavaAstVisitor" />
-    <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />
-  </Match>
   <Match>
     <Class name="com.puppycrawl.tools.checkstyle.JavaAstVisitor$DetailAstPair" />
     <Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
@@ -468,8 +468,9 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         // We also append the SEMI token to the first child [size() - 1],
         // until https://github.com/checkstyle/checkstyle/issues/3151
         processChildren(dummyNode, ctx.children.subList(1, ctx.children.size() - 1));
-        dummyNode.getFirstChild().addChild(create(ctx.SEMI()));
-        return dummyNode.getFirstChild();
+        final DetailAstImpl firstChild = dummyNode.getFirstChild();
+        firstChild.addChild(create(ctx.SEMI()));
+        return firstChild;
     }
 
     @Override
@@ -826,8 +827,9 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         processChildren(dummyNode, Collections.singletonList(ctx.children.get(1)));
         // We also append the SEMI token to the first child [size() - 1],
         // until https://github.com/checkstyle/checkstyle/issues/3151
-        dummyNode.getFirstChild().addChild(create(ctx.SEMI()));
-        return dummyNode.getFirstChild();
+        final DetailAstImpl firstChild = dummyNode.getFirstChild();
+        firstChild.addChild(create(ctx.SEMI()));
+        return firstChild;
     }
 
     @Override
@@ -1356,8 +1358,10 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         }
         else {
             DetailAstImpl firstChild = superSuffixParent;
-            while (firstChild.getFirstChild() != null) {
-                firstChild = firstChild.getFirstChild();
+            DetailAstImpl nextChild = firstChild.getFirstChild();
+            while (nextChild != null) {
+                firstChild = nextChild;
+                nextChild = firstChild.getFirstChild();
             }
             firstChild.addPreviousSibling(bop);
         }
@@ -2185,8 +2189,10 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
     private static void addLastSibling(DetailAstImpl self, DetailAstImpl sibling) {
         DetailAstImpl nextSibling = self;
         if (nextSibling != null) {
-            while (nextSibling.getNextSibling() != null) {
-                nextSibling = nextSibling.getNextSibling();
+            DetailAstImpl next = nextSibling.getNextSibling();
+            while (next != null) {
+                nextSibling = next;
+                next = nextSibling.getNextSibling();
             }
             nextSibling.setNextSibling(sibling);
         }


### PR DESCRIPTION
Issue #16979

Removed suppression of `PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS` from `config/spotbugs-exclude.xml` and resolved the 4 false positives in  `JavaAstVisitor.java` by caching repeated method calls into local variables.


this is the last suppression with the comment ` <!-- until https://github.com/checkstyle/checkstyle/issues/16979 -->` so maybe this PR should close the issue .