### PR TITLE
Issue #4750: deprecate CommentListener as comments are available in AST

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -34,6 +34,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 /**
  * Represents the contents of a file.
  *
+ * @noinspection deprecation
+ * @noinspectionreason deprecation - FileContents implements deprecated CommentListener.
  */
 public final class FileContents implements CommentListener {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/grammar/CommentListener.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/grammar/CommentListener.java
@@ -23,9 +23,14 @@ package com.puppycrawl.tools.checkstyle.grammar;
  * This interface is used to be notified by parser about comments
  * in the parsed code.
  *
- * @noinspection ClassOnlyUsedInOnePackage
+ * @deprecated Comments are now available directly in the AST via
+ *     {\@code TokenTypes.SINGLE_LINE_COMMENT} and {\@code TokenTypes.BLOCK_COMMENT_BEGIN}.
+ * @noinspection ClassOnlyUsedInOnePackage, DeprecatedIsStillUsed
  * @noinspectionreason ClassOnlyUsedInOnePackage - we restrict all parsing to a single package
+ * @noinspectionreason DeprecatedIsStillUsed - will be removed in a future release once
+ *     FileContents no longer implements it
  */
+@Deprecated(since = "13.4.1")
 public interface CommentListener {
 
     /**


### PR DESCRIPTION
fixes #4750
`CommentListener` is deprecated as comment tokens are now available directly in the AST via `TokenTypes.SINGLE_LINE_COMMENT` and `TokenTypes.BLOCK_COMMENT_BEGIN`.