### PR TITLE
Issue #19813: Add new property in ConstructorsDeclarationGroupingCheck

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -410,7 +410,9 @@
     <module name="AvoidDoubleBraceInitialization"/>
     <module name="AvoidInlineConditionals"/>
     <module name="AvoidNoArgumentSuperConstructorCall"/>
-    <module name="ConstructorsDeclarationGrouping"/>
+    <module name="ConstructorsDeclarationGrouping">
+      <property name="orderByIncreasingParameterCount" value="true"/>
+    </module>
     <module name="CovariantEquals"/>
     <module name="DeclarationOrder"/>
     <module name="DefaultComesLast"/>

--- a/config/suppressions-xpath.xml
+++ b/config/suppressions-xpath.xml
@@ -511,4 +511,13 @@
           checks="LocalVariableNameCheck"
           query="//METHOD_DEF[./IDENT[@text='getLineNumbersFromExpected']]
                 //VARIABLE_DEF/IDENT[@text='i']"/>
+
+  <!-- Property orderByIncreasingParameterCount of ConstructorsDeclarationGrouping conflicts
+  with CustomDeclarationOrder.CustomDeclarationOrder intentionally keeps publicly usable
+  constructors before private implementation details, even if it breaks constructor ordering
+  by params for private constructors.      -->
+  <suppress-xpath
+          files="IndentLevel.java"
+          checks="ConstructorsDeclarationGroupingCheck"
+          query="//CTOR_DEF[./IDENT[@text='IndentLevel']][./MODIFIERS/LITERAL_PRIVATE]"/>
 </suppressions>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheck.java
