### PR TITLE
Issue #19755: Added checks for OpenJDK Style §4.3 - Method Names

### DIFF
--- a/src/it/java/com/openjdk/checkstyle/test/chapter4naming/rule43methodnames/MethodNameTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapter4naming/rule43methodnames/MethodNameTest.java
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapter4naming.rule43methodnames;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class MethodNameTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapter4naming/rule43methodnames";
+    }
+
+    @Test
+    public void testMethodNameInvalid() throws Exception {
+        verifyWithWholeConfig(getPath("InputMethodNameInvalid.java"));
+    }
+
+    @Test
+    public void testMethodNameValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputMethodNameValid.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule43methodnames/InputMethodNameInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule43methodnames/InputMethodNameInvalid.java
@@ -1,0 +1,18 @@
+package com.openjdk.checkstyle.test.chapter4naming.rule43methodnames;
+
+/** Invalid method names for OpenJDK style section 4.3. */
+public class InputMethodNameInvalid {
+
+    public void a() { // violation 'Name 'a' must match pattern'
+    }
+
+    public void _do() { // violation 'Name '_do' must match pattern'
+    }
+
+    public void BadName() { // violation 'Name 'BadName' must match pattern'
+    }
+
+    public void bad_name() { // violation 'Name 'bad_name' must match pattern'
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule43methodnames/InputMethodNameValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule43methodnames/InputMethodNameValid.java
@@ -1,0 +1,18 @@
+package com.openjdk.checkstyle.test.chapter4naming.rule43methodnames;
+
+/** Valid method names for OpenJDK style section 4.3. */
+public class InputMethodNameValid {
+
+    public void is() {
+    }
+
+    public void go() {
+    }
+
+    public void getName() {
+    }
+
+    private void doSomething() {
+    }
+
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -74,6 +74,10 @@
 
     <module name="MultipleVariableDeclarations"/>
 
+    <module name="MethodName">
+      <property name="format" value="^[a-z]{2,}[a-zA-Z0-9]*$"/>
+    </module>
+
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.openjdk.suppressionxpathfilter.config}"

--- a/src/site/xdoc/checks/naming/methodname.xml
+++ b/src/site/xdoc/checks/naming/methodname.xml
@@ -249,6 +249,10 @@ class Example7 {
             Sun Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodName">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodName">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/naming/methodname.xml.template
+++ b/src/site/xdoc/checks/naming/methodname.xml.template
@@ -143,6 +143,10 @@
             Sun Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodName">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodName">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -736,8 +736,22 @@
                     4.3 Method Names
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_blue.png" alt="" />
+                  </span>
+                  <a href="checks/naming/methodname.html#MethodName">MethodName</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodName">
+                  config</a>)
+                  <br />
+                  Method names should typically be verbs or other descriptions of actions.
+                  This cannot be fully covered because Checkstyle does not have English vocabulary
+                  to determine whether a method name is a verb or action description.
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapter4naming/rule43methodnames">
+                    samples</a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
closes #19755 

#### Changes
[openjdk_checks.xml]: Added MethodName module with format pattern ^[a-z]{2,}[a-zA-Z0-9]*$
Integration Tests: Created new test class MethodNameTest.java with:
Valid cases: is(), go(), getName(), doSomething()
Invalid cases: a() (single char), _do() (underscore prefix), BadName() (uppercase start), bad_name() (underscores)
Documentation: Updated openjdk_style.xml coverage table and added OpenJDK links to MethodName check documentation

#### Pattern Details
✅ Allowed: Method names starting with 2+ lowercase letters, followed by any letters/digits
❌ Not Allowed: Single-letter names, uppercase start, underscores, starting digits
