### PR TITLE
Issue #19707: TextBlockGoogleStyleFormatting should flag question operator with text block

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheck.java
@@ -136,10 +136,12 @@ public class TextBlockGoogleStyleFormattingCheck extends AbstractCheck {
             if (parent.getType() == TokenTypes.METHOD_DEF) {
                 quotesAreNotPreceded = !quotesArePrecededWithComma(openingQuotes);
             }
-            else if (parent.getType() == TokenTypes.QUESTION
-                    && openingQuotes.getPreviousSibling() != null) {
-                quotesAreNotPreceded = !TokenUtil.areOnSameLine(openingQuotes,
-                        openingQuotes.getPreviousSibling());
+            else if (parent.getType() == TokenTypes.QUESTION) {
+                // Check both previousSibling and the QUESTION token itself (parent)
+                final DetailAST previousSibling = openingQuotes.getPreviousSibling();
+                quotesAreNotPreceded = !TokenUtil.areOnSameLine(openingQuotes, parent)
+                        && (previousSibling == null
+                                || !TokenUtil.areOnSameLine(openingQuotes, previousSibling));
             }
             else {
                 quotesAreNotPreceded = !TokenUtil.areOnSameLine(openingQuotes, parent);


### PR DESCRIPTION
Fixes #19707

## Problem
TextBlockGoogleStyleFormatting was not flagging ternary operators (question mark) when the opening text-block quotes were on the same line.

When both branches of a ternary operator have text blocks with opening quotes on the same line, only the colon branch was flagged as a violation, while the question mark branch was missed.

## Root Cause
The check only examined previousSibling() for the QUESTION token, but the question operator is the parent QUESTION node, not a sibling. This caused the same-line check to never see the question operator when the condition was on a different line.

## Solution
Updated the QUESTION token handling to check both:
1. The parent QUESTION node itself
2. The previousSibling (for completeness)

This ensures violations are caught regardless of whether the condition is on the same line or a different line.

## Changes
- Modified openingQuotesAreAloneOnTheLine() method in TextBlockGoogleStyleFormattingCheck.java
- Added check for parent QUESTION node in addition to previousSibling
- Ensures both question and colon operators are properly validated

## Testing
Verified with existing test cases for ternary operators. All tests pass.