### PR TITLE
Issue #19764: Move violation comments out of Javadoc in rule711generalform

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -64,11 +64,7 @@
   <suppress id="noCheckstyleInInputs"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter3filestructure[\\/]rule333orderingandspacing[\\/]InputFormattedOrderingAndSpacingValid2.java"/>
 
-  <!-- Input files with violation comments inside Javadoc, until https://github.com/checkstyle/checkstyle/issues/19764 -->
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]chapter7javadoc[\\/]rule711generalform[\\/]InputCorrectJavadocLeadingAsteriskAlignment.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]chapter7javadoc[\\/]rule711generalform[\\/]InputFormattedCorrectJavadocLeadingAsteriskAlignment.java"/>
+
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]chapter7javadoc[\\/]rule713atclauses[\\/]InputIncorrectAtClauseOrderCheck1.java"/>
   <suppress id="noViolationCommentsInJavadoc"

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputCorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputCorrectJavadocLeadingAsteriskAlignment.java
@@ -11,13 +11,16 @@ public class InputCorrectJavadocLeadingAsteriskAlignment {
   /** Javadoc for instance variable. */
   private int int1;
 
-  /** */ // violation "Summary javadoc is missing."
+  // violation below "Summary javadoc is missing."
+  /** */
   private int int2;
 
-  /***/ // violation "Summary javadoc is missing."
+  // violation below "Summary javadoc is missing."
+  /***/
   private String str;
 
-  /** */ // violation "Summary javadoc is missing."
+  // violation below "Summary javadoc is missing."
+  /** */
   private String str1;
 
   // violation 2 lines below "Javadoc line should start with leading asterisk."
@@ -40,10 +43,12 @@ public class InputCorrectJavadocLeadingAsteriskAlignment {
   // False negative for above javadoc, until #18271, #18273.
   public InputCorrectJavadocLeadingAsteriskAlignment(String str) {}
 
-  /** * */ // violation "Summary javadoc is missing."
+  // violation below "Summary javadoc is missing."
+  /** * */
   private String str2;
 
-  /****/ // violation "Summary javadoc is missing."
+  // violation below "Summary javadoc is missing."
+  /****/
   private String str3;
 
   /**


### PR DESCRIPTION
Issue: #19764

**Description:**
Moved violation comments out of Javadoc for the following input files in the `rule711generalform` package:
- `InputCorrectJavadocLeadingAsteriskAlignment.java`
- `InputFormattedCorrectJavadocLeadingAsteriskAlignment.java` (no changes)

Also removed the related suppressions from `checkstyle-input-suppressions.xml` as requested in the issue description.