### PR TITLE
Issue #14120: add module-info.java for checkstyle as a proper Java module

### DIFF
--- a/.ci/eclipse-compiler-javac.sh
+++ b/.ci/eclipse-compiler-javac.sh
@@ -50,6 +50,12 @@ mkdir -p target/classes target/test-classes target/eclipse
 
 RESULT_FILE=target/eclipse/report.txt
 
+# Temporarily exclude module-info.java which ECJ cannot handle in classpath mode
+MODULE_INFO="src/main/java/module-info.java"
+MODULE_INFO_TMP="src/main/java/module-info.java.bak"
+mv "$MODULE_INFO" "$MODULE_INFO_TMP"
+trap 'mv "$MODULE_INFO_TMP" "$MODULE_INFO"' EXIT
+
 echo "Executing eclipse compiler, output is redirected to $RESULT_FILE..."
 echo "java -jar $ECJ_PATH -target ${JAVA_RELEASE} -source ${JAVA_RELEASE} -cp $1  ..."
 

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -63,7 +63,7 @@ check-missing-pitests)
     "com.puppycrawl.tools.checkstyle.grammar.JavadocCommentsParserUtil"
     "com.puppycrawl.tools.checkstyle.grammar.SimpleToken" "${list[@]}")
 
-  CMD="find src/main/java -type f ! -name 'package-info.java'"
+  CMD="find src/main/java -type f ! -name 'package-info.java' ! -name 'module-info.java'"
 
   for item in "${list[@]}"
   do

--- a/config/ant-phase-verify-sevntu.xml
+++ b/config/ant-phase-verify-sevntu.xml
@@ -30,7 +30,8 @@
                excludes="**/it/resources/**/*,**/it/resources-noncompilable/**/*,
                ,**/test/resources/**/*,**/test/resources-noncompilable/**/*,
                ,**/xdocs-examples/resources/**/*,**/xdocs-examples/resources-noncompilable/**/*,
-               ,**/gen/**"/>
+               ,**/gen/**,
+                 main/java/module-info.java"/>
       <formatter type="plain"/>
       <formatter type="xml" toFile="${mvn.project.build.directory}/cs_sevntu_errors.xml"/>
       <property key="checkstyle.sevntu.cache.file"

--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -40,7 +40,8 @@
                includes="**/*"
                excludes="it/resources/**/*,it/resources-noncompilable/**/*,
                test/resources/**/*,test/resources-noncompilable/**/*,**/gen/**,
-               xdocs-examples/resources/**/*,xdocs-examples/resources-noncompilable/**/*"/>
+               xdocs-examples/resources/**/*,xdocs-examples/resources-noncompilable/**/*,
+                 main/java/module-info.java"/>
       <formatter type="plain"/>
       <formatter type="xml" toFile="${mvn.project.build.directory}/cs_errors.xml"/>
       <formatter type="sarif" toFile="${mvn.project.build.directory}/cs_errors.sarif"/>

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -94,6 +94,7 @@ Backquote
 backticks
 badpackage
 baeldung
+bak
 baratali
 Barowski
 basedir

--- a/pom.xml
+++ b/pom.xml
@@ -572,6 +572,17 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.6.2</version>
+          <configuration>
+            <filters>
+              <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                  <exclude>module-info.class</exclude>
+                  <exclude>META-INF/versions/*/module-info.class</exclude>
+                </excludes>
+              </filter>
+            </filters>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.pitest</groupId>
@@ -606,6 +617,12 @@
             <failOnWarnings>true</failOnWarnings>
             <doclint>-missing</doclint>
             <linksource>true</linksource>
+            <sourceFileExcludes>
+              <sourceFileExclude>module-info.java</sourceFileExclude>
+            </sourceFileExcludes>
+            <additionalOptions>
+              <additionalOption>--add-reads=com.puppycrawl.tools.checkstyle=ALL-UNNAMED</additionalOption>
+            </additionalOptions>
             <tags>
               <tag>
                 <name>noinspection</name>
@@ -982,6 +999,16 @@
         <configuration>
           <compilerArgs>
             <arg>-Xpkginfo:always</arg>
+            <arg>--add-reads</arg>
+            <arg>com.puppycrawl.tools.checkstyle=ALL-UNNAMED</arg>
+            <arg>--add-modules</arg>
+            <arg>jdk.security.auth,jdk.compiler</arg>
+            <arg>--add-reads</arg>
+            <arg>com.puppycrawl.tools.checkstyle=jdk.security.auth</arg>
+            <arg>--add-reads</arg>
+            <arg>com.puppycrawl.tools.checkstyle=jdk.compiler</arg>
+            <arg>--add-exports</arg>
+            <arg>com.google.common/com.google.common.base.internal=com.puppycrawl.tools.checkstyle</arg>
           </compilerArgs>
         </configuration>
       </plugin>
@@ -1779,6 +1806,7 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.5.5</version>
         <configuration>
+          <useModulePath>false</useModulePath>
           <includes>
             <include>com/google/**/*.java</include>
             <include>org/checkstyle/**/*.java</include>
