### PR TITLE
Issue #19734: Added checks for OpenJDK Style §3.3.1 - Wildcard Imports

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1490,6 +1490,7 @@ Wifi
 wiki
 wikipedia
 wiktionary
+wildcardimports
 windowsservercore
 withgoogle
 wj

--- a/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule331wildcardimports/WildcardImportsTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule331wildcardimports/WildcardImportsTest.java
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapter3formatting.rule331wildcardimports;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class WildcardImportsTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapter3formatting/rule331wildcardimports";
+    }
+
+    @Test
+    public void testWildcardImportsValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputWildcardImportsValid.java"));
+    }
+
+    @Test
+    public void testWildcardImportsInvalid() throws Exception {
+        verifyWithWholeConfig(getPath("InputWildcardImportsInvalid.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule331wildcardimports/InputWildcardImportsInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule331wildcardimports/InputWildcardImportsInvalid.java
@@ -1,0 +1,14 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule331wildcardimports;
+
+import java.util.*;
+
+import static java.lang.Math.*; // violation, 'Only '1' star import is allowed per file.'
+
+public class InputWildcardImportsInvalid {
+
+    private final List<String> items = List.of("one", "two");
+
+    public int maxValue(int first, int second) {
+        return max(first, second) + items.size();
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule331wildcardimports/InputWildcardImportsValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule331wildcardimports/InputWildcardImportsValid.java
@@ -1,0 +1,24 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule331wildcardimports;
+
+import java.util.*;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.Math.max;
+
+public class InputWildcardImportsValid {
+
+    private final List<String> items;
+
+    public InputWildcardImportsValid(List<String> items) {
+        this.items = items;
+    }
+
+    public Map<String, String> getItems() {
+        return Map.of("size", String.valueOf(items.size()));
+    }
+
+    public int maxValue(int first, int second) {
+        return max(first, second);
+    }
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -92,6 +92,9 @@
     </module>
 
     <!-- §3.3: Import statements should be sorted -->
+    <module name="AvoidStarImport">
+      <property name="maxAllowedStarImports" value="1"/>
+    </module>
     <module name="ImportOrder">
       <property name="groups" value="java,javax"/>
       <property name="ordered" value="true"/>

--- a/src/site/xdoc/checks/imports/avoidstarimport.xml
+++ b/src/site/xdoc/checks/imports/avoidstarimport.xml
@@ -240,6 +240,10 @@ import java.net.*; // violation, 'Only '1' star import is allowed per file.'
       <subsection name="Example of Usage" id="AvoidStarImport_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidStarImport">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidStarImport">
             Google Style</a>
           </li>

--- a/src/site/xdoc/checks/imports/avoidstarimport.xml.template
+++ b/src/site/xdoc/checks/imports/avoidstarimport.xml.template
@@ -162,6 +162,10 @@
       <subsection name="Example of Usage" id="AvoidStarImport_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidStarImport">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidStarImport">
             Google Style</a>
           </li>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -312,8 +312,19 @@
                     Wildcard Imports
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/imports/avoidstarimport.html#AvoidStarImport">AvoidStarImport</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidStarImport">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule331wildcardimports">
+                    samples
+                  </a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
fixes #19734 

Implements OpenJDK Style §3.3.1 (Wildcard Imports) for issue #19734.

This PR adds AvoidStarImport to OpenJDK config, updates OpenJDK style coverage docs, and adds integration tests for both regular and static wildcard imports.

Parent umbrella issue: #19604

