### PR TITLE
Issue #19743: added checks for OpenJDK Style §3.8.1 - Wrapping Class …

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1485,6 +1485,7 @@ wontfix
 workaround
 workflow
 wq
+wrappingclassdeclarations
 wrappinglines
 writetag
 writingchecks

--- a/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule381wrappingclassdeclarations/WrappingClassDeclarationsTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapter3formatting/rule381wrappingclassdeclarations/WrappingClassDeclarationsTest.java
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapter3formatting.rule381wrappingclassdeclarations;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class WrappingClassDeclarationsTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapter3formatting/rule381wrappingclassdeclarations";
+    }
+
+    @Test
+    public void testWrappingClassDeclarationsValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputWrappingClassDeclarationsValid.java"));
+    }
+
+    @Test
+    public void testWrappingClassDeclarationsInvalid() throws Exception {
+        verifyWithWholeConfig(getPath("InputWrappingClassDeclarationsInvalid.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule381wrappingclassdeclarations/InputWrappingClassDeclarationsInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule381wrappingclassdeclarations/InputWrappingClassDeclarationsInvalid.java
@@ -1,0 +1,14 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule381wrappingclassdeclarations;
+
+import java.util.HashMap;
+
+public abstract class InputWrappingClassDeclarationsInvalid<T, S>
+    extends HashMap<T, S> // violation '.* incorrect indentation level 4, expected .* 8.'
+    implements Comparable<T> { // violation '.* incorrect indentation level 4, expected .* 8.'
+}
+
+class AnotherInvalidClass<
+    K, // violation '.* incorrect indentation level 4, expected .* 8.'
+    R, // violation '.* incorrect indentation level 4, expected .* 8.'
+    V> { // violation '.* incorrect indentation level 4, expected .* 8.'
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule381wrappingclassdeclarations/InputWrappingClassDeclarationsValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule381wrappingclassdeclarations/InputWrappingClassDeclarationsValid.java
@@ -1,0 +1,14 @@
+package com.openjdk.checkstyle.test.chapter3formatting.rule381wrappingclassdeclarations;
+
+import java.util.HashMap;
+
+public abstract class InputWrappingClassDeclarationsValid<T, S>
+        extends HashMap<T, S>
+        implements Comparable<T> {
+}
+
+class AnotherValidClass<
+        K,
+        R,
+        V> {
+}

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -429,8 +429,20 @@
                     3.8.1 Wrapping Class Declarations
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/misc/indentation.html#Indentation">
+                    Indentation</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter3formatting/rule381wrappingclassdeclarations">
+                    samples
+                  </a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
closes #19743 

#### Summary
This PR fills in the missing OpenJDK Style coverage entry for “Wrapping Class Declarations” and links it to the Indentation check, which is the rule that enforces the wrapping/indentation behavior for class headers in the current OpenJDK config. It also adds a dedicated OpenJDK integration test package with valid and invalid examples that cover wrapped extends / implements clauses and wrapped type-parameter lists.