### PR TITLE
Issue #11440: add comment over testEqualsAndHashCode in XpathFilterElementTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
@@ -130,6 +130,13 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 .isTrue();
     }
 
+    /**
+     * This test should remain as a low level pure unit test.
+     * It uses {@link EqualsVerifier} library to validate {@code equals()}
+     * and {@code hashCode()} methods on all edge cases. This is a very
+     * technical method with implementation by strict rules, not related
+     * to checkstyle's target of validation.
+     */
     @Test
     public void testEqualsAndHashCode() throws Exception {
         final XPathEvaluator xpathEvaluator = new XPathEvaluator(Configuration.newConfiguration());


### PR DESCRIPTION
Issue #11440 

comment on testEqualsAndHashCode explaining why it can't be converted to use verifyxxx methods 