### PR TITLE
Issue #19707: Fix false negative for opening """ preceded by ? in ter…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheck.java
@@ -126,8 +126,12 @@ public class TextBlockGoogleStyleFormattingCheck extends AbstractCheck {
      * @return true if the opening quotes are on the new line.
      */
     private static boolean openingQuotesAreAloneOnTheLine(DetailAST openingQuotes) {
+        final DetailAST prevSibling = openingQuotes.getPreviousSibling();
+        final boolean precededBySibling = prevSibling != null
+                && TokenUtil.areOnSameLine(openingQuotes, prevSibling);
+
         DetailAST parent = openingQuotes;
-        boolean quotesAreNotPreceded = true;
+        boolean quotesAreNotPreceded = !precededBySibling;
         while (quotesAreNotPreceded || parent.getType() == TokenTypes.ELIST
                 || parent.getType() == TokenTypes.EXPR) {
 
@@ -135,11 +139,6 @@ public class TextBlockGoogleStyleFormattingCheck extends AbstractCheck {
 
             if (parent.getType() == TokenTypes.METHOD_DEF) {
                 quotesAreNotPreceded = !quotesArePrecededWithComma(openingQuotes);
-            }
-            else if (parent.getType() == TokenTypes.QUESTION
-                    && openingQuotes.getPreviousSibling() != null) {
-                quotesAreNotPreceded = !TokenUtil.areOnSameLine(openingQuotes,
-                        openingQuotes.getPreviousSibling());
             }
             else {
                 quotesAreNotPreceded = !TokenUtil.areOnSameLine(openingQuotes, parent);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheckTest.java
@@ -383,4 +383,18 @@ public class TextBlockGoogleStyleFormattingCheckTest extends AbstractModuleTestS
         verifyWithInlineConfigParser(
                 getPath("InputTextBlockGoogleStyleFormattingAnnotations.java"), expected);
     }
+
+    @Test
+    public void testDefaultTextBlockFormatWithTernary() throws Exception {
+        final String[] expected = {
+            "14:11: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+            "17:11: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+            "23:23: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+            "25:11: " + getCheckMessage(MSG_VERTICALLY_UNALIGNED),
+            "26:11: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+            "35:11: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputTextBlockGoogleStyleFormattingWithTernary.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/textblockgooglestyleformatting/InputTextBlockGoogleStyleFormattingWithTernary.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/textblockgooglestyleformatting/InputTextBlockGoogleStyleFormattingWithTernary.java
@@ -1,0 +1,48 @@
+/*
+TextBlockGoogleStyleFormatting
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.textblockgooglestyleformatting;
+
+public class InputTextBlockGoogleStyleFormattingWithTernary {
+    boolean flag = true;
+
+    // violation 2 lines below 'Opening quotes (""") of text-block must be on the new line'
+    String a = flag
+        ? """
+          yes
+          """
+        : """
+          no
+          """;
+    // violation 3 lines above 'Opening quotes (""") of text-block must be on the new line'
+
+    // violation below 'Opening quotes (""") of text-block must be on the new line'
+    String b = flag ? """
+          yes
+          """ // violation 'Text-block quotes are not vertically aligned'
+        : """
+          no
+          """;
+    // violation 3 lines above 'Opening quotes (""") of text-block must be on the new line'
+
+    String c = flag ?
+        """
+        yes
+        """
+        : """
+          no
+          """;
+    // violation 3 lines above 'Opening quotes (""") of text-block must be on the new line'
+
+    String d = flag ?
+        """
+        yes
+        """
+        :
+        """
+        no
+        """;
+}


### PR DESCRIPTION
Issue #19707:

Fixed false negative in `TextBlockGoogleStyleFormattingCheck` where opening `"""` preceded by `?` in a ternary was not flagged when the condition was on a different line. The check now also compares against the parent `QUESTION` node, not just `previousSibling`