### PR TITLE
minor: make SarifLogger.renderSeverityLevel null-safe and future-proof, build: enable experimental ByteBuddy support for tests on JDK 23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1832,6 +1832,7 @@
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
             -XX:+EnableDynamicAgentLoading
             -Xshare:off
+            -Dnet.bytebuddy.experimental=true
           </argLine>
           <additionalClasspathElements>
             <additionalClasspathElement>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
@@ -447,15 +447,20 @@ public final class SarifLogger extends AbstractAutomaticBean implements AuditLis
     /**
      * Render the severity level into SARIF severity level.
      *
-     * @param severityLevel the Severity level.
-     * @return the rendered severity level in string.
+     * @param severityLevel the Severity level (may be {@code null}).
+     * @return the rendered SARIF severity string.
      */
     private static String renderSeverityLevel(SeverityLevel severityLevel) {
+        if (severityLevel == null) {
+            return "none";
+        }
         return switch (severityLevel) {
             case IGNORE -> "none";
             case INFO -> "note";
             case WARNING -> "warning";
             case ERROR -> "error";
+            // Future‑proof: if a new level appears, treat it as a warning.
+            default -> "warning";
         };
     }
 


### PR DESCRIPTION
SarifLogger: Previously, if a null or a new (future) severity level was passed, the code would crash with an exception. Now, it gracefully returns "none" or "warning", making the SARIF report generation much more stable.

pom.xml: By enabling the ByteBuddy experimental flag, I have fixed a "breaking" test failure that occurs when running this older version of Checkstyle on the very new Java 23. This allows the 'mvn clean verify' to finish successfully.