### PR TITLE
 Issue #19772: Excluded plexus-utils due to vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,6 +505,10 @@
           <groupId>com.google.collections</groupId>
           <artifactId>google-collections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
checkstyle#19772

Excluded `org.codehaus.plexus:plexus-utils` from `org.apache.maven.doxia:doxia-core` due to CVE-2025-67030