### PR TITLE
Add New OpenJDK Style 3.12 Lambda Expressions Rule 3

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -749,6 +749,7 @@ Kordas
 Kotlin
 Kp
 lambdabodylength
+lambdaexpressions
 lambdaparametername
 LBRACE
 LBRACK

--- a/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule312lambdaexpressions/LambdaBodyLengthTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule312lambdaexpressions/LambdaBodyLengthTest.java
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapter3formatting.rule312lambdaexpressions;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class LambdaBodyLengthTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapter3formatting/rule312lambdaexpressions";
+    }
+
+    @Test
+    public void lambdaBodyLengthTest() throws Exception {
+        verifyWithWholeConfig(getPath("InputLambdaExpressionsBodyLength.java"));
+    }
+
+    @Test
+    public void lambdaBodyLengthValidTest() throws Exception {
+        verifyWithWholeConfig(getPath("InputLambdaExpressionsBodyLengthValid.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule312lambdaexpressions/InputLambdaExpressionsBodyLength.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule312lambdaexpressions/InputLambdaExpressionsBodyLength.java
@@ -1,0 +1,42 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule312lambdaexpressions;
+
+/**
+ * Test input for lambda body length with violations.
+ */
+public class InputLambdaExpressionsBodyLength {
+
+    /**
+     * Illegal method - lambda expression body exceeds 10 lines.
+     */
+    public void doIllegal() {
+        Runnable r = () -> { // violation 'Lambda body length is 11 lines (max allowed is 10).'
+            int a = 1;
+            int b = 2;
+            int c = 3;
+            int d = 4;
+            int e = 5;
+            int f = 6;
+            int g = 7;
+            int h = 8;
+            int i = 9;
+            int j = 10;
+        };
+    }
+
+    /**
+     * Simple legal method.
+     */
+    public void doLegal() {
+        Runnable r = () -> {
+            int a = 1;
+            int b = 2;
+            int c = 3;
+            int d = 4;
+            int e = 5;
+            int f = 6;
+            int g = 7;
+            int h = 8;
+            int i = 9;
+        };
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule312lambdaexpressions/InputLambdaExpressionsBodyLengthValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule312lambdaexpressions/InputLambdaExpressionsBodyLengthValid.java
@@ -1,0 +1,48 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule312lambdaexpressions;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Test input for lambda body length with no violations.
+ */
+public class InputLambdaExpressionsBodyLengthValid {
+
+    /**
+     * Valid block body within the limit.
+     */
+    public void sumLegal() {
+        BiFunction<Integer, Integer, String> checkSum = (a, b) -> {
+            int sum = a + b;
+            if (sum > 100) {
+                return "That is a large number: " + sum;
+            } else {
+                return "That is a small number: " + sum;
+            }
+        };
+    }
+
+    /**
+     * A short, single-expression lambda without braces.
+     */
+    public void testShortExpressionLambda() {
+        Function<Integer, Integer> square = x -> x * x;
+    }
+
+    /**
+     * Simple legal method.
+     */
+    public void doLegal() {
+        Runnable r = () -> {
+            int a = 1;
+            int b = 2;
+            int c = 3;
+            int d = 4;
+            int e = 5;
+            int f = 6;
+            int g = 7;
+            int h = 8;
+            int i = 9;
+        };
+    }
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -39,6 +39,9 @@
     <!-- Add TreeWalker checks based on OpenJDK style guide -->
     <module name="OneStatementPerLine"/>
 
+    <!-- §3.12: Expression lambda body length check based on OpenJDK style guide -->
+    <module name="LambdaBodyLength"/>
+
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.openjdk.suppressionxpathfilter.config}"

--- a/src/site/xdoc/checks/sizes/lambdabodylength.xml
+++ b/src/site/xdoc/checks/sizes/lambdabodylength.xml
@@ -142,6 +142,10 @@ class Example2 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+LambdaBodyLength">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LambdaBodyLength">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/sizes/lambdabodylength.xml.template
+++ b/src/site/xdoc/checks/sizes/lambdabodylength.xml.template
@@ -68,6 +68,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+LambdaBodyLength">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LambdaBodyLength">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -521,8 +521,20 @@
                     3.12 Lambda Expressions
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/sizes/lambdabodylength.html#LambdaBodyLength">
+                    LambdaBodyLength</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LambdaBodyLength">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule312lambdaexpressions">
+                    samples
+                  </a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
Part3 of issue: #19662 

Summary
---
1. Add integration test for rule: lambda body length shouldn't exceed 10.
2. Update `openjdk_style.xml`
3. Update config in `openjdk_checks.xml`
4. Add reference to OpenJDK example usage in `LambdaBodyLength` check page.