@@ -56,6 +56,28 @@ public class ConstructorsDeclarationGroupingCheck extends AbstractCheck {
      */
     public static final String MSG_KEY = "constructors.declaration.grouping";
 
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_ORDER = "constructors.declaration.order";
+
+    /**
+     * Control whether to order constructors by increasing parameter count or not.
+     */
+    private boolean orderByIncreasingParameterCount;
+
+    /**
+     * Setter to control whether to enforce order by increasing parameter count (arity) or not.
+     *
+     * @param orderByIncreasingParameterCount true if order by increasing parameter
+     *        count is required.
+     * @since 13.6.0
+     */
+    public void setOrderByIncreasingParameterCount(boolean orderByIncreasingParameterCount) {
+        this.orderByIncreasingParameterCount = orderByIncreasingParameterCount;
+    }
+
     @Override
     public int[] getDefaultTokens() {
         return getRequiredTokens();
@@ -118,6 +140,25 @@ public class ConstructorsDeclarationGroupingCheck extends AbstractCheck {
             // log all constructors that are not grouped
             constructorsToLog
                     .forEach(ctor -> log(ctor, MSG_KEY, lastGroupedConstructor.getLineNo()));
+
+            if (orderByIncreasingParameterCount) {
+
+                // list of all constructor ASTs
+                final List<DetailAST> allConstructors = children.stream()
+                        .filter(ConstructorsDeclarationGroupingCheck::isConstructor)
+                        .toList();
+
+                int previousParamCount = 0;
+                boolean isOrdered = true;
+                for (DetailAST constructor : allConstructors) {
+                    final int currentParamCount = getParameterCount(constructor);
+                    isOrdered = isOrdered && currentParamCount >= previousParamCount;
+                    previousParamCount = currentParamCount;
+                    if (!isOrdered) {
+                        log(constructor, MSG_ORDER);
+                    }
+                }
+            }
         }
     }
 
@@ -146,5 +187,20 @@ public class ConstructorsDeclarationGroupingCheck extends AbstractCheck {
     private static boolean isConstructor(DetailAST ast) {
         return ast.getType() == TokenTypes.CTOR_DEF
                 || ast.getType() == TokenTypes.COMPACT_CTOR_DEF;
+    }
+
+    /**
+     * Get the parameter count of a constructor.
+     *
+     * @param constructor the constructor AST
+     * @return the parameter count of the constructor
+     */
+    private static int getParameterCount(DetailAST constructor) {
+        final DetailAST params = constructor.findFirstToken(TokenTypes.PARAMETERS);
+        int parameterCount = 0;
+        if (params != null) {
+            parameterCount = params.getChildCount(TokenTypes.PARAMETER_DEF);
+        }
+        return parameterCount;
     }
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages.properties
@@ -4,6 +4,7 @@ avoid.clone.method=Avoid using clone method.
 avoid.double.brace.init=Avoid double brace initialization.
 avoid.finalizer.method=Avoid using finalizer method.
 constructors.declaration.grouping=Constructors should be grouped together. The last grouped constructor is declared at line ''{0}''.
+constructors.declaration.order=Constructors should be ordered by increasing parameter count.
 covariant.equals=covariant equals without overriding equals(java.lang.Object).
 declaration.order.access=Variable access definition in wrong order.
 declaration.order.constructor=Constructor definition in wrong order.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_de.properties
@@ -4,6 +4,7 @@ avoid.clone.method=Die Methode clone() sollte vermieden werden.
 avoid.double.brace.init=Vermeiden Sie doppelte geschweifte Klammern.
 avoid.finalizer.method=Die Methode finalize() sollte vermieden werden.
 constructors.declaration.grouping=Alle Konstruktoren sollten zusammengefasst werden. Der vorherige Konstruktor befand sich in der Zeilennummer ''{0}''.
+constructors.declaration.order=Konstruktoren sollten nach zunehmender Parameteranzahl geordnet werden.
 covariant.equals=Kovariante Definition von equals(), ohne equals(java.lang.Object) zu überschreiben.
 declaration.order.access=Fehlerhafte Deklarationsreihenfolge für diesen Scope.
 declaration.order.constructor=Der Konstruktor steht an der falschen Stelle.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_es.properties
@@ -4,6 +4,7 @@ avoid.clone.method=Evite el uso de método clone.
 avoid.double.brace.init=Evite la inicialización de llaves dobles.
 avoid.finalizer.method=Evite el uso de método de finalizador.
 constructors.declaration.grouping=Todos los constructores deben agruparse. El constructor anterior estaba en la línea número ''{0}''.
+constructors.declaration.order=Los constructores deben ordenarse aumentando el número de parámetros.
 covariant.equals=equals covariante sin sobrescribir equals(java.lang.Object).
 declaration.order.access=Definición de acceso a variable en orden incorrecto.
 declaration.order.constructor=Definición de constructor en orden incorrecto.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_fi.properties
@@ -4,6 +4,7 @@ avoid.clone.method=Vältä klooni menetelmää.
 avoid.double.brace.init=Vältä kaksinkertaista ahdintuen alustamista.
 avoid.finalizer.method=Vältä Finalizer menetelmää.
 constructors.declaration.grouping=Rakentajat tulee ryhmitellä yhteen. Viimeinen ryhmitelty rakentaja ilmoitetaan rivillä ''{0}''.
+constructors.declaration.order=Rakentajat tulee järjestää lisäämällä parametrien määrää.
 covariant.equals=covariant vastaa ilman painavaa tasavertaisten (java.lang.Object).
 declaration.order.access=Muuttuja pääsy määritelmä väärässä järjestyksessä.
 declaration.order.constructor=Rakentaja määritelmä väärässä järjestyksessä.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_fr.properties
@@ -4,6 +4,7 @@ avoid.clone.method=Évitez d''utiliser la méthode de clonage.
 avoid.double.brace.init=Évitez l''initialisation à double accolade.
 avoid.finalizer.method=Évitez d''utiliser la méthode de finalisation.
 constructors.declaration.grouping=Les constructeurs doivent être regroupés. Le dernier constructeur groupé est déclaré à la ligne ''{0}''.
+constructors.declaration.order=Les constructeurs doivent être classés par nombre croissant de paramètres.
 covariant.equals=Votre méthode equals compare uniquement les objets de votre classe. N''oubliez pas de surcharger la méthode equals(java.lang.Object).
 declaration.order.access=La définition des variables n''est pas triée suivant leur portée.
 declaration.order.constructor=La définition des constructeurs n''apparaît pas dans le bon ordre.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_ja.properties
@@ -4,6 +4,7 @@ avoid.clone.method=cloneメソッドを使用しないでください。
 avoid.double.brace.init=二重中括弧を使った初期化は使用しないでください。
 avoid.finalizer.method=ファイナライザメソッドを使用しないでください。
 constructors.declaration.grouping=コンストラクターはグループ化する必要があります。最後にグループ化されたコンストラクターは行 ''{0}'' で宣言されます。
+constructors.declaration.order=コンストラクターは、パラメーター数を増やすことによって順序付けする必要があります。
 covariant.equals=equals(java.lang.Object) をオーバーライドせずに共変 な equals を定義しています。
 declaration.order.access=変数アクセスの定義順序が間違っています。
 declaration.order.constructor=コンストラクタの定義順序が間違っています。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_pt.properties
@@ -4,6 +4,7 @@ avoid.clone.method=Evite o uso do método ''clone()''.
 avoid.double.brace.init=Evite a inicialização entre chaves.
 avoid.finalizer.method=Evite o uso do método ''finalize()''.
 constructors.declaration.grouping=Os construtores devem ser agrupados. O último construtor agrupado é declarado na linha ''{0}''.
+constructors.declaration.order=Os construtores devem ser ordenados aumentando a contagem de parâmetros.
 covariant.equals="equals" covariante sem sobrescrever ''equals(java.lang.Object)''.
 declaration.order.access=Definição de acesso a variável em ordem errada.
 declaration.order.constructor=Definição de construtor em ordem errada.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_ru.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_ru.properties
@@ -4,6 +4,7 @@ avoid.clone.method=Избегайте использования метода cl
 avoid.double.brace.init=Избегайте инициализации в двойных скобках.
 avoid.finalizer.method=Избегайте использования метода finalize().
 constructors.declaration.grouping=Конструкторы должны быть сгруппированы вместе. Последний сгруппированный конструктор объявляется в строке ''{0}''.
+constructors.declaration.order=Конструкторы следует упорядочивать по увеличению количества параметров.
 covariant.equals=Ковариантный equals() без переопределения equals(java.lang.Object).
 declaration.order.access=Объявляйте переменные в порядке расширения доступа.
 declaration.order.constructor=Определение конструктора в неправильном порядке.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_tr.properties
@@ -4,6 +4,7 @@ avoid.clone.method=''clone'' metodu kullanılmamalıdır.
 avoid.double.brace.init=Çift ayraç başlatmadan kaçının.
 avoid.finalizer.method=''finalize'' metodu kullanılmamalıdır.
 constructors.declaration.grouping=Yapıcılar birlikte gruplandırılmalıdır. Gruplandırılan son kurucu ''{0}'' satırında bildirildi.
+constructors.declaration.order=Yapıcılar parametre sayısı artırılarak sıralanmalıdır.
 covariant.equals=java.lang.Object sınıfının ''equals'' metodundan başka bir ''equals'' metodu tanımlanmış, java.lang.Object sınıfından gelen ''equals'' metodu da ezilmelidir (override).
 declaration.order.access=Değişken, erişim seviyesine göre yanlış sırada tanımlanmış.
 declaration.order.constructor=''constructor'' tanımı yanlış sırada yapılmış.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_zh.properties
@@ -4,6 +4,7 @@ avoid.clone.method=避免重写 clone 方法。
 avoid.double.brace.init=避免双括号初始化。
 avoid.finalizer.method=避免重写finalize方法。
 constructors.declaration.grouping=构造函数应该组合在一起。最后一个分组构造函数在''{0}''行声明。
+constructors.declaration.order=构造函数应该按照参数数量增序排序。
 covariant.equals=重写''equals()''方法时，必须确保重写了''equals(java.lang.Object)''方法。
 declaration.order.access=属性访问器定义顺序错误。
 declaration.order.constructor=构造器定义顺序错误。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/ConstructorsDeclarationGroupingCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/ConstructorsDeclarationGroupingCheck.xml
@@ -18,8 +18,16 @@
  the different ways an object can be instantiated
  and the tasks performed by each constructor.
  &lt;/p&gt;</description>
+         <properties>
+            <property default-value="false"
+                      name="orderByIncreasingParameterCount"
+                      type="boolean">
+               <description>Control whether to enforce order by increasing parameter count (arity) or not.</description>
+            </property>
+         </properties>
          <message-keys>
             <message-key key="constructors.declaration.grouping"/>
+            <message-key key="constructors.declaration.order"/>
          </message-keys>
       </check>
    </module>

--- a/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
+++ b/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
@@ -25,6 +25,27 @@
         </p>
       </subsection>
 
+      <subsection name="Properties" id="ConstructorsDeclarationGrouping_Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td><a id="orderByIncreasingParameterCount"/><a href="#orderByIncreasingParameterCount">orderByIncreasingParameterCount</a></td>
+              <td>Control whether to enforce order by increasing parameter count (arity) or not.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>13.6.0</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
       <subsection name="Examples" id="ConstructorsDeclarationGrouping_Examples">
         <p id="Example1-config">To configure the check:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
@@ -34,22 +55,22 @@
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example1-code">Example of correct grouping of constructors:</p>
+        <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
-
   int x;
-
   Example1() {}
 
-  Example1(String s) {}
+  Example1(String s, int x, int y) {}
 
   // comments between constructors are allowed.
   Example1(int x) {}
 
-  Example1(String s, int x) {}
+  int a = 0;
 
-  void foo() {}
+  // violation 2 lines below """Constructors should be grouped together.
+  // The last grouped constructor is declared at line '21'."""
+  Example1(String s, int x) {}
 
   private enum ExampleEnum {
 
@@ -57,56 +78,81 @@ public class Example1 {
 
     ExampleEnum() {}
 
-    ExampleEnum(int x) {}
-
-    ExampleEnum(String s) {}
-
-    int x = 10;
-
     void foo() {}
+
+    // violation 2 lines below """Constructors should be grouped together.
+    // The last grouped constructor is declared at line '33'."""
+    ExampleEnum(int x, int y) {}
+
+    // violation 2 lines below """Constructors should be grouped together.
+    // The last grouped constructor is declared at line '33'."""
+    ExampleEnum(String s, int x) {}
+
+  }
+
+  class InputWithOrderedCtors {
+    InputWithOrderedCtors() {}
+    InputWithOrderedCtors(String s) {}
+    InputWithOrderedCtors(int x) {}
+    InputWithOrderedCtors(String s, int x) {}
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example2-code">Example of incorrect grouping of constructors:</p>
+        <p id="Example2-config"> To configure the check according to
+          <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-class-structure">
+          OpenJDK guidelines</a>,
+          where constructors should be grouped together and ordered by increasing parameter count:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ConstructorsDeclarationGrouping"&gt;
+      &lt;property name="orderByIncreasingParameterCount" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
-
   int x;
-
   Example2() {}
 
-  Example2(String s){}
+  Example2(String s, int x, int y) {}
 
-  void foo() {}
-
-  // violation 2 lines below """Constructors should be grouped together. The last
-  //  grouped constructor is declared at line '18'."""
+  // comments between constructors are allowed.
   Example2(int x) {}
+  // violation above 'Constructors should be ordered by increasing parameter count.'
+  int a = 0;
 
-  // violation 2 lines below """Constructors should be grouped together. The last
-  //  grouped constructor is declared at line '18'."""
+  // violation 2 lines below """Constructors should be grouped together.
+  // The last grouped constructor is declared at line '21'."""
   Example2(String s, int x) {}
-
+  // violation above 'Constructors should be ordered by increasing parameter count.'
   private enum ExampleEnum {
 
     ONE, TWO, THREE;
 
     ExampleEnum() {}
 
-    ExampleEnum(int x) {}
-
-    final int x = 10;
+    void foo() {}
 
     // violation 2 lines below """Constructors should be grouped together.
-    //  The last grouped constructor is declared at line '36'."""
-    ExampleEnum(String str) {}
+    // The last grouped constructor is declared at line '33'."""
+    ExampleEnum(int x, int y) {}
 
-    void foo() {}
+    // violation 2 lines below """Constructors should be grouped together.
+    // The last grouped constructor is declared at line '33'."""
+    ExampleEnum(String s, int x) {}
+
   }
 
-  // violation 2 lines below """Constructors should be grouped together.
-  //  The last grouped constructor is declared at line '18'."""
-  Example2(float f) {}
+  class InputWithOrderedCtors {
+    InputWithOrderedCtors() {}
+    InputWithOrderedCtors(String s) {}
+    InputWithOrderedCtors(int x) {}
+    InputWithOrderedCtors(String s, int x) {}
+  }
 }
 </code></pre></div>
       </subsection>
@@ -129,6 +175,11 @@ public class Example2 {
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22constructors.declaration.grouping%22">
               constructors.declaration.grouping
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22constructors.declaration.order%22">
+              constructors.declaration.order
             </a>
           </li>
         </ul>

--- a/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml.template
+++ b/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml.template
@@ -18,6 +18,15 @@
         </macro>
       </subsection>
 
+      <subsection name="Properties" id="ConstructorsDeclarationGrouping_Properties">
+        <div class="wrapper">
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheck.java"/>
+          </macro>
+        </div>
+      </subsection>
+
       <subsection name="Examples" id="ConstructorsDeclarationGrouping_Examples">
         <p id="Example1-config">To configure the check:</p>
         <macro name="example">
@@ -25,13 +34,23 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example1-code">Example of correct grouping of constructors:</p>
+        <p id="Example1-code">Example:</p>
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example1.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example2-code">Example of incorrect grouping of constructors:</p>
+        <p id="Example2-config"> To configure the check according to
+          <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-class-structure">
+          OpenJDK guidelines</a>,
+          where constructors should be grouped together and ordered by increasing parameter count:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code">Example:</p>
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example2.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.ConstructorsDeclarationGroupingCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.checks.coding.ConstructorsDeclarationGroupingCheck.MSG_ORDER;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,13 +36,13 @@ public class ConstructorsDeclarationGroupingCheckTest extends AbstractModuleTest
     @Test
     public void testDefault() throws Exception {
         final String[] expected = {
-            "23:5: " + getCheckMessage(MSG_KEY, 19),
-            "28:5: " + getCheckMessage(MSG_KEY, 19),
-            "45:9: " + getCheckMessage(MSG_KEY, 39),
-            "55:13: " + getCheckMessage(MSG_KEY, 49),
-            "59:9: " + getCheckMessage(MSG_KEY, 39),
-            "63:5: " + getCheckMessage(MSG_KEY, 19),
-            "66:5: " + getCheckMessage(MSG_KEY, 19),
+            "24:5: " + getCheckMessage(MSG_KEY, 20),
+            "29:5: " + getCheckMessage(MSG_KEY, 20),
+            "46:9: " + getCheckMessage(MSG_KEY, 40),
+            "56:13: " + getCheckMessage(MSG_KEY, 50),
+            "60:9: " + getCheckMessage(MSG_KEY, 40),
+            "64:5: " + getCheckMessage(MSG_KEY, 20),
+            "67:5: " + getCheckMessage(MSG_KEY, 20),
         };
         verifyWithInlineConfigParser(
                 getPath("InputConstructorsDeclarationGrouping.java"), expected);
@@ -50,10 +51,10 @@ public class ConstructorsDeclarationGroupingCheckTest extends AbstractModuleTest
     @Test
     public void testConstructorsDeclarationGroupingInner() throws Exception {
         final String[] expected = {
-            "29:9: " + getCheckMessage(MSG_KEY, 25),
-            "34:9: " + getCheckMessage(MSG_KEY, 25),
-            "37:9: " + getCheckMessage(MSG_KEY, 25),
-            "41:5: " + getCheckMessage(MSG_KEY, 11),
+            "30:9: " + getCheckMessage(MSG_KEY, 26),
+            "35:9: " + getCheckMessage(MSG_KEY, 26),
+            "38:9: " + getCheckMessage(MSG_KEY, 26),
+            "42:5: " + getCheckMessage(MSG_KEY, 12),
 
         };
         verifyWithInlineConfigParser(
@@ -64,14 +65,60 @@ public class ConstructorsDeclarationGroupingCheckTest extends AbstractModuleTest
     public void testConstructorsDeclarationGroupingRecords() throws Exception {
 
         final String[] expected = {
-            "20:9: " + getCheckMessage(MSG_KEY, 12),
-            "23:9: " + getCheckMessage(MSG_KEY, 12),
-            "28:9: " + getCheckMessage(MSG_KEY, 12),
-            "45:9: " + getCheckMessage(MSG_KEY, 39),
+            "21:9: " + getCheckMessage(MSG_KEY, 13),
+            "24:9: " + getCheckMessage(MSG_KEY, 13),
+            "29:9: " + getCheckMessage(MSG_KEY, 13),
+            "46:9: " + getCheckMessage(MSG_KEY, 40),
         };
 
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputConstructorsDeclarationGroupingRecords.java"),
+                expected);
+    }
+
+    @Test
+    public void testConstructorsDeclarationGroupingArity() throws Exception {
+
+        final String[] expected = {
+            "14:5: " + getCheckMessage(MSG_ORDER),
+            "17:5: " + getCheckMessage(MSG_ORDER),
+            "20:5: " + getCheckMessage(MSG_ORDER),
+            "31:5: " + getCheckMessage(MSG_ORDER),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputConstructorsDeclarationGroupingArity.java"),
+                expected);
+    }
+
+    @Test
+    public void testConstructorsDeclarationGroupingRecordArity() throws Exception {
+
+        final String[] expected = {
+            "24:9: " + getCheckMessage(MSG_ORDER),
+            "33:9: " + getCheckMessage(MSG_ORDER),
+            "37:9: " + getCheckMessage(MSG_ORDER),
+            "41:9: " + getCheckMessage(MSG_ORDER),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputConstructorsDeclarationGroupingRecord.java"),
+                expected);
+    }
+
+    @Test
+    public void testConstructorsDeclarationGroupingMisc() throws Exception {
+
+        final String[] expected = {
+            "20:5: " + getCheckMessage(MSG_KEY, 15),
+            "20:5: " + getCheckMessage(MSG_ORDER),
+            "30:9: " + getCheckMessage(MSG_KEY, 25),
+            "35:9: " + getCheckMessage(MSG_KEY, 25),
+            "35:9: " + getCheckMessage(MSG_ORDER),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputConstructorsDeclarationGroupingMisc.java"),
                 expected);
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGroupingRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGroupingRecords.java
@@ -1,5 +1,6 @@
 /*
 ConstructorsDeclarationGrouping
+orderByIncreasingParameterCount = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGrouping.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGrouping.java
@@ -1,5 +1,6 @@
 /*
 ConstructorsDeclarationGrouping
+orderByIncreasingParameterCount = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGroupingArity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGroupingArity.java
@@ -1,0 +1,34 @@
+/*
+ConstructorsDeclarationGrouping
+orderByIncreasingParameterCount = true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.constructorsdeclarationgrouping;
+
+public class InputConstructorsDeclarationGroupingArity {
+    public InputConstructorsDeclarationGroupingArity(int i, int j) {
+    }
+
+    public InputConstructorsDeclarationGroupingArity() {
+    } // violation above 'Constructors should be ordered by increasing parameter count.'
+
+    public InputConstructorsDeclarationGroupingArity(Object o, int i) {
+    } // violation above 'Constructors should be ordered by increasing parameter count.'
+
+    public InputConstructorsDeclarationGroupingArity(Object o) {
+    } // violation above 'Constructors should be ordered by increasing parameter count.'
+
+    private enum ExampleEnum {
+
+    ONE, TWO, THREE;
+
+    ExampleEnum() {}
+
+    ExampleEnum(int x, int y) {}
+
+    ExampleEnum(String s) {}
+    // violation above 'Constructors should be ordered by increasing parameter count.'
+  }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGroupingInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGroupingInner.java
@@ -1,5 +1,6 @@
 /*
 ConstructorsDeclarationGrouping
+orderByIncreasingParameterCount = (default)false
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGroupingMisc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGroupingMisc.java
@@ -1,0 +1,39 @@
+/*
+ConstructorsDeclarationGrouping
+orderByIncreasingParameterCount = true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.constructorsdeclarationgrouping;
+
+public class InputConstructorsDeclarationGroupingMisc {
+
+    public InputConstructorsDeclarationGroupingMisc() {
+    }
+
+    public InputConstructorsDeclarationGroupingMisc(int a, int b) {
+    }
+
+    int a;
+
+    public InputConstructorsDeclarationGroupingMisc(int a) {
+    } // violation above 'Constructors should be grouped together.*'
+    // violation 2 lines above 'Constructors should be ordered by increasing parameter count.'
+
+    public record MyRecord(int a, int b) {
+        public MyRecord(int a) {
+            this(a, a);
+        }
+        static int d = 10;
+
+        public MyRecord(int a, int b, int c, int d) {
+            this(a + b, c + d);
+        } // violation 2 lines above 'Constructors should be grouped together.*'
+        static int c = 20;
+
+        public MyRecord(int a, int b, int c) {
+            this(a + b, c); // violation above 'Constructors should be grouped together.*'
+        }// violation 2 lines above 'Constructors should be ordered by increasing parameter count.'
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGroupingRecord.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/InputConstructorsDeclarationGroupingRecord.java
@@ -1,0 +1,45 @@
+/*
+ConstructorsDeclarationGrouping
+orderByIncreasingParameterCount = true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.constructorsdeclarationgrouping;
+
+public class InputConstructorsDeclarationGroupingRecord {
+    public record MyRecord(int a, int b) {
+
+        public MyRecord {
+        }
+
+        public MyRecord(int a) {
+            this(a, a);
+        }
+
+        public MyRecord(int a, int b, int c, int d) {
+            this(a+b, c+d);
+        }
+
+        public MyRecord(int a, int b, int c) {
+            this(a + b, c);
+        }// violation 2 lines above 'Constructors should be ordered by increasing parameter count.'
+    }
+
+    static class Inner {
+        public Inner(int a, int b) {
+        }
+
+        public Inner(int a) {
+            this(a, a);
+        }// violation 2 lines above 'Constructors should be ordered by increasing parameter count.'
+
+        public Inner(int a, int b, int c, int d) {
+            this(a+b, c+d);
+        }// violation 2 lines above 'Constructors should be ordered by increasing parameter count.'
+
+        public Inner(int a, int b, int c) {
+            this(a + b, c);
+        }// violation 2 lines above 'Constructors should be ordered by increasing parameter count.'
+    }
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheckExamplesTest.java
@@ -33,7 +33,9 @@ public class ConstructorsDeclarationGroupingCheckExamplesTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-
+            "27:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 21),
+            "39:5: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 33),
+            "43:5: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 33),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -42,10 +44,11 @@ public class ConstructorsDeclarationGroupingCheckExamplesTest
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "24:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
-            "28:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
-            "42:5: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 36),
-            "49:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 18),
+            "21:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_ORDER),
+            "27:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 21),
+            "27:3: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_ORDER),
+            "39:5: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 33),
+            "43:5: " + getCheckMessage(ConstructorsDeclarationGroupingCheck.MSG_KEY, 33),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example1.java
@@ -4,25 +4,27 @@
     <module name="ConstructorsDeclarationGrouping"/>
   </module>
 </module>
+
+
 */
 
 package com.puppycrawl.tools.checkstyle.checks.coding.constructorsdeclarationgrouping;
 
 // xdoc section -- start
 public class Example1 {
-
   int x;
-
   Example1() {}
 
-  Example1(String s) {}
+  Example1(String s, int x, int y) {}
 
   // comments between constructors are allowed.
   Example1(int x) {}
 
-  Example1(String s, int x) {}
+  int a = 0;
 
-  void foo() {}
+  // violation 2 lines below """Constructors should be grouped together.
+  // The last grouped constructor is declared at line '21'."""
+  Example1(String s, int x) {}
 
   private enum ExampleEnum {
 
@@ -30,13 +32,23 @@ public class Example1 {
 
     ExampleEnum() {}
 
-    ExampleEnum(int x) {}
-
-    ExampleEnum(String s) {}
-
-    int x = 10;
-
     void foo() {}
+
+    // violation 2 lines below """Constructors should be grouped together.
+    // The last grouped constructor is declared at line '33'."""
+    ExampleEnum(int x, int y) {}
+
+    // violation 2 lines below """Constructors should be grouped together.
+    // The last grouped constructor is declared at line '33'."""
+    ExampleEnum(String s, int x) {}
+
+  }
+
+  class InputWithOrderedCtors {
+    InputWithOrderedCtors() {}
+    InputWithOrderedCtors(String s) {}
+    InputWithOrderedCtors(int x) {}
+    InputWithOrderedCtors(String s, int x) {}
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping/Example2.java
@@ -1,7 +1,9 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="ConstructorsDeclarationGrouping"/>
+    <module name="ConstructorsDeclarationGrouping">
+      <property name="orderByIncreasingParameterCount" value="true"/>
+    </module>
   </module>
 </module>
 */
@@ -10,42 +12,43 @@ package com.puppycrawl.tools.checkstyle.checks.coding.constructorsdeclarationgro
 
 // xdoc section -- start
 public class Example2 {
-
   int x;
-
   Example2() {}
 
-  Example2(String s){}
+  Example2(String s, int x, int y) {}
 
-  void foo() {}
-
-  // violation 2 lines below """Constructors should be grouped together. The last
-  //  grouped constructor is declared at line '18'."""
+  // comments between constructors are allowed.
   Example2(int x) {}
+  // violation above 'Constructors should be ordered by increasing parameter count.'
+  int a = 0;
 
-  // violation 2 lines below """Constructors should be grouped together. The last
-  //  grouped constructor is declared at line '18'."""
+  // violation 2 lines below """Constructors should be grouped together.
+  // The last grouped constructor is declared at line '21'."""
   Example2(String s, int x) {}
-
+  // violation above 'Constructors should be ordered by increasing parameter count.'
   private enum ExampleEnum {
 
     ONE, TWO, THREE;
 
     ExampleEnum() {}
 
-    ExampleEnum(int x) {}
-
-    final int x = 10;
+    void foo() {}
 
     // violation 2 lines below """Constructors should be grouped together.
-    //  The last grouped constructor is declared at line '36'."""
-    ExampleEnum(String str) {}
+    // The last grouped constructor is declared at line '33'."""
+    ExampleEnum(int x, int y) {}
 
-    void foo() {}
+    // violation 2 lines below """Constructors should be grouped together.
+    // The last grouped constructor is declared at line '33'."""
+    ExampleEnum(String s, int x) {}
+
   }
 
-  // violation 2 lines below """Constructors should be grouped together.
-  //  The last grouped constructor is declared at line '18'."""
-  Example2(float f) {}
+  class InputWithOrderedCtors {
+    InputWithOrderedCtors() {}
+    InputWithOrderedCtors(String s) {}
+    InputWithOrderedCtors(int x) {}
+    InputWithOrderedCtors(String s, int x) {}
+  }
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue: #19813 

This pr adds a new property `orderByIncreasingArity`  in  `ConstructorsDeclarationGroupingCheck` to follow the openjdk guidelines for  [Order of Constructors and Overloaded Methods](https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-class-structure) .


Discussion on how avoid conflict with CusomDeclarationOrder - https://github.com/checkstyle/checkstyle/pull/19831#issuecomment-4470974055

### Diff regression configuration

Diff Regression config: https://gist.githubusercontent.com/Aman-Baliyan/8cd9c64285f7f3d79e6756389e16e776/raw/b28691833102d225c9aab24ff741316132cfcbc4/constructorBase.xml

Diff Regression patch config: https://gist.githubusercontent.com/Aman-Baliyan/ad59bc76b2e54703a25adbb9b2dc77ae/raw/9de69a146fada1c95172ea70b3f8d5bf518cfa84/constructor.xml