### PR TITLE
Issue #19384: Add clearer error messages for invalid Checkstyle confi…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -308,8 +308,19 @@ public final class ConfigurationLoader {
                     exc.getMessage(), exc.getLineNumber(), exc.getColumnNumber());
             throw new CheckstyleException(message, exc);
         }
-        catch (final ParserConfigurationException | IOException | SAXException exc) {
-            throw new CheckstyleException(UNABLE_TO_PARSE_EXCEPTION_PREFIX, exc);
+        catch (final IOException exc) {
+            throw new CheckstyleException(
+                UNABLE_TO_PARSE_EXCEPTION_PREFIX
+                + " - Could not read the Checkstyle configuration file."
+                + " Check that the file path is correct and the file is readable: "
+                + exc.getMessage(), exc);
+        }
+        catch (final ParserConfigurationException | SAXException exc) {
+            throw new CheckstyleException(
+                UNABLE_TO_PARSE_EXCEPTION_PREFIX
+                + " - Failed to parse the Checkstyle configuration file."
+                + " Ensure the file is valid XML and follows the Checkstyle DTD format: "
+                + exc.getMessage(), exc);
         }
     }
 


### PR DESCRIPTION
Issue #19384: Add clearer error messages for invalid Checkstyle configuration files

## Problem
When a Checkstyle configuration file contains errors, the error messages
were not descriptive enough for users to understand what went wrong.

## Solution
Split the generic catch block in `ConfigurationLoader.java` into two
specific catches:
- `IOException`: indicates the file could not be read, with a suggestion
  to check the file path.
- `ParserConfigurationException | SAXException`: indicates the XML is
  invalid, with a suggestion to verify the DTD format.

## Files changed
- `src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java`
## Changes in detail
In `ConfigurationLoader.java`, replaced the generic catch block (line ~280):

**Before:**
```java
catch (final ParserConfigurationException | IOException | SAXException exc) {
    throw new CheckstyleException(UNABLE_TO_PARSE_EXCEPTION_PREFIX, exc);
}
```

**After:**
```java
catch (final IOException exc) {
    throw new CheckstyleException(
        UNABLE_TO_PARSE_EXCEPTION_PREFIX
        + " - Could not read the Checkstyle configuration file."
        + " Check that the file path is correct and the file is readable: "
        + exc.getMessage(), exc);
}
catch (final ParserConfigurationException | SAXException exc) {
    throw new CheckstyleException(
        UNABLE_TO_PARSE_EXCEPTION_PREFIX
        + " - Failed to parse the Checkstyle configuration file."
        + " Ensure the file is valid XML and follows the Checkstyle DTD format: "
        + exc.getMessage(), exc);
}