### PR TITLE
Issue #11440: comment and remove remaining tests in XpathFilterElementTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
@@ -41,6 +41,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck;
+import com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -77,6 +78,19 @@ public class SuppressionXpathSingleFilterTest
 
         verifyFilterWithInlineConfigParser(
             getPath("InputSuppressionXpathSingleFilterNonMatchingTokenType.java"), expected,
+            removeSuppressed(expected, suppressed));
+    }
+
+    @Test
+    public void testNonMatchingTokenTypeByXpath() throws Exception {
+        final String[] expected = {
+            "18:5: " + getCheckMessage(RedundantModifierCheck.class, "redundantModifier", "public"),
+        };
+
+        final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyFilterWithInlineConfigParser(
+            getPath("InputSuppressionXpathSingleFilterNonMatchingTokenType2.java"), expected,
             removeSuppressed(expected, suppressed));
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
@@ -58,18 +58,6 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNonMatchingTokenType() throws Exception {
-        final String xpath = "//METHOD_DEF[./IDENT[@text='countTokens']]";
-        final XpathFilterElement filter = new XpathFilterElement(
-                "InputXpathFilterElementSuppressByXpath", "Test", null, null, xpath);
-        final TreeWalkerAuditEvent ev = getEvent(4, 4,
-                TokenTypes.CLASS_DEF);
-        assertWithMessage("Event should be accepted")
-                .that(filter.accept(ev))
-                .isTrue();
-    }
-
-    @Test
     public void testNonMatchingColumnNumber() throws Exception {
         final String xpath = "//CLASS_DEF[./IDENT[@text='InputXpathFilterElementSuppressByXpath']]";
         final XpathFilterElement filter = new XpathFilterElement(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingTokenType2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingTokenType2.java
@@ -1,0 +1,19 @@
+/*
+SuppressionXpathSingleFilter
+files = InputSuppressionXpathSingleFilterNonMatchingTokenType2
+checks = RedundantModifierCheck
+message = (default)(null)
+id = (default)(null)
+query = //METHOD_DEF[./IDENT[@text='bar']]
+
+com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck
+jdkVersion = (default)22
+tokens = METHOD_DEF
+
+*/
+package com.puppycrawl.tools.checkstyle.filters.suppressionxpathsinglefilter;
+
+public interface InputSuppressionXpathSingleFilterNonMatchingTokenType2 {
+
+    public void bar(); // violation 'Redundant 'public' modifier.'
+}


### PR DESCRIPTION
Issue #11440

- removed the last 3 unecessary tests
- added comment over `testEqualsAndHashCode` why it can't use verifyxxx methods  
- added comment over remaining explaining why we can't remove them even tho we have equivalent ones in `SuppressionXpathSingleFilterTest`