### PR TITLE
Issue #15056: Add Indentation Check Support for Java 21 Unnamed Variables & Patterns Syntax

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4030,6 +4030,26 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testIndentationUnnamedPattern() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("throwsIndent", "8");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+
+        final String fileName = getNonCompilablePath(
+                "InputIndentationUnnamedPattern.java");
+        final String[] expected = {
+            "26:9: " + getCheckMessage(MSG_CHILD_ERROR, "if", 8, 12),
+            "29:1: " + getCheckMessage(MSG_CHILD_ERROR, "if", 0, 12),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
     public void testIndentationCodeBlocks1() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("tabWidth", "4");

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationUnnamedPattern.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationUnnamedPattern.java
@@ -1,0 +1,32 @@
+// Java21                                                                   //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
+
+
+/* Config:                                                                  //indent:0 exp:0
+ * basicOffset = 4                                                          //indent:1 exp:1
+ * braceAdjustment = 0                                                      //indent:1 exp:1
+ * caseIndent = 4                                                           //indent:1 exp:1
+ * tabWidth = 4                                                             //indent:1 exp:1
+ * throwsIndent = 8                                                         //indent:1 exp:1
+ * forceStrictCondition = false                                             //indent:1 exp:1
+ */                                                                         //indent:1 exp:1
+public class InputIndentationUnnamedPattern {                               //indent:0 exp:0
+    record ColoredPoint(boolean p) { }                                      //indent:4 exp:4
+
+    void test(Object obj) {                                                 //indent:4 exp:4
+        if (obj instanceof ColoredPoint(_)) {                               //indent:8 exp:8
+        }                                                                   //indent:8 exp:8
+        if (obj instanceof ColoredPoint(                                    //indent:8 exp:8
+                _)) {                                                       //indent:16 exp:>=12
+        }                                                                   //indent:8 exp:8
+        if (obj instanceof ColoredPoint(                                    //indent:8 exp:8
+                        _)) {                                               //indent:24 exp:>=12
+        }                                                                   //indent:8 exp:8
+        if (obj instanceof ColoredPoint(                                    //indent:8 exp:8
+        _)) {                                                               //indent:8 exp:>=12 warn
+        }                                                                   //indent:8 exp:8
+        if (obj instanceof ColoredPoint(                                    //indent:8 exp:8
+_)) {                                                                       //indent:0 exp:>=12 warn
+        }                                                                   //indent:8 exp:8
+    }                                                                       //indent:4 exp:4
+}                                                                           //indent:0 exp:0


### PR DESCRIPTION
Issue #15056

Adds Indentation check support for Java 21 unnamed patterns.

Previously, the Indentation check reported false violations for unnamed patterns (`_`) used inside `instanceof` record pattern expressions when line wrapping was involved.

This update fixes indentation handling for unnamed pattern variables and adds regression test coverage for valid and invalid indentation cases.

## Problem
`
PS D:\CS\test> java  -jar checkstyle-10.17.0-all.jar -c config.xml src/Test.java
Starting audit...
[ERROR] D:\CS\test\src\Test.java:18:9: 'if' child has incorrect indentation level 8, expected level should be 12. [Indentation]
[ERROR] D:\CS\test\src\Test.java:21:1: 'if' child has incorrect indentation level 0, expected level should be 12. [Indentation]
Audit done.
Checkstyle ends with 2 errors.
`

## After fix
<img width="1750" height="228" alt="Screenshot 2026-05-06 220012" src="https://github.com/user-attachments/assets/7bcd418b-f715-4538-8bae-6ffce0ad6cea" />

