### PR TITLE
Issue #19764: Move violation comments out of Javadoc for InputUnusedImportsJavadocSetters

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -86,8 +86,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckCommentsContent.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]imports[\\/]unusedimports[\\/]InputUnusedImportsJavadocSetters.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationJavadoc.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderMethodReturningArrayType.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -386,7 +386,7 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testJavadocSetters() throws Exception {
         final String[] expected = {
-            "13: " + getCheckMessage(MSG_KEY_UNCLOSED_HTML_TAG, "p"),
+            "14: " + getCheckMessage(MSG_KEY_UNCLOSED_HTML_TAG, "p"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedImportsJavadocSetters.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsJavadocSetters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsJavadocSetters.java
@@ -9,8 +9,9 @@ package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
 
 class InputUnusedImportsJavadocSetters {
 
+    // violation 2 lines below 'Unclosed HTML tag found: p'
     /**
-     * <p> // violation, 'Unclosed HTML tag found: p'
+     * <p>
      */
     public static final int CONST = 12;
 


### PR DESCRIPTION
Issue: #19764

Fixed input file:
- InputUnusedImportsJavadocSetters.java

Removed one suppression;

Updated violation line number.