### PR TITLE
Issue #19617: added Checks to cover special characters OpenJDK Style §2 - Java Source Files

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1246,6 +1246,7 @@ sourceforge
 sourcepath
 sourcesets
 spacebar
+specialcharacters
 specialescape
 spellchecker
 spliterator

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1245,6 +1245,7 @@ sourceforge
 sourcepath
 sourcesets
 spacebar
+specialcharacters
 specialescape
 spellchecker
 spliterator

--- a/src/it/java/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters/SpecialCharactersTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters/SpecialCharactersTest.java
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapter2javasourcefiles.rule21specialcharacters;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class SpecialCharactersTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters";
+    }
+
+    @Test
+    public void testSpecialCharactersValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputSpecialCharactersValid.java"));
+    }
+
+    @Test
+    public void testSpecialCharactersInvalid() throws Exception {
+        verifyWithWholeConfig(getPath("InputSpecialCharactersInvalid.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters/InputSpecialCharactersInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters/InputSpecialCharactersInvalid.java
@@ -1,0 +1,11 @@
+package com.openjdk.checkstyle.test.chapter2javasourcefiles.rule21specialcharacters;
+
+public class InputSpecialCharactersInvalid {
+
+    private final String escapedTab = "\011";
+    // violation above 'Consider using special escape sequence.'
+
+    private final String escapedLetter = "\u0041";
+    // violation above 'Unicode escape(s) usage should be avoided.'
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters/InputSpecialCharactersInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters/InputSpecialCharactersInvalid.java
@@ -1,0 +1,48 @@
+package com.openjdk.checkstyle.test.chapter2javasourcefiles.rule21specialcharacters;
+
+public class InputSpecialCharactersInvalid {
+    // The short forms (e.g. \t) are commonly used and easier to recognize than
+    // the corresponding longer forms (\011, \u0009).
+    // \', \", \\, \t, \b, \r, \f, and \n should be preferred over corresponding
+    // octal (e.g. \047) or Unicode (e.g. \u0027) escaped characters.
+
+    private final char apostropheOctal = '\047';
+    // violation above 'special escape sequence'
+    // Should use: \'  (short escape for apostrophe)
+
+    private final char quoteOctal = '\042';
+    // violation above 'special escape sequence'
+    // Should use: \" (short escape for quote)
+
+    private final char slashOctal = '\134';
+    // violation above 'special escape sequence'
+    // Should use: \\ (short escape for backslash)
+
+    private final char backspaceOctal = '\010';
+    // violation above 'special escape sequence'
+    // Should use: \b (short escape for backspace)
+
+    private final char tabOctal = '\011';
+    // violation above 'special escape sequence'
+    // Should use: \t (short escape for tab)
+
+    private final char formFeedOctal = '\014';
+    // violation above 'special escape sequence'
+    // Should use: \f (short escape for form feed)
+
+    private final char carriageReturnOctal = '\015';
+    // violation above 'special escape sequence'
+    // Should use: \r (short escape for carriage return)
+
+    private final char newLineOctal = '\012';
+    // violation above 'special escape sequence'
+    // Should use: \n (short escape for newline)
+
+    private final char escapedLetter = '\u0041';
+    // violation above 'Unicode escape(s) usage should be avoided.'
+    // Should use: 'A' (plain ASCII character instead of Unicode escape)
+
+    private final char spaceOctal = '\040';
+    // violation above 'special escape sequence'
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters/InputSpecialCharactersValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters/InputSpecialCharactersValid.java
@@ -1,0 +1,11 @@
+package com.openjdk.checkstyle.test.chapter2javasourcefiles.rule21specialcharacters;
+
+public class InputSpecialCharactersValid {
+
+    private final String apostrophe = "\'";
+    private final String quote = "\"";
+    private final String slash = "\\";
+    private final String tab = "\t";
+    private final String newLine = "\n";
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters/InputSpecialCharactersValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters/InputSpecialCharactersValid.java
@@ -1,0 +1,20 @@
+package com.openjdk.checkstyle.test.chapter2javasourcefiles.rule21specialcharacters;
+
+public class InputSpecialCharactersValid {
+
+    private final char apostrophe = '\'';
+    private final char quote = '"';
+    private final char slash = '\\';
+    private final char backspace = '\b';
+    private final char tab = '\t';
+    private final char formFeed = '\f';
+    private final char carriageReturn = '\r';
+    private final char newLine = '\n';
+    private final char space = ' ';
+
+    // Unicode escapes (for reference, shown as plain text):
+    // apostrophe: \\u0027, quote: \\u0022, backslash: \\u005c
+    // tab: \\u0009, backspace: \\u0008, carriage return: \\u000d
+    // form feed: \\u000c, newline: \\u000a, space: \\u0020
+
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -64,6 +64,14 @@
 
     <module name="OneStatementPerLine"/>
     <module name="OuterTypeFilename"/>
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL, TEXT_BLOCK_CONTENT"/>
+      <property name="format"
+          value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|20|22|27|5(C|c))|\\(0(10|11|12|14|15|40|42|47)|134)"/>
+      <property name="message"
+                value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+    </module>
+    <module name="AvoidEscapedUnicodeCharacters"/>
 
     <!-- §3.12: Expression lambda body length check based on OpenJDK style guide -->
     <module name="LambdaBodyLength"/>

--- a/src/site/xdoc/checks/coding/illegaltokentext.xml
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml
@@ -216,6 +216,10 @@ public class Example5 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalTokenText">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalTokenText">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/illegaltokentext.xml.template
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml.template
@@ -115,6 +115,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalTokenText">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalTokenText">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml
+++ b/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml
@@ -245,6 +245,10 @@ public class Example5 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidEscapedUnicodeCharacters">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidEscapedUnicodeCharacters">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml.template
+++ b/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml.template
@@ -120,6 +120,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidEscapedUnicodeCharacters">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidEscapedUnicodeCharacters">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -19,6 +19,12 @@
           Draft v6, December 2015.
         </p>
         <p>
+          The OpenJDK style guide says that, apart from <code>LF</code>, the only allowed
+          whitespace character is Space, and that <code>\'</code>, <code>\"</code>, <code>\\</code>,
+          <code>\t</code>, <code>\b</code>, <code>\r</code>, <code>\f</code>, and <code>\n</code>
+          should be preferred over corresponding octal or Unicode escaped characters.
+        </p>
+        <p>
           <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/openjdk_checks.xml">
             Incomplete Checkstyle configuration for 'OpenJDK Java Style'</a>
         </p>
@@ -138,6 +144,7 @@
                   <span class="wrapper inline">
                     <img src="images/ok_green.png" alt=""/>
                   </span>
+                  <a href="https://checkstyle.org/config.html#Checker">charset=US-ASCII</a>,
                   <a href="checks/misc/lineending.html#LineEnding">LineEnding</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineEnding">
                   config</a>)
@@ -184,9 +191,20 @@
                   <span class="wrapper inline">
                     <img src="images/ok_green.png" alt=""/>
                   </span>
-                  <a href="https://checkstyle.org/config.html#Checker">charset=US-ASCII</a>
+                  <a href="checks/coding/illegaltokentext.html#IllegalTokenText">
+                    IllegalTokenText</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalTokenText">
+                  config</a>),
+                  <a href="checks/misc/avoidescapedunicodecharacters.html#AvoidEscapedUnicodeCharacters">
+                    AvoidEscapedUnicodeCharacters</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidEscapedUnicodeCharacters">
+                  config</a>)
                 </td>
-                <td>--</td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters">
+                    samples
+                  </a>
+                </td>
               </tr>
               <!-- 3 Formatting -->
               <tr>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -138,6 +138,7 @@
                   <span class="wrapper inline">
                     <img src="images/ok_green.png" alt=""/>
                   </span>
+                  <a href="https://checkstyle.org/config.html#Checker">charset=US-ASCII</a>,
                   <a href="checks/misc/lineending.html#LineEnding">LineEnding</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineEnding">
                   config</a>),
@@ -174,9 +175,20 @@
                   <span class="wrapper inline">
                     <img src="images/ok_green.png" alt=""/>
                   </span>
-                  <a href="https://checkstyle.org/config.html#Checker">charset=US-ASCII</a>
+                  <a href="checks/coding/illegaltokentext.html#IllegalTokenText">
+                    IllegalTokenText</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalTokenText">
+                  config</a>),
+                  <a href="checks/misc/avoidescapedunicodecharacters.html#AvoidEscapedUnicodeCharacters">
+                    AvoidEscapedUnicodeCharacters</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidEscapedUnicodeCharacters">
+                  config</a>)
                 </td>
-                <td>--</td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter2javasourcefiles/rule21specialcharacters">
+                    samples
+                  </a>
+                </td>
               </tr>
               <!-- 3 Formatting -->
               <tr>


### PR DESCRIPTION
fixes #19617 
#### Summary 

- Added special-character checks to OpenJDK style config: [openjdk_checks.xml:66]

- Added IllegalTokenText with the OpenJDK escape-preference pattern

- Added AvoidEscapedUnicodeCharacters

- Updated OpenJDK style coverage page so mapping is accurate: [openjdk_style.xml:141]

- Section 2 now explicitly includes charset=US-ASCII

- Section 2.1 now references IllegalTokenText and AvoidEscapedUnicodeCharacters

- Added new OpenJDK Chapter 2 integration tests:
[SpecialCharactersTest.java:1]
[InputSpecialCharactersValid.java:1]
[InputSpecialCharactersInvalid.java:1]