### PR TITLE
Issue #19724: Align JavadocMethod accessModifiers with MissingJavadoc…

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/WhereJavadocIsUsedTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/WhereJavadocIsUsedTest.java
@@ -46,6 +46,16 @@ public class WhereJavadocIsUsedTest extends AbstractGoogleModuleTestSupport {
     }
 
     @Test
+    public void testJavadocMethodProtectedScopeCorrect() throws Exception {
+        verifyWithWholeConfig(getPath("InputJavadocMethodProtectedScopeCorrect.java"));
+    }
+
+    @Test
+    public void testJavadocMethodProtectedScopeIncorrect() throws Exception {
+        verifyWithWholeConfig(getPath("InputJavadocMethodProtectedScopeIncorrect.java"));
+    }
+
+    @Test
     public void testJavadocTypeOnRecord() throws Exception {
         verifyWithWholeConfig(getPath("InputJavadocTypeOnRecord.java"));
     }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodProtectedScopeCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodProtectedScopeCorrect.java
@@ -1,0 +1,19 @@
+package com.google.checkstyle.test.chapter7javadoc.rule73wherejavadocrequired;
+
+/** Some javadoc. */
+public class InputJavadocMethodProtectedScopeCorrect {
+
+  /**
+   * Process data.
+   *
+   * @param actual this parameter exist
+   */
+  protected void processData(int actual) {}
+
+  /**
+   * Process data.
+   *
+   * @param actual this parameter exist
+   */
+  public void processDataPublic(int actual) {}
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodProtectedScopeIncorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodProtectedScopeIncorrect.java
@@ -1,0 +1,21 @@
+package com.google.checkstyle.test.chapter7javadoc.rule73wherejavadocrequired;
+
+/** Some javadoc. */
+public class InputJavadocMethodProtectedScopeIncorrect {
+
+  /**
+   * Process data.
+   *
+   * @param nonExistent this parameter does not exist
+   */
+  // violation 2 lines above 'Unused @param tag for 'nonExistent'.'
+  protected void processData(int actual) {}
+
+  /**
+   * Process data.
+   *
+   * @param nonExistent this parameter does not exist
+   */
+  // violation 2 lines above 'Unused @param tag for 'nonExistent'.'
+  public void processDataPublic(int actual) {}
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -411,7 +411,7 @@
                                   VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="accessModifiers" value="public"/>
+      <property name="accessModifiers" value="public, protected"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>


### PR DESCRIPTION
Issue #19724: 

In google_checks.xml, `MissingJavadocMethod` uses `scope=protected` which requires Javadoc on both `public` and `protected` methods per Google Style Guide section 7.3. However, `JavadocMethod` uses `accessModifiers=public`, so it only validates Javadoc content on `public` methods. This means invalid `@param`/`@return`/`@throws` tags on `protected` methods are silently ignored.

This PR adds `protected` to `JavadocMethod`'s `accessModifiers` so that Javadoc content validation matches the same scope as Javadoc presence enforcement.

Diff Regression config: https://gist.githubusercontent.com/vivek-0509/27490bfdde07197b4ce820f4d30fc49d/raw/8de9bd1e0d55351504ecfd9d525d8f8503c9f583/base_config.xml

Diff Regression patch config: https://gist.githubusercontent.com/vivek-0509/a8e14c9db7081db1a12dd3cbc93bf897/raw/61dc610fc8af95dfceff8c965cc9c57f119ce76a/patch_config.xml