### PR TITLE
Issue #19764: Move violation comments out of Javadoc for javadoctype

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -125,22 +125,7 @@
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationOffset3.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationPreTag.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocTypeBadTag.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocTypeParamDescriptionWithAngularTags.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocTypeRecordComponents2.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocTypeRecordParamDescriptionWithAngularTags.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocTypeTestTrimProperty.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocTypeTypeParamsTags.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocTypeTypeParamsTags_1.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctype[\\/]InputJavadocTypeUnusedParamInJavadocForClass.java"/>
+
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]summaryjavadoc[\\/]InputSummaryJavadocInlineReturn.java"/>
   <suppress id="noViolationCommentsInJavadoc"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -256,12 +256,12 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTypeParameters() throws Exception {
         final String[] expected = {
-            "21:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<D123>"),
-            "25:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <C456>"),
-            "59:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
-            "62:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <B>"),
-            "75:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
-            "79:5: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL, "@param"),
+            "22:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<D123>"),
+            "26:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <C456>"),
+            "61:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
+            "64:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <B>"),
+            "77:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
+            "81:5: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL, "@param"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeTypeParamsTags_1.java"), expected);
@@ -270,9 +270,9 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAllowMissingTypeParameters() throws Exception {
         final String[] expected = {
-            "21:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<D123>"),
-            "58:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
-            "74:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
+            "22:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<D123>"),
+            "60:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
+            "76:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeTypeParamsTags.java"), expected);
@@ -281,9 +281,9 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDontAllowUnusedParameterTag() throws Exception {
         final String[] expected = {
-            "20:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "BAD"),
-            "21:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<BAD>"),
-            "23:4: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL, "@param"),
+            "23:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "BAD"),
+            "24:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<BAD>"),
+            "25:4: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL, "@param"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeUnusedParamInJavadocForClass.java"),
@@ -293,9 +293,9 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testBadTag() throws Exception {
         final String[] expected = {
-            "19:4: " + getCheckMessage(MSG_UNKNOWN_TAG, "mytag"),
             "21:4: " + getCheckMessage(MSG_UNKNOWN_TAG, "mytag"),
-            "28:5: " + getCheckMessage(MSG_UNKNOWN_TAG, "mytag"),
+            "22:4: " + getCheckMessage(MSG_UNKNOWN_TAG, "mytag"),
+            "29:5: " + getCheckMessage(MSG_UNKNOWN_TAG, "mytag"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeBadTag.java"),
@@ -372,9 +372,9 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testJavadocTypeParamDescriptionWithAngularTags() throws Exception {
         final String[] expected = {
-            "49:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
-            "51:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
-            "55:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
+            "50:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
+            "52:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
+            "57:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
         };
 
         verifyWithInlineConfigParser(
@@ -384,12 +384,12 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testJavadocTypeRecordParamDescriptionWithAngularTags() throws Exception {
         final String[] expected = {
-            "56:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
-            "58:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
-            "62:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
-            "65:1: " + getCheckMessage(MSG_MISSING_TAG, "@param a"),
-            "78:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "e"),
-            "81:1: " + getCheckMessage(MSG_MISSING_TAG, "@param c"),
+            "57:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
+            "59:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
+            "64:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
+            "66:1: " + getCheckMessage(MSG_MISSING_TAG, "@param a"),
+            "80:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "e"),
+            "82:1: " + getCheckMessage(MSG_MISSING_TAG, "@param c"),
         };
 
         verifyWithInlineConfigParser(
@@ -403,17 +403,17 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
 
         final String[] expected = {
             "44:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <X>"),
-            "48:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
-            "59:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "notMyString"),
-            "62:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myString"),
-            "62:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myInt"),
-            "66:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
-            "68:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myList"),
-            "75:1: " + getCheckMessage(MSG_MISSING_TAG, "@param X"),
-            "78:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "notMyString"),
-            "81:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
-            "81:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myInt"),
-            "81:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myString"),
+            "49:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
+            "61:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "notMyString"),
+            "64:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myString"),
+            "64:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myInt"),
+            "69:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
+            "71:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myList"),
+            "78:1: " + getCheckMessage(MSG_MISSING_TAG, "@param X"),
+            "82:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "notMyString"),
+            "85:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "85:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myInt"),
+            "85:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myString"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeRecordComponents2.java"), expected);
@@ -433,7 +433,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTrimOptionProperty() throws Exception {
         final String[] expected = {
-            "21:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<D123>"),
+            "22:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<D123>"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeTestTrimProperty.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeBadTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeBadTag.java
@@ -14,10 +14,11 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
+// violation 4 lines below 'Unknown tag 'mytag'.'
+// violation 4 lines below 'Unknown tag 'mytag''
 /**
  * The following is a bad tag.
- * @mytag Hello   // violation 'Unknown tag 'mytag'.'
- * // violation below 'Unknown tag 'mytag''
+ * @mytag Hello
  * @mytag
  */
 public class InputJavadocTypeBadTag

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeParamDescriptionWithAngularTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeParamDescriptionWithAngularTags.java
@@ -44,15 +44,16 @@ class Shogun<T, U> {
     class Minowara<V> extends Shogun<T, U> implements Mandate<T, U, V> {}
 }
 
+// violation 3 lines below 'Unused @param tag for \'<P>\'.'
 /**
  * @param    <T>
- * @param <P> stuff <><><<stuff></></></> stuff // violation, 'Unused @param tag for '<P>'.'
+ * @param <P> stuff <><><<stuff></></></> stuff
  */
 interface Regent<T, U> {} // violation, 'Type Javadoc comment is missing @param <U> tag.'
 
+// violation 3 lines below 'Unused @param tag for 'region'.'
 /**
  *
  * @param region [(<>{@code stuff<stuff🐦‍🔥@@@>🐦‍🔥&lt;{stuff}&gt;}</>@)]{@code {&lt;stuff&gt;}}
- * // violation above, 'Unused @param tag for 'region'.'
  */
 class Fief {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents2.java
@@ -43,9 +43,10 @@ record MyRecord2(HashMap<String, String> myHashMap){}
  */
 record MyRecord3<X>(){} // violation 'missing @param <X> tag.'
 
+// violation 3 lines below 'Unused @param tag for 'x'.'
 /**
  *
- * @param x // violation 'Unused @param tag for 'x'.'
+ * @param x
  */
 record MyRecord4(){}
 
@@ -55,15 +56,17 @@ record MyRecord4(){}
  */
 record MyRecord5<X>(){}
 
+// violation 2 lines below 'Unused @param tag for 'notMyString'.'
 /**
- * @param notMyString // violation 'Unused @param tag for 'notMyString'.'
+ * @param notMyString
  * @param <X>
  */
 record MyRecord6<X>(String myString, int myInt){} // 2 violations
 
+// violation 3 lines below 'Unused @param tag for 'x'.'
 /**
  *
- * @param x // violation 'Unused @param tag for 'x'.'
+ * @param x
  */
 record MyRecord7(List<String>myList){} // violation 'missing @param myList tag.'
 
@@ -74,8 +77,9 @@ record MyRecord7(List<String>myList){} // violation 'missing @param myList tag.'
  */
 record MyRecord8<X, T>(String X){} // violation 'missing @param X tag.'
 
+// violation 2 lines below 'Unused @param tag for 'notMyString'.'
 /**
- * @param notMyString // violation 'Unused @param tag for 'notMyString'.'
+ * @param notMyString
  * @param <X>
  */
 record MyRecord9<X, T>(String myString, int myInt){} // 3 violations

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordParamDescriptionWithAngularTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordParamDescriptionWithAngularTags.java
@@ -51,16 +51,17 @@ record Record2<T>(int a, int b) {
     record Record4<V>() {}
 }
 
+// violation 3 lines below 'Unused @param tag for \'<P>\'.'
 /**
  * @param <T>
- * @param    <P>     stuff <><><<stuff></></></> stuff // violation,'Unused @param tag for '<P>'.'
+ * @param    <P>     stuff <><><<stuff></></></> stuff
  */
 record Record5<T, U>() {} // violation, 'Type Javadoc comment is missing @param <U> tag.'
 
+// violation 3 lines below 'Unused @param tag for \'region\'.'
 /**
  *
  * @param region [(<>{@code stuff<stuff🐦‍🔥>🐦‍🔥&lt;stuff&gt;}</>)]{@code {&lt;stuff&gt;}}
- * // violation above, 'Unused @param tag for 'region'.'
  */
 record Record6(int a) {} // violation, 'Type Javadoc comment is missing @param a tag.'
 
@@ -72,11 +73,11 @@ record Record6(int a) {} // violation, 'Type Javadoc comment is missing @param a
  */
 record Record7<T>(int a, int b) {}
 
+// violation 4 lines below 'Unused @param tag for \'e\'.'
 /**
  * @param a <<></>></><<></>></>
  * @param b stuff<stuff>:<>:<>:<🐦‍🔥<<🐦‍🔥>>🐦‍🔥>
  * @param e [(<>{@code stuff<stuff🐦[(‍{🔥}])>🐦‍🔥&lt;stuff&gt;}</>)]{@code {&lt;stuff&gt;}}
- * // violation above, 'Unused @param tag for 'e'.'
  */
 record Record8(int a, int b, int c) { // violation, 'Type Javadoc comment is missing @param c tag.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTestTrimProperty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTestTrimProperty.java
@@ -14,11 +14,12 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
+// violation 5 lines below 'Unused @param tag for \'<D123>\'.'
 /**
  * Some explanation.
  * @param < A  > A type param
  * @param <B1> Another type param
- * @param <D123> The wrong type param   // violation 'Unused @param tag for '<D123>'.'
+ * @param <D123> The wrong type param
  * @author Nobody
  * @version 1.0
  */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags.java
@@ -14,11 +14,12 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
+// violation 5 lines below 'Unused @param tag for \'<D123>\'.'
 /**
  * Some explanation.
  * @param <A> A type param
  * @param <B1> Another type param
- * @param <D123> The wrong type param   // violation 'Unused @param tag for '<D123>'.'
+ * @param <D123> The wrong type param
  * @author Nobody
  * @version 1.0
  */
@@ -52,10 +53,11 @@ public class InputJavadocTypeTypeParamsTags<A,B1,C456 extends Comparable>
     {
     }
 
+    // violation 4 lines below 'Unused @param tag for \'<C>\'.'
     /**
      * Example inner class.
      * @param <A> documented parameter
-     * @param <C> extra parameter  // violation 'Unused @param tag for '<C>'.'
+     * @param <C> extra parameter
      */
 
     public static class InnerClass<A,B>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags_1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags_1.java
@@ -14,11 +14,12 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
+// violation 5 lines below 'Unused @param tag for \'<D123>\'.'
 /**
  * Some explanation.
  * @param <A> A type param
  * @param <B1> Another type param
- * @param <D123> The wrong type param  // violation 'Unused @param tag for '<D123>'.'
+ * @param <D123> The wrong type param
  * @author Nobody
  * @version 1.0
  */
@@ -53,10 +54,11 @@ public class InputJavadocTypeTypeParamsTags_1<A,B1,C456 extends Comparable>
     {
     }
 
+    // violation 4 lines below 'Unused @param tag for \'<C>\'.'
     /**
      * Example inner class.
      * @param <A> documented parameter
-     * @param <C> extra parameter    // violation 'Unused @param tag for '<C>'.'
+     * @param <C> extra parameter
      */
 
     public static class InnerClass_1<A,B> // violation 'missing @param <B> tag.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeUnusedParamInJavadocForClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeUnusedParamInJavadocForClass.java
@@ -14,12 +14,14 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
+// violation 6 lines below 'Unused @param tag for \'BAD\'.'
+// violation 6 lines below 'Unused @param tag for \'<BAD>\'.'
+// violation 6 lines below 'Unused Javadoc tag'
 /**
  * InputJavadocTypeUnusedParamInJavadocForClass.
  *
- * @param BAD This is bad.   // violation 'Unused @param tag for 'BAD'.'
- * @param <BAD> This doesn't exist.   // violation 'Unused @param tag for '<BAD>'.'
- * // violation below 'Unused Javadoc tag'
+ * @param BAD This is bad.
+ * @param <BAD> This doesn't exist.
  * @param
  */
 public class InputJavadocTypeUnusedParamInJavadocForClass {


### PR DESCRIPTION
Issue: #19764

Fixed input files (javadoctype package):
- InputJavadocTypeBadTag.java
- InputJavadocTypeParamDescriptionWithAngularTags.java
- InputJavadocTypeRecordComponents2.java
- InputJavadocTypeRecordParamDescriptionWithAngularTags.java
- InputJavadocTypeTestTrimProperty.java
- InputJavadocTypeTypeParamsTags.java
- InputJavadocTypeTypeParamsTags_1.java
- InputJavadocTypeUnusedParamInJavadocForClass.java

Removed 8 suppressions; Updated violation line numbers in unit tests.

