### PR TITLE
Issue #19770: Improve JavadocTypeCheck to handle parameter …

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -407,8 +407,11 @@ public class JavadocTypeCheck
 
         final boolean found = tags
             .stream()
-            .filter(JavadocTag::isParamTag)
-            .anyMatch(tag -> tag.getFirstArg().indexOf(recordComponentName) == 0);
+                .filter(JavadocTag::isParamTag).anyMatch(tag -> {
+                    final String arg = tag.getFirstArg();
+                    return arg.equals(recordComponentName)
+                            || arg.startsWith(recordComponentName + SPACE);
+                });
 
         if (!found) {
             log(ast, MSG_MISSING_TAG, JavadocTagInfo.PARAM.getText()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -370,6 +370,23 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testJavadocTypeRecordComponentNameMismatch() throws Exception {
+        final String[] expected1 = {
+            "21:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "valueExtra"),
+            "23:1: " + getCheckMessage(MSG_MISSING_TAG, "@param value"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocTypeRecordComponentNameMismatch.java"), expected1);
+
+        final String[] expected2 = {
+            "23:1: " + getCheckMessage(MSG_MISSING_TAG, "@param value"),
+            "21:4: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocTypeRecordComponentNameMismatch2.java"), expected2);
+    }
+
+    @Test
     public void testJavadocTypeParamDescriptionWithAngularTags() throws Exception {
         final String[] expected = {
             "50:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponentNameMismatch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponentNameMismatch.java
@@ -1,0 +1,25 @@
+/*
+JavadocType
+scope = protected
+excludeScope = (default)null
+authorFormat = (default)null
+versionFormat = (default)null
+allowMissingParamTags = (default)false
+allowUnknownTags = (default)false
+allowedAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+
+// violation 4 lines below 'Unused @param tag for 'valueExtra'.'
+/**
+ * Example case
+ *
+ * @param valueExtra wrong tag for a different component
+ */
+public record InputJavadocTypeRecordComponentNameMismatch(String value) {
+    // violation above 'Type Javadoc comment is missing @param value tag.'
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponentNameMismatch2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponentNameMismatch2.java
@@ -1,0 +1,25 @@
+/*
+JavadocType
+scope = protected
+excludeScope = (default)null
+authorFormat = (default)null
+versionFormat = (default)null
+allowMissingParamTags = (default)false
+allowUnknownTags = (default)false
+allowedAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+
+// violation 4 lines below 'Unused Javadoc tag.'
+/**
+ * Example case with bare @param tag
+ *
+ * @param
+ */
+public record InputJavadocTypeRecordComponentNameMismatch2(String value) {
+    // violation above 'Type Javadoc comment is missing @param value tag.'
+}


### PR DESCRIPTION
## Description

Fixes checkstyle/checkstyle#19770 - JavadocTypeCheck incorrectly matches record component @param tags using prefix instead of exact match.

### Root Cause

In `JavadocTypeCheck.checkComponentParamTag()`, the matching logic used `indexOf() == 0`:

```java
.anyMatch(tag -> tag.getFirstArg().indexOf(recordComponentName) == 0);
```

This means any `@param` tag whose argument **starts with** the component name as a prefix would match. For example, with a record component named `john`, `@param john123` was incorrectly treated as documenting `john` because `john123.indexOf(john) == 0`.

### Fix

Changed to exact match or space-separated match:

```java
.anyMatch(tag -> {
    final String arg = tag.getFirstArg();
    return arg.equals(recordComponentName)
            || arg.startsWith(recordComponentName + " ");
});
```

This ensures:
- `@param john` matches record component `john` (exact match)
- `@param john some description` matches record component `john` (name + space prefix)
- `@param john123` does NOT match record component `john` (different name)

The existing `checkUnusedParamTags()` already uses `extractParamNameFromTag()` which properly extracts the param name via regex, so it correctly reports `john123` as an unused tag.

### Testing

Added `InputJavadocTypeRecordComponentPrefixMatch.java` test case that reproduces the exact scenario from issue #19770.