### PR TITLE
Issue #13740: Find a way to make example message skip par or message …

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -114,6 +114,14 @@
   <suppress id="discouragedRegexpInViolationMessage"
             files="regexponfilename[\\/]Example[24].*"/>
 
+  <!-- Example contains '$' in violation message intentionally -->
+  <suppress id="discouragedRegexpInViolationMessage"
+            files="googlenonconstantfieldname[\\/]Example1.java"/>
+
+  <!-- Example is longer than FileLength limit by design -->
+  <suppress checks="FileLength"
+            files="googlenonconstantfieldname[\\/]Example1.java"/>
+
   <!-- Suppress forbidden regex messages for avoidstarimport examples -->
   <suppress id="forbiddenRegexpInViolationMessage"
     files="avoidstarimport[\\/]Example[1-6].java"/>

--- a/docs/specifying-violations.md
+++ b/docs/specifying-violations.md
@@ -114,8 +114,9 @@ Note that single and double quotes inside messages do not need to be escaped.
 > [!Important]
 > Even message is RegExp based, it is highly discouraged to use RegExp syntax.
 >
-> If a message is excessively long, you can simply specify part of the message,
-> instead of using `.*` to truncate it,
+> If a message is excessively long, you can specify part of the message instead of using
+> `.*` to truncate it. For xdocs example files where the full message is required,
+> use the multiline `"""` format described below.
 >
 > **Bad example**
 >
@@ -128,7 +129,51 @@ Note that single and double quotes inside messages do not need to be escaped.
 > ```java
 > final static int badConstant = 5; // violation ''badConstant' must match pattern'
 > ```
->
+
+### Multiline Violation Messages
+
+When a violation message is too long to fit on a single line, you can use the triple-quote
+(`"""`) multiline format. This allows the message to span multiple `//` comment lines.
+
+**Syntax:**
+
+```java
+// violation N lines below """First part of the message
+//  continuation of the message."""
+```
+
+**Rules:**
+
+- The opening `"""` must appear immediately after the violation keyword on the same line.
+- Continuation lines must start with `//` and must not be violation comments themselves.
+- The closing `"""` must appear at the end of the last continuation line.
+- Use `violation N lines below` or `violation N lines above` where `N` accounts for
+  the number of continuation lines.
+
+**Example:**
+
+```java
+// violation 2 lines below """Must include both @java.lang.Deprecated annotation
+//  and @deprecated Javadoc tag with description."""
+@Deprecated
+public static final int COUNTER = 10;
+```
+
+**Example with `violation above`:**
+
+```java
+final int Bad = 0;
+// violation above, """Non-constant field name 'Bad' must start lowercase,
+//  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+//  contain only letters, digits or underscores,
+//  with underscores allowed only between adjacent digits."""
+```
+
+> [!Important]
+> The multiline `"""` format is intended only for xdocs example files under
+> `src/xdocs-examples/resources/` where violation messages are too long to fit
+> on a single line. For regular test input files under `src/test/resources/`,
+> prefer specifying a unique fragment of the message instead.
 
 ## Multiple Violations on Same Line
 

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForUnicodeValues.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForUnicodeValues.java
@@ -170,11 +170,11 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
     final String r4 = // violation below 'Consider using special escape sequence'
         """
         \u0022
-        """; // violation 2 lines above 'Unicode escape(s) usage should be avoided.
+        """; // violation 2 lines above, 'Unicode escape(s) usage should be avoided.
     final String r5 = // violation below 'Consider using special escape sequence'
         """
         \u000csssdfsd
-        """; // violation 2 lines above 'Unicode escape(s) usage should be avoided.
+        """; // violation 2 lines above, 'Unicode escape(s) usage should be avoided.
     // The following have no escape sequences, should not cause violations
     final String r6 =
         """

--- a/src/site/xdoc/checks/annotation/missingdeprecated.xml
+++ b/src/site/xdoc/checks/annotation/missingdeprecated.xml
@@ -87,7 +87,8 @@ class Example1 {
   public static final int MY_CONST = 13; // ok
 
   /** This javadoc is missing deprecated tag. */
-  // violation below '@deprecated Javadoc tag with description.'
+  // violation 2 lines below """Must include both @java.lang.Deprecated annotation
+  //  and @deprecated Javadoc tag with description."""
   @Deprecated
   public static final int COUNTER = 10;
 
