### PR TITLE
Issue #19620: Add Literals Section

### DIFF
--- a/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule314literals/LiteralsTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule314literals/LiteralsTest.java
@@ -1,0 +1,38 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapter3formatting.rule314literals;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class LiteralsTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapter3formatting/rule314literals";
+    }
+
+    @Test
+    public void testLiterals() throws Exception {
+        verifyWithWholeConfig(getPath("InputLiterals.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule314literals/InputLiterals.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule314literals/InputLiterals.java
@@ -1,0 +1,89 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule314literals;
+
+/**
+ * Test input for literals.
+ */
+public class InputLiterals {
+
+    /**
+     * Test hex literal case.
+     */
+    public void testHexLiteralCase() {
+      byte b1  = 0x1b;          // violation  'Should use uppercase hexadecimal letters.'
+      byte b2  = 0x1B;
+
+      short s1 = 0xF5f;         // violation  'Should use uppercase hexadecimal letters.'
+      short s2 = 0xF5F;
+
+      int i1 = 0x11 + 0xabc;    // violation  'Should use uppercase hexadecimal letters.'
+      int i2 = 0x11 + 0xABC;
+      int i3 = 0x123 + 0xabc;   // violation  'Should use uppercase hexadecimal letters.'
+      int i4 = 0x123 + 0xABC;
+      int i5 = 0xdeadbeef;      // violation  'Should use uppercase hexadecimal letters.'
+      int i6 = 0xDEADBEEF;
+
+      long l1 = 0x7fff_ffff_ffff_ffffL;
+      // violation above 'Should use uppercase hexadecimal letters.'
+      long l2 = 0x7FFF_FFFF_FFFF_FFFFL;
+
+      long l3 = 0x7FFF_AAA_bBB_DDDL;
+      // violation above 'Should use uppercase hexadecimal letters.'
+      long l4 = 0x7FFF_AAA_BBB_DDDL;
+
+      float c = 0x1ap1f; // violation  'Should use uppercase hexadecimal letters.'
+      float c2 = 0x1Ap1f;
+      double e = 0x1AbC.p1d; // violation  'Should use uppercase hexadecimal letters.'
+      double e2 = 0x1ABC.p1d;
+      float g = 0x1b.p1f; // violation  'Should use uppercase hexadecimal letters.'
+      float g2 = 0x1B.p1f;
+
+    }
+
+    /**
+     * Test numerical prefixes, infixes, and suffixes character case.
+     */
+    public void testNumericalPrefixesInfixesSuffixesCharacterCase() {
+      int hex1 = 0X1A; // violation 'Numerical prefix should be in lowercase.'
+      int hex2 = 0x1A;
+
+      int bin1 = 0B1010; // violation 'Numerical prefix should be in lowercase.'
+      int bin2 = 0b1010;
+
+      float exp1 = 1.23E3f; // violation 'Numerical infix should be in lowercase.'
+      float exp2 = 1.23e3f;
+
+      double hexEx1 = 0x1.3P2; // violation 'Numerical infix should be in lowercase.'
+      double hexEx2 = 0x1.3p2;
+
+      float suf1 = 10F; // violation 'Numerical suffix should be in lowercase.'
+      float suf2 = 10f;
+
+      double suf3 = 10D; // violation 'Numerical suffix should be in lowercase.'
+      double suf4 = 10d;
+
+      float mix1 = 1.2E3F; // violation 'Numerical infix should be in lowercase.'
+      float mix3 = 1.2e3f;
+
+      double mix4 = 0x1.3P2D; // violation 'Numerical infix should be in lowercase.'
+      double mix5 = 0x1.3p2D; // violation 'Numerical suffix should be in lowercase.'
+    }
+
+    /**
+     * Test long suffix character case.
+     */
+    void testLong() {
+      long var1 = 508987L;
+      long var2 = 508987l; // violation 'Should use uppercase 'L'.'
+    }
+
+    /**
+     * Test mix cases.
+     */
+    void mixCases() {
+      float h = 0x1b.P1F; // violation  'Should use uppercase hexadecimal letters.'
+      // violation above 'Numerical infix should be in lowercase.'
+      double f = 0x1AbC.P1D; // violation  'Should use uppercase hexadecimal letters.'
+      // violation above 'Numerical infix should be in lowercase.'
+    }
+
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -68,6 +68,10 @@
     <!-- §3.12: Expression lambda body length check based on OpenJDK style guide -->
     <module name="LambdaBodyLength"/>
 
+    <module name="UpperEll"/>
+    <module name="HexLiteralCase"/>
+    <module name="NumericalPrefixesInfixesSuffixesCharacterCase"/>
+
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.openjdk.suppressionxpathfilter.config}"

--- a/src/site/xdoc/checks/misc/hexliteralcase.xml
+++ b/src/site/xdoc/checks/misc/hexliteralcase.xml
@@ -77,6 +77,10 @@ class Example1 {
       <subsection name="Example of Usage" id="HexLiteralCase_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+HexLiteralCase">
+            OpenJDK Style</a>
+          </li>
+          <li>
            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+HexLiteralCase">
            Checkstyle Style
             </a>

--- a/src/site/xdoc/checks/misc/hexliteralcase.xml.template
+++ b/src/site/xdoc/checks/misc/hexliteralcase.xml.template
@@ -37,6 +37,10 @@
       <subsection name="Example of Usage" id="HexLiteralCase_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+HexLiteralCase">
+            OpenJDK Style</a>
+          </li>
+          <li>
            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+HexLiteralCase">
            Checkstyle Style
             </a>

--- a/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml
+++ b/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml
@@ -77,6 +77,10 @@ public class Example1 {
         id="NumericalPrefixesInfixesSuffixesCharacterCase_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NumericalPrefixesInfixesSuffixesCharacterCase">
+            OpenJDK Style</a>
+          </li>
+          <li>
            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NumericalPrefixesInfixesSuffixesCharacterCase">
            Checkstyle Style
             </a>

--- a/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml.template
+++ b/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml.template
@@ -38,6 +38,10 @@
         id="NumericalPrefixesInfixesSuffixesCharacterCase_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NumericalPrefixesInfixesSuffixesCharacterCase">
+            OpenJDK Style</a>
+          </li>
+          <li>
            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NumericalPrefixesInfixesSuffixesCharacterCase">
            Checkstyle Style
             </a>

--- a/src/site/xdoc/checks/misc/upperell.xml
+++ b/src/site/xdoc/checks/misc/upperell.xml
@@ -54,6 +54,10 @@ class Example1 {
             Sun Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+UpperEll">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UpperEll">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/misc/upperell.xml.template
+++ b/src/site/xdoc/checks/misc/upperell.xml.template
@@ -46,6 +46,10 @@
             Sun Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+UpperEll">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UpperEll">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -611,8 +611,36 @@
                     3.14 Literals
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/misc/upperell.html#UpperEll">UpperEll</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+UpperEll">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/misc/hexliteralcase.html#HexLiteralCase">
+                    HexLiteralCase</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+HexLiteralCase">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/misc/numericalprefixesinfixessuffixescharactercase.html#NumericalPrefixesInfixesSuffixesCharacterCase">
+                    NumericalPrefixesInfixesSuffixesCharacterCase</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NumericalPrefixesInfixesSuffixesCharacterCase">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule314literals">
+                    samples</a>
+                </td>
               </tr>
               <tr>
                 <td>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -611,8 +611,36 @@
                     3.14 Literals
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/upperell.html#UpperEll">UpperEll</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+UpperEll">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/hexliteralcase.html#HexLiteralCase">
+                    HexLiteralCase</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+HexLiteralCase">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/numericalprefixesinfixessuffixescharactercase.html#NumericalPrefixesInfixesSuffixesCharacterCase">
+                    NumericalPrefixesInfixesSuffixesCharacterCase</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NumericalPrefixesInfixesSuffixesCharacterCase">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule314literals">
+                    samples</a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
Issue: #19620 

In this pr i have added three modules in openjdk_check.xml  which covers all rules as related to the [literals](https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-literals) section of openjdk guidelines.

The added modules are - 

```
<module name="UpperEll"/>
<module name="HexLiteralCase"/>
<module name="NumericalPrefixesInfixesSuffixesCharacterCase"/>
```