### PR TITLE
Issue #19750: PatternVariableAssignment false positive when pattern variable used as array index

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -2984,17 +2984,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PatternVariableAssignmentCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter startingBranch of PatternVariableAssignmentCheck.traverseUntilNeededBranchType.</message>
-    <lineContent>assignIdent, assignToken.getFirstChild(), TokenTypes.IDENT) != null) {</lineContent>
-    <details>
-      found   : @Initialized @Nullable DetailAST
-      required: @Initialized @NonNull DetailAST
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg0 of Deque.push.</message>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PatternVariableAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PatternVariableAssignmentCheck.java
@@ -157,19 +157,14 @@ public class PatternVariableAssignmentCheck extends AbstractCheck {
             for (DetailAST branch : branches) {
                 for (DetailAST expressionBranch = branch;
                      expressionBranch != null;
-                     expressionBranch = traverseUntilNeededBranchType(
-                             expressionBranch, branch, TokenTypes.EXPR)) {
+                     expressionBranch = shiftToNextTraversedBranch(
+                             expressionBranch, branch)) {
 
                     final DetailAST assignToken =
                             getMatchedAssignToken(expressionBranch);
 
                     if (assignToken != null) {
-                        final DetailAST neededAssignIdent =
-                                getNeededAssignIdent(assignToken);
-
-                        if (neededAssignIdent.getPreviousSibling() == null) {
-                            reassignedVariableIdents.add(neededAssignIdent);
-                        }
+                        reassignedVariableIdents.add(assignToken.getFirstChild());
                     }
                 }
             }
@@ -204,34 +199,6 @@ public class PatternVariableAssignmentCheck extends AbstractCheck {
         }
 
         return statements;
-    }
-
-    /**
-     * Traverses along the AST tree to locate the first branch of certain token type.
-     *
-     * @param startingBranch AST branch to start the traverse from, but not check.
-     * @param bound AST Branch that the traverse cannot further extend to.
-     * @param neededTokenType Token type whose first encountered branch is to look for.
-     * @return the AST tree of first encountered branch of needed token type.
-     */
-    @Nullable
-    private static DetailAST traverseUntilNeededBranchType(DetailAST startingBranch,
-                              DetailAST bound, int neededTokenType) {
-
-        DetailAST match = null;
-
-        DetailAST iteratedBranch = shiftToNextTraversedBranch(startingBranch, bound);
-
-        while (iteratedBranch != null) {
-            if (iteratedBranch.getType() == neededTokenType) {
-                match = iteratedBranch;
-                break;
-            }
-
-            iteratedBranch = shiftToNextTraversedBranch(iteratedBranch, bound);
-        }
-
-        return match;
     }
 
     /**
@@ -282,25 +249,6 @@ public class PatternVariableAssignmentCheck extends AbstractCheck {
         }
 
         return matchedAssignToken;
-    }
-
-    /**
-     * Gets the needed AST Ident of reassigned variable for check to compare.
-     *
-     * @param assignToken The AST branch of reassigned variable's ASSIGN token.
-     * @return needed AST Ident.
-     */
-    private static DetailAST getNeededAssignIdent(DetailAST assignToken) {
-        DetailAST assignIdent = assignToken;
-
-        while (traverseUntilNeededBranchType(
-            assignIdent, assignToken.getFirstChild(), TokenTypes.IDENT) != null) {
-
-            assignIdent =
-                traverseUntilNeededBranchType(assignIdent, assignToken, TokenTypes.IDENT);
-        }
-
-        return assignIdent;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/PatternVariableAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/PatternVariableAssignmentCheckTest.java
@@ -117,4 +117,17 @@ public class PatternVariableAssignmentCheckTest extends AbstractModuleTestSuppor
                 getPath("InputPatternVariableAssignmentExtendedScope2.java"), expected);
     }
 
+    @Test
+    public void testPatternVariableAssignmentCheck3() throws Exception {
+
+        final String[] expected = {
+            "18:13: " + getCheckMessage(MSG_KEY, "integer3"),
+            "24:13: " + getCheckMessage(MSG_KEY, "arr2"),
+            "33:13: " + getCheckMessage(MSG_KEY, "s"),
+        };
+
+        verifyWithInlineXmlConfig(getPath(
+            "InputPatternVariableAssignmentCheck3.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/patternvariableassignment/InputPatternVariableAssignmentCheck3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/patternvariableassignment/InputPatternVariableAssignmentCheck3.java
@@ -1,0 +1,36 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="PatternVariableAssignment"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.patternvariableassignment;
+public class InputPatternVariableAssignmentCheck3 {
+    void foo(Object object, String[] sessions) {
+        if (object instanceof Integer integer1) {
+            sessions[integer1] = null;
+        }
+        if (object instanceof Integer integer2) {
+            sessions[integer2] += "x";
+        }
+        if (object instanceof Integer integer3) {
+            integer3 = 5; // violation, "Assignment of pattern variable 'integer3' is not allowed."
+        }
+        if (object instanceof String[] arr) {
+            arr[0] = "value";
+        }
+        if (object instanceof String[] arr2) {
+            arr2 = new String[5];
+            // violation above, "Assignment of pattern variable 'arr2' is not allowed."
+        }
+        if (object instanceof int[] arr3) {
+            arr3[0] = 1;
+        }
+        if (object instanceof String s) {
+            System.out.println(s);
+            System.out.println("test");
+            s = "hello"; // violation, "Assignment of pattern variable 's' is not allowed."
+        }
+    }
+}


### PR DESCRIPTION
Fix #19750

`PatternVariableAssignment` was giving a false positive - 
```
if (object instanceof Integer integer1) {
    sessions[integer1] = null; // wrongly flagged
}
```
here `integer1` is just used as an array index, not reassigned. check was mistakenly looking the array index on the left of the assignment. fixed by only flagging when pattern variable is directly being assigned to..

Diff Regression config: https://gist.githubusercontent.com/ayushactiveat/57bcff440a1b311a83a09f39f00a6118/raw/e08ab48bbf2a681776cdc22004e7ba6ee15e291c/base_config.xml

Diff Regression patch config: https://gist.githubusercontent.com/ayushactiveat/12857b08d7df95d3b0b0c97ce3e390cc/raw/3eac3adee8424ad22f8f5f52bcbbb1563ed5a96c/patch_config.xml