@@ -1833,6 +1861,7 @@
             -XX:+EnableDynamicAgentLoading
             -Xshare:off
           </argLine>
+          <useModulePath>false</useModulePath>
           <additionalClasspathElements>
             <additionalClasspathElement>
               src/test/resources-noncompilable
@@ -1888,9 +1917,21 @@
         </configuration>
         <executions>
           <execution>
+            <id>default-test-jar</id>
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <archive>
+                <manifest>
+                  <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                  <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                </manifest>
+                <manifestEntries>
+                  <Automatic-Module-Name>${project.groupId}.${project.artifactId}.tests</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -2231,6 +2272,11 @@
             </reports>
           </reportSet>
         </reportSets>
+        <configuration>
+          <sourceFileExcludes>
+            <sourceFileExclude>module-info.java</sourceFileExclude>
+          </sourceFileExcludes>
+        </configuration>
       </plugin>
 
       <plugin>
@@ -5577,6 +5623,35 @@
               <threads>${pitest.plugin.threads}</threads>
               <outputFormats>${pitest.plugin.output.formats}</outputFormats>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>sonatype-oss-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.12.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <sourceFileExcludes>
+                    <sourceFileExclude>module-info.java</sourceFileExclude>
+                  </sourceFileExcludes>
+                  <additionalOptions>
+                    <additionalOption>--add-reads=com.puppycrawl.tools.checkstyle=ALL-UNNAMED</additionalOption>
+                  </additionalOptions>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -576,6 +576,17 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.6.2</version>
+          <configuration>
+            <filters>
+              <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                  <exclude>module-info.class</exclude>
+                  <exclude>META-INF/versions/*/module-info.class</exclude>
+                </excludes>
+              </filter>
+            </filters>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.pitest</groupId>
@@ -610,6 +621,12 @@
             <failOnWarnings>true</failOnWarnings>
             <doclint>-missing</doclint>
             <linksource>true</linksource>
+            <sourceFileExcludes>
+              <sourceFileExclude>module-info.java</sourceFileExclude>
+            </sourceFileExcludes>
+            <additionalOptions>
+              <additionalOption>--add-reads=com.puppycrawl.tools.checkstyle=ALL-UNNAMED</additionalOption>
+            </additionalOptions>
             <tags>
               <tag>
                 <name>noinspection</name>
@@ -986,6 +1003,16 @@
         <configuration>
           <compilerArgs>
             <arg>-Xpkginfo:always</arg>
+            <arg>--add-reads</arg>
+            <arg>com.puppycrawl.tools.checkstyle=ALL-UNNAMED</arg>
+            <arg>--add-modules</arg>
+            <arg>jdk.security.auth,jdk.compiler</arg>
+            <arg>--add-reads</arg>
+            <arg>com.puppycrawl.tools.checkstyle=jdk.security.auth</arg>
+            <arg>--add-reads</arg>
+            <arg>com.puppycrawl.tools.checkstyle=jdk.compiler</arg>
+            <arg>--add-exports</arg>
+            <arg>com.google.common/com.google.common.base.internal=com.puppycrawl.tools.checkstyle</arg>
           </compilerArgs>
         </configuration>
       </plugin>
@@ -1783,6 +1810,7 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.5.5</version>
         <configuration>
+          <useModulePath>false</useModulePath>
           <includes>
             <include>com/google/**/*.java</include>
             <include>org/checkstyle/**/*.java</include>
@@ -1837,6 +1865,7 @@
             -XX:+EnableDynamicAgentLoading
             -Xshare:off
           </argLine>
+          <useModulePath>false</useModulePath>
           <additionalClasspathElements>
             <additionalClasspathElement>
               src/test/resources-noncompilable
