### PR TITLE
Issue #19764: Move violation comments out of Javadoc for MissingDeprecated

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -82,10 +82,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity[\\/]InputClassFanOutComplexityRemoveIncorrectAnnotationToken.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedClass.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedSpecialCase.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckBlockCommentBegin.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckCommentsContent.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckTest.java
@@ -107,16 +107,16 @@ public class MissingDeprecatedCheckTest extends AbstractModuleTestSupport {
     public void testSpecialCaseDeprecated() throws Exception {
 
         final String[] expected = {
-            "12: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
-            "19: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
-            "21: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
-            "26: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
-            "40: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
-            "49: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
-            "58: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
-            "99: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
-            "106: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
-            "113: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
+            "13: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
+            "21: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
+            "23: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
+            "28: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
+            "41: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
+            "50: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
+            "59: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
+            "95: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
+            "102: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
+            "109: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
         };
 
         verifyWithInlineConfigParser(
@@ -139,8 +139,8 @@ public class MissingDeprecatedCheckTest extends AbstractModuleTestSupport {
     public void testTwoInJavadocWithoutAnnotation() throws Exception {
 
         final String[] expected = {
-            "15: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
-            "19: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
+            "17: " + getCheckMessage(MSG_KEY_JAVADOC_DUPLICATE_TAG, "@deprecated"),
+            "21: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedClass.java
@@ -8,11 +8,13 @@ violateExecutionOnNonTightHtml = (default)false
 package com.puppycrawl.tools.checkstyle.checks.annotation.missingdeprecated;
 
 import java.lang.annotation.Inherited;
+
+// violation 5 lines below 'Duplicate @deprecated tag.'
 /**
  *
  * @author idubinin
  *@deprecated
- *@deprecated // violation 'Duplicate @deprecated tag.'
+ *@deprecated
  *stuff
  *stuff
  */ // violation below 'Must include.*@java.lang.Deprecated annotation.*@deprecated.*description.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedSpecialCase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedSpecialCase.java
@@ -7,16 +7,18 @@ violateExecutionOnNonTightHtml = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.missingdeprecated;
 
+// violation 3 lines below 'Duplicate @deprecated tag.'
 /**
  * @deprecated bleh
- * @deprecated boo // violation 'Duplicate @deprecated tag.'
+ * @deprecated boo
  */
 @Deprecated
 public class InputMissingDeprecatedSpecialCase
 {
+    // violation 3 lines below 'Duplicate @deprecated tag.'
     /**
      * @deprecated bleh
-     * @deprecated boo // violation 'Duplicate @deprecated tag.'
+     * @deprecated boo
      */
     public int i; // violation 'Must include both @java.lang.Deprecated annotation.*@deprecated.*'
 
@@ -24,7 +26,6 @@ public class InputMissingDeprecatedSpecialCase
      * @deprecated
      */
     public void foo() { // violation 'Must.*@java.lang.Deprecated annotation.*@deprecated.*'
-
     }
 
     /**
@@ -32,38 +33,36 @@ public class InputMissingDeprecatedSpecialCase
      */
     @Deprecated
     public void foo2() {
-
     }
 
+    // violation 3 lines below 'Duplicate @deprecated tag.'
     /**
      * @deprecated
-     * @deprecated // violation 'Duplicate @deprecated tag.'
+     * @deprecated
      */
     @Deprecated
     public void foo3() {
-
     }
 
+    // violation 3 lines below 'Duplicate @deprecated tag.'
     /**
      * @deprecated bleh
-     * @deprecated // violation 'Duplicate @deprecated tag.'
+     * @deprecated
      */
     @Deprecated
     public void foo4() {
-
     }
 
+    // violation 3 lines below 'Duplicate @deprecated tag.'
     /**
      * @deprecated
-     * @deprecated bleh // violation 'Duplicate @deprecated tag.'
+     * @deprecated bleh
      */
     @Deprecated
     public void foo5() {
-
     }
 
     void local(@Deprecated String s) {
-
     }
 
     void local2(
@@ -73,14 +72,12 @@ public class InputMissingDeprecatedSpecialCase
     }
 
     void local3(/** @deprecated */ @Deprecated String s) {
-
     }
 
     /**
      * @Deprecated
      */
     void dontUse() {
-
     }
 
     /**
@@ -90,7 +87,6 @@ public class InputMissingDeprecatedSpecialCase
      */
     @Deprecated
     void dontUse2() {
-
     }
 
     /**


### PR DESCRIPTION
Issue: #19764 

Fixed input files:
- InputMissingDeprecatedClass.java
- InputMissingDeprecatedSpecialCase.java

Removed two suppressions;

Updated violation line numbers.
