### PR TITLE
Issue #19716: Fix SimplifyBooleanExpressionCheck with parenthesized boolean literals

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
@@ -75,11 +75,12 @@ public class SimplifyBooleanExpressionCheck
                  TokenTypes.LAND -> log(parent, MSG_KEY);
 
             case TokenTypes.QUESTION -> {
-                final DetailAST nextSibling = ast.getNextSibling();
-                if (TokenUtil.isBooleanLiteralType(parent.getFirstChild().getType())
-                        || nextSibling != null && nextSibling.getNextSibling() != null
+                final DetailAST firstChild = skipParentheses(parent.getFirstChild());
+                final DetailAST nextSibling = skipParentheses(ast.getNextSibling());
+                if (TokenUtil.isBooleanLiteralType(firstChild.getType())
+                        || nextSibling != null
                         && TokenUtil.isBooleanLiteralType(
-                        nextSibling.getNextSibling().getType())) {
+                                skipParentheses(nextSibling.getNextSibling()).getType())) {
                     log(parent, MSG_KEY);
                 }
             }
@@ -88,6 +89,21 @@ public class SimplifyBooleanExpressionCheck
                 // do nothing
             }
         }
+    }
+
+    /**
+     * Iterates sibling nodes, skipping parentheses.
+     *
+     * @param node The starting node.
+     * @return The first sibling not of type {@code TokenTypes.LPAREN} or
+     *     {@code TokenTypes.RPAREN}, or {@code null} if no such node exists.
+     */
+    private static DetailAST skipParentheses(DetailAST node) {
+        DetailAST result = node;
+        while (TokenUtil.isOfType(result, TokenTypes.LPAREN, TokenTypes.RPAREN)) {
+            result = result.getNextSibling();
+        }
+        return result;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheckTest.java
@@ -37,19 +37,23 @@ public class SimplifyBooleanExpressionCheckTest
     @Test
     public void testIt() throws Exception {
         final String[] expected = {
-            "22:18: " + getCheckMessage(MSG_KEY),
-            "43:36: " + getCheckMessage(MSG_KEY),
-            "44:36: " + getCheckMessage(MSG_KEY),
-            "45:16: " + getCheckMessage(MSG_KEY),
-            "45:32: " + getCheckMessage(MSG_KEY),
-            "95:27: " + getCheckMessage(MSG_KEY),
-            "96:24: " + getCheckMessage(MSG_KEY),
-            "98:27: " + getCheckMessage(MSG_KEY),
-            "104:23: " + getCheckMessage(MSG_KEY),
-            "106:17: " + getCheckMessage(MSG_KEY),
-            "109:21: " + getCheckMessage(MSG_KEY),
-            "110:23: " + getCheckMessage(MSG_KEY),
-            "111:20: " + getCheckMessage(MSG_KEY),
+            "20:18: " + getCheckMessage(MSG_KEY),
+            "41:36: " + getCheckMessage(MSG_KEY),
+            "42:36: " + getCheckMessage(MSG_KEY),
+            "43:16: " + getCheckMessage(MSG_KEY),
+            "43:32: " + getCheckMessage(MSG_KEY),
+            "93:27: " + getCheckMessage(MSG_KEY),
+            "94:24: " + getCheckMessage(MSG_KEY),
+            "96:27: " + getCheckMessage(MSG_KEY),
+            "102:23: " + getCheckMessage(MSG_KEY),
+            "104:17: " + getCheckMessage(MSG_KEY),
+            "107:21: " + getCheckMessage(MSG_KEY),
+            "108:23: " + getCheckMessage(MSG_KEY),
+            "109:20: " + getCheckMessage(MSG_KEY),
+            "111:27: " + getCheckMessage(MSG_KEY),
+            "112:35: " + getCheckMessage(MSG_KEY),
+            "114:31: " + getCheckMessage(MSG_KEY),
+            "115:35: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputSimplifyBooleanExpression.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheckTest.java
@@ -50,6 +50,8 @@ public class SimplifyBooleanExpressionCheckTest
             "109:21: " + getCheckMessage(MSG_KEY),
             "110:23: " + getCheckMessage(MSG_KEY),
             "111:20: " + getCheckMessage(MSG_KEY),
+            "113:27: " + getCheckMessage(MSG_KEY),
+            "114:31: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputSimplifyBooleanExpression.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanexpression/InputSimplifyBooleanExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanexpression/InputSimplifyBooleanExpression.java
@@ -8,12 +8,10 @@ package com.puppycrawl.tools.checkstyle.checks.coding.simplifybooleanexpression;
 
 /**
    Contains boolean logic that can be simplified.
-
    @author lkuehne
  */
 public class InputSimplifyBooleanExpression
 {
-
     public static boolean isOddMillis()
     {
         boolean even = System.currentTimeMillis() % 2 == 0;
@@ -110,5 +108,13 @@ public class InputSimplifyBooleanExpression
         int d = false ? 1 : 2; // violation, 'Expression can be simplified'
         temp = a() ? true : true; // violation, 'Expression can be simplified'
         temp = value != null ? value : (false);
+        boolean w = c > 1 ? (true) : ((false)); // violation, 'Expression can be simplified'
+        boolean wNoParens = c > 1 ? true : false; // violation, 'Expression can be simplified'
+        boolean wFullySimplified = c > 1;
+        boolean x = ((false)) ? c == 1 : c > 10; // violation, 'Expression can be simplified'
+        boolean xNoParens = false ? c == 1 : c > 10; // violation, 'Expression can be simplified'
+        boolean xFullySimplified = c > 10;
+        boolean y = c > 1 ? (c < 10 ? false : a) : false;
+        boolean z = (c < 10 ? false : a) ? c == 1 : c > 10;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanexpression/InputSimplifyBooleanExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanexpression/InputSimplifyBooleanExpression.java
@@ -110,5 +110,9 @@ public class InputSimplifyBooleanExpression
         int d = false ? 1 : 2; // violation, 'Expression can be simplified'
         temp = a() ? true : true; // violation, 'Expression can be simplified'
         temp = value != null ? value : (false);
+        boolean w = c > 1 ? (true) : ((false)); // violation, 'Expression can be simplified'
+        boolean x = ((false)) ? c == 1 : c > 10; // violation, 'Expression can be simplified'
+        boolean y = c > 1 ? (c < 10 ? false : a) : false;
+        boolean z = (c < 10 ? false : a) ? c == 1 : c > 10;
     }
 }


### PR DESCRIPTION
fixes: #19716

Adds logic to skip parentheses when checking operands of ternary operators.