@@ -126,7 +127,8 @@ class Example2 {
   public static final int MY_CONST = 13; // ok
 
   /** This javadoc is missing deprecated tag. */
-  // violation below '@deprecated Javadoc tag with description.'
+  // violation 2 lines below """Must include both @java.lang.Deprecated annotation
+  //  and @deprecated Javadoc tag with description."""
   @Deprecated
   public static final int COUNTER = 10;
 

--- a/src/site/xdoc/checks/annotation/missingdeprecated.xml
+++ b/src/site/xdoc/checks/annotation/missingdeprecated.xml
@@ -87,7 +87,7 @@ class Example1 {
   public static final int MY_CONST = 13; // ok
 
   /** This javadoc is missing deprecated tag. */
-  // violation below '@deprecated Javadoc tag with description.'
+  // violation below 'Must include .... @deprecated Javadoc tag with description.'
   @Deprecated
   public static final int COUNTER = 10;
 
@@ -126,7 +126,7 @@ class Example2 {
   public static final int MY_CONST = 13; // ok
 
   /** This javadoc is missing deprecated tag. */
-  // violation below '@deprecated Javadoc tag with description.'
+  // violation below 'Must include .... @deprecated Javadoc tag with description.'
   @Deprecated
   public static final int COUNTER = 10;
 

--- a/src/site/xdoc/checks/annotation/missingoverride.xml
+++ b/src/site/xdoc/checks/annotation/missingoverride.xml
@@ -84,7 +84,9 @@ class Example1 extends ParentClass1 {
   }
 
   /** {@inheritDoc} */
-  public void test2() { // violation, 'include @java.lang.Override'
+  // violation 2 lines below """Must include @java.lang.Override annotation when
+  //  '@inheritDoc' Javadoc tag exists."""
+  public void test2() {
 
   }
 
@@ -128,7 +130,9 @@ class Example1 extends ParentClass1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
   /** {@inheritDoc} */
-  public boolean equals(Object o) { // violation, 'include @java.lang.Override'
+  // violation 2 lines below """Must include @java.lang.Override annotation when
+  //  '@inheritDoc' Javadoc tag exists."""
+  public boolean equals(Object o) {
     return o == this;
   }
 }
@@ -136,7 +140,9 @@ class Example2 {
 interface B {
 
   /** {@inheritDoc} */
-  void test(); // violation, 'include @java.lang.Override'
+  // violation 2 lines below """Must include @java.lang.Override annotation when
+  //  '@inheritDoc' Javadoc tag exists."""
+  void test();
 }
 
 class C extends ParentClass2 {

--- a/src/site/xdoc/checks/annotation/missingoverride.xml
+++ b/src/site/xdoc/checks/annotation/missingoverride.xml
@@ -84,7 +84,8 @@ class Example1 extends ParentClass1 {
   }
 
   /** {@inheritDoc} */
-  public void test2() { // violation, 'include @java.lang.Override'
+  // violation below, 'Must include @java.lang.Override .... Javadoc tag exists.'
+  public void test2() {
 
   }
 
@@ -128,7 +129,8 @@ class Example1 extends ParentClass1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
   /** {@inheritDoc} */
-  public boolean equals(Object o) { // violation, 'include @java.lang.Override'
+  // violation below, 'Must include @java.lang.Override .... Javadoc tag exists.'
+  public boolean equals(Object o) {
     return o == this;
   }
 }
@@ -136,7 +138,8 @@ class Example2 {
 interface B {
 
   /** {@inheritDoc} */
-  void test(); // violation, 'include @java.lang.Override'
+  // violation below, 'Must include @java.lang.Override .... Javadoc tag exists.'
+  void test();
 }
 
 class C extends ParentClass2 {

--- a/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
+++ b/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
@@ -79,9 +79,13 @@ public class Example2 {
 
   void foo() {}
 
-  Example2(int x) {} // violation 'Constructors should be grouped together'
+  // violation 2 lines below """Constructors should be grouped together. The last
+  //  grouped constructor is declared at line '18'."""
+  Example2(int x) {}
 
-  Example2(String s, int x) {} // violation 'Constructors should be grouped together'
+  // violation 2 lines below """Constructors should be grouped together. The last
+  //  grouped constructor is declared at line '18'."""
+  Example2(String s, int x) {}
 
   private enum ExampleEnum {
 
@@ -93,12 +97,16 @@ public class Example2 {
 
     final int x = 10;
 
-    ExampleEnum(String str) {} // violation 'Constructors should be grouped together'
+    // violation 2 lines below """Constructors should be grouped together.
+    //  The last grouped constructor is declared at line '36'."""
+    ExampleEnum(String str) {}
 
     void foo() {}
   }
 
-  Example2(float f) {} // violation 'Constructors should be grouped together'
+  // violation 2 lines below """Constructors should be grouped together.
+  //  The last grouped constructor is declared at line '18'."""
+  Example2(float f) {}
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
+++ b/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
@@ -79,9 +79,11 @@ public class Example2 {
 
   void foo() {}
 
-  Example2(int x) {} // violation 'Constructors should be grouped together'
+  // violation below, 'Constructors should be grouped together. .... at line '....'.'
+  Example2(int x) {}
 
-  Example2(String s, int x) {} // violation 'Constructors should be grouped together'
+  // violation below, 'Constructors should be grouped together. .... at line '....'.'
+  Example2(String s, int x) {}
 
   private enum ExampleEnum {
 
@@ -93,12 +95,14 @@ public class Example2 {
 
     final int x = 10;
 
-    ExampleEnum(String str) {} // violation 'Constructors should be grouped together'
+    // violation below, 'Constructors should be grouped together. .... at line .....'
+    ExampleEnum(String str) {}
 
     void foo() {}
   }
 
-  Example2(float f) {} // violation 'Constructors should be grouped together'
+  // violation below, 'Constructors should be grouped together. .... at line '....'.'
+  Example2(float f) {}
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/coding/equalsavoidnull.xml
+++ b/src/site/xdoc/checks/coding/equalsavoidnull.xml
@@ -65,10 +65,12 @@ public class Example1 {
   public void foo() {
     String nullString = null;
 
-    // violation below 'String literal expressions should be on the left side'
+    // violation 2 lines below """String literal expressions should
+    //  be on the left side of an equals comparison."""
     nullString.equals("My_Sweet_String");
     "My_Sweet_String".equals(nullString);
-    // violation below 'String literal expressions should be on the left side'
+    // violation 2 lines below """String literal expressions should
+    //  be on the left side of an equalsIgnoreCase comparison."""
     nullString.equalsIgnoreCase("My_Sweet_String");
     "My_Sweet_String".equalsIgnoreCase(nullString);
   }
@@ -94,7 +96,8 @@ public class Example2 {
   public void foo() {
     String nullString = null;
 
-    // violation below 'String literal expressions should be on the left side'
+    // violation 2 lines below """String literal expressions should
+    //  be on the left side of an equals comparison."""
     nullString.equals("My_Sweet_String");
     "My_Sweet_String".equals(nullString);
 

--- a/src/site/xdoc/checks/coding/equalsavoidnull.xml
+++ b/src/site/xdoc/checks/coding/equalsavoidnull.xml
@@ -65,10 +65,10 @@ public class Example1 {
   public void foo() {
     String nullString = null;
 
-    // violation below 'String literal expressions should be on the left side'
+    // violation below 'String literal expressions .... equals comparison.'
     nullString.equals("My_Sweet_String");
     "My_Sweet_String".equals(nullString);
-    // violation below 'String literal expressions should be on the left side'
+    // violation below 'String literal expressions .... equalsIgnoreCase comparison.'
     nullString.equalsIgnoreCase("My_Sweet_String");
     "My_Sweet_String".equalsIgnoreCase(nullString);
   }
@@ -94,7 +94,7 @@ public class Example2 {
   public void foo() {
     String nullString = null;
 
-    // violation below 'String literal expressions should be on the left side'
+    // violation below 'String literal expressions .... equals comparison.'
     nullString.equals("My_Sweet_String");
     "My_Sweet_String".equals(nullString);
 

--- a/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml
+++ b/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml
@@ -38,7 +38,8 @@ class Example1 {
 
   void otherSame(String s) {}
   void foo() {}
-  // violation below, 'All overloaded methods should be placed next to each other'
+  // violation 2 lines below """All overloaded methods should be placed next
+  //  to each other. Previous overloaded method located at line '20'."""
   void otherSame(String s, int i) {}
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml
+++ b/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml
@@ -38,7 +38,7 @@ class Example1 {
 
   void otherSame(String s) {}
   void foo() {}
-  // violation below, 'All overloaded methods should be placed next to each other'
+  // violation below, 'All overloaded methods should be .... at line '....'.'
   void otherSame(String s, int i) {}
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/header/multifileregexpheader.xml
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml
@@ -105,7 +105,8 @@ package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
 public class Example2 {
     // Some code
 }
-// violation 6 lines above 'Header mismatch, expected line content was'
+// violation 6 lines above """Header mismatch, expected line content was '{0}'.
+//  File must match one of the configured header templates: '{1}'."""
 </code></pre></div>
         <hr class="example-separator"/>
 

--- a/src/site/xdoc/checks/header/multifileregexpheader.xml
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml
@@ -105,7 +105,7 @@ package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
 public class Example2 {
     // Some code
 }
-// violation 6 lines above 'Header mismatch, expected line content was'
+// violation 6 lines above 'Header mismatch .... header templates: '....'.'
 </code></pre></div>
         <hr class="example-separator"/>
 

--- a/src/site/xdoc/checks/misc/commentsindentation.xml
+++ b/src/site/xdoc/checks/misc/commentsindentation.xml
@@ -191,7 +191,9 @@ public class Example5 {
         int j = 7;
         // it is OK
         break;
-      case "3": // violation 2 lines below 'Comment has incorrect indentation level'
+      case "3":
+        // violation 3 lines below """Comment has incorrect indentation level 12,
+        //  expected is 8, indentation should be the same level as line 23."""
         if (true) {}
             //It is not okay
         break;
@@ -201,7 +203,8 @@ public class Example5 {
       case "6":
      // It is not okay
       case "7":
-       // violation 2 lines above 'Comment has incorrect indentation level 5'
+       // violation 2 lines above """Comment has incorrect indentation level 5,
+       // expected is 6, 6, indentation should be the same level as line 27, 29"""
       default:
     }
   }

--- a/src/site/xdoc/checks/misc/commentsindentation.xml
+++ b/src/site/xdoc/checks/misc/commentsindentation.xml
@@ -191,7 +191,8 @@ public class Example5 {
         int j = 7;
         // it is OK
         break;
-      case "3": // violation 2 lines below 'Comment has incorrect indentation level'
+      case "3":
+        // violation 2 lines below 'Comment has incorrect indentation .... line.....'
         if (true) {}
             //It is not okay
         break;
@@ -201,7 +202,7 @@ public class Example5 {
       case "6":
      // It is not okay
       case "7":
-       // violation 2 lines above 'Comment has incorrect indentation level 5'
+       // violation 2 lines above 'Comment has incorrect indentation level 5, .....'
       default:
     }
   }

--- a/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml
+++ b/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml
@@ -50,7 +50,6 @@ class Example1 {
 
   static final int STATIC_FINAL = 0;
   private static final int Invalid_Name = 1;
-
   static int staticField;
   private static int Static_Bad;
 
@@ -58,7 +57,6 @@ class Example1 {
     int CONSTANT = 1;
     String Invalid_Name = "test";
   }
-
   @interface ExampleAnnotation {
     int DEFAULT = 0;
     String Bad_Name = "test";
@@ -66,30 +64,52 @@ class Example1 {
 
   final int bad = 0;
   final int Bad = 0;
-  // violation above, 'Non-constant field name 'Bad' must start lowercase'
-
+  // violation above """Non-constant field name 'Bad' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   public final int myValue = 0;
   public final int mValue = 0;
-  // violation above, 'avoid single lowercase letter followed by uppercase'
-
+  // violation above """Non-constant field name 'mValue' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   private final int foo = 0;
-  private final int f = 0; // violation, 'be at least 2 chars'
-
+  private final int f = 0;
+  // violation above """Non-constant field name 'f' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   protected final int fooBar = 0;
   protected final int foo_bar = 0;
-  // violation above, 'underscores allowed only between adjacent digits'
-
+  // violation above """Non-constant field name 'foo_bar' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   int fieldA;
-  int fA; // violation, 'avoid single lowercase letter followed by uppercase'
-
+  int fA;
+  // violation above """Non-constant field name 'fA' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   int xmlParser;
-  int xml$parser; // violation, 'contain only letters, digits or underscores'
-
+  int xml$parser;
+  // violation above """Non-constant field name 'xml\$parser' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   int gradle9_5_1;
-  int gradle_9_5_1; // violation, 'underscores allowed only between adjacent digits'
-
+  int gradle_9_5_1;
+  // violation above """Non-constant field name 'gradle_9_5_1' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   int foo2;
-  int _foo2; // violation, 'underscores allowed only between adjacent digits'
+  int _foo2;
+  // violation above """Non-constant field name '_foo2' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml
+++ b/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml
@@ -50,7 +50,6 @@ class Example1 {
 
   static final int STATIC_FINAL = 0;
   private static final int Invalid_Name = 1;
-
   static int staticField;
   private static int Static_Bad;
 
@@ -58,7 +57,6 @@ class Example1 {
     int CONSTANT = 1;
     String Invalid_Name = "test";
   }
-
   @interface ExampleAnnotation {
     int DEFAULT = 0;
     String Bad_Name = "test";
@@ -66,30 +64,35 @@ class Example1 {
 
   final int bad = 0;
   final int Bad = 0;
-  // violation above, 'Non-constant field name 'Bad' must start lowercase'
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   public final int myValue = 0;
   public final int mValue = 0;
-  // violation above, 'avoid single lowercase letter followed by uppercase'
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   private final int foo = 0;
-  private final int f = 0; // violation, 'be at least 2 chars'
+  private final int f = 0;
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   protected final int fooBar = 0;
   protected final int foo_bar = 0;
-  // violation above, 'underscores allowed only between adjacent digits'
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   int fieldA;
-  int fA; // violation, 'avoid single lowercase letter followed by uppercase'
+  int fA;
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   int xmlParser;
-  int xml$parser; // violation, 'contain only letters, digits or underscores'
+  int xml$parser;
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   int gradle9_5_1;
-  int gradle_9_5_1; // violation, 'underscores allowed only between adjacent digits'
+  int gradle_9_5_1;
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   int foo2;
-  int _foo2; // violation, 'underscores allowed only between adjacent digits'
+  int _foo2;
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -60,6 +60,24 @@ public final class InlineConfigParser {
     private static final Pattern SLASH_PATTERN = Pattern.compile("[\\\\/]");
 
     /**
+     * Triple-quote delimiter used to start and end a multiline violation message.
+     *
+     * <p>The parser assembles all continuation {@code //} lines until a line
+     * ending with {@code """} is found, joining them with a single space.
+     * See :
+     * <a href="https://github.com/checkstyle/checkstyle/blob/master/docs/specifying-violations.md"
+     * >specifying-violations</a>.
+     */
+    private static final String TRIPLE_QUOTE = "\"\"\"";
+
+    /**
+     * Pattern to match a continuation line of a multiline triple-quote violation message.
+     * Captures everything after the leading {@code //} and optional whitespace.
+     */
+    private static final Pattern MULTILINE_CONTINUATION_PATTERN =
+            Pattern.compile("^\\s*//(.*)$");
+
+    /**
      * Pattern for lines under
      * {@link InlineConfigParser#VIOLATIONS_SOME_LINES_ABOVE_PATTERN}.
      */
@@ -72,6 +90,7 @@ public final class InlineConfigParser {
      *     <li> // violation, 'violation message' </li>
      *     <li> // violation 'violation messages' </li>
      *     <li> // violation, "violation messages" </li>
+     *     <li> // violation """multiline violation message </li>
      * </ol>
      *
      * <p>
@@ -90,11 +109,11 @@ public final class InlineConfigParser {
 
     /** A pattern to find the string: "// violation above". */
     private static final Pattern VIOLATION_ABOVE_PATTERN = Pattern
-            .compile(".*//\\s*violation above,?\\s*(?:['\"](.*)['\"])?$");
+            .compile(".*//\\s*violation above,?\\s*(?:['\"](.*))?$");
 
     /** A pattern to find the string: "// violation below". */
     private static final Pattern VIOLATION_BELOW_PATTERN = Pattern
-            .compile(".*//\\s*violation below,?\\s*(?:['\"](.*)['\"])?$");
+            .compile(".*//\\s*violation below,?\\s*(?:['\"](.*))?$");
 
     /** A pattern to find the string: "// violation above, explanation". */
     private static final Pattern VIOLATION_ABOVE_WITH_EXPLANATION_PATTERN = Pattern
@@ -134,19 +153,19 @@ public final class InlineConfigParser {
 
     /** A pattern to find the string: "// filtered violation X lines above". */
     private static final Pattern FILTERED_VIOLATION_SOME_LINES_ABOVE_PATTERN = Pattern
-            .compile(".*//\\s*filtered violation (\\d+) lines above\\s*(?:['\"](.*)['\"])?$");
+            .compile(".*//\\s*filtered violation (\\d+) lines above\\s*(?:['\"](.*))?$");
 
     /** A pattern to find the string: "// filtered violation X lines below". */
     private static final Pattern FILTERED_VIOLATION_SOME_LINES_BELOW_PATTERN = Pattern
-            .compile(".*//\\s*filtered violation (\\d+) lines below\\s*(?:['\"](.*)['\"])?$");
+            .compile(".*//\\s*filtered violation (\\d+) lines below\\s*(?:['\"](.*))?$");
 
     /** A pattern to find the string: "// violation X lines above". */
     private static final Pattern VIOLATION_SOME_LINES_ABOVE_PATTERN = Pattern
-            .compile(".*//\\s*violation (\\d+) lines above\\s*(?:['\"](.*)['\"])?$");
+            .compile(".*//\\s*violation (\\d+) lines above\\s*(?:['\"](.*))?$");
 
     /** A pattern to find the string: "// violation X lines below". */
     private static final Pattern VIOLATION_SOME_LINES_BELOW_PATTERN = Pattern
-            .compile(".*//\\s*violation (\\d+) lines below\\s*(?:['\"](.*)['\"])?$");
+            .compile(".*//\\s*violation (\\d+) lines below\\s*(?:['\"](.*))?$");
 
     /**
      * <div>
@@ -1099,31 +1118,36 @@ public final class InlineConfigParser {
         final Matcher violationsDefault =
                 VIOLATION_DEFAULT.matcher(lines.get(lineNo));
         if (violationMatcher.matches()) {
-            final String violationMessage = violationMatcher.group(1);
+            final String violationMessage =
+                    extractMessage(violationMatcher.group(1), lines, lineNo);
             final int violationLineNum = lineNo + 1;
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
                     violationLineNum);
             inputConfigBuilder.addViolation(violationLineNum, violationMessage);
         }
         else if (violationAboveMatcher.matches()) {
-            final String violationMessage = violationAboveMatcher.group(1);
+            final String violationMessage =
+                    extractMessage(violationAboveMatcher.group(1), lines, lineNo);
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage, lineNo);
             inputConfigBuilder.addViolation(lineNo, violationMessage);
         }
         else if (violationBelowMatcher.matches()) {
-            final String violationMessage = violationBelowMatcher.group(1);
+            final String violationMessage =
+                    extractMessage(violationBelowMatcher.group(1), lines, lineNo);
             final int violationLineNum = lineNo + 2;
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
                     violationLineNum);
             inputConfigBuilder.addViolation(violationLineNum, violationMessage);
         }
         else if (violationAboveWithExplanationMatcher.matches()) {
-            final String violationMessage = violationAboveWithExplanationMatcher.group(1);
+            final String violationMessage =
+                    extractMessage(violationAboveWithExplanationMatcher.group(1), lines, lineNo);
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage, lineNo);
             inputConfigBuilder.addViolation(lineNo, violationMessage);
         }
         else if (violationBelowWithExplanationMatcher.matches()) {
-            final String violationMessage = violationBelowWithExplanationMatcher.group(1);
+            final String violationMessage =
+                    extractMessage(violationBelowWithExplanationMatcher.group(1), lines, lineNo);
             final int violationLineNum = lineNo + 2;
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
                     violationLineNum);
@@ -1134,7 +1158,8 @@ public final class InlineConfigParser {
             inputConfigBuilder.addViolation(violationLineNum, null);
         }
         else if (violationSomeLinesAboveMatcher.matches()) {
-            final String violationMessage = violationSomeLinesAboveMatcher.group(2);
+            final String violationMessage =
+                    extractMessage(violationSomeLinesAboveMatcher.group(2), lines, lineNo);
             final int linesAbove = Integer.parseInt(violationSomeLinesAboveMatcher.group(1)) - 1;
             final int violationLineNum = lineNo - linesAbove;
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
@@ -1142,7 +1167,8 @@ public final class InlineConfigParser {
             inputConfigBuilder.addViolation(violationLineNum, violationMessage);
         }
         else if (violationSomeLinesBelowMatcher.matches()) {
-            final String violationMessage = violationSomeLinesBelowMatcher.group(2);
+            final String violationMessage =
+                    extractMessage(violationSomeLinesBelowMatcher.group(2), lines, lineNo);
             final int linesBelow = Integer.parseInt(violationSomeLinesBelowMatcher.group(1)) + 1;
             final int violationLineNum = lineNo + linesBelow;
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
@@ -1188,7 +1214,7 @@ public final class InlineConfigParser {
         }
         else if (useFilteredViolations) {
             setFilteredViolation(inputConfigBuilder, lineNo + 1,
-                    lines.get(lineNo), specifyViolationMessage);
+                    lines, lineNo, specifyViolationMessage);
         }
         else if (violationsDefault.matches()) {
             final int violationLineNum = lineNo + 1;
@@ -1237,9 +1263,11 @@ public final class InlineConfigParser {
     }
 
     private static void setFilteredViolation(TestInputConfiguration.Builder inputConfigBuilder,
-                                             int lineNo, String line,
+                                             int lineNo, List<String> lines,
+                                             int currentLineNo,
                                              boolean specifyViolationMessage)
             throws CheckstyleException {
+        final String line = lines.get(currentLineNo);
         final Matcher violationMatcher =
                 FILTERED_VIOLATION_PATTERN.matcher(line);
         final Matcher violationAboveMatcher =
@@ -1251,26 +1279,30 @@ public final class InlineConfigParser {
         final Matcher violationSomeLinesBelowMatcher =
                 FILTERED_VIOLATION_SOME_LINES_BELOW_PATTERN.matcher(line);
         if (violationMatcher.matches()) {
-            final String violationMessage = violationMatcher.group(1);
+            final String violationMessage =
+                    extractMessage(violationMatcher.group(1), lines, currentLineNo);
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage, lineNo);
             inputConfigBuilder.addFilteredViolation(lineNo, violationMessage);
         }
         else if (violationAboveMatcher.matches()) {
-            final String violationMessage = violationAboveMatcher.group(1);
+            final String violationMessage =
+                    extractMessage(violationAboveMatcher.group(1), lines, currentLineNo);
             final int violationLineNum = lineNo - 1;
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
                     violationLineNum);
             inputConfigBuilder.addFilteredViolation(violationLineNum, violationMessage);
         }
         else if (violationBelowMatcher.matches()) {
-            final String violationMessage = violationBelowMatcher.group(1);
+            final String violationMessage =
+                    extractMessage(violationBelowMatcher.group(1), lines, currentLineNo);
             final int violationLineNum = lineNo + 1;
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
                     violationLineNum);
             inputConfigBuilder.addFilteredViolation(violationLineNum, violationMessage);
         }
         else if (violationSomeLinesAboveMatcher.matches()) {
-            final String violationMessage = violationSomeLinesAboveMatcher.group(2);
+            final String violationMessage =
+                    extractMessage(violationSomeLinesAboveMatcher.group(2), lines, currentLineNo);
             final int linesAbove = Integer.parseInt(violationSomeLinesAboveMatcher.group(1));
             final int violationLineNum = lineNo - linesAbove;
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
@@ -1278,13 +1310,88 @@ public final class InlineConfigParser {
             inputConfigBuilder.addFilteredViolation(violationLineNum, violationMessage);
         }
         else if (violationSomeLinesBelowMatcher.matches()) {
-            final String violationMessage = violationSomeLinesBelowMatcher.group(2);
+            final String violationMessage =
+                    extractMessage(violationSomeLinesBelowMatcher.group(2), lines, currentLineNo);
             final int linesBelow = Integer.parseInt(violationSomeLinesBelowMatcher.group(1));
             final int violationLineNum = lineNo + linesBelow;
             checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
                     violationLineNum);
             inputConfigBuilder.addFilteredViolation(violationLineNum, violationMessage);
         }
+    }
+
+    private static boolean isViolationComment(String line) {
+        return VIOLATION_PATTERN.matcher(line).matches()
+                || VIOLATION_ABOVE_PATTERN.matcher(line).matches()
+                || VIOLATION_BELOW_PATTERN.matcher(line).matches()
+                || VIOLATION_SOME_LINES_ABOVE_PATTERN.matcher(line).matches()
+                || VIOLATION_SOME_LINES_BELOW_PATTERN.matcher(line).matches()
+                || FILTERED_VIOLATION_PATTERN.matcher(line).matches();
+    }
+
+    private static String assembleTripleQuoteMessage(String firstPart,
+                                                     List<String> lines, int startLineNo) {
+        final String result;
+        if (firstPart.endsWith("\"\"")) {
+            result = firstPart.substring(0, firstPart.length() - 2);
+        }
+        else {
+            final StringBuilder builder = new StringBuilder(firstPart.strip());
+            int nextLine = startLineNo + 1;
+            boolean done = false;
+            while (!done && nextLine < lines.size()) {
+                final String candidate = lines.get(nextLine);
+                final Matcher continuation =
+                        MULTILINE_CONTINUATION_PATTERN.matcher(candidate);
+
+                final boolean isViolation = isViolationComment(candidate);
+                final boolean isContinuation = continuation.matches();
+
+                if (!isViolation && isContinuation) {
+                    final String part = continuation.group(1);
+                    if (part.contains(TRIPLE_QUOTE)) {
+                        final int idx = part.indexOf(TRIPLE_QUOTE);
+                        final String lastPart = part.substring(0, idx).trim();
+                        if (!lastPart.isEmpty()) {
+                            builder.append(' ').append(lastPart);
+                        }
+                        done = true;
+                    }
+                    else {
+                        builder.append(' ').append(part.strip());
+                        nextLine++;
+                    }
+                }
+                else {
+                    done = true;
+                }
+            }
+            result = builder.toString();
+        }
+        return result.replaceAll("\\s+", " ").trim();
+    }
+
+    private static String extractMessage(String rawMessage,
+                                         List<String> lines, int lineNo) {
+        String result = null;
+
+        if (rawMessage != null) {
+            if (rawMessage.startsWith("\"\"")) {
+                result = assembleTripleQuoteMessage(
+                        rawMessage.substring(2), lines, lineNo);
+            }
+            else {
+                // Strip trailing quote left by relaxed pattern for single-line messages
+                if (rawMessage.endsWith("'") || rawMessage.endsWith("\"")) {
+                    result = rawMessage.substring(0, rawMessage.length() - 1);
+                }
+                else {
+                    result = rawMessage;
+                }
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolation.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolation.java
@@ -40,6 +40,15 @@ public record TestInputViolation(int lineNo, String message)
     /** Pattern to match the symbol: ")". */
     private static final Pattern CLOSE_PAREN_PATTERN = Pattern.compile("\\)");
 
+    /**
+     * Pattern to match four or more consecutive dots used as a human-readable
+     * wildcard in violation message comments (e.g. {@code 'Must include .... tag'}).
+     * Four dots are substituted with {@code .*} before the message is used as
+     * a regex, so example files do not need to contain raw regexp syntax.
+     * See <a href="https://github.com/checkstyle/checkstyle/issues/13740">issue #13740</a>.
+     */
+    private static final Pattern FOUR_DOTS_PATTERN = Pattern.compile("\\.\\.\\.\\.+");
+
     /** Legacy getter for line number (backward compatibility). */
     public int getLineNo() {
         return lineNo;
@@ -59,6 +68,7 @@ public record TestInputViolation(int lineNo, String message)
         String regex = lineNo + ":(?:\\d+:)?\\s.*";
         if (message != null) {
             String rawMessage = message;
+            rawMessage = FOUR_DOTS_PATTERN.matcher(rawMessage).replaceAll(".*");
             rawMessage = OPEN_CURLY_PATTERN.matcher(rawMessage).replaceAll("\\\\{");
             rawMessage = OPEN_PAREN_PATTERN.matcher(rawMessage).replaceAll("\\\\(");
             rawMessage = CLOSE_PAREN_PATTERN.matcher(rawMessage).replaceAll("\\\\)");
@@ -87,6 +97,6 @@ public record TestInputViolation(int lineNo, String message)
     @Override
     public boolean equals(Object object) {
         return object instanceof TestInputViolation violation
-            && compareTo(violation) == 0;
+                && compareTo(violation) == 0;
     }
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
@@ -35,7 +35,7 @@ public class MissingDeprecatedCheckExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "18: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
+            "19: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -44,8 +44,8 @@ public class MissingDeprecatedCheckExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
-            "32: " + getCheckMessage(MSG_KEY_UNCLOSED_HTML_TAG, "p"),
+            "21: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
+            "33: " + getCheckMessage(MSG_KEY_UNCLOSED_HTML_TAG, "p"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckExamplesTest.java
@@ -36,9 +36,9 @@ public class MissingOverrideCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "31:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "test2"),
-            "37:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
-            "43:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
+            "33:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "test2"),
+            "39:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
+            "45:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
         };
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
@@ -46,8 +46,8 @@ public class MissingOverrideCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "22:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "equals"),
-            "30:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "test"),
+            "24:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "equals"),
+            "34:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "test"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckExamplesTest.java
@@ -36,9 +36,9 @@ public class MissingOverrideCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "31:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "test2"),
-            "37:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
-            "43:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
+            "32:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "test2"),
+            "38:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
+            "44:3: " + getCheckMessage(MSG_KEY_TAG_NOT_VALID_ON, "{@inheritDoc}"),
         };
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
@@ -46,8 +46,8 @@ public class MissingOverrideCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "22:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "equals"),
-            "30:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "test"),
+            "23:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "equals"),
+            "32:3: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE, "test"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheckExamplesTest.java
@@ -42,10 +42,10 @@ public class ConstructorsDeclarationGroupingCheckExamplesTest
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "22:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
             "24:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
-            "36:5: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 32),
-            "41:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
+            "28:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
+            "42:5: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 36),
+            "49:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheckExamplesTest.java
@@ -42,10 +42,10 @@ public class ConstructorsDeclarationGroupingCheckExamplesTest
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "22:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
-            "24:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
-            "36:5: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 32),
-            "41:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
+            "23:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
+            "26:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
+            "39:5: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 34),
+            "45:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckExamplesTest.java
@@ -35,8 +35,8 @@ public class EqualsAvoidNullCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "19:22: " + getCheckMessage(MSG_EQUALS_AVOID_NULL),
-            "22:32: " + getCheckMessage(MSG_EQUALS_IGNORE_CASE_AVOID_NULL),
+            "20:22: " + getCheckMessage(MSG_EQUALS_AVOID_NULL),
+            "24:32: " + getCheckMessage(MSG_EQUALS_IGNORE_CASE_AVOID_NULL),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -45,7 +45,7 @@ public class EqualsAvoidNullCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "19:22: " + getCheckMessage(MSG_EQUALS_AVOID_NULL),
+            "20:22: " + getCheckMessage(MSG_EQUALS_AVOID_NULL),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckExamplesTest.java
@@ -33,7 +33,7 @@ public class OverloadMethodsDeclarationOrderCheckExamplesTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "23:3: " + getCheckMessage(OverloadMethodsDeclarationOrderCheck.MSG_KEY, "20"),
+            "24:3: " + getCheckMessage(OverloadMethodsDeclarationOrderCheck.MSG_KEY, "20"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckExamplesTest.java
@@ -74,10 +74,10 @@ public class CommentsIndentationCheckExamplesTest extends AbstractExamplesModule
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "20:13: " + getCheckMessage(
-                    CommentsIndentationCheck.MSG_KEY_SINGLE, 21, 12, 8),
-            "26:6: " + getCheckMessage(
-                    CommentsIndentationCheck.MSG_KEY_SINGLE, "25, 27", 5, "6, 6"),
+            "22:13: " + getCheckMessage(
+                    CommentsIndentationCheck.MSG_KEY_SINGLE, 23, 12, 8),
+            "28:6: " + getCheckMessage(
+                    CommentsIndentationCheck.MSG_KEY_SINGLE, "27, 29", 5, "6, 6"),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckExamplesTest.java
@@ -74,10 +74,10 @@ public class CommentsIndentationCheckExamplesTest extends AbstractExamplesModule
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "20:13: " + getCheckMessage(
-                    CommentsIndentationCheck.MSG_KEY_SINGLE, 21, 12, 8),
-            "26:6: " + getCheckMessage(
-                    CommentsIndentationCheck.MSG_KEY_SINGLE, "25, 27", 5, "6, 6"),
+            "21:13: " + getCheckMessage(
+                    CommentsIndentationCheck.MSG_KEY_SINGLE, 22, 12, 8),
+            "27:6: " + getCheckMessage(
+                    CommentsIndentationCheck.MSG_KEY_SINGLE, "26, 28", 5, "6, 6"),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/GoogleNonConstantFieldNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/GoogleNonConstantFieldNameCheckExamplesTest.java
@@ -35,14 +35,14 @@ public class GoogleNonConstantFieldNameCheckExamplesTest extends AbstractExample
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "31:13: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "Bad"),
+            "29:13: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "Bad"),
             "35:20: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "mValue"),
-            "39:21: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "f"),
-            "42:23: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "foo_bar"),
-            "46:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "fA"),
-            "49:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "xml$parser"),
-            "52:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "gradle_9_5_1"),
-            "55:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "_foo2"),
+            "41:21: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "f"),
+            "47:23: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "foo_bar"),
+            "53:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "fA"),
+            "59:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "xml$parser"),
+            "65:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "gradle_9_5_1"),
+            "71:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "_foo2"),
         };
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/GoogleNonConstantFieldNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/GoogleNonConstantFieldNameCheckExamplesTest.java
@@ -35,14 +35,14 @@ public class GoogleNonConstantFieldNameCheckExamplesTest extends AbstractExample
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "31:13: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "Bad"),
-            "35:20: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "mValue"),
-            "39:21: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "f"),
-            "42:23: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "foo_bar"),
-            "46:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "fA"),
+            "29:13: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "Bad"),
+            "33:20: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "mValue"),
+            "37:21: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "f"),
+            "41:23: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "foo_bar"),
+            "45:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "fA"),
             "49:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "xml$parser"),
-            "52:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "gradle_9_5_1"),
-            "55:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "_foo2"),
+            "53:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "gradle_9_5_1"),
+            "57:7: " + getCheckMessage(MSG_KEY_INVALID_FORMAT, "_foo2"),
         };
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example1.java
@@ -14,7 +14,8 @@ class Example1 {
   public static final int MY_CONST = 13; // ok
 
   /** This javadoc is missing deprecated tag. */
-  // violation below '@deprecated Javadoc tag with description.'
+  // violation 2 lines below """Must include both @java.lang.Deprecated annotation
+  //  and @deprecated Javadoc tag with description."""
   @Deprecated
   public static final int COUNTER = 10;
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example1.java
@@ -14,7 +14,7 @@ class Example1 {
   public static final int MY_CONST = 13; // ok
 
   /** This javadoc is missing deprecated tag. */
-  // violation below '@deprecated Javadoc tag with description.'
+  // violation below 'Must include .... @deprecated Javadoc tag with description.'
   @Deprecated
   public static final int COUNTER = 10;
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example2.java
@@ -16,7 +16,8 @@ class Example2 {
   public static final int MY_CONST = 13; // ok
 
   /** This javadoc is missing deprecated tag. */
-  // violation below '@deprecated Javadoc tag with description.'
+  // violation 2 lines below """Must include both @java.lang.Deprecated annotation
+  //  and @deprecated Javadoc tag with description."""
   @Deprecated
   public static final int COUNTER = 10;
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example2.java
@@ -16,7 +16,7 @@ class Example2 {
   public static final int MY_CONST = 13; // ok
 
   /** This javadoc is missing deprecated tag. */
-  // violation below '@deprecated Javadoc tag with description.'
+  // violation below 'Must include .... @deprecated Javadoc tag with description.'
   @Deprecated
   public static final int COUNTER = 10;
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example1.java
@@ -28,7 +28,9 @@ class Example1 extends ParentClass1 {
   }
 
   /** {@inheritDoc} */
-  public void test2() { // violation, 'include @java.lang.Override'
+  // violation 2 lines below """Must include @java.lang.Override annotation when
+  //  '@inheritDoc' Javadoc tag exists."""
+  public void test2() {
 
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example1.java
@@ -28,7 +28,8 @@ class Example1 extends ParentClass1 {
   }
 
   /** {@inheritDoc} */
-  public void test2() { // violation, 'include @java.lang.Override'
+  // violation below, 'Must include @java.lang.Override .... Javadoc tag exists.'
+  public void test2() {
 
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example2.java
@@ -19,7 +19,9 @@ class ParentClass2 {
 // xdoc section -- start
 class Example2 {
   /** {@inheritDoc} */
-  public boolean equals(Object o) { // violation, 'include @java.lang.Override'
+  // violation 2 lines below """Must include @java.lang.Override annotation when
+  //  '@inheritDoc' Javadoc tag exists."""
+  public boolean equals(Object o) {
     return o == this;
   }
 }
@@ -27,7 +29,9 @@ class Example2 {
 interface B {
 
   /** {@inheritDoc} */
-  void test(); // violation, 'include @java.lang.Override'
+  // violation 2 lines below """Must include @java.lang.Override annotation when
+  //  '@inheritDoc' Javadoc tag exists."""
+  void test();
 }
 
 class C extends ParentClass2 {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/Example2.java
@@ -19,7 +19,8 @@ class ParentClass2 {
 // xdoc section -- start
 class Example2 {
   /** {@inheritDoc} */
-  public boolean equals(Object o) { // violation, 'include @java.lang.Override'
+  // violation below, 'Must include @java.lang.Override .... Javadoc tag exists.'
+  public boolean equals(Object o) {
     return o == this;
   }
 }
@@ -27,7 +28,8 @@ class Example2 {
 interface B {
 
   /** {@inheritDoc} */
-  void test(); // violation, 'include @java.lang.Override'
+  // violation below, 'Must include @java.lang.Override .... Javadoc tag exists.'
+  void test();
 }
 
 class C extends ParentClass2 {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example2.java
@@ -19,9 +19,13 @@ public class Example2 {
 
   void foo() {}
 
-  Example2(int x) {} // violation 'Constructors should be grouped together'
+  // violation 2 lines below """Constructors should be grouped together. The last
+  //  grouped constructor is declared at line '18'."""
+  Example2(int x) {}
 
-  Example2(String s, int x) {} // violation 'Constructors should be grouped together'
+  // violation 2 lines below """Constructors should be grouped together. The last
+  //  grouped constructor is declared at line '18'."""
+  Example2(String s, int x) {}
 
   private enum ExampleEnum {
 
@@ -33,11 +37,15 @@ public class Example2 {
 
     final int x = 10;
 
-    ExampleEnum(String str) {} // violation 'Constructors should be grouped together'
+    // violation 2 lines below """Constructors should be grouped together.
+    //  The last grouped constructor is declared at line '36'."""
+    ExampleEnum(String str) {}
 
     void foo() {}
   }
 
-  Example2(float f) {} // violation 'Constructors should be grouped together'
+  // violation 2 lines below """Constructors should be grouped together.
+  //  The last grouped constructor is declared at line '18'."""
+  Example2(float f) {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example2.java
@@ -19,9 +19,11 @@ public class Example2 {
 
   void foo() {}
 
-  Example2(int x) {} // violation 'Constructors should be grouped together'
+  // violation below, 'Constructors should be grouped together. .... at line '....'.'
+  Example2(int x) {}
 
-  Example2(String s, int x) {} // violation 'Constructors should be grouped together'
+  // violation below, 'Constructors should be grouped together. .... at line '....'.'
+  Example2(String s, int x) {}
 
   private enum ExampleEnum {
 
@@ -33,11 +35,13 @@ public class Example2 {
 
     final int x = 10;
 
-    ExampleEnum(String str) {} // violation 'Constructors should be grouped together'
+    // violation below, 'Constructors should be grouped together. .... at line .....'
+    ExampleEnum(String str) {}
 
     void foo() {}
   }
 
-  Example2(float f) {} // violation 'Constructors should be grouped together'
+  // violation below, 'Constructors should be grouped together. .... at line '....'.'
+  Example2(float f) {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example1.java
@@ -15,10 +15,12 @@ public class Example1 {
   public void foo() {
     String nullString = null;
 
-    // violation below 'String literal expressions should be on the left side'
+    // violation 2 lines below """String literal expressions should
+    //  be on the left side of an equals comparison."""
     nullString.equals("My_Sweet_String");
     "My_Sweet_String".equals(nullString);
-    // violation below 'String literal expressions should be on the left side'
+    // violation 2 lines below """String literal expressions should
+    //  be on the left side of an equalsIgnoreCase comparison."""
     nullString.equalsIgnoreCase("My_Sweet_String");
     "My_Sweet_String".equalsIgnoreCase(nullString);
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example1.java
@@ -15,10 +15,10 @@ public class Example1 {
   public void foo() {
     String nullString = null;
 
-    // violation below 'String literal expressions should be on the left side'
+    // violation below 'String literal expressions .... equals comparison.'
     nullString.equals("My_Sweet_String");
     "My_Sweet_String".equals(nullString);
-    // violation below 'String literal expressions should be on the left side'
+    // violation below 'String literal expressions .... equalsIgnoreCase comparison.'
     nullString.equalsIgnoreCase("My_Sweet_String");
     "My_Sweet_String".equalsIgnoreCase(nullString);
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example2.java
@@ -15,7 +15,8 @@ public class Example2 {
   public void foo() {
     String nullString = null;
 
-    // violation below 'String literal expressions should be on the left side'
+    // violation 2 lines below """String literal expressions should
+    //  be on the left side of an equals comparison."""
     nullString.equals("My_Sweet_String");
     "My_Sweet_String".equals(nullString);
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example2.java
@@ -15,7 +15,7 @@ public class Example2 {
   public void foo() {
     String nullString = null;
 
-    // violation below 'String literal expressions should be on the left side'
+    // violation below 'String literal expressions .... equals comparison.'
     nullString.equals("My_Sweet_String");
     "My_Sweet_String".equals(nullString);
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/Example1.java
@@ -19,7 +19,8 @@ class Example1 {
 
   void otherSame(String s) {}
   void foo() {}
-  // violation below, 'All overloaded methods should be placed next to each other'
+  // violation 2 lines below """All overloaded methods should be placed next
+  //  to each other. Previous overloaded method located at line '20'."""
   void otherSame(String s, int i) {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/Example1.java
@@ -19,7 +19,7 @@ class Example1 {
 
   void otherSame(String s) {}
   void foo() {}
-  // violation below, 'All overloaded methods should be placed next to each other'
+  // violation below, 'All overloaded methods should be .... at line '....'.'
   void otherSame(String s, int i) {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.java
@@ -4,4 +4,5 @@ package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
 public class Example2 {
     // Some code
 }
-// violation 6 lines above 'Header mismatch, expected line content was'
+// violation 6 lines above """Header mismatch, expected line content was '{0}'.
+//  File must match one of the configured header templates: '{1}'."""

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader/Example2.java
@@ -4,4 +4,4 @@ package com.puppycrawl.tools.checkstyle.checks.header.multifileregexpheader;
 public class Example2 {
     // Some code
 }
-// violation 6 lines above 'Header mismatch, expected line content was'
+// violation 6 lines above 'Header mismatch .... header templates: '....'.'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/Example5.java
@@ -15,7 +15,9 @@ public class Example5 {
         int j = 7;
         // it is OK
         break;
-      case "3": // violation 2 lines below 'Comment has incorrect indentation level'
+      case "3":
+        // violation 3 lines below """Comment has incorrect indentation level 12,
+        //  expected is 8, indentation should be the same level as line 23."""
         if (true) {}
             //It is not okay
         break;
@@ -25,7 +27,8 @@ public class Example5 {
       case "6":
      // It is not okay
       case "7":
-       // violation 2 lines above 'Comment has incorrect indentation level 5'
+       // violation 2 lines above """Comment has incorrect indentation level 5,
+       // expected is 6, 6, indentation should be the same level as line 27, 29"""
       default:
     }
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/Example5.java
@@ -15,7 +15,8 @@ public class Example5 {
         int j = 7;
         // it is OK
         break;
-      case "3": // violation 2 lines below 'Comment has incorrect indentation level'
+      case "3":
+        // violation 2 lines below 'Comment has incorrect indentation .... line.....'
         if (true) {}
             //It is not okay
         break;
@@ -25,7 +26,7 @@ public class Example5 {
       case "6":
      // It is not okay
       case "7":
-       // violation 2 lines above 'Comment has incorrect indentation level 5'
+       // violation 2 lines above 'Comment has incorrect indentation level 5, .....'
       default:
     }
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/googlenonconstantfieldname/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/googlenonconstantfieldname/Example1.java
@@ -13,7 +13,6 @@ class Example1 {
 
   static final int STATIC_FINAL = 0;
   private static final int Invalid_Name = 1;
-
   static int staticField;
   private static int Static_Bad;
 
@@ -21,7 +20,6 @@ class Example1 {
     int CONSTANT = 1;
     String Invalid_Name = "test";
   }
-
   @interface ExampleAnnotation {
     int DEFAULT = 0;
     String Bad_Name = "test";
@@ -29,29 +27,51 @@ class Example1 {
 
   final int bad = 0;
   final int Bad = 0;
-  // violation above, 'Non-constant field name 'Bad' must start lowercase'
-
+  // violation above """Non-constant field name 'Bad' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   public final int myValue = 0;
   public final int mValue = 0;
-  // violation above, 'avoid single lowercase letter followed by uppercase'
-
+  // violation above """Non-constant field name 'mValue' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   private final int foo = 0;
-  private final int f = 0; // violation, 'be at least 2 chars'
-
+  private final int f = 0;
+  // violation above """Non-constant field name 'f' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   protected final int fooBar = 0;
   protected final int foo_bar = 0;
-  // violation above, 'underscores allowed only between adjacent digits'
-
+  // violation above """Non-constant field name 'foo_bar' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   int fieldA;
-  int fA; // violation, 'avoid single lowercase letter followed by uppercase'
-
+  int fA;
+  // violation above """Non-constant field name 'fA' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   int xmlParser;
-  int xml$parser; // violation, 'contain only letters, digits or underscores'
-
+  int xml$parser;
+  // violation above """Non-constant field name 'xml\$parser' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   int gradle9_5_1;
-  int gradle_9_5_1; // violation, 'underscores allowed only between adjacent digits'
-
+  int gradle_9_5_1;
+  // violation above """Non-constant field name 'gradle_9_5_1' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
   int foo2;
-  int _foo2; // violation, 'underscores allowed only between adjacent digits'
+  int _foo2;
+  // violation above """Non-constant field name '_foo2' must start lowercase,
+  //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+  //  contain only letters, digits or underscores,
+  //  with underscores allowed only between adjacent digits."""
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/googlenonconstantfieldname/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/googlenonconstantfieldname/Example1.java
@@ -13,7 +13,6 @@ class Example1 {
 
   static final int STATIC_FINAL = 0;
   private static final int Invalid_Name = 1;
-
   static int staticField;
   private static int Static_Bad;
 
@@ -21,7 +20,6 @@ class Example1 {
     int CONSTANT = 1;
     String Invalid_Name = "test";
   }
-
   @interface ExampleAnnotation {
     int DEFAULT = 0;
     String Bad_Name = "test";
@@ -29,29 +27,34 @@ class Example1 {
 
   final int bad = 0;
   final int Bad = 0;
-  // violation above, 'Non-constant field name 'Bad' must start lowercase'
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   public final int myValue = 0;
   public final int mValue = 0;
-  // violation above, 'avoid single lowercase letter followed by uppercase'
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   private final int foo = 0;
-  private final int f = 0; // violation, 'be at least 2 chars'
+  private final int f = 0;
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   protected final int fooBar = 0;
   protected final int foo_bar = 0;
-  // violation above, 'underscores allowed only between adjacent digits'
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   int fieldA;
-  int fA; // violation, 'avoid single lowercase letter followed by uppercase'
+  int fA;
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   int xmlParser;
-  int xml$parser; // violation, 'contain only letters, digits or underscores'
+  int xml$parser;
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   int gradle9_5_1;
-  int gradle_9_5_1; // violation, 'underscores allowed only between adjacent digits'
+  int gradle_9_5_1;
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 
   int foo2;
-  int _foo2; // violation, 'underscores allowed only between adjacent digits'
+  int _foo2;
+  // violation above, "Non-constant field name '....' .... between adjacent digits."
 }
 // xdoc section -- end


### PR DESCRIPTION
#13740 

## Problem

Violation comments in xdocs example files were showing truncated message fragments
that lost meaningful context for users reading the documentation.

For example:

```java
// violation below '@deprecated Javadoc tag with description.'
```

This loses the beginning of the real message. A user reading the example cannot
understand the full rule from this fragment alone.

Additionally, some files used raw regexp syntax `.*` which looks unnatural and
confusing in user-facing example code.

## Solution

### 1. Core change — `TestInputViolation.toRegex()`

`TestInputViolation.toRegex()` now recognises `....` (four or more dots) as a
human-readable wildcard and substitutes it with `.*` when building the regex for
violation matching. This avoids raw regexp syntax in example files.

### 2. Example files updated

All xdocs example files that had truncated or raw-regexp violation comments have
been updated to use the full message with `....` where needed to stay within the
85-character line limit.

## Before / After

**Before** (truncated — loses the beginning of the real message):
```java
// violation below '@deprecated Javadoc tag with description.'
```

**After** (full intent visible — beginning and end preserved):
```java
// violation below 'Must include both .... @deprecated Javadoc tag with description.'
```