### PR TITLE
Issue #19791: Exclude test/jdk/jdk/jfr/event/tracing/TestConstructors.java from jdk25 no-exception run

### DIFF
--- a/config/projects-to-test/openjdk25-excluded.files
+++ b/config/projects-to-test/openjdk25-excluded.files
@@ -34,6 +34,9 @@
 
 <!-- until https://github.com/checkstyle/checkstyle/issues/17052 -->
 <module name="BeforeExecutionExclusionFileFilter">
+  <property name="fileNamePattern" value="[\\/]test[\\/]jdk[\\/]jdk[\\/]jfr[\\/]event[\\/]tracing[\\/]TestConstructors.java$"/>
+</module>
+<module name="BeforeExecutionExclusionFileFilter">
   <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]diags[\\/]examples[\\/]FeatureFlexibleConstructors.java$"/>
 </module>
 <module name="BeforeExecutionExclusionFileFilter">


### PR DESCRIPTION
issue #19791 