### PR TITLE
Issue #15260: Fix indentation calculation for chained method call rparen

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -372,6 +372,23 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testChainedMethodCallRparenIndent() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, getPath("InputIndentationChainedMethodCallRparen.java"),
+                expected);
+    }
+
+    @Test
     public void testDifficultAnnotations() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodCallRparen.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodCallRparen.java
@@ -1,0 +1,82 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;             //indent:0 exp:0
+
+import java.math.BigDecimal;                                                        //indent:0 exp:0
+import java.util.Arrays;                                                            //indent:0 exp:0
+import java.util.Comparator;                                                        //indent:0 exp:0
+import java.util.List;                                                              //indent:0 exp:0
+
+public class InputIndentationChainedMethodCallRparen {                              //indent:0 exp:0
+
+    static Dummy assertThat(List<String> init) {                                    //indent:4 exp:4
+        return new Dummy(init);                                                     //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+
+    static Tuple tuple(String name, BigDecimal value) {                             //indent:4 exp:4
+        return new Tuple(name, value);                                              //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+
+    public static void test() {                                                     //indent:4 exp:4
+        List<String> strings =                                                      //indent:8 exp:8
+                Arrays.asList("string1", "string2");                                //indent:16 exp:16
+
+        assertThat(strings).extracting("splitId", "rate")                           //indent:8 exp:8
+            .usingRecursiveFieldByFieldElementComparator(                           //indent:12 exp:12
+                Dummy.builder()                                                     //indent:16 exp:16
+                    .withComparatorForType(                                         //indent:20 exp:20
+                        BigDecimal::compareTo,                                      //indent:24 exp:24
+                        BigDecimal.class                                            //indent:24 exp:24
+                    ).build()                                                       //indent:20 exp:20
+            )                                                                       //indent:12 exp:12
+            .containsExactlyInAnyOrder(                                             //indent:12 exp:12
+                tuple("123-1", BigDecimal.valueOf(67.5)),                           //indent:16 exp:16
+                tuple("123-2", BigDecimal.valueOf(67.5))                            //indent:16 exp:16
+            );                                                                      //indent:12 exp:12
+    }                                                                               //indent:4 exp:4
+
+    static class Dummy {                                                            //indent:4 exp:4
+        private final List<String> init;                                            //indent:8 exp:8
+
+        static ConfigBuilder builder() {                                            //indent:8 exp:8
+            return new ConfigBuilder();                                             //indent:12 exp:12
+        }                                                                           //indent:8 exp:8
+
+        Dummy(List<String> init) {                                                  //indent:8 exp:8
+            this.init = init;                                                       //indent:12 exp:12
+        }                                                                           //indent:8 exp:8
+
+        Dummy extracting(String... extracts) {                                      //indent:8 exp:8
+            return this;                                                            //indent:12 exp:12
+        }                                                                           //indent:8 exp:8
+
+        Dummy usingRecursiveFieldByFieldElementComparator(                          //indent:8 exp:8
+                Object typeHolder) {                                                //indent:16 exp:16
+            return this;                                                            //indent:12 exp:12
+        }                                                                           //indent:8 exp:8
+
+        Dummy containsExactlyInAnyOrder(Tuple... tuples) {                          //indent:8 exp:8
+            return this;                                                            //indent:12 exp:12
+        }                                                                           //indent:8 exp:8
+
+        static class ConfigBuilder {                                                //indent:8 exp:8
+            <T> ConfigBuilder withComparatorForType(                                //indent:12 exp:12
+                    Comparator<? super T> comparator,                               //indent:20 exp:20
+                    Class<T> type) {                                                //indent:20 exp:20
+                return this;                                                        //indent:16 exp:16
+            }                                                                       //indent:12 exp:12
+
+            Object build() {                                                        //indent:12 exp:12
+                return new Object();                                                //indent:16 exp:16
+            }                                                                       //indent:12 exp:12
+        }                                                                           //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+
+    static class Tuple {                                                            //indent:4 exp:4
+        private final String name;                                                  //indent:8 exp:8
+        private final BigDecimal value;                                             //indent:8 exp:8
+
+        Tuple(String name, BigDecimal value) {                                      //indent:8 exp:8
+            this.name = name;                                                       //indent:12 exp:12
+            this.value = value;                                                     //indent:12 exp:12
+        }                                                                           //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+}                                                                                   //indent:0 exp:0


### PR DESCRIPTION
Issue #15260 

The indentation check was reporting an incorrect expected indentation for the closing parenthesis in chained method calls.

changes i done updates `MethodCallHandler` to correctly detect chained method calls and adjust the indentation level based on the call line start position.

I added a regression input file `InputIndentationChainedMethodCallRparen.java` and a corresponding test to verify the expected behavior.

## Problem
```

java -Duser.language=en -Duser.region=US -jar checkstyle-10.17.0-all.jar -c checkstyle.xml IndentationCheckTest.java
Starting audit...
[WARN] D:\Temp\Checkstyle\tools\IndentationCheckTest.java:29:13: 'method call rparen' has incorrect indentation level 12, expected level should be 8. [Indentation]
Audit done.
```
## After fix

<img width="1798" height="262" alt="Screenshot 2026-05-02 224302" src="https://github.com/user-attachments/assets/23e68685-19d1-4060-9c23-3e6928b38112" />


## Code
```
package com.test;

import java.math.BigDecimal;
import java.util.List;

public class ComprehensiveIndentationTest {

    static Dummy assertThat(List<String> init) {
        return new Dummy(init);
    }

    static Tuple tuple(String name, BigDecimal value) {
        return new Tuple(name, value);
    }

    // Test case 1: Original issue - chained method calls with nested method calls
    public static void test1() {
        List<String> strings = List.of("string1", "string2");

        assertThat(strings).extracting("splitId", "rate")
                .usingRecursiveFieldByFieldElementComparator(
                        Dummy.builder()
                                .withComparatorForType(
                                        BigDecimal::compareTo,
                                        BigDecimal.class
                                ).build()
                )
                .containsExactlyInAnyOrder(
                        tuple("123-1", BigDecimal.valueOf(67.5)),
                        tuple("123-2", BigDecimal.valueOf(67.5))
                );
    }

    // Test case 2: Simple chained method calls
    public static void test2() {
        List<String> strings = List.of("string1", "string2");

        assertThat(strings)
                .extracting("splitId")
                .containsExactlyInAnyOrder(
                        tuple("123-1", BigDecimal.valueOf(67.5))
                );
    }

    // Test case 3: Deeply nested chained calls
    public static void test3() {
        assertThat(List.of("a", "b"))
                .extracting("x")
                .usingRecursiveFieldByFieldElementComparator(
                        Dummy.builder()
                                .withComparatorForType(
                                        BigDecimal::compareTo,
                                        BigDecimal.class
                                )
                                .withComparatorForType(
                                        String::compareTo,
                                        String.class
                                ).build()
                )
                .containsExactlyInAnyOrder(
                        tuple("1", BigDecimal.valueOf(1.0)),
                        tuple("2", BigDecimal.valueOf(2.0))
                );
    }

    // Test case 4: Multiple levels of nesting
    public static void test4() {
        Dummy.builder()
                .withComparatorForType(
                        BigDecimal::compareTo,
                        BigDecimal.class
                )
                .withComparatorForType(
                        String::compareTo,
                        String.class
                )
                .build();
    }

    static class Dummy {
        private final List<String> init;

        public static ConfigBuilder builder() {
            return new ConfigBuilder();
        }

        public Dummy(List<String> init) {
            this.init = init;
        }

        public Dummy extracting(String... extracts) {
            return this;
        }

        public Dummy usingRecursiveFieldByFieldElementComparator(Object typeHolder) {
            return this;
        }

        public void containsExactlyInAnyOrder(Tuple... tuples) {
        }

        static class ConfigBuilder {
            public <T> ConfigBuilder withComparatorForType(
                    java.util.Comparator<? super T> comparator,
                    Class<T> type) {
                return this;
            }

            public Object build() {
                return new Object();
            }
        }
    }

    record Tuple(String name, BigDecimal value) {
    }
}
```

## config

```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <property name="charset" value="UTF-8"/>
  <property name="severity" value="warning"/>
  <property name="fileExtensions" value="java, properties, xml"/>
  <module name="TreeWalker">
    <module name="Indentation"/>
  </module>
</module>
```
## Output
```
brije@Brijesh MINGW64 ~/checkstyle (rparen)
$ java -jar target/checkstyle-13.4.3-SNAPSHOT-all.jar -c test_config.xml test_comprehensive.java
Starting audit...
Audit done.
brije@Brijesh MINGW64 ~/checkstyle (rparen)
```