### PR TITLE
Issue #14101: update AnnotationLocation in checkstyle-checks.xml to s…

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -280,6 +280,12 @@
       <property name="tokens" value="PACKAGE_DEF"/>
       <property name="tokens" value="ENUM_CONSTANT_DEF"/>
       <property name="tokens" value="VARIABLE_DEF"/>
+      <property name="tokens" value="METHOD_DEF"/>
+      <property name="tokens" value="CTOR_DEF"/>
+      <property name="tokens" value="CLASS_DEF"/>
+      <property name="tokens" value="INTERFACE_DEF"/>
+      <property name="tokens" value="ENUM_DEF"/>
+      <property name="tokens" value="RECORD_DEF"/>
       <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
     </module>
     <module name="AnnotationOnSameLine">


### PR DESCRIPTION
Issue: #14101

Updated the AnnotationLocation module in config/checkstyle-checks.xml to include
METHOD_DEF, CTOR_DEF, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, and RECORD_DEF tokens,
enforcing that annotations are placed on their own line for all supported token types.

The change was made in config/checkstyle-checks.xml in the AnnotationLocation module.
6 new tokens were added before the allowSamelineSingleParameterlessAnnotation property:

Before:
```xml
<property name="tokens" value="VARIABLE_DEF"/>
<property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
```

After:
```xml
<property name="tokens" value="VARIABLE_DEF"/>
<property name="tokens" value="METHOD_DEF"/>
<property name="tokens" value="CTOR_DEF"/>
<property name="tokens" value="CLASS_DEF"/>
<property name="tokens" value="INTERFACE_DEF"/>
<property name="tokens" value="ENUM_DEF"/>
<property name="tokens" value="RECORD_DEF"/>
<property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
```