### PR TITLE
minor: remove old jdk syntax special comment that are below or java21

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputOverloadsNeverSplitRecords.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/InputOverloadsNeverSplitRecords.java
@@ -1,4 +1,4 @@
-// Java17
+//
 
 package com.google.checkstyle.test.chapter3filestructure.rule3421overloadsplit;
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundArrow.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundArrow.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
 import java.awt.event.ActionEvent;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundWhen.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedWhitespaceAroundWhen.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
 class InputFormattedWhitespaceAroundWhen {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
 import java.awt.event.ActionEvent;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrowCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrowCorrect.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
 import java.awt.event.ActionEvent;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundWhen.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundWhen.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
 class InputWhitespaceAroundWhen {

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputCatchParametersOnNewLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputCatchParametersOnNewLine.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 /** Some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedCatchParametersOnNewLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedCatchParametersOnNewLine.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 /** Some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedLambdaAndChildOnTheSameLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedLambdaAndChildOnTheSameLine.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.lang.reflect.Proxy;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedLambdaChild.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedLambdaChild.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.util.List;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedSwitchOnStartOfTheLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputFormattedSwitchOnStartOfTheLine.java
@@ -1,5 +1,3 @@
-// Java17
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 /** Some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaAndChildOnTheSameLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaAndChildOnTheSameLine.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.lang.reflect.Proxy;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaChild.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaChild.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.util.List;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaChildCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaChildCorrect.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.util.List;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputMultilineStatementsCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputMultilineStatementsCorrect.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 /** Some class. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurly.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 /**Some javadoc.*/

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurlyCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSingleSwitchStatementWithoutCurlyCorrect.java
@@ -1,5 +1,3 @@
-// Java21
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 /** Some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchOnStartOfTheLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchOnStartOfTheLine.java
@@ -1,5 +1,3 @@
-// Java17
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 /**Some javadoc.*/

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchOnStartOfTheLineCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchOnStartOfTheLineCorrect.java
@@ -1,5 +1,3 @@
-// Java17
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 /** Some javadoc. */

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentation.java
@@ -1,5 +1,3 @@
-// Java17
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.util.List;

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentationCorrect.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputSwitchWrappingIndentationCorrect.java
@@ -1,5 +1,3 @@
-// Java17
-
 package com.google.checkstyle.test.chapter4formatting.rule4841indentation;
 
 import java.util.List;

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InputRecordTypeParameterNameOne.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InputRecordTypeParameterNameOne.java
@@ -1,5 +1,3 @@
-// Java17
-
 package com.google.checkstyle.test.chapter5naming.rule528typevariablenames;
 
 import java.io.Serializable;

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/covariantequals/InputXpathCovariantEqualsInRecord.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/covariantequals/InputXpathCovariantEqualsInRecord.java
@@ -1,4 +1,4 @@
-// Java17
+
 
 package org.checkstyle.suppressionxpathfilter.coding.covariantequals;
 

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedcatchparametershouldbeunnamed/InputXpathUnusedCatchParameterShouldBeUnnamedConstructor.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedcatchparametershouldbeunnamed/InputXpathUnusedCatchParameterShouldBeUnnamedConstructor.java
@@ -1,4 +1,4 @@
-// Java21
+
 package org.checkstyle.suppressionxpathfilter.coding.unusedcatchparametershouldbeunnamed;
 
 public class InputXpathUnusedCatchParameterShouldBeUnnamedConstructor {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedcatchparametershouldbeunnamed/InputXpathUnusedCatchParameterShouldBeUnnamedNested.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedcatchparametershouldbeunnamed/InputXpathUnusedCatchParameterShouldBeUnnamedNested.java
@@ -1,4 +1,4 @@
-// Java21
+
 package org.checkstyle.suppressionxpathfilter.coding.unusedcatchparametershouldbeunnamed;
 
 public class InputXpathUnusedCatchParameterShouldBeUnnamedNested {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedcatchparametershouldbeunnamed/InputXpathUnusedCatchParameterShouldBeUnnamedSimple.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedcatchparametershouldbeunnamed/InputXpathUnusedCatchParameterShouldBeUnnamedSimple.java
@@ -1,4 +1,4 @@
-// Java21
+
 package org.checkstyle.suppressionxpathfilter.coding.unusedcatchparametershouldbeunnamed;
 
 public class InputXpathUnusedCatchParameterShouldBeUnnamedSimple {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedlambdaparametershouldbeunnamed/InputXpathUnusedLambdaParameterShouldBeUnnamedNested.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedlambdaparametershouldbeunnamed/InputXpathUnusedLambdaParameterShouldBeUnnamedNested.java
@@ -1,4 +1,4 @@
-// Java21
+
 package org.checkstyle.suppressionxpathfilter.coding.unusedlambdaparametershouldbeunnamed;
 
 import java.util.function.Function;

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedlambdaparametershouldbeunnamed/InputXpathUnusedLambdaParameterShouldBeUnnamedSimple.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedlambdaparametershouldbeunnamed/InputXpathUnusedLambdaParameterShouldBeUnnamedSimple.java
@@ -1,4 +1,4 @@
-// Java21
+
 package org.checkstyle.suppressionxpathfilter.coding.unusedlambdaparametershouldbeunnamed;
 
 import java.util.function.Function;

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedlambdaparametershouldbeunnamed/InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/coding/unusedlambdaparametershouldbeunnamed/InputXpathUnusedLambdaParameterShouldBeUnnamedStaticBlock.java
@@ -1,4 +1,4 @@
-// Java21
+
 package org.checkstyle.suppressionxpathfilter.coding.unusedlambdaparametershouldbeunnamed;
 
 import java.util.function.Function;

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/design/sealedshouldhavepermitslist/InputXpathSealedShouldHavePermitsListInner.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/design/sealedshouldhavepermitslist/InputXpathSealedShouldHavePermitsListInner.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.design.sealedshouldhavepermitslist;
 
 public class InputXpathSealedShouldHavePermitsListInner {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/design/sealedshouldhavepermitslist/InputXpathSealedShouldHavePermitsListInterface.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/design/sealedshouldhavepermitslist/InputXpathSealedShouldHavePermitsListInterface.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.design.sealedshouldhavepermitslist;
 
 public sealed interface InputXpathSealedShouldHavePermitsListInterface { // warn

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/design/sealedshouldhavepermitslist/InputXpathSealedShouldHavePermitsListTopLevel.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/design/sealedshouldhavepermitslist/InputXpathSealedShouldHavePermitsListTopLevel.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.design.sealedshouldhavepermitslist;
 
 public sealed class InputXpathSealedShouldHavePermitsListTopLevel { // warn

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/illegalidentifiername/InputXpathIllegalIdentifierNameInnerClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/illegalidentifiername/InputXpathIllegalIdentifierNameInnerClass.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.naming.illegalidentifiername;
 
 /* Config:

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/illegalidentifiername/InputXpathIllegalIdentifierNameOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/illegalidentifiername/InputXpathIllegalIdentifierNameOne.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.naming.illegalidentifiername;
 
 /* Config:

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/illegalidentifiername/InputXpathIllegalIdentifierNameTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/illegalidentifiername/InputXpathIllegalIdentifierNameTwo.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.naming.illegalidentifiername;
 
 /* Config:

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/patternvariablename/InputXpathPatternVariableNameFour.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/patternvariablename/InputXpathPatternVariableNameFour.java
@@ -1,4 +1,4 @@
-// java21
+
 package org.checkstyle.suppressionxpathfilter.naming.patternvariablename;
 
 public class InputXpathPatternVariableNameFour {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/patternvariablename/InputXpathPatternVariableNameOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/patternvariablename/InputXpathPatternVariableNameOne.java
@@ -1,4 +1,4 @@
-// java21
+
 package org.checkstyle.suppressionxpathfilter.naming.patternvariablename;
 
 public class InputXpathPatternVariableNameOne {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/patternvariablename/InputXpathPatternVariableNameThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/patternvariablename/InputXpathPatternVariableNameThree.java
@@ -1,4 +1,4 @@
-// java21
+
 package org.checkstyle.suppressionxpathfilter.naming.patternvariablename;
 
 public class InputXpathPatternVariableNameThree {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/patternvariablename/InputXpathPatternVariableNameTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/patternvariablename/InputXpathPatternVariableNameTwo.java
@@ -1,4 +1,4 @@
-// java21
+
 package org.checkstyle.suppressionxpathfilter.naming.patternvariablename;
 
 public class InputXpathPatternVariableNameTwo {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordcomponentname/InputXpathRecordComponentNameDefault.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordcomponentname/InputXpathRecordComponentNameDefault.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.naming.recordcomponentname;
 
 /* Config: default

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordcomponentname/InputXpathRecordComponentNameFormat.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordcomponentname/InputXpathRecordComponentNameFormat.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.naming.recordcomponentname;
 
 /* Config:

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordcomponentname/InputXpathRecordComponentNameNested.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordcomponentname/InputXpathRecordComponentNameNested.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.naming.recordcomponentname;
 
 /* Config: default

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordtypeparametername/InputXpathRecordTypeParameterNameNested.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordtypeparametername/InputXpathRecordTypeParameterNameNested.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.naming.recordtypeparametername;
 
 public class InputXpathRecordTypeParameterNameNested {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordtypeparametername/InputXpathRecordTypeParameterNameTypeDeclared.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordtypeparametername/InputXpathRecordTypeParameterNameTypeDeclared.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.naming.recordtypeparametername;
 
 import java.io.Serializable;

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordtypeparametername/InputXpathRecordTypeParameterNameTypeDefault.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/recordtypeparametername/InputXpathRecordTypeParameterNameTypeDefault.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.naming.recordtypeparametername;
 
 public record InputXpathRecordTypeParameterNameTypeDefault<t>(Integer x, String str) { // warn

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/staticvariablename/InputXpathStaticVariableNameInnerClassField.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/staticvariablename/InputXpathStaticVariableNameInnerClassField.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.naming.staticvariablename;
 
 public class InputXpathStaticVariableNameInnerClassField {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/staticvariablename/InputXpathStaticVariableNameNoAccessModifier.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/naming/staticvariablename/InputXpathStaticVariableNameNoAccessModifier.java
@@ -1,4 +1,4 @@
-// java21
+
 package org.checkstyle.suppressionxpathfilter.naming.staticvariablename;
 
 public class InputXpathStaticVariableNameNoAccessModifier {

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/sizes/recordcomponentnumber/InputXpathRecordComponentNumberCustomMax.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/sizes/recordcomponentnumber/InputXpathRecordComponentNumberCustomMax.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.sizes.recordcomponentnumber;
 
 /* Config:

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/sizes/recordcomponentnumber/InputXpathRecordComponentNumberDefault.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/sizes/recordcomponentnumber/InputXpathRecordComponentNumberDefault.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.sizes.recordcomponentnumber;
 
 /* Config:

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/sizes/recordcomponentnumber/InputXpathRecordComponentNumberInnerClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/sizes/recordcomponentnumber/InputXpathRecordComponentNumberInnerClass.java
@@ -1,4 +1,4 @@
-// Java17
+
 package org.checkstyle.suppressionxpathfilter.sizes.recordcomponentnumber;
 
 /* Config:

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/asttreestringprinter/InputAstTreeStringPrinterTextBlocksEscapesAreOneChar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/asttreestringprinter/InputAstTreeStringPrinterTextBlocksEscapesAreOneChar.java
@@ -1,4 +1,4 @@
-// Java17
+
 
 public class InputAstTreeStringPrinterTextBlocksEscapesAreOneChar {
 String emptyTextBlock = """

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationRecordsAndCompactCtors.java
@@ -9,7 +9,7 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, PACKAGE_DEF, ENUM_CONSTANT_DEF, \
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
 
 public class InputAnnotationLocationRecordsAndCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineRecordsAndCompactCtors.java
@@ -6,7 +6,7 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, \
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationonsameline;
 
 public class InputAnnotationOnSameLineRecordsAndCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineTwo.java
@@ -6,7 +6,7 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, \
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationonsameline;
 
 import java.lang.annotation.Target;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsRecords.java
@@ -8,7 +8,7 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarnings;
 
 import java.lang.annotation.Documented;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersEscapedS.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersEscapedS.java
@@ -8,7 +8,7 @@ allowNonPrintableEscapes = (default)false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
 
 public class InputAvoidEscapedUnicodeCharactersEscapedS {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersTextBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersTextBlocks.java
@@ -8,7 +8,7 @@ allowNonPrintableEscapes = (default)false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
 
 public class InputAvoidEscapedUnicodeCharactersTextBlocks {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersTextBlocksAllowByComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersTextBlocksAllowByComment.java
@@ -8,7 +8,7 @@ allowNonPrintableEscapes = (default)false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
 
 public class InputAvoidEscapedUnicodeCharactersTextBlocksAllowByComment {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/InputEmptyBlockSwitchExpressionsOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/InputEmptyBlockSwitchExpressionsOne.java
@@ -6,7 +6,7 @@ tokens = LITERAL_DEFAULT, LITERAL_CASE, LITERAL_SWITCH
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.emptyblock;
 
 public class InputEmptyBlockSwitchExpressionsOne {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/InputEmptyBlockSwitchExpressionsTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/InputEmptyBlockSwitchExpressionsTwo.java
@@ -6,7 +6,7 @@ tokens = LITERAL_DEFAULT, LITERAL_CASE, LITERAL_SWITCH
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.emptyblock;
 
 public class InputEmptyBlockSwitchExpressionsTwo {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestRecordsAndCompactCtors.java
@@ -11,7 +11,7 @@ tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
 import org.w3c.dom.Node;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestSwitchExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestSwitchExpressions.java
@@ -11,7 +11,7 @@ tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 
 public class InputLeftCurlyTestSwitchExpressions {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestSwitchExpressionsNewLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestSwitchExpressionsNewLine.java
@@ -11,7 +11,7 @@ tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 // violation below ''{' at column 57 should be on a new line'
 public class InputLeftCurlyTestSwitchExpressionsNewLine {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesPatternMatchingForSwitch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesPatternMatchingForSwitch.java
@@ -7,7 +7,7 @@ tokens = LITERAL_CASE, LITERAL_DEFAULT, LAMBDA
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.needbraces;
 
 public class InputNeedBracesPatternMatchingForSwitch {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesPatternMatchingForSwitchAllowSingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesPatternMatchingForSwitchAllowSingleLine.java
@@ -7,7 +7,7 @@ tokens = LITERAL_CASE, LITERAL_DEFAULT, LAMBDA
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.needbraces;
 
 public class InputNeedBracesPatternMatchingForSwitchAllowSingleLine {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesSwitchExpressionAndLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesSwitchExpressionAndLambda.java
@@ -7,7 +7,7 @@ tokens = LITERAL_CASE, LITERAL_DEFAULT, LAMBDA
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.needbraces;
 
 import java.util.Arrays;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesSwitchExpressionAndLambdaAllowSingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesSwitchExpressionAndLambdaAllowSingleLine.java
@@ -7,7 +7,7 @@ tokens = LITERAL_CASE, LITERAL_DEFAULT, LAMBDA
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.needbraces;
 
 import java.util.Arrays;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesTestSwitchExpression1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesTestSwitchExpression1.java
@@ -7,7 +7,7 @@ tokens = LITERAL_CASE, LITERAL_DEFAULT, LAMBDA
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.needbraces;
 
 public class InputNeedBracesTestSwitchExpression1 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesTestSwitchExpression2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesTestSwitchExpression2.java
@@ -7,7 +7,7 @@ tokens = LITERAL_CASE, LITERAL_DEFAULT, LAMBDA
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.needbraces;
 
 public class InputNeedBracesTestSwitchExpression2 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesTestSwitchExpressionNoSingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/needbraces/InputNeedBracesTestSwitchExpressionNoSingleLine.java
@@ -7,7 +7,7 @@ tokens = LITERAL_CASE, LITERAL_DEFAULT, LAMBDA
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.needbraces;
 
 public class InputNeedBracesTestSwitchExpressionNoSingleLine {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchExpressionAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchExpressionAlone.java
@@ -5,7 +5,7 @@ tokens = LITERAL_CASE, LITERAL_IF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyCaseBlocksWithSwitchExpressionAlone {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchExpressionAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchExpressionAloneOrSingleline.java
@@ -5,7 +5,7 @@ tokens = LITERAL_CASE, LITERAL_IF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyCaseBlocksWithSwitchExpressionAloneOrSingleline {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchRuleAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchRuleAlone.java
@@ -5,7 +5,7 @@ tokens = LITERAL_CASE
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyCaseBlocksWithSwitchRuleAlone {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchRuleAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchRuleAloneOrSingleline.java
@@ -5,7 +5,7 @@ tokens = LITERAL_CASE
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyCaseBlocksWithSwitchRuleAloneOrSingleline {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestRecordsAndCompactCtors.java
@@ -6,7 +6,7 @@ tokens = RECORD_DEF, COMPACT_CTOR_DEF, CTOR_DEF, METHOD_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 import org.w3c.dom.Node;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression.java
@@ -6,7 +6,7 @@ tokens = LITERAL_SWITCH, LITERAL_IF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyTestSwitchExpression {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression2.java
@@ -6,7 +6,7 @@ tokens = LITERAL_SWITCH, LITERAL_IF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyTestSwitchExpression2 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression3.java
@@ -6,7 +6,7 @@ tokens = LITERAL_SWITCH, LITERAL_IF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyTestSwitchExpression3 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression4.java
@@ -5,7 +5,7 @@ tokens = LITERAL_SWITCH
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyTestSwitchExpression4 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression5.java
@@ -5,7 +5,7 @@ tokens = LITERAL_SWITCH
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 import java.io.IOException;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression6.java
@@ -5,7 +5,7 @@ tokens = LITERAL_SWITCH
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyTestSwitchExpression6 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression7.java
@@ -5,7 +5,7 @@ tokens = LITERAL_SWITCH
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyTestSwitchExpression7 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/covariantequals/InputCovariantEqualsRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/covariantequals/InputCovariantEqualsRecords.java
@@ -4,7 +4,7 @@ CovariantEquals
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.covariantequals;
 
 public class InputCovariantEqualsRecords {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderRecordsAndCompactCtors.java
@@ -6,7 +6,7 @@ ignoreModifiers = (default)false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.declarationorder;
 
 import java.util.HashMap;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSwitchExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSwitchExpressions.java
@@ -5,7 +5,7 @@ skipIfLastAndSharedWithCase = (default)false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.defaultcomeslast;
 
 public class InputDefaultComesLastSwitchExpressions {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSwitchExpressionsSkipIfLast.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSwitchExpressionsSkipIfLast.java
@@ -5,7 +5,7 @@ skipIfLastAndSharedWithCase = true
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.defaultcomeslast;
 
 public class InputDefaultComesLastSwitchExpressionsSkipIfLast {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullEnhancedInstanceof.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullEnhancedInstanceof.java
@@ -5,7 +5,7 @@ ignoreEqualsIgnoreCase = (default)false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.equalsavoidnull;
 
 public class InputEqualsAvoidNullEnhancedInstanceof {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullRecordsAndCompactCtors.java
@@ -5,7 +5,7 @@ ignoreEqualsIgnoreCase = (default)false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.equalsavoidnull;
 
 public class InputEqualsAvoidNullRecordsAndCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullTextBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullTextBlocks.java
@@ -5,7 +5,7 @@ ignoreEqualsIgnoreCase = (default)false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.equalsavoidnull;
 
 public class InputEqualsAvoidNullTextBlocks {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough10.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough10.java
@@ -6,7 +6,7 @@ reliefPattern = (default)falls?[ -]?thr(u|ough)
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.fallthrough;
 
 public class InputFallThrough10 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough11.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough11.java
@@ -6,7 +6,7 @@ reliefPattern = (default)falls?[ -]?thr(u|ough)
 
 */
 
-// Java19
+
 package com.puppycrawl.tools.checkstyle.checks.coding.fallthrough;
 
 public class InputFallThrough11 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough9.java
@@ -6,7 +6,7 @@ reliefPattern = (default)falls?[ -]?thr(u|ough)
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.fallthrough;
 
 public class InputFallThrough9

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughSwitchRules.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughSwitchRules.java
@@ -6,7 +6,7 @@ reliefPattern = (default)falls?[ -]?thr(u|ough)
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.fallthrough;
 
 public class InputFallThroughSwitchRules {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldClassNestedInRecord.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldClassNestedInRecord.java
@@ -10,7 +10,7 @@ tokens = (default)VARIABLE_DEF, PARAMETER_DEF, PATTERN_VARIABLE_DEF, LAMBDA, REC
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.hiddenfield;
 
 public class InputHiddenFieldClassNestedInRecord {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldEnhancedInstanceof.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldEnhancedInstanceof.java
@@ -10,7 +10,7 @@ tokens = PATTERN_VARIABLE_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.hiddenfield;
 
 import java.util.Locale;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldInnerRecordsImplicitlyStatic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldInnerRecordsImplicitlyStatic.java
@@ -8,7 +8,7 @@ tokens = (default)VARIABLE_DEF, PARAMETER_DEF, PATTERN_VARIABLE_DEF, LAMBDA, REC
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.hiddenfield;
 
 import java.time.Clock;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldRecords.java
@@ -10,7 +10,7 @@ tokens = (default)VARIABLE_DEF, PARAMETER_DEF, PATTERN_VARIABLE_DEF, LAMBDA, REC
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.hiddenfield;
 
 import java.util.Locale;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldRecordsImplicitlyStaticClassComparison.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldRecordsImplicitlyStaticClassComparison.java
@@ -8,7 +8,7 @@ tokens = (default)VARIABLE_DEF, PARAMETER_DEF, PATTERN_VARIABLE_DEF, LAMBDA, REC
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.hiddenfield;
 
 import java.io.Externalizable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldSwitchExpression.java
@@ -10,7 +10,7 @@ tokens = (default)VARIABLE_DEF, PARAMETER_DEF, PATTERN_VARIABLE_DEF, LAMBDA, REC
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.hiddenfield;
 
 import java.util.stream.Stream;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocks.java
@@ -8,7 +8,7 @@ tokens = STRING_LITERAL, TEXT_BLOCK_CONTENT
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
 
 public class InputIllegalTokenTextTextBlocks {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocksQuotes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocksQuotes.java
@@ -8,7 +8,7 @@ tokens = STRING_LITERAL, TEXT_BLOCK_CONTENT
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
 
 public class InputIllegalTokenTextTextBlocksQuotes {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeInPermitsList.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeInPermitsList.java
@@ -13,7 +13,7 @@ tokens = (default)ANNOTATION_FIELD_DEF, CLASS_DEF, INTERFACE_DEF, METHOD_CALL, M
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 class D { }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsAndCompactCtors.java
@@ -15,7 +15,7 @@ tokens = (default)ANNOTATION_FIELD_DEF, CLASS_DEF, INTERFACE_DEF, METHOD_CALL, M
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 import java.util.HashMap;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsWithMemberModifiersDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsWithMemberModifiersDefault.java
@@ -15,7 +15,7 @@ tokens = (default)ANNOTATION_FIELD_DEF, CLASS_DEF, INTERFACE_DEF, METHOD_CALL, M
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 import java.util.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsWithMemberModifiersFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsWithMemberModifiersFinal.java
@@ -15,7 +15,7 @@ tokens = (default)ANNOTATION_FIELD_DEF, CLASS_DEF, INTERFACE_DEF, METHOD_CALL, M
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 import java.util.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsWithMemberModifiersPrivateFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsWithMemberModifiersPrivateFinal.java
@@ -15,7 +15,7 @@ tokens = (default)ANNOTATION_FIELD_DEF, CLASS_DEF, INTERFACE_DEF, METHOD_CALL, M
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 import java.util.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsWithMemberModifiersPublicProtectedStatic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsWithMemberModifiersPublicProtectedStatic.java
@@ -15,7 +15,7 @@ tokens = (default)ANNOTATION_FIELD_DEF, CLASS_DEF, INTERFACE_DEF, METHOD_CALL, M
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 import java.util.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestEnhancedInstanceof.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestEnhancedInstanceof.java
@@ -15,7 +15,7 @@ tokens = (default)ANNOTATION_FIELD_DEF, CLASS_DEF, INTERFACE_DEF, METHOD_CALL, M
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 import java.util.HashMap;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/innerassignment/InputInnerAssignmentSwitchAndSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/innerassignment/InputInnerAssignmentSwitchAndSwitchExpression.java
@@ -3,7 +3,7 @@ InnerAssignment
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.innerassignment;
 
 public class InputInnerAssignmentSwitchAndSwitchExpression {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckNullCaseLabel.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckNullCaseLabel.java
@@ -4,7 +4,7 @@ MissingSwitchDefault
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.coding.missingswitchdefault;
 
 public class InputMissingSwitchDefaultCheckNullCaseLabel {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressionUnderMethodCall.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressionUnderMethodCall.java
@@ -4,7 +4,7 @@ MissingSwitchDefault
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.missingswitchdefault;
 
 import java.util.Optional;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressions.java
@@ -4,7 +4,7 @@ MissingSwitchDefault
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.missingswitchdefault;
 
 public class InputMissingSwitchDefaultCheckSwitchExpressions {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressionsThree.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressionsThree.java
@@ -4,7 +4,7 @@ MissingSwitchDefault
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.missingswitchdefault;
 
 import java.util.stream.Stream;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressionsTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressionsTwo.java
@@ -4,7 +4,7 @@ MissingSwitchDefault
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.missingswitchdefault;
 
 public class InputMissingSwitchDefaultCheckSwitchExpressionsTwo {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
@@ -7,7 +7,7 @@ ignoreOccurrenceContext = (default)ANNOTATION
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiteralsTextBlocks1 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks2.java
@@ -7,7 +7,7 @@ ignoreOccurrenceContext = (default)ANNOTATION
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiteralsTextBlocks2 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/InputNestedIfDepthInsideCaseBody.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/InputNestedIfDepthInsideCaseBody.java
@@ -4,7 +4,7 @@ max = (default)1
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.coding.nestedifdepth;
 
 public class InputNestedIfDepthInsideCaseBody {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderRecords.java
@@ -4,7 +4,7 @@ OverloadMethodsDeclarationOrder
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
 
 public class InputOverloadMethodsDeclarationOrderRecords {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/parameterassignment/InputParameterAssignmentWithEnhancedSwitch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/parameterassignment/InputParameterAssignmentWithEnhancedSwitch.java
@@ -4,7 +4,7 @@ ParameterAssignment
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.parameterassignment;
 
 public class InputParameterAssignmentWithEnhancedSwitch {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/patternvariableassignment/InputPatternVariableAssignmentCheck1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/patternvariableassignment/InputPatternVariableAssignmentCheck1.java
@@ -6,7 +6,7 @@
 </module>
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.coding.patternvariableassignment;
 
 public class InputPatternVariableAssignmentCheck1 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordAsTopLevel.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordAsTopLevel.java
@@ -7,7 +7,7 @@ validateOnlyOverlapping = false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
 
 public record InputRequireThisRecordAsTopLevel(int x, int y) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordCompactCtors.java
@@ -7,7 +7,7 @@ validateOnlyOverlapping = false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
 import java.util.Map;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordDefault.java
@@ -7,7 +7,7 @@ validateOnlyOverlapping = (default)true
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
 
 public record InputRequireThisRecordDefault(int x, int y) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordsAndCompactCtors.java
@@ -7,7 +7,7 @@ validateOnlyOverlapping = false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
 
 public class InputRequireThisRecordsAndCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordsWithCheckFields.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordsWithCheckFields.java
@@ -7,7 +7,7 @@ validateOnlyOverlapping = (default)true
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
 
 public record InputRequireThisRecordsWithCheckFields(String a) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordsWithCheckFieldsOverlap.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordsWithCheckFieldsOverlap.java
@@ -7,7 +7,7 @@ validateOnlyOverlapping = false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
 
 public record InputRequireThisRecordsWithCheckFieldsOverlap(String a) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisValidateOnlyOverlappingFalseLeaves.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisValidateOnlyOverlappingFalseLeaves.java
@@ -6,7 +6,7 @@ validateOnlyOverlapping = false
 
 
 */
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
 
 public class InputRequireThisValidateOnlyOverlappingFalseLeaves {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanreturn/InputSimplifyBooleanReturnWithYield.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanreturn/InputSimplifyBooleanReturnWithYield.java
@@ -3,7 +3,7 @@ SimplifyBooleanReturn
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.coding.simplifybooleanreturn;
 
 public class InputSimplifyBooleanReturnWithYield {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityCheckTextBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityCheckTextBlocks.java
@@ -4,7 +4,7 @@ StringLiteralEquality
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.stringliteralequality;
 
 public class InputStringLiteralEqualityCheckTextBlocks {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityConcatenatedTextBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityConcatenatedTextBlocks.java
@@ -4,7 +4,7 @@ StringLiteralEquality
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.stringliteralequality;
 
 public class InputStringLiteralEqualityConcatenatedTextBlocks {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfPair.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfPair.java
@@ -3,7 +3,7 @@ UnnecessaryNullCheckWithInstanceOf
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarynullcheckwithinstanceof;
 
 record Pair<T, U>(T first, U second) {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof/InputUnnecessaryNullCheckWithInstanceOfTwo.java
@@ -3,7 +3,7 @@ UnnecessaryNullCheckWithInstanceOf
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarynullcheckwithinstanceof;
 
 public class InputUnnecessaryNullCheckWithInstanceOfTwo {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckSwitchExpression.java
@@ -11,7 +11,7 @@ tokens = (default)EXPR, IDENT, NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG, \
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.unnecessaryparentheses;
 
 public class InputUnnecessaryParenthesesCheckSwitchExpression {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckTextBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckTextBlocks.java
@@ -11,7 +11,7 @@ tokens = (default)EXPR, IDENT, NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG, \
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.unnecessaryparentheses;
 
 public class InputUnnecessaryParenthesesCheckTextBlocks {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesWhenExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesWhenExpressions.java
@@ -11,7 +11,7 @@ tokens = (default)EXPR, IDENT, NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG, \
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.coding.unnecessaryparentheses;
 
 public class InputUnnecessaryParenthesesWhenExpressions {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/InputUnnecessarySemicolonAfterOuterTypeDeclarationRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/InputUnnecessarySemicolonAfterOuterTypeDeclarationRecords.java
@@ -5,7 +5,7 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarysemicolonafteroutertypedeclaration;
 
 public record InputUnnecessarySemicolonAfterOuterTypeDeclarationRecords() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonaftertypememberdeclaration/InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonaftertypememberdeclaration/InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords.java
@@ -7,7 +7,7 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, VARIABLE_D
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarysemicolonaftertypememberdeclaration;
 
 public record InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/InputUnusedCatchParameterShouldBeUnnamedInsideAnonClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedcatchparametershouldbeunnamed/InputUnusedCatchParameterShouldBeUnnamedInsideAnonClass.java
@@ -3,7 +3,7 @@ UnusedCatchParameterShouldBeUnnamed
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedcatchparametershouldbeunnamed;
 
 public class InputUnusedCatchParameterShouldBeUnnamedInsideAnonClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableRecords.java
@@ -8,7 +8,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
 
 import java.util.function.Predicate;
 
-// Java17
+
 public record InputUnusedLocalVariableRecords(int a, int b) {
     public InputUnusedLocalVariableRecords {
         int ab = 12;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableSwitchExpression.java
@@ -4,7 +4,7 @@ allowUnnamedVariables = false
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
 
 public class InputUnusedLocalVariableSwitchExpression {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/InputWhenShouldBeUsedNonPatternsSwitch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused/InputWhenShouldBeUsedNonPatternsSwitch.java
@@ -3,7 +3,7 @@ WhenShouldBeUsed
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.coding.whenshouldbeused;
 
 public class InputWhenShouldBeUsedNonPatternsSwitch {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRecords.java
@@ -6,7 +6,7 @@ requiredJavadocPhrase = (default).*
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 
 public record InputDesignForExtensionRecords(String string) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassConstructorInRecord.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassConstructorInRecord.java
@@ -4,7 +4,7 @@ FinalClass
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.design.finalclass;
 
 public record InputFinalClassConstructorInRecord(String string) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedInRecord.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedInRecord.java
@@ -4,7 +4,7 @@ FinalClass
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.design.finalclass;
 
 public record InputFinalClassNestedInRecord(int a) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedStaticClassInsideInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedStaticClassInsideInnerClass.java
@@ -4,7 +4,7 @@ FinalClass
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.design.finalclass;
 
 public class InputFinalClassNestedStaticClassInsideInnerClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/InputInnerTypeLastRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/InputInnerTypeLastRecords.java
@@ -4,7 +4,7 @@ InnerTypeLast
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.design.innertypelast;
 
 public class InputInnerTypeLastRecords {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassRecords.java
@@ -4,7 +4,7 @@ OneTopLevelClass
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
 
 public record InputOneTopLevelClassRecords() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListInnerClass.java
@@ -2,7 +2,7 @@
 SealedShouldHavePermitsList
 
 */
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.design.sealedshouldhavepermitslist;
 
 public class InputSealedShouldHavePermitsListInnerClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListInnerInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListInnerInterface.java
@@ -3,7 +3,7 @@ SealedShouldHavePermitsList
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.design.sealedshouldhavepermitslist;
 
 public class InputSealedShouldHavePermitsListInnerInterface {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListJepExample.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListJepExample.java
@@ -3,7 +3,7 @@ SealedShouldHavePermitsList
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.design.sealedshouldhavepermitslist;
 
 // violation below 'Sealed classes or interfaces should explicitly declare permitted subclasses'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListTopLevelSealedClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListTopLevelSealedClass.java
@@ -3,7 +3,7 @@ SealedShouldHavePermitsList
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.design.sealedshouldhavepermitslist;
 
 public sealed class InputSealedShouldHavePermitsListTopLevelSealedClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListTopLevelSealedInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/sealedshouldhavepermitslist/InputSealedShouldHavePermitsListTopLevelSealedInterface.java
@@ -3,7 +3,7 @@ SealedShouldHavePermitsList
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.design.sealedshouldhavepermitslist;
 
 public sealed interface InputSealedShouldHavePermitsListTopLevelSealedInterface {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPatternVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPatternVariables.java
@@ -7,7 +7,7 @@ tokens = PATTERN_VARIABLE_DEF
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 
 public class InputFinalParametersPatternVariables {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsRecordsAndCompactCtors.java
@@ -5,7 +5,7 @@ violateExecutionOnNonTightHtml = (default)false
 
 
 */
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
 
 import java.util.ArrayDeque;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationRecordsAndCompactCtors.java
@@ -5,7 +5,7 @@ tokens = (default)SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;
 
 public class InputCommentsIndentationRecordsAndCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSingleSwitchStatementsWithoutCurly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSingleSwitchStatementsWithoutCurly.java
@@ -1,4 +1,4 @@
-// Java17                                                               //indent:0 exp:0
+//                                                                      //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
 
 /* Config:                                                              //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpression.java
@@ -1,4 +1,4 @@
-// Java17                                                                //indent:0 exp:0
+//                                                                       //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;  //indent:0 exp:0
                                                                                   //indent:82 exp:82
 /* Config:                                                               //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionCorrect.java
@@ -1,4 +1,4 @@
-// Java17                                                                //indent:0 exp:0
+//                                                                       //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;  //indent:0 exp:0
                                                                                   //indent:82 exp:82
 /* Config:                                                               //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionDeclaration.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionDeclaration.java
@@ -1,4 +1,4 @@
-// Java17                                                                  //indent:0 exp:0
+//                                                                         //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
                                                                                   //indent:82 exp:82
 /* Config:                                                                 //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionDeclarationLCurlyNewLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionDeclarationLCurlyNewLine.java
@@ -1,4 +1,4 @@
-// Java17                                                                     //indent:0 exp:0
+//                                                                            //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;       //indent:0 exp:0
 
 /* Config:                                                                    //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionNewLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionNewLine.java
@@ -1,4 +1,4 @@
-// Java17                                                                  //indent:0 exp:0
+//                                                                         //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;    //indent:0 exp:0
                                                                                   //indent:82 exp:82
 /* Config:                                                                 //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCodeBlocks2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCodeBlocks2.java
@@ -1,5 +1,5 @@
 
-// Java17                                                                    //indent:0 exp:0
+//                                                                           //indent:0 exp:0
 
 /* Config:                                                                   //indent:0 exp:0
  * This test-input is intended to be checked using following configuration:  //indent:1 exp:1

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaAndChildOnTheSameLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaAndChildOnTheSameLine.java
@@ -1,4 +1,4 @@
-// Java17                                                                   //indent:0 exp:0
+//                                                                          //indent:0 exp:0
 
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaChild.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaChild.java
@@ -1,4 +1,4 @@
-// Java17                                                                    //indent:0 exp:0
+//                                                                           //indent:0 exp:0
 
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLineWrappedRecordDeclaration.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLineWrappedRecordDeclaration.java
@@ -1,4 +1,4 @@
-// Java17                                                               //indent:0 exp:0
+//                                                                      //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
                                                                         //indent:72 exp:72
 import java.io.IOException;                                             //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationMultilineStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationMultilineStatements.java
@@ -1,4 +1,4 @@
-// Java17                                                                      //indent:0 exp:0
+//                                                                             //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;        //indent:0 exp:0
 
 /**                                                                            //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationPatternMatchingForSwitch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationPatternMatchingForSwitch.java
@@ -1,4 +1,4 @@
-// Java21                                                                   //indent:0 exp:0
+//                                                                          //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
 //indent:0 exp:0
 //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationRecords.java
@@ -1,4 +1,4 @@
-// Java17                                                                     //indent:0 exp:0
+//                                                                            //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;       //indent:0 exp:0
                                                                                   //indent:82 exp:82
 import java.util.List;                                                        //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationRecordsAndCompactCtors.java
@@ -1,4 +1,4 @@
-// Java17                                                                 //indent:0 exp:0
+//                                                                        //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;   //indent:0 exp:0
                                                                                   //indent:82 exp:82
 import org.w3c.dom.Node;                                                  //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSealedClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSealedClasses.java
@@ -1,4 +1,4 @@
-// Java21                                                                   //indent:0 exp:0
+//                                                                          //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSwitchExpressionWrappingIndentation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSwitchExpressionWrappingIndentation.java
@@ -1,4 +1,4 @@
-// Java17                                                                    //indent:0 exp:0
+//                                                                           //indent:0 exp:0
 
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSwitchOnStartOfLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSwitchOnStartOfLine.java
@@ -1,4 +1,4 @@
-// Java17                                                                    //indent:0 exp:0
+//                                                                           //indent:0 exp:0
 
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;      //indent:0 exp:0
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTextBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTextBlock.java
@@ -1,4 +1,4 @@
-// Java17                                                                   //indent:0 exp:0
+//                                                                          //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
 
 /* Config:                                                                  //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldForceStrict.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldForceStrict.java
@@ -1,4 +1,4 @@
-// Java17                                                                 //indent:0 exp:0
+//                                                                        //indent:0 exp:0
 
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;   //indent:0 exp:0
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldStatement.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationYieldStatement.java
@@ -1,4 +1,4 @@
-// Java17                                                                   //indent:0 exp:0
+//                                                                          //indent:0 exp:0
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
                                                                                   //indent:82 exp:82
 enum Day {                                                                  //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords1.java
@@ -9,7 +9,7 @@ tagOrder = (default)@author, @version, @param, @return, @throws, @exception, @se
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 
 import java.io.IOException;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords2.java
@@ -9,7 +9,7 @@ tagOrder = (default)@author, @version, @param, @return, @throws, @exception, @se
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 
 import java.io.IOException;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords3.java
@@ -10,7 +10,7 @@ tagOrder = (default)@author, @version, @param, @return, @throws, @exception, @se
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 
 import java.io.IOException;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords4.java
@@ -9,7 +9,7 @@ tagOrder = (default)@author, @version, @param, @return, @throws, @exception, @se
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 
 import java.io.IOException;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
@@ -9,7 +9,7 @@ tagOrder = (default)@author, @version, @param, @return, @throws, @exception, @se
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 
 import java.io.Serializable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompilationUnit.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompilationUnit.java
@@ -10,7 +10,7 @@ tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 
 */
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 @Deprecated @ProblemCauser

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords.java
@@ -11,7 +11,7 @@ tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords2.java
@@ -11,7 +11,7 @@ tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords3.java
@@ -11,7 +11,7 @@ tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
@@ -11,7 +11,7 @@ tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodRecordsAndCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleRecordsAndCompactCtors.java
@@ -13,7 +13,7 @@ tokens = (default)ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, \
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
 
 public class InputJavadocStyleRecordsAndCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents.java
@@ -12,7 +12,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents2.java
@@ -12,7 +12,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
 import java.util.HashMap;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordParamDescriptionWithAngularTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordParamDescriptionWithAngularTags.java
@@ -9,7 +9,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecords.java
@@ -12,7 +12,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodBasic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodBasic.java
@@ -7,7 +7,7 @@ allowMissingPropertyJavadoc = true
 tokens = (default)METHOD_DEF , CTOR_DEF , ANNOTATION_FIELD_DEF , COMPACT_CTOR_DEF
 
 */
-// java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
 public class InputMissingJavadocMethodBasic {
     public void validAssign(String result) {// violation 'Missing a Javadoc comment'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodRecordsAndCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodRecordsAndCtors.java
@@ -11,7 +11,7 @@ tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
 
-// java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
 
 public class InputMissingJavadocMethodRecordsAndCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodRecordsAndCtorsMinLineCount.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodRecordsAndCtorsMinLineCount.java
@@ -11,7 +11,7 @@ tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
 
-// java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
 
 public class InputMissingJavadocMethodRecordsAndCtorsMinLineCount {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeRecords.java
@@ -9,7 +9,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 */
 
-// java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 public record InputMissingJavadocTypeRecords() { // violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagRecordsAndCompactCtors.java
@@ -8,7 +8,7 @@ tokens = INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, COMPACT
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordLeaves.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordLeaves.java
@@ -6,7 +6,7 @@ tokens = (default)LAND, BAND, LOR, BOR, BXOR
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.booleanexpressioncomplexity;
 
 public record InputBooleanExpressionComplexityRecordLeaves() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityRecordsAndCompactCtors.java
@@ -6,7 +6,7 @@ tokens = (default)LAND, BAND, LOR, BOR, BXOR
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.booleanexpressioncomplexity;
 
 public class InputBooleanExpressionComplexityRecordsAndCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingRecords.java
@@ -18,7 +18,7 @@ excludedPackages = (default)
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling;
 
 import java.sql.Time;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityRecords.java
@@ -18,7 +18,7 @@ excludedPackages = (default)
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 
 import javax.naming.NamingException;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexitySealedClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexitySealedClasses.java
@@ -18,7 +18,7 @@ excludedPackages = (default)
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 
 // violation below, 'Class Fan-Out Complexity is 2 (max allowed is 0)'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityRecords1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityRecords1.java
@@ -8,7 +8,7 @@ tokens = (default)LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_SW
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexityRecords1 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityRecords2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityRecords2.java
@@ -8,7 +8,7 @@ tokens = (default)LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_SW
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexityRecords2 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexitySwitchBlocks6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexitySwitchBlocks6.java
@@ -8,7 +8,7 @@ tokens = (default)LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_SW
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexitySwitchBlocks6 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityWhenExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityWhenExpression.java
@@ -7,7 +7,7 @@ tokens = (default)LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_SW
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexityWhenExpression {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityWhenSwitchAsSinglePoint.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity/InputCyclomaticComplexityWhenSwitchAsSinglePoint.java
@@ -7,7 +7,7 @@ tokens = (default)LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_SW
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.cyclomaticcomplexity;
 
 public class InputCyclomaticComplexityWhenSwitchAsSinglePoint {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSRecordsAndCompactCtors.java
@@ -8,7 +8,7 @@ recordMaximum = 4
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.javancss;  // violation 'NCSS for this file is 55 (max allowed is 2).'
 
 public class InputJavaNCSSRecordsAndCompactCtors {  // violation '.* is 54 (max allowed is 3).'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSRecordsMax.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSRecordsMax.java
@@ -8,7 +8,7 @@ recordMaximum = 100
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.javancss;
 
 public class InputJavaNCSSRecordsMax {// violation 'NCSS for this class is 105 (max allowed is 80)'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityCheckSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityCheckSwitchExpression.java
@@ -5,7 +5,7 @@ max = 1
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.npathcomplexity;
 
 public class InputNPathComplexityCheckSwitchExpression {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityDefault3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityDefault3.java
@@ -5,7 +5,7 @@ max = 0
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.npathcomplexity;
 
 public class InputNPathComplexityDefault3 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityRecords.java
@@ -5,7 +5,7 @@ max = 1
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.npathcomplexity;
 
 public class InputNPathComplexityRecords {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityWhenExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityWhenExpression.java
@@ -5,7 +5,7 @@ max = 1
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.metrics.npathcomplexity;
 
 public class InputNPathComplexityWhenExpression {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierSealedClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierSealedClasses.java
@@ -11,7 +11,7 @@ violateImpliedStaticNested = (default)true
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.modifier.interfacememberimpliedmodifier;
 
 public interface InputInterfaceMemberImpliedModifierSealedClasses {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderSealedAndNonSealed.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderSealedAndNonSealed.java
@@ -4,7 +4,7 @@ ModifierOrder
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.modifier.modifierorder;
 // violation below ''public' modifier out of order with the JLS suggestions.'
 sealed public class InputModifierOrderSealedAndNonSealed

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderSealedAndNonSealedNoViolation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderSealedAndNonSealedNoViolation.java
@@ -4,7 +4,7 @@ ModifierOrder
 
 */
 
-// java17
+
 package com.puppycrawl.tools.checkstyle.checks.modifier.modifierorder;
 
 public sealed class InputModifierOrderSealedAndNonSealedNoViolation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckEnhancedInstanceof.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckEnhancedInstanceof.java
@@ -13,7 +13,7 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
 import java.util.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckEnhancedInstanceofAllowXmlLength1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckEnhancedInstanceofAllowXmlLength1.java
@@ -13,7 +13,7 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
 import java.util.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckRecords.java
@@ -13,7 +13,7 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
 import org.w3c.dom.Node;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/lambdaparametername/InputLambdaParameterNameSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/lambdaparametername/InputLambdaParameterNameSwitchExpression.java
@@ -5,7 +5,7 @@ format = (default)^([a-z][a-zA-Z0-9]*|_)$
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.lambdaparametername;
 
 import java.util.stream.Stream;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameRecordInInterfaceBody.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNameRecordInInterfaceBody.java
@@ -9,7 +9,7 @@ applyToPrivate = (default)true
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 
 public interface InputMethodNameRecordInInterfaceBody {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofNoSingleChar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofNoSingleChar.java
@@ -5,7 +5,7 @@ format = ^[a-z][a-zA-Z0-9]+$
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.patternvariablename;
 
 import java.util.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofTestDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofTestDefault.java
@@ -5,7 +5,7 @@ format = (default)^([a-z][a-zA-Z0-9]*|_)$
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.patternvariablename;
 
 import java.util.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/InputRecordComponentNameDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/InputRecordComponentNameDefault.java
@@ -5,7 +5,7 @@ format = (default)^[a-z][a-zA-Z0-9]*$
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.recordcomponentname;
 
 import java.io.Serializable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/InputRecordComponentNameLowercase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/InputRecordComponentNameLowercase.java
@@ -5,7 +5,7 @@ format = ^[a-z0-9]+$
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.recordcomponentname;
 
 import java.io.Serializable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordtypeparametername/InputRecordTypeParameterName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordtypeparametername/InputRecordTypeParameterName.java
@@ -5,7 +5,7 @@ format = (default)^[A-Z]$
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.recordtypeparametername;
 
 import java.io.Serializable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordtypeparametername/InputRecordTypeParameterNameFoo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordtypeparametername/InputRecordTypeParameterNameFoo.java
@@ -5,7 +5,7 @@ format = ^foo$
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.recordtypeparametername;
 
 import java.io.Serializable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/typename/InputTypeNameRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/typename/InputTypeNameRecords.java
@@ -10,7 +10,7 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.naming.typename;
 
 public class InputTypeNameRecords {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountRecords.java
@@ -6,7 +6,7 @@ tokens = (default)CTOR_DEF, METHOD_DEF, INSTANCE_INIT, STATIC_INIT, COMPACT_CTOR
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.executablestatementcount;
 
 public class InputExecutableStatementCountRecords {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/lambdabodylength/InputLambdaBodyLengthSwitchExps.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/lambdabodylength/InputLambdaBodyLengthSwitchExps.java
@@ -5,7 +5,7 @@ max = (default)10
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.lambdabodylength;
 
 import java.util.stream.Stream;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringImportStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringImportStatements.java
@@ -6,7 +6,7 @@ max = 75
 tabWidth = (default)0
 
 */
-// Java17
+
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringPackageStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthIgnoringPackageStatements.java
@@ -6,7 +6,7 @@ max = 75
 tabWidth = (default)0
 
 */
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
 
 public class InputLineLengthIgnoringPackageStatements {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountRecords.java
@@ -10,7 +10,7 @@ tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTAT
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodcount;
 
 public class InputMethodCountRecords {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCompactCtorsCountEmpty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCompactCtorsCountEmpty.java
@@ -7,7 +7,7 @@ tokens = (default)METHOD_DEF, CTOR_DEF, COMPACT_CTOR_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
 
 public class InputMethodLengthCompactCtorsCountEmpty {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthRecordsAndCompactCtors.java
@@ -7,7 +7,7 @@ tokens = (default)METHOD_DEF, CTOR_DEF, COMPACT_CTOR_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
 
 public class InputMethodLengthRecordsAndCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthTextBlocksCountEmpty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthTextBlocksCountEmpty.java
@@ -7,7 +7,7 @@ tokens = (default)METHOD_DEF, CTOR_DEF, COMPACT_CTOR_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
 
 public class InputMethodLengthTextBlocksCountEmpty {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberRecords.java
@@ -5,7 +5,7 @@ max = (default)1
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber; // violation
 
 class InputOuterTypeNumberRecords { }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberMax1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberMax1.java
@@ -6,7 +6,7 @@ accessModifiers = (default)public, protected, package, private
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 
 import java.awt.Point;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberMax20.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberMax20.java
@@ -6,7 +6,7 @@ accessModifiers = (default)public, protected, package, private
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 
 import java.awt.Point;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberOne.java
@@ -6,7 +6,7 @@ accessModifiers = (default)public, protected, package, private
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 
 import java.awt.Point;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberPrivateModifierOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberPrivateModifierOne.java
@@ -7,7 +7,7 @@ accessModifiers = private
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 
 import java.awt.Point;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberPrivateModifierTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberPrivateModifierTwo.java
@@ -7,7 +7,7 @@ accessModifiers = private
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 
 import java.util.ArrayDeque;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTopLevel1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTopLevel1.java
@@ -6,7 +6,7 @@ accessModifiers = (default)public, protected, package, private
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 
 public record InputRecordComponentNumberTopLevel1(int x, int y, int z, // violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTopLevel2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTopLevel2.java
@@ -6,7 +6,7 @@ accessModifiers = (default)public, protected, package, private
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 
 public record InputRecordComponentNumberTopLevel2<T>() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTwo.java
@@ -6,7 +6,7 @@ accessModifiers = (default)public, protected, package, private
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 
 import java.util.ArrayDeque;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderTextBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderTextBlocks.java
@@ -14,7 +14,7 @@ applyToPrivate = (default)true
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
 
 /* Config:

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainBeginTree2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainBeginTree2.java
@@ -4,7 +4,7 @@ UncommentedMain
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.uncommentedmain;
 
 public record InputUncommentedMainBeginTree2(Integer x) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainRecords.java
@@ -5,7 +5,7 @@ excludedClasses = (default)^$
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.uncommentedmain;
 
 public record InputUncommentedMainRecords(Integer x) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainRecords2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainRecords2.java
@@ -5,7 +5,7 @@ excludedClasses = (default)^$
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.uncommentedmain;
 
 public record InputUncommentedMainRecords2(Integer x) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorMultipleLines3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorMultipleLines3.java
@@ -10,7 +10,7 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 
 */
 
-// Java17
+
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorRecordsAndCompactCtors.java
@@ -10,7 +10,7 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 
 */
 
-// Java17
+//
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; // violation ''package' should be separated from previous line.'
 
 public class InputEmptyLineSeparatorRecordsAndCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorRecordsAndCompactCtorsNoEmptyLines.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorRecordsAndCompactCtorsNoEmptyLines.java
@@ -10,7 +10,7 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 
 */
 
-// Java17
+//
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; // violation ''package' should be separated from previous line.'
 
 public class InputEmptyLineSeparatorRecordsAndCompactCtorsNoEmptyLines {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceBeforeRecordHeader.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceBeforeRecordHeader.java
@@ -4,7 +4,7 @@ GenericWhitespace
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.genericwhitespace;
 
 import java.lang.annotation.Target;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPadRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPadRecords.java
@@ -8,7 +8,7 @@ tokens = (default)CTOR_DEF, CTOR_CALL, LITERAL_NEW, METHOD_CALL, METHOD_DEF, SUP
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.methodparampad;
 
 import org.w3c.dom.Node;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapRecordsAndCompactCtors.java
@@ -5,7 +5,7 @@ tokens = RECORD_DEF, CLASS_DEF, CTOR_DEF, COMPACT_CTOR_DEF
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.nolinewrap;
 
 public class InputNoLineWrapRecordsAndCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeTextBlocksTabIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeTextBlocksTabIndent.java
@@ -6,7 +6,7 @@ tokens = (default)COMMA, SEMI, POST_INC, POST_DEC, ELLIPSIS, LABELED_STAT
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebefore;
 
 public class InputNoWhitespaceBeforeTextBlocksTabIndent {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebeforecasedefaultcolon/InputNoWhitespaceBeforeCaseDefaultColonEnumAndStrings.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebeforecasedefaultcolon/InputNoWhitespaceBeforeCaseDefaultColonEnumAndStrings.java
@@ -4,7 +4,7 @@ NoWhitespaceBeforeCaseDefaultColon
 
 */
 
-// java21
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespacebeforecasedefaultcolon;
 
 class InputNoWhitespaceBeforeCaseDefaultColonEnumAndStrings {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterLiteralWhen.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterLiteralWhen.java
@@ -4,7 +4,7 @@ tokens = LITERAL_WHEN
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespaceafter;
 
 public class InputWhitespaceAfterLiteralWhen {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterLiteralYield.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterLiteralYield.java
@@ -5,7 +5,7 @@ tokens = LITERAL_YIELD
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespaceafter;
 
 public class InputWhitespaceAfterLiteralYield {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterSwitchStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/InputWhitespaceAfterSwitchStatements.java
@@ -4,7 +4,7 @@ tokens = LITERAL_SWITCH, LAMBDA
 
 */
 
-// java21
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespaceafter;
 
 public class InputWhitespaceAfterSwitchStatements {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAfterPermitsList.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAfterPermitsList.java
@@ -19,7 +19,7 @@ tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, B
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 public class InputWhitespaceAroundAfterPermitsList {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyCompactCtors.java
@@ -19,7 +19,7 @@ tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, B
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 public class InputWhitespaceAroundAllowEmptyCompactCtors {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundLiteralWhen.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundLiteralWhen.java
@@ -12,7 +12,7 @@ tokens = LITERAL_WHEN
 
 */
 
-// Java21
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 public class InputWhitespaceAroundLiteralWhen {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundRecords.java
@@ -19,7 +19,7 @@ tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, B
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 public class InputWhitespaceAroundRecords {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundRecordsAllowEmptyTypes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundRecordsAllowEmptyTypes.java
@@ -19,7 +19,7 @@ tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, B
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 public class InputWhitespaceAroundRecordsAllowEmptyTypes {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSwitchCasesParens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSwitchCasesParens.java
@@ -19,7 +19,7 @@ tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, B
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 public class InputWhitespaceAroundSwitchCasesParens {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSwitchCasesParensWithAllowEmptySwitchBlockStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSwitchCasesParensWithAllowEmptySwitchBlockStatements.java
@@ -19,7 +19,7 @@ tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, B
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 public class InputWhitespaceAroundSwitchCasesParensWithAllowEmptySwitchBlockStatements {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSwitchExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundSwitchExpressions.java
@@ -19,7 +19,7 @@ tokens = (default)ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, B
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 import java.util.Optional;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/antlr4/ExpectedAntlr4AstRegressionJava15FinalLocalRecord.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/antlr4/ExpectedAntlr4AstRegressionJava15FinalLocalRecord.txt
@@ -1,6 +1,4 @@
 COMPILATION_UNIT -> COMPILATION_UNIT [2:1]
-|--SINGLE_LINE_COMMENT -> // [1:1]
-|   `--COMMENT_CONTENT ->  Java17\n [1:3]
 |--PACKAGE_DEF -> package [2:1]
 |   |--ANNOTATIONS -> ANNOTATIONS [2:48]
 |   |--DOT -> . [2:48]

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionInterfaceRecordDef.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionInterfaceRecordDef.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.antlr4;
 
 public interface InputAntlr4AstRegressionInterfaceRecordDef {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionJava15FinalLocalRecord.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionJava15FinalLocalRecord.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.antlr4;
 
 public class InputAntlr4AstRegressionJava15FinalLocalRecord {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionJava16LocalEnumAndInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionJava16LocalEnumAndInterface.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.antlr4;
 
 public class InputAntlr4AstRegressionJava16LocalEnumAndInterface {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14EscapedS.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14EscapedS.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.java14;
 
 public class InputJava14EscapedS {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14LocalRecordAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14LocalRecordAnnotation.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.java14;
 
 @Deprecated @ProblemCauser

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14Records.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14Records.java
@@ -9,7 +9,7 @@ applyToPrivate = (default)true
 
 */
 
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.java14;
 
 import java.io.Serializable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14RecordsTopLevel.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14RecordsTopLevel.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.java14;
 
 public record InputJava14RecordsTopLevel(Integer i, String s, Character c) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14TextBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14TextBlocks.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.java14;
 
 public class InputJava14TextBlocks

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14TextBlocksEscapesAreOneChar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14TextBlocksEscapesAreOneChar.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.java14;
 
 public class InputJava14TextBlocksEscapesAreOneChar {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14TextBlocksTabSize.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14TextBlocksTabSize.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.java14;
 
 public class InputJava14TextBlocksTabSize {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java15/InputAstRegressionSealedAndPermits.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java15/InputAstRegressionSealedAndPermits.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.java15;
 
 public sealed class InputAstRegressionSealedAndPermits permits Circle, Square, Rectangle {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java15/InputTopLevelNonSealed.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java15/InputTopLevelNonSealed.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.java15;
 
 public non-sealed class InputTopLevelNonSealed extends OtherClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java16/InputPatternVariableWithModifiers.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java16/InputPatternVariableWithModifiers.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.grammar.java16;
 
 public class InputPatternVariableWithModifiers {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport1.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport1 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport10.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport10.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport10 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport11.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport11.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport11 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport12.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport12.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport12 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport13.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport13.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport13 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport14.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport14.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport14 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport15.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport15.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport15 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport16.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport16.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport16 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport2.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport2 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport3.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport3 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport4.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport4 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport5.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport5 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport6.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport6 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport7.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport7 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport8.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport8 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserFullJavaIdentifierSupport9.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserFullJavaIdentifierSupport9 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserTextBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserTextBlocks.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.javaparser;
 
 public class InputJavaParserTextBlocks {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnCompactCtor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnCompactCtor.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
 
 public record InputBlockCommentPositionOnCompactCtor() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnRecord.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnRecord.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
 /**
  * I'm a javadoc

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperTextBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperTextBlock.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.xpath.xpathmapper;
 
 public class InputXpathMapperTextBlock {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlock.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.xpath.xpathquerygenerator;
 
 public class InputXpathQueryGeneratorTextBlock {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlockCrlf.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlockCrlf.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.xpath.xpathquerygenerator;
 
 public class InputXpathQueryGeneratorTextBlockCrlf {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlockNewLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlockNewLine.java
@@ -1,4 +1,4 @@
-// Java17
+
 package com.puppycrawl.tools.checkstyle.xpath.xpathquerygenerator;
 
 public class InputXpathQueryGeneratorTextBlockNewLine {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example9.java
@@ -13,7 +13,7 @@
 
 
 */
-// Java17
+
 package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
 
 // xdoc section -- start


### PR DESCRIPTION
left ofver from migration to jdk21

no comment in file , means compiled by compilaton jdk of checksyle , currently jdk21