### PR TITLE
infra: fix regex for LocalVariableName, MemberName, ParameterName, LambdaParameterName, and StaticVariableName

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -568,7 +568,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter loader of ResourceBundle.getBundle.</message>
-    <lineContent>return ResourceBundle.getBundle(bundle, sLocale, sourceClass.getClassLoader(),</lineContent>
+    <lineContent>return ResourceBundle.getBundle(bundle, messageLocale, sourceClass.getClassLoader(),</lineContent>
     <details>
       found   : @Initialized @Nullable ClassLoader
       required: @Initialized @NonNull ClassLoader
@@ -2542,13 +2542,6 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference aMethodAST.findFirstToken(TokenTypes.IDENT)</message>
-    <lineContent>aMethodAST.findFirstToken(TokenTypes.IDENT).getText();</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java</fileName>
-    <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference ast.findFirstToken(TokenTypes.IDENT)</message>
     <lineContent>frameName = ast.findFirstToken(TokenTypes.IDENT).getText();</lineContent>
   </checkerFrameworkError>
@@ -2558,6 +2551,13 @@
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference child.findFirstToken(TokenTypes.IDENT)</message>
     <lineContent>child.findFirstToken(TokenTypes.IDENT).getText();</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference methodAST.findFirstToken(TokenTypes.IDENT)</message>
+    <lineContent>methodAST.findFirstToken(TokenTypes.IDENT).getText();</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
@@ -8150,22 +8150,22 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>argument</specifier>
-    <message>incompatible argument for parameter jTreeTable of ListToTreeSelectionModelWrapper constructor.</message>
-    <lineContent>ListToTreeSelectionModelWrapper(this);</lineContent>
+    <message>incompatible argument for parameter selectionModel of JTree.setSelectionModel.</message>
+    <lineContent>tree.setSelectionModel(selectionWrapper);</lineContent>
     <details>
-      found   : @UnderInitialization(javax.swing.JTable.class) @NonNull TreeTable
-      required: @Initialized @NonNull TreeTable
+      found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.gui.ListToTreeSelectionModelWrapper.class) @NonNull ListToTreeSelectionModelWrapper
+      required: @Initialized @NonNull TreeSelectionModel
     </details>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>argument</specifier>
-    <message>incompatible argument for parameter selectionModel of JTree.setSelectionModel.</message>
-    <lineContent>tree.setSelectionModel(selectionWrapper);</lineContent>
+    <message>incompatible argument for parameter treeTable of ListToTreeSelectionModelWrapper constructor.</message>
+    <lineContent>ListToTreeSelectionModelWrapper(this);</lineContent>
     <details>
-      found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.gui.ListToTreeSelectionModelWrapper.class) @NonNull ListToTreeSelectionModelWrapper
-      required: @Initialized @NonNull TreeSelectionModel
+      found   : @UnderInitialization(javax.swing.JTable.class) @NonNull TreeTable
+      required: @Initialized @NonNull TreeTable
     </details>
   </checkerFrameworkError>
 

