### PR TITLE
Issue #9834: rename getMessages to getViolations and FileMessages to FileViolations

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -181,7 +181,7 @@ public final class DefaultConfiguration implements Configuration {
      * @return unmodifiable map containing custom messages
      */
     @Override
-    public Map<String, String> getMessages() {
+    public Map<String, String> getViolations() {
         return new HashMap<>(messages);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -63,8 +63,8 @@ public final class XMLLogger
     /** Close output stream in auditFinished. */
     private final boolean closeStream;
 
-    /** Holds all messages for the given file. */
-    private final Map<String, FileMessages> fileMessages =
+    /** Holds all violations for the given file. */
+    private final Map<String, FileViolations> fileViolations =
             new HashMap<>();
 
     /**
@@ -138,29 +138,29 @@ public final class XMLLogger
 
     @Override
     public void fileStarted(AuditEvent event) {
-        fileMessages.put(event.getFileName(), new FileMessages());
+        fileViolations.put(event.getFileName(), new FileViolations());
     }
 
     @Override
     public void fileFinished(AuditEvent event) {
         final String fileName = event.getFileName();
-        final FileMessages messages = fileMessages.remove(fileName);
-        writeFileMessages(fileName, messages);
+        final FileViolations violations = fileViolations.remove(fileName);
+        writeFileViolations(fileName, violations);
     }
 
     /**
      * Prints the file section with all file errors and exceptions.
      *
      * @param fileName The file name, as should be printed in the opening file tag.
-     * @param messages The file messages.
+     * @param violations The file violations.
      */
-    private void writeFileMessages(String fileName, FileMessages messages) {
+    private void writeFileViolations(String fileName, FileViolations violations) {
         writeFileOpeningTag(fileName);
-        if (messages != null) {
-            for (AuditEvent errorEvent : messages.getErrors()) {
+        if (violations != null) {
+            for (AuditEvent errorEvent : violations.getErrors()) {
                 writeFileError(errorEvent);
             }
-            for (Throwable exception : messages.getExceptions()) {
+            for (Throwable exception : violations.getExceptions()) {
                 writeException(exception);
             }
         }
@@ -187,9 +187,9 @@ public final class XMLLogger
     public void addError(AuditEvent event) {
         if (event.getSeverityLevel() != SeverityLevel.IGNORE) {
             final String fileName = event.getFileName();
-            final FileMessages messages = fileMessages.get(fileName);
-            if (messages != null) {
-                messages.addError(event);
+            final FileViolations violations = fileViolations.get(fileName);
+            if (violations != null) {
+                violations.addError(event);
             }
             else {
                 writeFileError(event);
@@ -229,9 +229,9 @@ public final class XMLLogger
     @Override
     public void addException(AuditEvent event, Throwable throwable) {
         final String fileName = event.getFileName();
-        final FileMessages messages = fileMessages.get(fileName);
-        if (messages != null) {
-            messages.addException(throwable);
+        final FileViolations violations = fileViolations.get(fileName);
+        if (violations != null) {
+            violations.addException(throwable);
         }
         else {
             writeException(throwable);
@@ -336,9 +336,9 @@ public final class XMLLogger
     }
 
     /**
-     * The registered file messages.
+     * The registered file violations.
      */
-    private static final class FileMessages {
+    private static final class FileViolations {
 
         /** The file error events. */
         private final List<AuditEvent> errors = new ArrayList<>();
@@ -356,7 +356,7 @@ public final class XMLLogger
         }
 
         /**
-         * Adds the given error event to the messages.
+         * Adds the given error event to the violations.
          *
          * @param event the error event.
          */
@@ -374,7 +374,7 @@ public final class XMLLogger
         }
 
         /**
-         * Adds the given exception to the messages.
+         * Adds the given exception to the violations.
          *
          * @param throwable the file exception
          */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
@@ -102,7 +102,7 @@ public abstract class AbstractViolationReporter
      * @return unmodifiable map containing custom messages
      */
     protected Map<String, String> getCustomMessages() {
-        return getConfiguration().getMessages();
+        return getConfiguration().getViolations();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
@@ -87,6 +87,6 @@ public interface Configuration extends Serializable {
      *
      * @return unmodifiable map containing custom messages
      */
-    Map<String, String> getMessages();
+    Map<String, String> getViolations();
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -19,11 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static com.google.common.truth.Truth.assertWithMessage;
-import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
-import static org.mockito.Mockito.mockConstruction;
-import static org.mockito.Mockito.when;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -35,13 +30,17 @@ import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader.IgnoredModulesOptions;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 /**
  * Unit test for ConfigurationLoader.
@@ -426,12 +425,12 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
 
         final Configuration[] children = config.getChildren();
         final Configuration[] grandchildren = children[0].getChildren();
-        final List<String> messages = new ArrayList<>(grandchildren[0].getMessages().values());
+        final List<String> messages = new ArrayList<>(grandchildren[0].getViolations().values());
         final String expectedKey = "name.invalidPattern";
         final List<String> expectedMessages = Collections
                 .singletonList("Member ''{0}'' must start with ''m'' (checked pattern ''{1}'').");
         assertWithMessage("Messages should contain key: %s", expectedKey)
-                .that(grandchildren[0].getMessages())
+                .that(grandchildren[0].getViolations())
                 .containsKey(expectedKey);
         assertWithMessage("Message is not expected")
                 .that(messages)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
@@ -19,13 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static com.google.common.truth.Truth.assertWithMessage;
-
 import java.util.Map;
 import java.util.TreeMap;
 
 import org.junit.jupiter.api.Test;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 public class DefaultConfigurationTest {
@@ -109,7 +108,7 @@ public class DefaultConfigurationTest {
         final Map<String, String> expected = new TreeMap<>();
         expected.put("key", "value");
         assertWithMessage("Invalid message map")
-            .that(config.getMessages())
+            .that(config.getViolations())
             .isEqualTo(expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -1013,7 +1013,7 @@ public final class InlineConfigParser {
             }
         }
 
-        final Map<String, String> messages = module.getMessages();
+        final Map<String, String> messages = module.getViolations();
         for (final Map.Entry<String, String> entry : messages.entrySet()) {
             final String key = entry.getKey();
             final String value = entry.getValue();


### PR DESCRIPTION
Issue: #9834

Renamed remaining references from Messages to Violation to be consistent
with the renaming done in #9761 (LocalizedMessage -> Violation).

Changes made:
- Configuration.java: getMessages() -> getViolations()
- DefaultConfiguration.java: getMessages() -> getViolations()
- AbstractViolationReporter.java: getMessages() -> getViolations()
- XMLLogger.java: FileMessages -> FileViolations, fileMessages -> fileViolations,
  writeFileMessages -> writeFileViolations
- ConfigurationLoaderTest.java: updated test calls to getViolations()
- DefaultConfigurationTest.java: updated test calls to getViolations()
- bdd/InlineConfigParser.java: updated call to getViolations()