### PR TITLE
Issue #19709: Fix Indentation false positive for nested yield switch expression

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/YieldHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/YieldHandler.java
@@ -42,6 +42,18 @@ public class YieldHandler extends AbstractExpressionHandler {
     }
 
     @Override
+    public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
+        final IndentLevel result;
+        if (TokenUtil.areOnSameLine(getMainAst(), child.getMainAst())) {
+            result = getIndent();
+        }
+        else {
+            result = super.getSuggestedChildIndent(child);
+        }
+        return result;
+    }
+
+    @Override
     public void checkIndentation() {
         checkYield();
         final DetailAST expression = getMainAst().getFirstChild();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -3859,6 +3859,50 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testIndentationYieldWithNestedSwitchExpression() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+
+        final String fileName = getPath("InputIndentationYieldSwitchExpression.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testIndentationYieldWithWrappedSwitchExpression() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+
+        final String fileName = getPath("InputIndentationYieldSwitchExpressionWrapped.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testYieldNestedSwitchExpressionWithCaseIndentZero() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("caseIndent", "0");
+
+        final String[] expected = {
+            "21:21: " + getCheckMessage(MSG_CHILD_ERROR, "case", 20, 16),
+            "22:21: " + getCheckMessage(MSG_CHILD_ERROR, "case", 20, 16),
+        };
+
+        verify(checkConfig,
+            getPath("InputIndentationYieldNestedSwitchExpressionCaseIndentZero.java"),
+            expected);
+    }
+
+    @Test
     public void testInputIndentationLambdaChild() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("tabWidth", "4");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -3859,6 +3859,34 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testIndentationYieldWithNestedSwitchExpression() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+
+        final String fileName = getPath("InputIndentationYieldSwitchExpression.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testIndentationYieldWithWrappedSwitchExpression() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+
+        final String fileName = getPath("InputIndentationYieldSwitchExpressionWrapped.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
     public void testInputIndentationLambdaChild() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("tabWidth", "4");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldNestedSwitchExpressionCaseIndentZero.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldNestedSwitchExpressionCaseIndentZero.java
@@ -1,0 +1,30 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
+
+/*                                                                         //indent:0 exp:0
+ * Config:                                                                 //indent:1 exp:1
+ *                                                                         //indent:1 exp:1
+ * basicOffset = 4                                                         //indent:1 exp:1
+ * braceAdjustment = 0                                                     //indent:1 exp:1
+ * caseIndent = 0                                                          //indent:1 exp:1
+ * throwsIndent = 4                                                        //indent:1 exp:1
+ * arrayInitIndent = 4                                                     //indent:1 exp:1
+ * lineWrappingIndentation = 4                                             //indent:1 exp:1
+ * forceStrictCondition = false                                            //indent:1 exp:1
+ */                                                                        //indent:1 exp:1
+public class InputIndentationYieldNestedSwitchExpressionCaseIndentZero {   //indent:0 exp:0
+
+    int test(int i) {                                                      //indent:4 exp:4
+        return switch (i) {                                                //indent:8 exp:8
+        case 42:                                                           //indent:8 exp:8
+            if (i == 0) {                                                  //indent:12 exp:12
+                yield 41 + switch (0) {                                    //indent:16 exp:16
+                    case 0 -> 1;                                           //indent:20 exp:16 warn
+                    default -> -1;                                         //indent:20 exp:20
+                };                                                         //indent:16 exp:16
+            }                                                              //indent:12 exp:12
+            yield 43;                                                      //indent:12 exp:12
+        default:                                                           //indent:8 exp:8
+            yield -1;                                                      //indent:12 exp:12
+        };                                                                 //indent:8 exp:8
+    }                                                                      //indent:4 exp:4
+}                                                                          //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldSwitchExpression.java
@@ -1,0 +1,26 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+/* Config:                                                                   //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:  //indent:1 exp:1
+ * tabWidth = 4                                                              //indent:1 exp:1
+ * basicOffset = 4                                                           //indent:1 exp:1
+ * braceAdjustment = 0                                                       //indent:1 exp:1
+ * caseIndent = 4                                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                               //indent:1 exp:1
+ */                                                                          //indent:1 exp:1
+
+public class InputIndentationYieldSwitchExpression {                         //indent:0 exp:0
+    void foo() {                                                             //indent:4 exp:4
+        int i = 0;                                                           //indent:8 exp:8
+        int j = switch (i) {                                                 //indent:8 exp:8
+            case 0 -> {                                                      //indent:12 exp:12
+                yield switch (i) {                                           //indent:16 exp:16
+                    case 0 -> 0;                                             //indent:20 exp:20
+                    default -> 1;                                            //indent:20 exp:20
+                };                                                           //indent:16 exp:16
+            }                                                                //indent:12 exp:12
+            default -> 1;                                                    //indent:12 exp:12
+        };                                                                   //indent:8 exp:8
+    }                                                                        //indent:4 exp:4
+}                                                                            //indent:0 exp:0
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldSwitchExpression.java
@@ -1,0 +1,27 @@
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+/* Config:                                                                   //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:  //indent:1 exp:1
+ * tabWidth = 4                                                              //indent:1 exp:1
+ * basicOffset = 4                                                           //indent:1 exp:1
+ * braceAdjustment = 0                                                       //indent:1 exp:1
+ * caseIndent = 4                                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                               //indent:1 exp:1
+ */                                                                          //indent:1 exp:1
+
+public class InputIndentationYieldSwitchExpression {                         //indent:0 exp:0
+    void foo() {                                                             //indent:4 exp:4
+        int i = 0;                                                           //indent:8 exp:8
+        int j = switch (i) {                                                 //indent:8 exp:8
+            case 0 -> {                                                      //indent:12 exp:12
+                yield switch (i) {                                           //indent:16 exp:16
+                    case 0 -> 0;                                             //indent:20 exp:20
+                    default -> 1;                                            //indent:20 exp:20
+                };                                                           //indent:16 exp:16
+            }                                                                //indent:12 exp:12
+            default -> 1;                                                    //indent:12 exp:12
+        };                                                                   //indent:8 exp:8
+    }                                                                        //indent:4 exp:4
+}                                                                            //indent:0 exp:0
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldSwitchExpressionWrapped.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldSwitchExpressionWrapped.java
@@ -1,0 +1,26 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+/* Config:                                                                   //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:  //indent:1 exp:1
+ * tabWidth = 4                                                              //indent:1 exp:1
+ * basicOffset = 4                                                           //indent:1 exp:1
+ * braceAdjustment = 0                                                       //indent:1 exp:1
+ * caseIndent = 4                                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                               //indent:1 exp:1
+ */                                                                          //indent:1 exp:1
+
+public class InputIndentationYieldSwitchExpressionWrapped {                  //indent:0 exp:0
+    int bar(int i) {                                                         //indent:4 exp:4
+        return switch (i) {                                                  //indent:8 exp:8
+            case 0 -> {                                                      //indent:12 exp:12
+                yield                                                        //indent:16 exp:16
+                    switch (i) {                                             //indent:20 exp:20
+                        case 0 -> 0;                                         //indent:24 exp:24
+                        default -> 1;                                        //indent:24 exp:24
+                    };                                                       //indent:20 exp:20
+            }                                                                //indent:12 exp:12
+            default -> 1;                                                    //indent:12 exp:12
+        };                                                                   //indent:8 exp:8
+    }                                                                        //indent:4 exp:4
+}                                                                            //indent:0 exp:0
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldSwitchExpressionWrapped.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldSwitchExpressionWrapped.java
@@ -1,0 +1,27 @@
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
+
+/* Config:                                                                   //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:  //indent:1 exp:1
+ * tabWidth = 4                                                              //indent:1 exp:1
+ * basicOffset = 4                                                           //indent:1 exp:1
+ * braceAdjustment = 0                                                       //indent:1 exp:1
+ * caseIndent = 4                                                            //indent:1 exp:1
+ * lineWrappingIndentation = 4                                               //indent:1 exp:1
+ */                                                                          //indent:1 exp:1
+
+public class InputIndentationYieldSwitchExpressionWrapped {                  //indent:0 exp:0
+    int bar(int i) {                                                         //indent:4 exp:4
+        return switch (i) {                                                  //indent:8 exp:8
+            case 0 -> {                                                      //indent:12 exp:12
+                yield                                                        //indent:16 exp:16
+                    switch (i) {                                             //indent:20 exp:20
+                        case 0 -> 0;                                         //indent:24 exp:24
+                        default -> 1;                                        //indent:24 exp:24
+                    };                                                       //indent:20 exp:20
+            }                                                                //indent:12 exp:12
+            default -> 1;                                                    //indent:12 exp:12
+        };                                                                   //indent:8 exp:8
+    }                                                                        //indent:4 exp:4
+}                                                                            //indent:0 exp:0
+


### PR DESCRIPTION
Issue #19709

The false positive came from over-indenting the nested expression under `yield` when both tokens were on the same line. With the updated child-indent suggestion, the inner `switch` cases are validated against the correct expected indentation.

This PR fixes an `Indentation` false positive for nested `switch` expressions used in `yield` within switch-rule blocks.

### Problem
A correctly formatted snippet like:

```java
yield switch (i) {
    case 0 -> 0;
    default -> 1;
};
```

was reported with incorrect expected indentation for inner `case` labels and the inner `switch` closing brace.

Output after fix:

<img width="1818" height="256" alt="Screenshot 2026-04-18 102925" src="https://github.com/user-attachments/assets/a8755f96-19a3-4676-9151-9d016fc050ae" />