@@ -1892,9 +1921,21 @@
         </configuration>
         <executions>
           <execution>
+            <id>default-test-jar</id>
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <archive>
+                <manifest>
+                  <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                  <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                </manifest>
+                <manifestEntries>
+                  <Automatic-Module-Name>${project.groupId}.${project.artifactId}.tests</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -2235,6 +2276,11 @@
             </reports>
           </reportSet>
         </reportSets>
+        <configuration>
+          <sourceFileExcludes>
+            <sourceFileExclude>module-info.java</sourceFileExclude>
+          </sourceFileExcludes>
+        </configuration>
       </plugin>
 
       <plugin>
@@ -5581,6 +5627,35 @@
               <threads>${pitest.plugin.threads}</threads>
               <outputFormats>${pitest.plugin.output.formats}</outputFormats>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>sonatype-oss-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.12.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <sourceFileExcludes>
+                    <sourceFileExclude>module-info.java</sourceFileExclude>
+                  </sourceFileExcludes>
+                  <additionalOptions>
+                    <additionalOption>--add-reads=com.puppycrawl.tools.checkstyle=ALL-UNNAMED</additionalOption>
+                  </additionalOptions>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,49 @@
+module com.puppycrawl.tools.checkstyle {
+
+    requires java.xml;
+    requires java.desktop;
+    requires java.logging;
+    requires java.naming;
+    requires java.xml.crypto;
+
+    requires info.picocli;
+    requires org.antlr.antlr4.runtime;
+    requires org.apache.commons.beanutils;
+    requires commons.logging;
+    requires com.google.common;
+    requires org.jspecify;
+    requires org.reflections;
+    requires Saxon.HE;
+
+    requires static ant;
+    opens com.puppycrawl.tools.checkstyle to org.apache.commons.beanutils;
+    opens com.puppycrawl.tools.checkstyle.checks to org.apache.commons.beanutils;
+    opens com.puppycrawl.tools.checkstyle.api to org.apache.commons.beanutils;
+
+    exports com.puppycrawl.tools.checkstyle;
+    exports com.puppycrawl.tools.checkstyle.api;
+    exports com.puppycrawl.tools.checkstyle.ant;
+    exports com.puppycrawl.tools.checkstyle.checks;
+    exports com.puppycrawl.tools.checkstyle.checks.annotation;
+    exports com.puppycrawl.tools.checkstyle.checks.blocks;
+    exports com.puppycrawl.tools.checkstyle.checks.coding;
+    exports com.puppycrawl.tools.checkstyle.checks.design;
+    exports com.puppycrawl.tools.checkstyle.checks.header;
+    exports com.puppycrawl.tools.checkstyle.checks.imports;
+    exports com.puppycrawl.tools.checkstyle.checks.indentation;
+    exports com.puppycrawl.tools.checkstyle.checks.javadoc;
+    exports com.puppycrawl.tools.checkstyle.checks.javadoc.utils;
+    exports com.puppycrawl.tools.checkstyle.checks.metrics;
+    exports com.puppycrawl.tools.checkstyle.checks.modifier;
+    exports com.puppycrawl.tools.checkstyle.checks.naming;
+    exports com.puppycrawl.tools.checkstyle.checks.regexp;
+    exports com.puppycrawl.tools.checkstyle.checks.sizes;
+    exports com.puppycrawl.tools.checkstyle.checks.whitespace;
+    exports com.puppycrawl.tools.checkstyle.filefilters;
+    exports com.puppycrawl.tools.checkstyle.filters;
+    exports com.puppycrawl.tools.checkstyle.gui;
+    exports com.puppycrawl.tools.checkstyle.utils;
+    exports com.puppycrawl.tools.checkstyle.xpath;
+    exports com.puppycrawl.tools.checkstyle.xpath.iterators;
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
@@ -134,7 +134,7 @@ public class AllTestsTest {
     }
 
     private static void grabAllFiles(Map<String, List<String>> allTests, File file) {
-        if (file.isFile()) {
+        if (file.isFile() && !"module-info.java".equals(file.getName())) {
             final String path;
 
             try {


### PR DESCRIPTION
fixes #14120
added `module-info.java` to declare checkstyle as proper named java module, fixed test JAR `Automatic-Module-Name` ,set `useModulePath=false` in surefire/failsafe