--- a/config/checker-framework-suppressions/checker-signature-gui-units-init-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-signature-gui-units-init-suppressions.xml
@@ -15,7 +15,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter baseName of ResourceBundle.getBundle.</message>
-    <lineContent>return ResourceBundle.getBundle(bundle, sLocale, sourceClass.getClassLoader(),</lineContent>
+    <lineContent>return ResourceBundle.getBundle(bundle, messageLocale, sourceClass.getClassLoader(),</lineContent>
     <details>
       found   : @SignatureUnknown String
       required: @BinaryName String
@@ -101,7 +101,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
-    <lineContent>editor.moveCaretPosition(pModel.getSelectionEnd());</lineContent>
+    <lineContent>editor.moveCaretPosition(presentationModel.getSelectionEnd());</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
@@ -115,7 +115,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
-    <lineContent>editor.setCaretPosition(pModel.getSelectionStart());</lineContent>
+    <lineContent>editor.setCaretPosition(presentationModel.getSelectionStart());</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -879,26 +879,26 @@
     <module name="InterfaceTypeParameterName"/>
     <module name="LocalFinalVariableName"/>
     <module name="LocalVariableName">
-      <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
+      <property name="format" value="^(?:id|[a-z][a-z0-9][a-zA-Z0-9]+)$"/>
     </module>
     <module name="MemberName">
-      <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
+      <property name="format" value="^(?:id|[a-z][a-z0-9][a-zA-Z0-9]+)$"/>
     </module>
     <module name="MethodName"/>
     <module name="MethodTypeParameterName"/>
     <module name="PackageName"/>
     <module name="ParameterName">
-      <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
+      <property name="format" value="^(?:id|[a-z][a-z0-9][a-zA-Z0-9]+)$"/>
       <property name="ignoreOverridden" value="true"/>
     </module>
     <module name="LambdaParameterName">
-      <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
+      <property name="format" value="^(?:id|[a-z][a-z0-9][a-zA-Z0-9]+)$"/>
     </module>
     <module name="CatchParameterName">
       <property name="format" value="^[a-z][a-z][a-zA-Z]+$"/>
     </module>
     <module name="StaticVariableName">
-      <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
+      <property name="format" value="^(?:id|[a-z][a-z0-9][a-zA-Z0-9]+)$"/>
     </module>
     <module name="TypeName"/>
     <module name="PatternVariableName"/>

--- a/src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java
@@ -62,18 +62,18 @@ public abstract class AbstractIndentationTestSupport extends AbstractGoogleModul
     /**
      * Returns line numbers for lines with 'warn' comments.
      *
-     * @param aFileName file name.
+     * @param fileName file name.
      * @param tabWidth tab width.
      * @return array of line numbers containing 'warn' comments ('warn').
      * @throws IOException while reading the file for checking lines.
      * @throws IllegalStateException if file has incorrect indentation in comment or
      *     comment is inconsistent or if file has no indentation comment.
      */
-    private static Integer[] getLinesWithWarnAndCheckComments(String aFileName,
+    private static Integer[] getLinesWithWarnAndCheckComments(String fileName,
             final int tabWidth)
                     throws IOException {
         final List<Integer> result = new ArrayList<>();
-        try (BufferedReader br = Files.newBufferedReader(Path.of(aFileName))) {
+        try (BufferedReader br = Files.newBufferedReader(Path.of(fileName))) {
             int lineNumber = 1;
             for (String line = br.readLine(); line != null; line = br.readLine()) {
                 final Matcher match = LINE_WITH_COMMENT_REGEX.matcher(line);
@@ -86,7 +86,7 @@ public abstract class AbstractIndentationTestSupport extends AbstractGoogleModul
                         throw new IllegalStateException(String.format(Locale.ROOT,
                                         "File \"%1$s\" has incorrect indentation in comment."
                                                         + "Line %2$d: comment:%3$d, actual:%4$d.",
-                                        aFileName,
+                                        fileName,
                                         lineNumber,
                                         indentInComment,
                                         actualIndent));
@@ -99,7 +99,7 @@ public abstract class AbstractIndentationTestSupport extends AbstractGoogleModul
                     if (!isCommentConsistent(comment)) {
                         throw new IllegalStateException(String.format(Locale.ROOT,
                                         "File \"%1$s\" has inconsistent comment on line %2$d",
-                                        aFileName,
+                                        fileName,
                                         lineNumber));
                     }
                 }
@@ -107,7 +107,7 @@ public abstract class AbstractIndentationTestSupport extends AbstractGoogleModul
                     throw new IllegalStateException(String.format(Locale.ROOT,
                                     "File \"%1$s\" has no indentation comment or its format "
                                                     + "malformed. Error on line: %2$d(%3$s)",
-                                    aFileName,
+                                    fileName,
                                     lineNumber,
                                     line));
                 }

--- a/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
+++ b/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
@@ -553,16 +553,17 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
      * Gets the check message 'as is' from appropriate 'messages.properties'
      * file.
      *
-     * @param aClass the package the message is located in.
+     * @param reporterClass the package the message is located in.
      * @param messageKey the key of message in 'messages.properties' file.
      * @param arguments  the arguments of message in 'messages.properties' file.
      * @return The message of the check with the arguments applied.
      * @throws IOException if there is a problem loading the property file.
      */
-    protected static String getCheckMessage(Class<? extends AbstractViolationReporter> aClass,
-            String messageKey, Object... arguments) throws IOException {
+    protected static String getCheckMessage(
+            Class<? extends AbstractViolationReporter> reporterClass, String messageKey,
+            Object... arguments) throws IOException {
         final Properties pr = new Properties();
-        pr.load(aClass.getResourceAsStream("messages.properties"));
+        pr.load(reporterClass.getResourceAsStream("messages.properties"));
         final MessageFormat formatter = new MessageFormat(pr.getProperty(messageKey),
                 Locale.ROOT);
         return formatter.format(arguments);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java
@@ -42,7 +42,7 @@ import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 public class LocalizedMessage {
 
     /** The locale to localise messages to. **/
-    private static Locale sLocale = Locale.getDefault();
+    private static Locale messageLocale = Locale.getDefault();
 
     /** Name of the resource bundle to get messages from. **/
     private final String bundle;
@@ -92,10 +92,10 @@ public class LocalizedMessage {
      */
     public static void setLocale(Locale locale) {
         if (Locale.ENGLISH.getLanguage().equals(locale.getLanguage())) {
-            sLocale = Locale.ROOT;
+            messageLocale = Locale.ROOT;
         }
         else {
-            sLocale = locale;
+            messageLocale = locale;
         }
     }
 
@@ -134,7 +134,7 @@ public class LocalizedMessage {
      * @return a ResourceBundle.
      */
     private ResourceBundle getBundle() {
-        return ResourceBundle.getBundle(bundle, sLocale, sourceClass.getClassLoader(),
+        return ResourceBundle.getBundle(bundle, messageLocale, sourceClass.getClassLoader(),
                 new Utf8Control());
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -183,17 +183,17 @@ public class SuppressWarningsCheck extends AbstractCheck {
     /**
      * Processes a single warning expression.
      *
-     * @param fChild  the first child AST of the expression
+     * @param firstChild  the first child AST of the expression
      * @param warning the parent warning AST node
      */
-    private void processWarningExpr(final DetailAST fChild, final DetailAST warning) {
-        switch (fChild.getType()) {
+    private void processWarningExpr(final DetailAST firstChild, final DetailAST warning) {
+        switch (firstChild.getType()) {
             case TokenTypes.STRING_LITERAL -> logMatch(warning,
                     removeQuotes(warning.getFirstChild().getText()));
 
             case TokenTypes.QUESTION ->
                 // ex: @SuppressWarnings((false) ? (true) ? "unchecked" : "foo" : "unused")
-                walkConditional(fChild);
+                walkConditional(firstChild);
 
             default -> {
             // Known limitation: cases like @SuppressWarnings("un" + "used") or

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -381,23 +381,23 @@ public class HiddenFieldCheck
 
     /**
      * Determine if a specific method identified by methodAST and a single
-     * variable name aName is a setter. This recognition partially depends
-     * on mSetterCanReturnItsClass property.
+     * variable name parameterName is a setter. This recognition partially depends
+     * on setterCanReturnItsClass property.
      *
-     * @param aMethodAST AST corresponding to a method call
-     * @param aName name of single parameter of this method.
+     * @param methodAST AST corresponding to a method call
+     * @param parameterName name of single parameter of this method.
      * @return true of false indicating of method is a setter or not.
      */
-    private boolean isSetterMethod(DetailAST aMethodAST, String aName) {
+    private boolean isSetterMethod(DetailAST methodAST, String parameterName) {
         final String methodName =
-            aMethodAST.findFirstToken(TokenTypes.IDENT).getText();
+            methodAST.findFirstToken(TokenTypes.IDENT).getText();
         boolean isSetterMethod = false;
 
-        if (("set" + capitalize(aName)).equals(methodName)) {
-            // method name did match set${Name}(${anyType} ${aName})
-            // where ${Name} is capitalized version of ${aName}
+        if (("set" + capitalize(parameterName)).equals(methodName)) {
+            // method name did match set${Name}(${anyType} ${parameterName})
+            // where ${Name} is capitalized version of ${parameterName}
             // therefore this method is potentially a setter
-            final DetailAST typeAST = aMethodAST.findFirstToken(TokenTypes.TYPE);
+            final DetailAST typeAST = methodAST.findFirstToken(TokenTypes.TYPE);
             final String returnType = typeAST.getFirstChild().getText();
             if (typeAST.findFirstToken(TokenTypes.LITERAL_VOID) != null
                     || setterCanReturnItsClass && frame.isEmbeddedIn(returnType)) {
@@ -410,7 +410,7 @@ public class HiddenFieldCheck
                 // or
                 //
                 // return type is not void, but it is the same as the class
-                // where method is declared and mSetterCanReturnItsClass
+                // where method is declared and setterCanReturnItsClass
                 // is set to true
                 isSetterMethod = true;
             }
@@ -501,7 +501,7 @@ public class HiddenFieldCheck
      * Setter to allow to expand the definition of a setter method to include methods
      * that return the class' instance.
      *
-     * @param aSetterCanReturnItsClass if true then setter can return
+     * @param setterCanReturnItsClass if true then setter can return
      *        either void or class in which it is declared. If false then
      *        in order to be recognized as setter method (otherwise
      *        already recognized as a setter) must return void.  Later is
@@ -509,8 +509,8 @@ public class HiddenFieldCheck
      * @since 6.3
      */
     public void setSetterCanReturnItsClass(
-        boolean aSetterCanReturnItsClass) {
-        setterCanReturnItsClass = aSetterCanReturnItsClass;
+        boolean setterCanReturnItsClass) {
+        this.setterCanReturnItsClass = setterCanReturnItsClass;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -173,16 +173,16 @@ public final class ImportControlLoader extends XmlLoader {
     @Override
     public void startElement(String namespaceUri,
                              String localName,
-                             String qName,
+                             String qualifiedName,
                              Attributes attributes)
             throws SAXException {
-        if ("import-control".equals(qName)) {
+        if ("import-control".equals(qualifiedName)) {
             final String pkg = safeGet(attributes, PKG_ATTRIBUTE_NAME);
             final MismatchStrategy strategyOnMismatch = getStrategyForImportControl(attributes);
             final boolean regex = containsRegexAttribute(attributes);
             stack.push(new PkgImportControl(pkg, regex, strategyOnMismatch));
         }
-        else if (SUBPACKAGE_ELEMENT_NAME.equals(qName)) {
+        else if (SUBPACKAGE_ELEMENT_NAME.equals(qualifiedName)) {
             final String name = safeGet(attributes, NAME_ATTRIBUTE_NAME);
             final MismatchStrategy strategyOnMismatch = getStrategyForSubpackage(attributes);
             final boolean regex = containsRegexAttribute(attributes);
@@ -192,7 +192,7 @@ public final class ImportControlLoader extends XmlLoader {
             parentImportControl.addChild(importControl);
             stack.push(importControl);
         }
-        else if (FILE_ELEMENT_NAME.equals(qName)) {
+        else if (FILE_ELEMENT_NAME.equals(qualifiedName)) {
             final String name = safeGet(attributes, NAME_ATTRIBUTE_NAME);
             final boolean regex = containsRegexAttribute(attributes);
             final PkgImportControl parentImportControl = (PkgImportControl) stack.peek();
@@ -202,7 +202,7 @@ public final class ImportControlLoader extends XmlLoader {
             stack.push(importControl);
         }
         else {
-            final AbstractImportRule rule = createImportRule(qName, attributes);
+            final AbstractImportRule rule = createImportRule(qualifiedName, attributes);
             stack.peek().addImportRule(rule);
         }
     }
@@ -211,15 +211,15 @@ public final class ImportControlLoader extends XmlLoader {
      * Constructs an instance of an import rule based on the given {@code name} and
      * {@code attributes}.
      *
-     * @param qName The qualified name.
+     * @param qualifiedName The qualified name.
      * @param attributes The attributes attached to the element.
      * @return The created import rule.
      * @throws SAXException if an error occurs.
      */
-    private static AbstractImportRule createImportRule(String qName, Attributes attributes)
+    private static AbstractImportRule createImportRule(String qualifiedName, Attributes attributes)
             throws SAXException {
 
-        final boolean isAllow = ALLOW_ELEMENT_NAME.equals(qName);
+        final boolean isAllow = ALLOW_ELEMENT_NAME.equals(qualifiedName);
         final boolean isLocalOnly = attributes.getValue("local-only") != null;
         final String pkg = attributes.getValue(PKG_ATTRIBUTE_NAME);
         final String module = attributes.getValue("module");
@@ -252,8 +252,9 @@ public final class ImportControlLoader extends XmlLoader {
 
     @Override
     public void endElement(String namespaceUri, String localName,
-        String qName) {
-        if (SUBPACKAGE_ELEMENT_NAME.equals(qName) || FILE_ELEMENT_NAME.equals(qName)) {
+        String qualifiedName) {
+        if (SUBPACKAGE_ELEMENT_NAME.equals(qualifiedName)
+            || FILE_ELEMENT_NAME.equals(qualifiedName)) {
             stack.pop();
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -96,15 +96,15 @@ public class TagParser {
      * @param lineNo the source line number.
      */
     private void parseTags(String[] text, int lineNo) {
-        final int nLines = text.length;
+        final int numLines = text.length;
         Point position = new Point(0, 0);
-        while (position.lineNo() < nLines) {
+        while (position.lineNo() < numLines) {
             // if this is html comment then skip it
             if (isCommentTag(text, position)) {
                 position = skipHtmlComment(text, position);
             }
             else if (isTag(text, position)) {
-                position = parseTag(text, lineNo, nLines, position);
+                position = parseTag(text, lineNo, numLines, position);
             }
             else {
                 position = getNextPoint(text, position);
@@ -118,19 +118,19 @@ public class TagParser {
      *
      * @param text the source line to parse.
      * @param lineNo the source line number.
-     * @param nLines line length
+     * @param numLines line length
      * @param position start position for parsing
      * @return position after tag
      */
-    private Point parseTag(String[] text, int lineNo, final int nLines, Point position) {
+    private Point parseTag(String[] text, int lineNo, final int numLines, Point position) {
         // find end of tag
         final Point endTag = findChar(text, '>', position);
-        final boolean incompleteTag = endTag.lineNo() >= nLines;
+        final boolean incompleteTag = endTag.lineNo() >= numLines;
         // get tag id (one word)
         final String tagId = getTagId(text, position);
         // is this closed tag
         final boolean closedTag =
-                endTag.lineNo() < nLines
+                endTag.lineNo() < numLines
                  && text[endTag.lineNo()]
                  .charAt(endTag.columnNo() - 1) == '/';
         // add new tag

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
@@ -36,7 +36,7 @@ public class CodeSelector {
     /** Editor. */
     private final JTextArea editor;
     /** Presentation model. */
-    private final CodeSelectorPresentation pModel;
+    private final CodeSelectorPresentation presentationModel;
 
     /**
      * Constructor.
@@ -49,11 +49,11 @@ public class CodeSelector {
                         final Collection<Integer> lines2position) {
         this.editor = editor;
         if (node instanceof DetailAST detailAst) {
-            pModel = new CodeSelectorPresentation(detailAst,
+            presentationModel = new CodeSelectorPresentation(detailAst,
                     new ArrayList<>(lines2position));
         }
         else {
-            pModel = new CodeSelectorPresentation((DetailNode) node,
+            presentationModel = new CodeSelectorPresentation((DetailNode) node,
                     new ArrayList<>(lines2position));
         }
     }
@@ -62,11 +62,11 @@ public class CodeSelector {
      * Set selection.
      */
     public void select() {
-        pModel.findSelectionPositions();
+        presentationModel.findSelectionPositions();
         editor.setSelectedTextColor(Color.blue);
         editor.requestFocusInWindow();
-        editor.setCaretPosition(pModel.getSelectionStart());
-        editor.moveCaretPosition(pModel.getSelectionEnd());
+        editor.setCaretPosition(presentationModel.getSelectionStart());
+        editor.moveCaretPosition(presentationModel.getSelectionEnd());
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java
@@ -45,10 +45,10 @@ public final class ListToTreeSelectionModelWrapper extends DefaultTreeSelectionM
     /**
      * Constructor to initialise treeTable.
      *
-     * @param jTreeTable TreeTable to perform updates on.
+     * @param treeTable TreeTable to perform updates on.
      */
-    /* package */ ListToTreeSelectionModelWrapper(TreeTable jTreeTable) {
-        treeTable = jTreeTable;
+    /* package */ ListToTreeSelectionModelWrapper(TreeTable treeTable) {
+        this.treeTable = treeTable;
         getListSelectionModel().addListSelectionListener(event -> {
             updateSelectedPathsFromSelectedRows();
         });

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModel.java
@@ -36,7 +36,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 public class ParseTreeTableModel implements TreeModel {
 
     /** Presentation model. */
-    private final ParseTreeTablePresentation pModel;
+    private final ParseTreeTablePresentation presentationModel;
 
     /**
      * A list of event listeners for the tree model.
@@ -44,12 +44,12 @@ public class ParseTreeTableModel implements TreeModel {
     private final EventListenerList listenerList = new EventListenerList();
 
     /**
-     * Initialise pModel.
+     * Initialise presentationModel.
      *
      * @param parseTree DetailAST parse tree.
      */
     public ParseTreeTableModel(DetailAST parseTree) {
-        pModel = new ParseTreeTablePresentation(parseTree);
+        presentationModel = new ParseTreeTablePresentation(parseTree);
         setParseTree(parseTree);
     }
 
@@ -59,8 +59,8 @@ public class ParseTreeTableModel implements TreeModel {
      * @param parseTree DetailAST parse tree.
      */
     protected final void setParseTree(DetailAST parseTree) {
-        pModel.setRoot(parseTree);
-        final Object[] path = {pModel.getRoot()};
+        presentationModel.setRoot(parseTree);
+        final Object[] path = {presentationModel.getRoot()};
         // no need to setup remaining info, as the call results in a
         // table structure changed event anyway - we just pass nulls
         fireTreeStructureChanged(this, path, null, CommonUtil.EMPTY_OBJECT_ARRAY);
@@ -72,7 +72,7 @@ public class ParseTreeTableModel implements TreeModel {
      * @param mode ParseMode enum
      */
     protected void setParseMode(ParseMode mode) {
-        pModel.setParseMode(mode);
+        presentationModel.setParseMode(mode);
     }
 
     /**
@@ -81,7 +81,7 @@ public class ParseTreeTableModel implements TreeModel {
      * @return the number of available column.
      */
     public int getColumnCount() {
-        return pModel.getColumnCount();
+        return presentationModel.getColumnCount();
     }
 
     /**
@@ -91,7 +91,7 @@ public class ParseTreeTableModel implements TreeModel {
      * @return the name for column number {@code column}.
      */
     public String getColumnName(int column) {
-        return pModel.getColumnName(column);
+        return presentationModel.getColumnName(column);
     }
 
     /**
@@ -103,7 +103,7 @@ public class ParseTreeTableModel implements TreeModel {
     // -@cs[ForbidWildcardAsReturnType] We need to satisfy javax.swing.table.AbstractTableModel
     // public Class<?> getColumnClass(int columnIndex) {...}
     public Class<?> getColumnClass(int column) {
-        return pModel.getColumnClass(column);
+        return presentationModel.getColumnClass(column);
     }
 
     /**
@@ -115,17 +115,17 @@ public class ParseTreeTableModel implements TreeModel {
      *     at column number {@code column}.
      */
     public Object getValueAt(Object node, int column) {
-        return pModel.getValueAt(node, column);
+        return presentationModel.getValueAt(node, column);
     }
 
     @Override
     public Object getChild(Object parent, int index) {
-        return pModel.getChild(parent, index);
+        return presentationModel.getChild(parent, index);
     }
 
     @Override
     public int getChildCount(Object parent) {
-        return pModel.getChildCount(parent);
+        return presentationModel.getChildCount(parent);
     }
 
     @Override
@@ -135,18 +135,18 @@ public class ParseTreeTableModel implements TreeModel {
 
     @Override
     public Object getRoot() {
-        return pModel.getRoot();
+        return presentationModel.getRoot();
     }
 
     @Override
     public boolean isLeaf(Object node) {
-        return pModel.isLeaf(node);
+        return presentationModel.isLeaf(node);
     }
 
     // This is not called in the JTree's default mode: use a naive implementation.
     @Override
     public int getIndexOfChild(Object parent, Object child) {
-        return pModel.getIndexOfChild(parent, child);
+        return presentationModel.getIndexOfChild(parent, child);
     }
 
     @Override
@@ -199,7 +199,7 @@ public class ParseTreeTableModel implements TreeModel {
      * @return true if editable
      */
     public boolean isCellEditable(int column) {
-        return pModel.isCellEditable(column);
+        return presentationModel.isCellEditable(column);
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
@@ -226,11 +226,11 @@ public final class XmlMetaReader {
      * Utility to get the children of an element by tag name.
      *
      * @param element parent element
-     * @param sTagName tag name of children required
+     * @param tagName tag name of children required
      * @return list of elements retrieved
      */
-    private static List<Element> getDirectChildsByTag(Element element, String sTagName) {
-        final NodeList children = element.getElementsByTagName(sTagName);
+    private static List<Element> getDirectChildsByTag(Element element, String tagName) {
+        final NodeList children = element.getElementsByTagName(tagName);
         final List<Element> res = new ArrayList<>();
         for (int i = 0; i < children.getLength(); i++) {
             if (children.item(i).getParentNode().equals(element)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -39,12 +39,12 @@ public final class ScopeUtil {
      * Returns the {@code Scope} explicitly specified by the modifier set.
      * Returns {@code null} if there are no modifiers.
      *
-     * @param aMods root node of a modifier set
+     * @param mods root node of a modifier set
      * @return a {@code Scope} value or {@code null}
      */
-    public static Optional<Scope> getDeclaredScopeFromMods(DetailAST aMods) {
+    public static Optional<Scope> getDeclaredScopeFromMods(DetailAST mods) {
         Optional<Scope> result = Optional.empty();
-        for (DetailAST token = aMods.getFirstChild(); token != null;
+        for (DetailAST token = mods.getFirstChild(); token != null;
              token = token.getNextSibling()) {
             result = switch (token.getType()) {
                 case TokenTypes.LITERAL_PUBLIC -> Optional.of(Scope.PUBLIC);
@@ -72,13 +72,13 @@ public final class ScopeUtil {
      * Returns the {@code Scope} specified by the modifier set. If no modifiers are present,
      * the default scope is used.
      *
-     * @param aMods root node of a modifier set
+     * @param mods root node of a modifier set
      * @return a {@code Scope} value
      * @see #getDefaultScope(DetailAST)
      */
-    public static Scope getScopeFromMods(DetailAST aMods) {
-        return getDeclaredScopeFromMods(aMods)
-                .orElseGet(() -> getDefaultScope(aMods));
+    public static Scope getScopeFromMods(DetailAST mods) {
+        return getDeclaredScopeFromMods(mods)
+                .orElseGet(() -> getDefaultScope(mods));
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -518,8 +518,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
             .that(context.get("basedir"))
             .isEqualTo("testBaseDir");
 
-        final Locale locale =
-                TestUtil.getInternalStaticState(LocalizedMessage.class, "sLocale", Locale.class);
+        final Locale locale = TestUtil.getInternalStaticState(LocalizedMessage.class,
+                "messageLocale", Locale.class);
         assertWithMessage("Locale is set to unexpected value")
             .that(locale)
             .isEqualTo(Locale.ITALY);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -59,11 +59,11 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
 
     private static final IndentComment[] EMPTY_INDENT_COMMENT_ARRAY = new IndentComment[0];
 
-    private static IndentComment[] getLinesWithWarnAndCheckComments(String aFileName,
+    private static IndentComment[] getLinesWithWarnAndCheckComments(String fileName,
             final int tabWidth)
             throws IOException {
         final List<IndentComment> result = new ArrayList<>();
-        try (BufferedReader br = Files.newBufferedReader(Path.of(aFileName))) {
+        try (BufferedReader br = Files.newBufferedReader(Path.of(fileName))) {
             int lineNumber = 1;
             String line = br.readLine();
             IndentComment pendingBelowComment = null;
@@ -87,14 +87,14 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
                     }
                     else {
                         final int actualIndent = getLineStart(line, tabWidth);
-                        processInlineComment(warn, actualIndent, lineNumber, aFileName, result);
+                        processInlineComment(warn, actualIndent, lineNumber, fileName, result);
                     }
                 }
                 else if (!line.isEmpty()) {
                     throw new IllegalStateException(String.format(Locale.ROOT,
                             "File \"%1$s\" has no indentation comment or its format "
                                     + "malformed. Error on line: %2$d",
-                            aFileName,
+                            fileName,
                             lineNumber));
                 }
 


### PR DESCRIPTION
This is a follow up from #2604.
The goal is to allow exactly `id` or `[a-z][a-z0-9][a-zA-Z0-9]+`.
I also switched to a non-capturing group.