### PR TITLE
Issue #19817: Fix duplicate anchor name warnings for Fully_Qualified_Name in xdoc files

### DIFF
--- a/src/site/xdoc/checks/annotation/annotationlocation.xml
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml
@@ -320,7 +320,7 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AnnotationLocation_Fully_Qualified_Name">
           <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck</p>
           <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/annotationlocation.xml.template
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml.template
@@ -121,7 +121,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AnnotationLocation_Fully_Qualified_Name">
           <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck</p>
           <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/annotationonsameline.xml
+++ b/src/site/xdoc/checks/annotation/annotationonsameline.xml
@@ -204,7 +204,7 @@ class Example2 implements Foo {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AnnotationOnSameLine_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationOnSameLineCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/annotationonsameline.xml.template
+++ b/src/site/xdoc/checks/annotation/annotationonsameline.xml.template
@@ -80,7 +80,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AnnotationOnSameLine_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationOnSameLineCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/annotationusestyle.xml
+++ b/src/site/xdoc/checks/annotation/annotationusestyle.xml
@@ -304,7 +304,7 @@ class TestStyle4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AnnotationUseStyle_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/annotationusestyle.xml.template
+++ b/src/site/xdoc/checks/annotation/annotationusestyle.xml.template
@@ -108,7 +108,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AnnotationUseStyle_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/missingdeprecated.xml
+++ b/src/site/xdoc/checks/annotation/missingdeprecated.xml
@@ -188,7 +188,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingDeprecated_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/missingdeprecated.xml.template
+++ b/src/site/xdoc/checks/annotation/missingdeprecated.xml.template
@@ -78,7 +78,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingDeprecated_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/missingoverride.xml
+++ b/src/site/xdoc/checks/annotation/missingoverride.xml
@@ -198,7 +198,7 @@ class E {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingOverride_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/missingoverride.xml.template
+++ b/src/site/xdoc/checks/annotation/missingoverride.xml.template
@@ -77,7 +77,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingOverride_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml
+++ b/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml
@@ -114,7 +114,7 @@ record Document(String title) implements Printable {
           see the documentation</a> to learn how to.
         </p>
       </subsection>
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+  <subsection name="Fully Qualified Name" id="MissingOverrideOnRecordAccessor_Fully_Qualified_Name">
     <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideOnRecordAccessorCheck</p>
     <p>
       Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml.template
+++ b/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml.template
@@ -68,7 +68,7 @@
           see the documentation</a> to learn how to.
         </p>
       </subsection>
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+  <subsection name="Fully Qualified Name" id="MissingOverrideOnRecordAccessor_Fully_Qualified_Name">
     <p> com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideOnRecordAccessorCheck</p>
     <p>
       Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/packageannotation.xml
+++ b/src/site/xdoc/checks/annotation/packageannotation.xml
@@ -85,7 +85,7 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation.exam
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="PackageAnnotation_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/packageannotation.xml.template
+++ b/src/site/xdoc/checks/annotation/packageannotation.xml.template
@@ -66,7 +66,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="PackageAnnotation_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/suppresswarnings.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarnings.xml
@@ -254,7 +254,7 @@ class Test2 {}
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressWarnings_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/suppresswarnings.xml.template
+++ b/src/site/xdoc/checks/annotation/suppresswarnings.xml.template
@@ -79,7 +79,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressWarnings_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
@@ -200,7 +200,7 @@ public class Example4 {
         </ul>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressWarningsHolder_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</p>
         <p>
          Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml.template
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml.template
@@ -108,7 +108,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressWarningsHolder_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</p>
         <p>
          Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/avoidnestedblocks.xml
+++ b/src/site/xdoc/checks/blocks/avoidnestedblocks.xml
@@ -165,7 +165,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AvoidNestedBlocks_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.AvoidNestedBlocksCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/avoidnestedblocks.xml.template
+++ b/src/site/xdoc/checks/blocks/avoidnestedblocks.xml.template
@@ -78,7 +78,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AvoidNestedBlocks_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.AvoidNestedBlocksCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/emptyblock.xml
+++ b/src/site/xdoc/checks/blocks/emptyblock.xml
@@ -254,7 +254,7 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyBlock_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/emptyblock.xml.template
+++ b/src/site/xdoc/checks/blocks/emptyblock.xml.template
@@ -95,7 +95,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyBlock_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/emptycatchblock.xml
+++ b/src/site/xdoc/checks/blocks/emptycatchblock.xml
@@ -314,7 +314,7 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyCatchBlock_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.EmptyCatchBlockCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/emptycatchblock.xml.template
+++ b/src/site/xdoc/checks/blocks/emptycatchblock.xml.template
@@ -136,7 +136,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyCatchBlock_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.EmptyCatchBlockCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/leftcurly.xml
+++ b/src/site/xdoc/checks/blocks/leftcurly.xml
@@ -322,7 +322,7 @@ class Example4
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LeftCurly_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/leftcurly.xml.template
+++ b/src/site/xdoc/checks/blocks/leftcurly.xml.template
@@ -107,7 +107,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LeftCurly_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/needbraces.xml
+++ b/src/site/xdoc/checks/blocks/needbraces.xml
@@ -425,7 +425,7 @@ class CustomCompletableFuture&lt;T&gt; {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NeedBraces_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/needbraces.xml.template
+++ b/src/site/xdoc/checks/blocks/needbraces.xml.template
@@ -145,7 +145,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NeedBraces_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/rightcurly.xml
+++ b/src/site/xdoc/checks/blocks/rightcurly.xml
@@ -441,7 +441,7 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RightCurly_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/blocks/rightcurly.xml.template
+++ b/src/site/xdoc/checks/blocks/rightcurly.xml.template
@@ -139,7 +139,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RightCurly_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/arraytrailingcomma.xml
+++ b/src/site/xdoc/checks/coding/arraytrailingcomma.xml
@@ -221,7 +221,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ArrayTrailingComma_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ArrayTrailingCommaCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/arraytrailingcomma.xml.template
+++ b/src/site/xdoc/checks/coding/arraytrailingcomma.xml.template
@@ -78,7 +78,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ArrayTrailingComma_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ArrayTrailingCommaCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/avoiddoublebraceinitialization.xml
+++ b/src/site/xdoc/checks/coding/avoiddoublebraceinitialization.xml
@@ -96,7 +96,8 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="AvoidDoubleBraceInitialization_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidDoubleBraceInitializationCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/avoiddoublebraceinitialization.xml.template
+++ b/src/site/xdoc/checks/coding/avoiddoublebraceinitialization.xml.template
@@ -57,7 +57,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="AvoidDoubleBraceInitialization_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidDoubleBraceInitializationCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/avoidinlineconditionals.xml
+++ b/src/site/xdoc/checks/coding/avoidinlineconditionals.xml
@@ -80,7 +80,7 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AvoidInlineConditionals_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidInlineConditionalsCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/avoidinlineconditionals.xml.template
+++ b/src/site/xdoc/checks/coding/avoidinlineconditionals.xml.template
@@ -55,7 +55,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AvoidInlineConditionals_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidInlineConditionalsCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/avoidnoargumentsuperconstructorcall.xml
+++ b/src/site/xdoc/checks/coding/avoidnoargumentsuperconstructorcall.xml
@@ -79,7 +79,8 @@ class Example1 extends SuperClass {
         </p>
       </subsection>
 
-   <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                 id="AvoidNoArgumentSuperConstructorCall_Fully_Qualified_Name">
      <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidNoArgumentSuperConstructorCallCheck</p>
      <p>
         Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/avoidnoargumentsuperconstructorcall.xml.template
+++ b/src/site/xdoc/checks/coding/avoidnoargumentsuperconstructorcall.xml.template
@@ -58,7 +58,8 @@
         </p>
       </subsection>
 
-   <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                 id="AvoidNoArgumentSuperConstructorCall_Fully_Qualified_Name">
      <p>com.puppycrawl.tools.checkstyle.checks.coding.AvoidNoArgumentSuperConstructorCallCheck</p>
      <p>
         Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
+++ b/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml
@@ -139,7 +139,8 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="ConstructorsDeclarationGrouping_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ConstructorsDeclarationGroupingCheck</p>
         <p>
            Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml.template
+++ b/src/site/xdoc/checks/coding/constructorsdeclarationgrouping.xml.template
@@ -63,7 +63,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="ConstructorsDeclarationGrouping_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ConstructorsDeclarationGroupingCheck</p>
         <p>
            Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/covariantequals.xml
+++ b/src/site/xdoc/checks/coding/covariantequals.xml
@@ -140,7 +140,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="CovariantEquals_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.CovariantEqualsCheck</p>
         <p>
            Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/covariantequals.xml.template
+++ b/src/site/xdoc/checks/coding/covariantequals.xml.template
@@ -66,7 +66,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="CovariantEquals_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.CovariantEqualsCheck</p>
         <p>
            Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/declarationorder.xml
+++ b/src/site/xdoc/checks/coding/declarationorder.xml
@@ -230,7 +230,7 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="DeclarationOrder_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/declarationorder.xml.template
+++ b/src/site/xdoc/checks/coding/declarationorder.xml.template
@@ -96,7 +96,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="DeclarationOrder_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/defaultcomeslast.xml
+++ b/src/site/xdoc/checks/coding/defaultcomeslast.xml
@@ -190,7 +190,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="DefaultComesLast_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/defaultcomeslast.xml.template
+++ b/src/site/xdoc/checks/coding/defaultcomeslast.xml.template
@@ -80,7 +80,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="DefaultComesLast_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/emptystatement.xml
+++ b/src/site/xdoc/checks/coding/emptystatement.xml
@@ -72,7 +72,7 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyStatement_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/emptystatement.xml.template
+++ b/src/site/xdoc/checks/coding/emptystatement.xml.template
@@ -61,7 +61,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyStatement_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/equalsavoidnull.xml
+++ b/src/site/xdoc/checks/coding/equalsavoidnull.xml
@@ -137,7 +137,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EqualsAvoidNull_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/equalsavoidnull.xml.template
+++ b/src/site/xdoc/checks/coding/equalsavoidnull.xml.template
@@ -82,7 +82,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EqualsAvoidNull_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/equalshashcode.xml
+++ b/src/site/xdoc/checks/coding/equalshashcode.xml
@@ -116,7 +116,7 @@ class ExampleNoValidEquals {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EqualsHashCode_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.EqualsHashCodeCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/equalshashcode.xml.template
+++ b/src/site/xdoc/checks/coding/equalshashcode.xml.template
@@ -59,7 +59,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EqualsHashCode_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.EqualsHashCodeCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/explicitinitialization.xml
+++ b/src/site/xdoc/checks/coding/explicitinitialization.xml
@@ -146,7 +146,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ExplicitInitialization_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck</p>
         <p>
            Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/explicitinitialization.xml.template
+++ b/src/site/xdoc/checks/coding/explicitinitialization.xml.template
@@ -79,7 +79,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ExplicitInitialization_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck</p>
         <p>
            Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/fallthrough.xml
+++ b/src/site/xdoc/checks/coding/fallthrough.xml
@@ -232,7 +232,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FallThrough_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/fallthrough.xml.template
+++ b/src/site/xdoc/checks/coding/fallthrough.xml.template
@@ -104,7 +104,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FallThrough_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/finallocalvariable.xml
+++ b/src/site/xdoc/checks/coding/finallocalvariable.xml
@@ -276,7 +276,7 @@ class Example5
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FinalLocalVariable_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/finallocalvariable.xml.template
+++ b/src/site/xdoc/checks/coding/finallocalvariable.xml.template
@@ -140,7 +140,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FinalLocalVariable_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/hiddenfield.xml
+++ b/src/site/xdoc/checks/coding/hiddenfield.xml
@@ -422,7 +422,7 @@ class Example7 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="HiddenField_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/hiddenfield.xml.template
+++ b/src/site/xdoc/checks/coding/hiddenfield.xml.template
@@ -163,7 +163,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="HiddenField_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegalcatch.xml
+++ b/src/site/xdoc/checks/coding/illegalcatch.xml
@@ -192,7 +192,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalCatch_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegalcatch.xml.template
+++ b/src/site/xdoc/checks/coding/illegalcatch.xml.template
@@ -83,7 +83,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalCatch_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegalinstantiation.xml
+++ b/src/site/xdoc/checks/coding/illegalinstantiation.xml
@@ -197,7 +197,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalInstantiation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegalinstantiation.xml.template
+++ b/src/site/xdoc/checks/coding/illegalinstantiation.xml.template
@@ -104,7 +104,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalInstantiation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegalsymbol.xml
+++ b/src/site/xdoc/checks/coding/illegalsymbol.xml
@@ -181,7 +181,7 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalSymbol_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalSymbolCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegalsymbol.xml.template
+++ b/src/site/xdoc/checks/coding/illegalsymbol.xml.template
@@ -98,7 +98,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalSymbol_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalSymbolCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegalthrows.xml
+++ b/src/site/xdoc/checks/coding/illegalthrows.xml
@@ -187,7 +187,7 @@ public class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalThrows_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegalthrows.xml.template
+++ b/src/site/xdoc/checks/coding/illegalthrows.xml.template
@@ -106,7 +106,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalThrows_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegaltoken.xml
+++ b/src/site/xdoc/checks/coding/illegaltoken.xml
@@ -128,7 +128,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalToken_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegaltoken.xml.template
+++ b/src/site/xdoc/checks/coding/illegaltoken.xml.template
@@ -78,7 +78,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalToken_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegaltokentext.xml
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml
@@ -238,7 +238,7 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalTokenText_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegaltokentext.xml.template
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml.template
@@ -133,7 +133,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalTokenText_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegaltype.xml
+++ b/src/site/xdoc/checks/coding/illegaltype.xml
@@ -950,7 +950,7 @@ public class Example9 extends TreeSet {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalType_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/illegaltype.xml.template
+++ b/src/site/xdoc/checks/coding/illegaltype.xml.template
@@ -185,7 +185,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalType_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/innerassignment.xml
+++ b/src/site/xdoc/checks/coding/innerassignment.xml
@@ -166,7 +166,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="InnerAssignment_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.InnerAssignmentCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/innerassignment.xml.template
+++ b/src/site/xdoc/checks/coding/innerassignment.xml.template
@@ -65,7 +65,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="InnerAssignment_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.InnerAssignmentCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/magicnumber.xml
+++ b/src/site/xdoc/checks/coding/magicnumber.xml
@@ -525,7 +525,7 @@ public class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MagicNumber_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/magicnumber.xml.template
+++ b/src/site/xdoc/checks/coding/magicnumber.xml.template
@@ -148,7 +148,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MagicNumber_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/matchxpath.xml
+++ b/src/site/xdoc/checks/coding/matchxpath.xml
@@ -292,7 +292,7 @@ public class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MatchXpath_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/matchxpath.xml.template
+++ b/src/site/xdoc/checks/coding/matchxpath.xml.template
@@ -187,7 +187,7 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MatchXpath_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/missingctor.xml
+++ b/src/site/xdoc/checks/coding/missingctor.xml
@@ -73,7 +73,7 @@ abstract class AbstractExample {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingCtor_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingCtorCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/missingctor.xml.template
+++ b/src/site/xdoc/checks/coding/missingctor.xml.template
@@ -55,7 +55,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingCtor_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingCtorCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/missingnullcaseinswitch.xml
+++ b/src/site/xdoc/checks/coding/missingnullcaseinswitch.xml
@@ -131,7 +131,7 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingNullCaseInSwitch_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingNullCaseInSwitchCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/missingnullcaseinswitch.xml.template
+++ b/src/site/xdoc/checks/coding/missingnullcaseinswitch.xml.template
@@ -57,7 +57,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingNullCaseInSwitch_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingNullCaseInSwitchCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/missingswitchdefault.xml
+++ b/src/site/xdoc/checks/coding/missingswitchdefault.xml
@@ -202,7 +202,7 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingSwitchDefault_Fully_Qualified_Name">
          <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingSwitchDefaultCheck</p>
          <p>
              Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/missingswitchdefault.xml.template
+++ b/src/site/xdoc/checks/coding/missingswitchdefault.xml.template
@@ -81,7 +81,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingSwitchDefault_Fully_Qualified_Name">
          <p>com.puppycrawl.tools.checkstyle.checks.coding.MissingSwitchDefaultCheck</p>
          <p>
              Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/modifiedcontrolvariable.xml
+++ b/src/site/xdoc/checks/coding/modifiedcontrolvariable.xml
@@ -156,7 +156,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ModifiedControlVariable_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/modifiedcontrolvariable.xml.template
+++ b/src/site/xdoc/checks/coding/modifiedcontrolvariable.xml.template
@@ -89,7 +89,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ModifiedControlVariable_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/multiplestringliterals.xml
+++ b/src/site/xdoc/checks/coding/multiplestringliterals.xml
@@ -190,7 +190,7 @@ public class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MultipleStringLiterals_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck</p>
         <p>
            Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/multiplestringliterals.xml.template
+++ b/src/site/xdoc/checks/coding/multiplestringliterals.xml.template
@@ -109,7 +109,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MultipleStringLiterals_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck</p>
         <p>
            Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml
+++ b/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml
@@ -95,7 +95,8 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="MultipleVariableDeclarations_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml.template
+++ b/src/site/xdoc/checks/coding/multiplevariabledeclarations.xml.template
@@ -69,7 +69,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="MultipleVariableDeclarations_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/nestedfordepth.xml
+++ b/src/site/xdoc/checks/coding/nestedfordepth.xml
@@ -144,7 +144,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NestedForDepth_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/nestedfordepth.xml.template
+++ b/src/site/xdoc/checks/coding/nestedfordepth.xml.template
@@ -78,7 +78,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NestedForDepth_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/nestedifdepth.xml
+++ b/src/site/xdoc/checks/coding/nestedifdepth.xml
@@ -164,7 +164,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NestedIfDepth_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/nestedifdepth.xml.template
+++ b/src/site/xdoc/checks/coding/nestedifdepth.xml.template
@@ -78,7 +78,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NestedIfDepth_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/nestedtrydepth.xml
+++ b/src/site/xdoc/checks/coding/nestedtrydepth.xml
@@ -146,7 +146,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NestedTryDepth_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/nestedtrydepth.xml.template
+++ b/src/site/xdoc/checks/coding/nestedtrydepth.xml.template
@@ -82,7 +82,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NestedTryDepth_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/noarraytrailingcomma.xml
+++ b/src/site/xdoc/checks/coding/noarraytrailingcomma.xml
@@ -88,7 +88,7 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoArrayTrailingComma_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NoArrayTrailingCommaCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/noarraytrailingcomma.xml.template
+++ b/src/site/xdoc/checks/coding/noarraytrailingcomma.xml.template
@@ -55,7 +55,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoArrayTrailingComma_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NoArrayTrailingCommaCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/noclone.xml
+++ b/src/site/xdoc/checks/coding/noclone.xml
@@ -166,7 +166,7 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoClone_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NoCloneCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/noclone.xml.template
+++ b/src/site/xdoc/checks/coding/noclone.xml.template
@@ -54,7 +54,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoClone_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NoCloneCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/noenumtrailingcomma.xml
+++ b/src/site/xdoc/checks/coding/noenumtrailingcomma.xml
@@ -106,7 +106,7 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoEnumTrailingComma_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NoEnumTrailingCommaCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/noenumtrailingcomma.xml.template
+++ b/src/site/xdoc/checks/coding/noenumtrailingcomma.xml.template
@@ -57,7 +57,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoEnumTrailingComma_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NoEnumTrailingCommaCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/nofinalizer.xml
+++ b/src/site/xdoc/checks/coding/nofinalizer.xml
@@ -83,7 +83,7 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoFinalizer_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/nofinalizer.xml.template
+++ b/src/site/xdoc/checks/coding/nofinalizer.xml.template
@@ -59,7 +59,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoFinalizer_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/onestatementperline.xml
+++ b/src/site/xdoc/checks/coding/onestatementperline.xml
@@ -202,7 +202,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OneStatementPerLine_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/onestatementperline.xml.template
+++ b/src/site/xdoc/checks/coding/onestatementperline.xml.template
@@ -102,7 +102,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OneStatementPerLine_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml
+++ b/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml
@@ -73,7 +73,8 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="OverloadMethodsDeclarationOrder_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml.template
+++ b/src/site/xdoc/checks/coding/overloadmethodsdeclarationorder.xml.template
@@ -57,7 +57,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="OverloadMethodsDeclarationOrder_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/packagedeclaration.xml
+++ b/src/site/xdoc/checks/coding/packagedeclaration.xml
@@ -115,7 +115,7 @@ public class Example2{
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="PackageDeclaration_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/packagedeclaration.xml.template
+++ b/src/site/xdoc/checks/coding/packagedeclaration.xml.template
@@ -78,7 +78,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="PackageDeclaration_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/parameterassignment.xml
+++ b/src/site/xdoc/checks/coding/parameterassignment.xml
@@ -95,7 +95,7 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ParameterAssignment_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ParameterAssignmentCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/parameterassignment.xml.template
+++ b/src/site/xdoc/checks/coding/parameterassignment.xml.template
@@ -57,7 +57,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ParameterAssignment_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ParameterAssignmentCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/patternvariableassignment.xml
+++ b/src/site/xdoc/checks/coding/patternvariableassignment.xml
@@ -84,7 +84,7 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="PatternVariableAssignment_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.PatternVariableAssignmentCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/patternvariableassignment.xml.template
+++ b/src/site/xdoc/checks/coding/patternvariableassignment.xml.template
@@ -57,7 +57,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="PatternVariableAssignment_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.PatternVariableAssignmentCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/requirethis.xml
+++ b/src/site/xdoc/checks/coding/requirethis.xml
@@ -281,7 +281,7 @@ class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RequireThis_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/requirethis.xml.template
+++ b/src/site/xdoc/checks/coding/requirethis.xml.template
@@ -138,7 +138,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RequireThis_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/returncount.xml
+++ b/src/site/xdoc/checks/coding/returncount.xml
@@ -368,7 +368,7 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ReturnCount_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/returncount.xml.template
+++ b/src/site/xdoc/checks/coding/returncount.xml.template
@@ -138,7 +138,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ReturnCount_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/simplifybooleanexpression.xml
+++ b/src/site/xdoc/checks/coding/simplifybooleanexpression.xml
@@ -85,7 +85,7 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SimplifyBooleanExpression_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanExpressionCheck</p>
         <p>
              Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/simplifybooleanexpression.xml.template
+++ b/src/site/xdoc/checks/coding/simplifybooleanexpression.xml.template
@@ -59,7 +59,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SimplifyBooleanExpression_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanExpressionCheck</p>
         <p>
              Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/simplifybooleanreturn.xml
+++ b/src/site/xdoc/checks/coding/simplifybooleanreturn.xml
@@ -116,7 +116,7 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SimplifyBooleanReturn_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanReturnCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/simplifybooleanreturn.xml.template
+++ b/src/site/xdoc/checks/coding/simplifybooleanreturn.xml.template
@@ -59,7 +59,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SimplifyBooleanReturn_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanReturnCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/stringliteralequality.xml
+++ b/src/site/xdoc/checks/coding/stringliteralequality.xml
@@ -93,7 +93,7 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="StringLiteralEquality_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/stringliteralequality.xml.template
+++ b/src/site/xdoc/checks/coding/stringliteralequality.xml.template
@@ -57,7 +57,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="StringLiteralEquality_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/superclone.xml
+++ b/src/site/xdoc/checks/coding/superclone.xml
@@ -84,7 +84,7 @@ class SuperCloneC {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuperClone_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.SuperCloneCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/superclone.xml.template
+++ b/src/site/xdoc/checks/coding/superclone.xml.template
@@ -55,7 +55,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuperClone_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.SuperCloneCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/superfinalize.xml
+++ b/src/site/xdoc/checks/coding/superfinalize.xml
@@ -74,7 +74,7 @@ class InvalidExample {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuperFinalize_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.SuperFinalizeCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/superfinalize.xml.template
+++ b/src/site/xdoc/checks/coding/superfinalize.xml.template
@@ -56,7 +56,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuperFinalize_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.SuperFinalizeCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/textblockgooglestyleformatting.xml
+++ b/src/site/xdoc/checks/coding/textblockgooglestyleformatting.xml
@@ -9,7 +9,7 @@
     <section xmlns="http://maven.apache.org/XDOC/2.0"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="TextBlockGoogleStyleFormatting">
       <p>Since Checkstyle 12.3.0</p>
-      <subsection name="Description" id="Description">
+      <subsection name="Description" id="TextBlockGoogleStyleFormatting_Description">
         <div>
           Checks correct format of
           <a href="https://docs.oracle.com/en/java/javase/17/text-blocks/index.html">Java Text Blocks</a>
@@ -34,7 +34,7 @@
           Note: Closing quotes can be followed by additional code on the same line.
       </subsection>
 
-      <subsection name="Examples" id="Examples">
+      <subsection name="Examples" id="TextBlockGoogleStyleFormatting_Examples">
         <p id="Example1-config">To configure the check:</p>
           <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -253,7 +253,7 @@ public class Example5 {
 </code></pre></div>
       </subsection>
 
-      <subsection name="Example of Usage" id="Example_of_Usage">
+      <subsection name="Example of Usage" id="TextBlockGoogleStyleFormatting_Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+TextBlockGoogleStyleFormatting">
@@ -266,7 +266,7 @@ public class Example5 {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="Violation_Messages">
+      <subsection name="Violation Messages" id="TextBlockGoogleStyleFormatting_Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22textblock.format.close%22">
@@ -296,7 +296,8 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="TextBlockGoogleStyleFormatting_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.TextBlockGoogleStyleFormattingCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is
@@ -304,7 +305,7 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="Parent_Module">
+      <subsection name="Parent Module" id="TextBlockGoogleStyleFormatting_Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/site/xdoc/checks/coding/textblockgooglestyleformatting.xml.template
+++ b/src/site/xdoc/checks/coding/textblockgooglestyleformatting.xml.template
@@ -12,14 +12,14 @@
         <param name="modulePath"
             value="src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheck.java"/>
       </macro>
-      <subsection name="Description" id="Description">
+      <subsection name="Description" id="TextBlockGoogleStyleFormatting_Description">
         <macro name="description">
             <param name="modulePath"
                    value="src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheck.java"/>
         </macro>
       </subsection>
 
-      <subsection name="Examples" id="Examples">
+      <subsection name="Examples" id="TextBlockGoogleStyleFormatting_Examples">
         <p id="Example1-config">To configure the check:</p>
           <macro name="example">
             <param name="path"
@@ -63,7 +63,7 @@
         </macro>
       </subsection>
 
-      <subsection name="Example of Usage" id="Example_of_Usage">
+      <subsection name="Example of Usage" id="TextBlockGoogleStyleFormatting_Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+TextBlockGoogleStyleFormatting">
@@ -76,7 +76,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="Violation_Messages">
+      <subsection name="Violation Messages" id="TextBlockGoogleStyleFormatting_Violation_Messages">
         <macro name="violation-messages">
           <param name="checkName" value="TextBlockGoogleStyleFormatting"/>
         </macro>
@@ -87,7 +87,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="TextBlockGoogleStyleFormatting_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.TextBlockGoogleStyleFormattingCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is
@@ -95,7 +96,7 @@
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="Parent_Module">
+      <subsection name="Parent Module" id="TextBlockGoogleStyleFormatting_Parent_Module">
         <macro name="parent-module">
           <param name="moduleName" value="OverloadMethodsDeclarationOrder"/>
         </macro>

--- a/src/site/xdoc/checks/coding/unnecessarynullcheckwithinstanceof.xml
+++ b/src/site/xdoc/checks/coding/unnecessarynullcheckwithinstanceof.xml
@@ -105,7 +105,8 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="UnnecessaryNullCheckWithInstanceOf_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryNullCheckWithInstanceOfCheck</p>
         <p>
            Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unnecessarynullcheckwithinstanceof.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessarynullcheckwithinstanceof.xml.template
@@ -58,7 +58,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="UnnecessaryNullCheckWithInstanceOf_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryNullCheckWithInstanceOfCheck</p>
         <p>
            Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unnecessaryparentheses.xml
+++ b/src/site/xdoc/checks/coding/unnecessaryparentheses.xml
@@ -463,7 +463,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UnnecessaryParentheses_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unnecessaryparentheses.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessaryparentheses.xml.template
@@ -104,7 +104,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UnnecessaryParentheses_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
@@ -164,7 +164,8 @@ enum U {
         </p>
       </subsection>
 
-<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+             id="UnnecessarySemicolonAfterOuterTypeDeclaration_Fully_Qualified_Name">
   <p>com.puppycrawl.tools.checkstyle.checks.coding.
   UnnecessarySemicolonAfterOuterTypeDeclarationCheck</p>
   <p>

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml.template
@@ -90,7 +90,8 @@
         </p>
       </subsection>
 
-<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+             id="UnnecessarySemicolonAfterOuterTypeDeclaration_Fully_Qualified_Name">
   <p>com.puppycrawl.tools.checkstyle.checks.coding.
   UnnecessarySemicolonAfterOuterTypeDeclarationCheck</p>
   <p>

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml
@@ -164,7 +164,8 @@ class Example1 {
         </p>
       </subsection>
 
-<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+             id="UnnecessarySemicolonAfterTypeMemberDeclaration_Fully_Qualified_Name">
   <p>com.puppycrawl.tools.checkstyle.checks.coding.
   UnnecessarySemicolonAfterTypeMemberDeclarationCheck</p>
   <p>

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml.template
@@ -74,7 +74,8 @@
         </p>
       </subsection>
 
-<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+             id="UnnecessarySemicolonAfterTypeMemberDeclaration_Fully_Qualified_Name">
   <p>com.puppycrawl.tools.checkstyle.checks.coding.
   UnnecessarySemicolonAfterTypeMemberDeclarationCheck</p>
   <p>

--- a/src/site/xdoc/checks/coding/unnecessarysemicoloninenumeration.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicoloninenumeration.xml
@@ -89,7 +89,8 @@ enum NoSemicolon {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="UnnecessarySemicolonInEnumeration_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInEnumerationCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unnecessarysemicoloninenumeration.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessarysemicoloninenumeration.xml.template
@@ -66,7 +66,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="UnnecessarySemicolonInEnumeration_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInEnumerationCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonintrywithresources.xml
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonintrywithresources.xml
@@ -119,7 +119,8 @@ class Example2 {
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="UnnecessarySemicolonInTryWithResources_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInTryWithResourcesCheck</p>
     <p>
       Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unnecessarysemicolonintrywithresources.xml.template
+++ b/src/site/xdoc/checks/coding/unnecessarysemicolonintrywithresources.xml.template
@@ -85,7 +85,8 @@
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="UnnecessarySemicolonInTryWithResources_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInTryWithResourcesCheck</p>
     <p>
       Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unusedcatchparametershouldbeunnamed.xml
+++ b/src/site/xdoc/checks/coding/unusedcatchparametershouldbeunnamed.xml
@@ -107,7 +107,8 @@ public class Example1 {
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="UnusedCatchParameterShouldBeUnnamed_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedCatchParameterShouldBeUnnamedCheck</p>
     <p>
         Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unusedcatchparametershouldbeunnamed.xml.template
+++ b/src/site/xdoc/checks/coding/unusedcatchparametershouldbeunnamed.xml.template
@@ -58,7 +58,8 @@
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="UnusedCatchParameterShouldBeUnnamed_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedCatchParameterShouldBeUnnamedCheck</p>
     <p>
         Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unusedlambdaparametershouldbeunnamed.xml
+++ b/src/site/xdoc/checks/coding/unusedlambdaparametershouldbeunnamed.xml
@@ -96,7 +96,8 @@ public class Example1 {
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="UnusedLambdaParameterShouldBeUnnamed_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLambdaParameterShouldBeUnnamedCheck</p>
     <p>
         Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unusedlambdaparametershouldbeunnamed.xml.template
+++ b/src/site/xdoc/checks/coding/unusedlambdaparametershouldbeunnamed.xml.template
@@ -59,7 +59,8 @@
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="UnusedLambdaParameterShouldBeUnnamed_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLambdaParameterShouldBeUnnamedCheck</p>
     <p>
         Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unusedlocalvariable.xml
+++ b/src/site/xdoc/checks/coding/unusedlocalvariable.xml
@@ -200,7 +200,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UnusedLocalVariable_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unusedlocalvariable.xml.template
+++ b/src/site/xdoc/checks/coding/unusedlocalvariable.xml.template
@@ -83,7 +83,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UnusedLocalVariable_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/useenhancedswitch.xml
+++ b/src/site/xdoc/checks/coding/useenhancedswitch.xml
@@ -131,7 +131,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UseEnhancedSwitch_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UseEnhancedSwitchCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/useenhancedswitch.xml.template
+++ b/src/site/xdoc/checks/coding/useenhancedswitch.xml.template
@@ -65,7 +65,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UseEnhancedSwitch_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UseEnhancedSwitchCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
+++ b/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
@@ -352,7 +352,8 @@ public class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="VariableDeclarationUsageDistance_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml.template
+++ b/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml.template
@@ -156,7 +156,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="VariableDeclarationUsageDistance_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/whenshouldbeused.xml
+++ b/src/site/xdoc/checks/coding/whenshouldbeused.xml
@@ -109,7 +109,7 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="WhenShouldBeUsed_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.WhenShouldBeUsedCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/whenshouldbeused.xml.template
+++ b/src/site/xdoc/checks/coding/whenshouldbeused.xml.template
@@ -57,7 +57,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="WhenShouldBeUsed_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.WhenShouldBeUsedCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/designforextension.xml
+++ b/src/site/xdoc/checks/design/designforextension.xml
@@ -397,7 +397,7 @@ public abstract class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="DesignForExtension_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/designforextension.xml.template
+++ b/src/site/xdoc/checks/design/designforextension.xml.template
@@ -113,7 +113,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="DesignForExtension_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/finalclass.xml
+++ b/src/site/xdoc/checks/design/finalclass.xml
@@ -125,7 +125,7 @@ public class Example1 { // ok, since it has a public constructor
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FinalClass_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/finalclass.xml.template
+++ b/src/site/xdoc/checks/design/finalclass.xml.template
@@ -59,7 +59,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FinalClass_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/hideutilityclassconstructor.xml
+++ b/src/site/xdoc/checks/design/hideutilityclassconstructor.xml
@@ -199,7 +199,7 @@ class Application2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="HideUtilityClassConstructor_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassConstructorCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/hideutilityclassconstructor.xml.template
+++ b/src/site/xdoc/checks/design/hideutilityclassconstructor.xml.template
@@ -83,7 +83,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="HideUtilityClassConstructor_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassConstructorCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/innertypelast.xml
+++ b/src/site/xdoc/checks/design/innertypelast.xml
@@ -73,7 +73,7 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="InnerTypeLast_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/innertypelast.xml.template
+++ b/src/site/xdoc/checks/design/innertypelast.xml.template
@@ -55,7 +55,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="InnerTypeLast_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/interfaceistype.xml
+++ b/src/site/xdoc/checks/design/interfaceistype.xml
@@ -140,7 +140,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="InterfaceIsType_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.InterfaceIsTypeCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/interfaceistype.xml.template
+++ b/src/site/xdoc/checks/design/interfaceistype.xml.template
@@ -82,7 +82,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="InterfaceIsType_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.InterfaceIsTypeCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/mutableexception.xml
+++ b/src/site/xdoc/checks/design/mutableexception.xml
@@ -231,7 +231,7 @@ class ThirdBadException extends java.lang.Exception {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MutableException_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.MutableExceptionCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/mutableexception.xml.template
+++ b/src/site/xdoc/checks/design/mutableexception.xml.template
@@ -94,7 +94,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MutableException_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.MutableExceptionCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/onetoplevelclass.xml
+++ b/src/site/xdoc/checks/design/onetoplevelclass.xml
@@ -96,7 +96,7 @@ public class Example3 { // ok, only one top-level class
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OneTopLevelClass_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/onetoplevelclass.xml.template
+++ b/src/site/xdoc/checks/design/onetoplevelclass.xml.template
@@ -81,7 +81,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OneTopLevelClass_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/sealedshouldhavepermitslist.xml
+++ b/src/site/xdoc/checks/design/sealedshouldhavepermitslist.xml
@@ -89,7 +89,7 @@ class CorrectedExample1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SealedShouldHavePermitsList_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.SealedShouldHavePermitsListCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/sealedshouldhavepermitslist.xml.template
+++ b/src/site/xdoc/checks/design/sealedshouldhavepermitslist.xml.template
@@ -57,7 +57,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SealedShouldHavePermitsList_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.SealedShouldHavePermitsListCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/throwscount.xml
+++ b/src/site/xdoc/checks/design/throwscount.xml
@@ -219,7 +219,7 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ThrowsCount_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.ThrowsCountCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/throwscount.xml.template
+++ b/src/site/xdoc/checks/design/throwscount.xml.template
@@ -99,7 +99,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ThrowsCount_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.ThrowsCountCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/visibilitymodifier.xml
+++ b/src/site/xdoc/checks/design/visibilitymodifier.xml
@@ -789,7 +789,7 @@ class Example12 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="VisibilityModifier_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/design/visibilitymodifier.xml.template
+++ b/src/site/xdoc/checks/design/visibilitymodifier.xml.template
@@ -246,7 +246,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="VisibilityModifier_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/header/header.xml
+++ b/src/site/xdoc/checks/header/header.xml
@@ -220,7 +220,7 @@ public class Example4 { }
         </p>
       </subsection>
 
-       <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+       <subsection name="Fully Qualified Name" id="Header_Fully_Qualified_Name">
          <p> com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck</p>
          <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/header/header.xml.template
+++ b/src/site/xdoc/checks/header/header.xml.template
@@ -125,7 +125,7 @@
         </p>
       </subsection>
 
-       <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+       <subsection name="Fully Qualified Name" id="Header_Fully_Qualified_Name">
          <p> com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck</p>
          <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/header/multifileregexpheader.xml
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml
@@ -203,7 +203,7 @@ public class Example4 { }
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MultiFileRegexpHeader_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.header.MultiFileRegexpHeaderCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/header/multifileregexpheader.xml.template
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml.template
@@ -143,7 +143,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MultiFileRegexpHeader_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.header.MultiFileRegexpHeaderCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/header/regexpheader.xml
+++ b/src/site/xdoc/checks/header/regexpheader.xml
@@ -220,7 +220,7 @@ public class Example4 { }
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RegexpHeader_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/header/regexpheader.xml.template
+++ b/src/site/xdoc/checks/header/regexpheader.xml.template
@@ -130,7 +130,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RegexpHeader_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/avoidstarimport.xml
+++ b/src/site/xdoc/checks/imports/avoidstarimport.xml
@@ -235,7 +235,7 @@ import java.net.*;
           to learn how to.
         </p>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AvoidStarImport_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/avoidstarimport.xml.template
+++ b/src/site/xdoc/checks/imports/avoidstarimport.xml.template
@@ -166,7 +166,7 @@
           to learn how to.
         </p>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AvoidStarImport_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/avoidstaticimport.xml
+++ b/src/site/xdoc/checks/imports/avoidstaticimport.xml
@@ -124,7 +124,7 @@ import java.util.*;
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AvoidStaticImport_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.AvoidStaticImportCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/avoidstaticimport.xml.template
+++ b/src/site/xdoc/checks/imports/avoidstaticimport.xml.template
@@ -90,7 +90,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AvoidStaticImport_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.AvoidStaticImportCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/customimportorder.xml
+++ b/src/site/xdoc/checks/imports/customimportorder.xml
@@ -723,7 +723,7 @@ import java.lang.String;
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="CustomImportOrder_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/customimportorder.xml.template
+++ b/src/site/xdoc/checks/imports/customimportorder.xml.template
@@ -345,7 +345,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="CustomImportOrder_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/illegalimport.xml
+++ b/src/site/xdoc/checks/imports/illegalimport.xml
@@ -291,7 +291,7 @@ public class Example6 {}
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalImport_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/illegalimport.xml.template
+++ b/src/site/xdoc/checks/imports/illegalimport.xml.template
@@ -190,7 +190,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalImport_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/importcontrol.xml
+++ b/src/site/xdoc/checks/imports/importcontrol.xml
@@ -907,7 +907,7 @@ public class Example14 {}
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ImportControl_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/importcontrol.xml.template
+++ b/src/site/xdoc/checks/imports/importcontrol.xml.template
@@ -549,7 +549,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ImportControl_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/importorder.xml
+++ b/src/site/xdoc/checks/imports/importorder.xml
@@ -595,7 +595,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ImportOrder_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/importorder.xml.template
+++ b/src/site/xdoc/checks/imports/importorder.xml.template
@@ -356,7 +356,7 @@ import static java.lang.Character.UnicodeBlock.BASIC_LATIN => java.lang.Characte
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ImportOrder_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/redundantimport.xml
+++ b/src/site/xdoc/checks/imports/redundantimport.xml
@@ -100,7 +100,7 @@ public class Example2{ }
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RedundantImport_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/redundantimport.xml.template
+++ b/src/site/xdoc/checks/imports/redundantimport.xml.template
@@ -70,7 +70,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RedundantImport_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/unusedimports.xml
+++ b/src/site/xdoc/checks/imports/unusedimports.xml
@@ -213,7 +213,7 @@ class Example2{
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UnusedImports_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/imports/unusedimports.xml.template
+++ b/src/site/xdoc/checks/imports/unusedimports.xml.template
@@ -82,7 +82,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UnusedImports_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml
@@ -287,7 +287,7 @@ enum Test3 {}
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AtclauseOrder_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml.template
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml.template
@@ -102,7 +102,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AtclauseOrder_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml
+++ b/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml
@@ -80,7 +80,7 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="InvalidJavadocPosition_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml.template
+++ b/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml.template
@@ -66,7 +66,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="InvalidJavadocPosition_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
@@ -156,7 +156,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocBlockTagLocation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
@@ -87,7 +87,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocBlockTagLocation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
@@ -200,7 +200,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocContentLocation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml.template
@@ -95,7 +95,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocContentLocation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
@@ -234,7 +234,7 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocLeadingAsteriskAlign_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocLeadingAsteriskAlignCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml.template
@@ -95,7 +95,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocLeadingAsteriskAlign_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocLeadingAsteriskAlignCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml
@@ -574,7 +574,7 @@ public class Example8 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocMethod_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
@@ -174,7 +174,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocMethod_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml
@@ -135,7 +135,8 @@ class Example1 {}
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="JavadocMissingLeadingAsterisk_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingLeadingAsteriskCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocmissingleadingasterisk.xml.template
@@ -68,7 +68,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="JavadocMissingLeadingAsterisk_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingLeadingAsteriskCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
@@ -112,7 +112,8 @@ class Example1 {
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="JavadocMissingWhitespaceAfterAsterisk_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingWhitespaceAfterAsteriskCheck</p>
     <p>
       Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml.template
@@ -68,7 +68,8 @@
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="JavadocMissingWhitespaceAfterAsterisk_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMissingWhitespaceAfterAsteriskCheck</p>
     <p>
       Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml
@@ -158,7 +158,7 @@ public class Example3 { }
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocPackage_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
@@ -124,7 +124,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocPackage_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocparagraph.xml
+++ b/src/site/xdoc/checks/javadoc/javadocparagraph.xml
@@ -275,7 +275,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocParagraph_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocparagraph.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocparagraph.xml.template
@@ -86,7 +86,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocParagraph_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocstyle.xml
+++ b/src/site/xdoc/checks/javadoc/javadocstyle.xml
@@ -736,7 +736,7 @@ public class Example8 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocStyle_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocstyle.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocstyle.xml.template
@@ -177,7 +177,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocStyle_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
@@ -285,7 +285,8 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="JavadocTagContinuationIndentation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml.template
@@ -110,7 +110,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="JavadocTagContinuationIndentation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctype.xml
@@ -573,7 +573,7 @@ public class Example8 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocType_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadoctype.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadoctype.xml.template
@@ -169,7 +169,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocType_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml
@@ -285,7 +285,7 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocVariable_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
@@ -139,7 +139,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavadocVariable_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml
@@ -433,7 +433,7 @@ public class Example7 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingJavadocMethod_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml.template
+++ b/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml.template
@@ -161,7 +161,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingJavadocMethod_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml
@@ -79,7 +79,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.noj
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingJavadocPackage_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml.template
+++ b/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml.template
@@ -61,7 +61,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingJavadocPackage_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
@@ -263,7 +263,7 @@ class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingJavadocType_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/missingjavadoctype.xml.template
+++ b/src/site/xdoc/checks/javadoc/missingjavadoctype.xml.template
@@ -131,7 +131,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MissingJavadocType_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml
+++ b/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml
@@ -178,7 +178,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NonEmptyAtclauseDescription_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml.template
+++ b/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml.template
@@ -88,7 +88,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NonEmptyAtclauseDescription_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/requireemptylinebeforeblocktaggroup.xml
+++ b/src/site/xdoc/checks/javadoc/requireemptylinebeforeblocktaggroup.xml
@@ -111,7 +111,8 @@ class Example1 {
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="RequireEmptyLineBeforeBlockTagGroup_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.javadoc.RequireEmptyLineBeforeBlockTagGroupCheck</p>
     <p>
        Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/requireemptylinebeforeblocktaggroup.xml.template
+++ b/src/site/xdoc/checks/javadoc/requireemptylinebeforeblocktaggroup.xml.template
@@ -72,7 +72,8 @@
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="RequireEmptyLineBeforeBlockTagGroup_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.javadoc.RequireEmptyLineBeforeBlockTagGroupCheck</p>
     <p>
        Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/singlelinejavadoc.xml
+++ b/src/site/xdoc/checks/javadoc/singlelinejavadoc.xml
@@ -288,7 +288,7 @@ public class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SingleLineJavadoc_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/singlelinejavadoc.xml.template
+++ b/src/site/xdoc/checks/javadoc/singlelinejavadoc.xml.template
@@ -118,7 +118,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SingleLineJavadoc_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
+++ b/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
@@ -301,7 +301,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SummaryJavadoc_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/summaryjavadoc.xml.template
+++ b/src/site/xdoc/checks/javadoc/summaryjavadoc.xml.template
@@ -98,7 +98,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SummaryJavadoc_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/writetag.xml
+++ b/src/site/xdoc/checks/javadoc/writetag.xml
@@ -311,7 +311,7 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="WriteTag_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/javadoc/writetag.xml.template
+++ b/src/site/xdoc/checks/javadoc/writetag.xml.template
@@ -135,7 +135,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="WriteTag_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml
+++ b/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml
@@ -209,7 +209,7 @@ public class Example3
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="BooleanExpressionComplexity_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml.template
+++ b/src/site/xdoc/checks/metrics/booleanexpressioncomplexity.xml.template
@@ -94,7 +94,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="BooleanExpressionComplexity_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
+++ b/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
@@ -506,7 +506,8 @@ class Example11 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="ClassDataAbstractionCoupling_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml.template
+++ b/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml.template
@@ -255,7 +255,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="ClassDataAbstractionCoupling_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/classfanoutcomplexity.xml
+++ b/src/site/xdoc/checks/metrics/classfanoutcomplexity.xml
@@ -353,7 +353,7 @@ class Time6 {}
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ClassFanOutComplexity_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/classfanoutcomplexity.xml.template
+++ b/src/site/xdoc/checks/metrics/classfanoutcomplexity.xml.template
@@ -201,7 +201,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ClassFanOutComplexity_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/cyclomaticcomplexity.xml
+++ b/src/site/xdoc/checks/metrics/cyclomaticcomplexity.xml
@@ -381,7 +381,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="CyclomaticComplexity_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.CyclomaticComplexityCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/cyclomaticcomplexity.xml.template
+++ b/src/site/xdoc/checks/metrics/cyclomaticcomplexity.xml.template
@@ -98,7 +98,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="CyclomaticComplexity_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.CyclomaticComplexityCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/javancss.xml
+++ b/src/site/xdoc/checks/metrics/javancss.xml
@@ -357,7 +357,7 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavaNCSS_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/javancss.xml.template
+++ b/src/site/xdoc/checks/metrics/javancss.xml.template
@@ -124,7 +124,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="JavaNCSS_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/npathcomplexity.xml
+++ b/src/site/xdoc/checks/metrics/npathcomplexity.xml
@@ -254,7 +254,7 @@ public abstract class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NPathComplexity_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/metrics/npathcomplexity.xml.template
+++ b/src/site/xdoc/checks/metrics/npathcomplexity.xml.template
@@ -82,7 +82,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NPathComplexity_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/arraytypestyle.xml
+++ b/src/site/xdoc/checks/misc/arraytypestyle.xml
@@ -142,7 +142,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ArrayTypeStyle_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/arraytypestyle.xml.template
+++ b/src/site/xdoc/checks/misc/arraytypestyle.xml.template
@@ -94,7 +94,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ArrayTypeStyle_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml
+++ b/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml
@@ -267,7 +267,8 @@ public class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="AvoidEscapedUnicodeCharacters_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml.template
+++ b/src/site/xdoc/checks/misc/avoidescapedunicodecharacters.xml.template
@@ -138,7 +138,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="AvoidEscapedUnicodeCharacters_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/commentsindentation.xml
+++ b/src/site/xdoc/checks/misc/commentsindentation.xml
@@ -309,7 +309,7 @@ public class Example8 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="CommentsIndentation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/commentsindentation.xml.template
+++ b/src/site/xdoc/checks/misc/commentsindentation.xml.template
@@ -146,7 +146,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="CommentsIndentation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/descendanttoken.xml
+++ b/src/site/xdoc/checks/misc/descendanttoken.xml
@@ -994,7 +994,7 @@ class Example17 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="DescendantToken_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/descendanttoken.xml.template
+++ b/src/site/xdoc/checks/misc/descendanttoken.xml.template
@@ -354,7 +354,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="DescendantToken_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/finalparameters.xml
+++ b/src/site/xdoc/checks/misc/finalparameters.xml
@@ -242,7 +242,7 @@ public class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FinalParameters_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.FinalParametersCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/finalparameters.xml.template
+++ b/src/site/xdoc/checks/misc/finalparameters.xml.template
@@ -123,7 +123,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FinalParameters_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.FinalParametersCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/hexliteralcase.xml
+++ b/src/site/xdoc/checks/misc/hexliteralcase.xml
@@ -103,7 +103,7 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="HexLiteralCase_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.HexLiteralCaseCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/hexliteralcase.xml.template
+++ b/src/site/xdoc/checks/misc/hexliteralcase.xml.template
@@ -59,7 +59,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="HexLiteralCase_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.HexLiteralCaseCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -459,7 +459,7 @@ class Example9 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="Indentation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/indentation.xml.template
+++ b/src/site/xdoc/checks/misc/indentation.xml.template
@@ -203,7 +203,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="Indentation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/lineending.xml
+++ b/src/site/xdoc/checks/misc/lineending.xml
@@ -145,7 +145,7 @@ public class Example3 {  // ␊ // violation 'Expected line ending for file is C
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LineEnding_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.LineEndingCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/lineending.xml.template
+++ b/src/site/xdoc/checks/misc/lineending.xml.template
@@ -105,7 +105,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LineEnding_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.LineEndingCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/newlineatendoffile.xml
+++ b/src/site/xdoc/checks/misc/newlineatendoffile.xml
@@ -203,7 +203,7 @@ Sample txt file. // ok, this file is not specified in the config.
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NewlineAtEndOfFile_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/newlineatendoffile.xml.template
+++ b/src/site/xdoc/checks/misc/newlineatendoffile.xml.template
@@ -126,7 +126,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NewlineAtEndOfFile_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/nocodeinfile.xml
+++ b/src/site/xdoc/checks/misc/nocodeinfile.xml
@@ -82,7 +82,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoCodeInFile_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/nocodeinfile.xml.template
+++ b/src/site/xdoc/checks/misc/nocodeinfile.xml.template
@@ -62,7 +62,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoCodeInFile_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml
+++ b/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml
@@ -114,7 +114,8 @@ public class Example1 {
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="NumericalPrefixesInfixesSuffixesCharacterCase_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.NumericalPrefixesInfixesSuffixesCharacterCaseCheck</p>
     <p>
       Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml.template
+++ b/src/site/xdoc/checks/misc/numericalprefixesinfixessuffixescharactercase.xml.template
@@ -61,7 +61,8 @@
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+                id="NumericalPrefixesInfixesSuffixesCharacterCase_Fully_Qualified_Name">
     <p>com.puppycrawl.tools.checkstyle.checks.NumericalPrefixesInfixesSuffixesCharacterCaseCheck</p>
     <p>
       Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/orderedproperties.xml
+++ b/src/site/xdoc/checks/misc/orderedproperties.xml
@@ -121,7 +121,7 @@ key.png=value
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OrderedProperties_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/orderedproperties.xml.template
+++ b/src/site/xdoc/checks/misc/orderedproperties.xml.template
@@ -82,7 +82,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OrderedProperties_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/outertypefilename.xml
+++ b/src/site/xdoc/checks/misc/outertypefilename.xml
@@ -94,7 +94,7 @@ class Example5ButNotSameName {}
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OuterTypeFilename_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/outertypefilename.xml.template
+++ b/src/site/xdoc/checks/misc/outertypefilename.xml.template
@@ -97,7 +97,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OuterTypeFilename_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/todocomment.xml
+++ b/src/site/xdoc/checks/misc/todocomment.xml
@@ -137,7 +137,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="TodoComment_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/todocomment.xml.template
+++ b/src/site/xdoc/checks/misc/todocomment.xml.template
@@ -98,7 +98,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="TodoComment_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/trailingcomment.xml
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml
@@ -307,7 +307,7 @@ public class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="TrailingComment_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/trailingcomment.xml.template
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml.template
@@ -161,7 +161,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="TrailingComment_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/translation.xml
+++ b/src/site/xdoc/checks/misc/translation.xml
@@ -230,7 +230,7 @@ messages_home.translations // violation,
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="Translation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.TranslationCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/translation.xml.template
+++ b/src/site/xdoc/checks/misc/translation.xml.template
@@ -168,7 +168,7 @@ messages_home.translations
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="Translation_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.TranslationCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/uncommentedmain.xml
+++ b/src/site/xdoc/checks/misc/uncommentedmain.xml
@@ -149,7 +149,7 @@ record MyRecord2() {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UncommentedMain_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/uncommentedmain.xml.template
+++ b/src/site/xdoc/checks/misc/uncommentedmain.xml.template
@@ -79,7 +79,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UncommentedMain_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/uniqueproperties.xml
+++ b/src/site/xdoc/checks/misc/uniqueproperties.xml
@@ -119,7 +119,7 @@ key.one=54
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UniqueProperties_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/uniqueproperties.xml.template
+++ b/src/site/xdoc/checks/misc/uniqueproperties.xml.template
@@ -91,7 +91,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UniqueProperties_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/upperell.xml
+++ b/src/site/xdoc/checks/misc/upperell.xml
@@ -79,7 +79,7 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UpperEll_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.UpperEllCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/misc/upperell.xml.template
+++ b/src/site/xdoc/checks/misc/upperell.xml.template
@@ -67,7 +67,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="UpperEll_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.UpperEllCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
+++ b/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
@@ -276,7 +276,7 @@ public final class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ClassMemberImpliedModifier_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml.template
+++ b/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml.template
@@ -123,7 +123,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ClassMemberImpliedModifier_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml
+++ b/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml
@@ -352,7 +352,8 @@ public interface Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="InterfaceMemberImpliedModifier_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml.template
+++ b/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml.template
@@ -130,7 +130,8 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="InterfaceMemberImpliedModifier_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/modifier/modifierorder.xml
+++ b/src/site/xdoc/checks/modifier/modifierorder.xml
@@ -111,7 +111,7 @@ public class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ModifierOrder_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/modifier/modifierorder.xml.template
+++ b/src/site/xdoc/checks/modifier/modifierorder.xml.template
@@ -61,7 +61,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ModifierOrder_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/modifier/redundantmodifier.xml
+++ b/src/site/xdoc/checks/modifier/redundantmodifier.xml
@@ -392,7 +392,7 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RedundantModifier_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/modifier/redundantmodifier.xml.template
+++ b/src/site/xdoc/checks/modifier/redundantmodifier.xml.template
@@ -101,7 +101,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RedundantModifier_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/abbreviationaswordinname.xml
+++ b/src/site/xdoc/checks/naming/abbreviationaswordinname.xml
@@ -398,7 +398,7 @@ class Example7 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AbbreviationAsWordInName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/abbreviationaswordinname.xml.template
+++ b/src/site/xdoc/checks/naming/abbreviationaswordinname.xml.template
@@ -166,7 +166,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AbbreviationAsWordInName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/abstractclassname.xml
+++ b/src/site/xdoc/checks/naming/abstractclassname.xml
@@ -184,7 +184,7 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AbstractClassName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/abstractclassname.xml.template
+++ b/src/site/xdoc/checks/naming/abstractclassname.xml.template
@@ -109,7 +109,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AbstractClassName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/catchparametername.xml
+++ b/src/site/xdoc/checks/naming/catchparametername.xml
@@ -154,7 +154,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="CatchParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.CatchParameterNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/catchparametername.xml.template
+++ b/src/site/xdoc/checks/naming/catchparametername.xml.template
@@ -87,7 +87,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="CatchParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.CatchParameterNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/classtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/classtypeparametername.xml
@@ -131,7 +131,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ClassTypeParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.ClassTypeParameterNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/classtypeparametername.xml.template
+++ b/src/site/xdoc/checks/naming/classtypeparametername.xml.template
@@ -97,7 +97,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ClassTypeParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.ClassTypeParameterNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/constantname.xml
+++ b/src/site/xdoc/checks/naming/constantname.xml
@@ -233,7 +233,7 @@ class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ConstantName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/constantname.xml.template
+++ b/src/site/xdoc/checks/naming/constantname.xml.template
@@ -129,7 +129,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ConstantName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml
+++ b/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml
@@ -142,7 +142,7 @@ class Example1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="GoogleNonConstantFieldName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.GoogleNonConstantFieldNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml.template
+++ b/src/site/xdoc/checks/naming/googlenonconstantfieldname.xml.template
@@ -59,7 +59,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="GoogleNonConstantFieldName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.GoogleNonConstantFieldNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/illegalidentifiername.xml
+++ b/src/site/xdoc/checks/naming/illegalidentifiername.xml
@@ -212,7 +212,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalIdentifierName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/illegalidentifiername.xml.template
+++ b/src/site/xdoc/checks/naming/illegalidentifiername.xml.template
@@ -83,7 +83,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="IllegalIdentifierName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/interfacetypeparametername.xml
+++ b/src/site/xdoc/checks/naming/interfacetypeparametername.xml
@@ -105,7 +105,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="InterfaceTypeParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/interfacetypeparametername.xml.template
+++ b/src/site/xdoc/checks/naming/interfacetypeparametername.xml.template
@@ -83,7 +83,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="InterfaceTypeParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/lambdaparametername.xml
+++ b/src/site/xdoc/checks/naming/lambdaparametername.xml
@@ -112,7 +112,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LambdaParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/lambdaparametername.xml.template
+++ b/src/site/xdoc/checks/naming/lambdaparametername.xml.template
@@ -83,7 +83,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LambdaParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml
@@ -181,7 +181,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LocalFinalVariableName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml.template
@@ -98,7 +98,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LocalFinalVariableName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/localvariablename.xml
+++ b/src/site/xdoc/checks/naming/localvariablename.xml
@@ -211,7 +211,7 @@ class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LocalVariableName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/localvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/localvariablename.xml.template
@@ -128,7 +128,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LocalVariableName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/membername.xml
+++ b/src/site/xdoc/checks/naming/membername.xml
@@ -179,7 +179,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MemberName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/membername.xml.template
+++ b/src/site/xdoc/checks/naming/membername.xml.template
@@ -101,7 +101,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MemberName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/methodname.xml
+++ b/src/site/xdoc/checks/naming/methodname.xml
@@ -279,7 +279,7 @@ class Example7 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MethodName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/methodname.xml.template
+++ b/src/site/xdoc/checks/naming/methodname.xml.template
@@ -164,7 +164,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MethodName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/methodtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/methodtypeparametername.xml
@@ -106,7 +106,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MethodTypeParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/methodtypeparametername.xml.template
+++ b/src/site/xdoc/checks/naming/methodtypeparametername.xml.template
@@ -82,7 +82,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MethodTypeParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/packagename.xml
+++ b/src/site/xdoc/checks/naming/packagename.xml
@@ -119,7 +119,7 @@ public class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="PackageName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/packagename.xml.template
+++ b/src/site/xdoc/checks/naming/packagename.xml.template
@@ -87,7 +87,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="PackageName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/parametername.xml
+++ b/src/site/xdoc/checks/naming/parametername.xml
@@ -224,7 +224,7 @@ class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/parametername.xml.template
+++ b/src/site/xdoc/checks/naming/parametername.xml.template
@@ -134,7 +134,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/patternvariablename.xml
+++ b/src/site/xdoc/checks/naming/patternvariablename.xml
@@ -185,7 +185,7 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="PatternVariableName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.PatternVariableNameCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/patternvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/patternvariablename.xml.template
@@ -116,7 +116,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="PatternVariableName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.PatternVariableNameCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/recordcomponentname.xml
+++ b/src/site/xdoc/checks/naming/recordcomponentname.xml
@@ -111,7 +111,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RecordComponentName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.RecordComponentNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/recordcomponentname.xml.template
+++ b/src/site/xdoc/checks/naming/recordcomponentname.xml.template
@@ -85,7 +85,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RecordComponentName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.RecordComponentNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/recordtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/recordtypeparametername.xml
@@ -111,7 +111,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RecordTypeParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.RecordTypeParameterNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/recordtypeparametername.xml.template
+++ b/src/site/xdoc/checks/naming/recordtypeparametername.xml.template
@@ -85,7 +85,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RecordTypeParameterName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.RecordTypeParameterNameCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/staticvariablename.xml
+++ b/src/site/xdoc/checks/naming/staticvariablename.xml
@@ -175,7 +175,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="StaticVariableName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.StaticVariableNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/staticvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/staticvariablename.xml.template
@@ -98,7 +98,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="StaticVariableName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.StaticVariableNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/typename.xml
+++ b/src/site/xdoc/checks/naming/typename.xml
@@ -223,7 +223,7 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="TypeName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/naming/typename.xml.template
+++ b/src/site/xdoc/checks/naming/typename.xml.template
@@ -121,7 +121,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="TypeName_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/regexp/regexp.xml
+++ b/src/site/xdoc/checks/regexp/regexp.xml
@@ -423,7 +423,7 @@ public class Example11 {}
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="Regexp_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/regexp/regexp.xml.template
+++ b/src/site/xdoc/checks/regexp/regexp.xml.template
@@ -209,7 +209,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="Regexp_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/regexp/regexpmultiline.xml
+++ b/src/site/xdoc/checks/regexp/regexpmultiline.xml
@@ -396,7 +396,7 @@ class Example5 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RegexpMultiline_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/regexp/regexpmultiline.xml.template
+++ b/src/site/xdoc/checks/regexp/regexpmultiline.xml.template
@@ -160,7 +160,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RegexpMultiline_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/regexp/regexponfilename.xml
+++ b/src/site/xdoc/checks/regexp/regexponfilename.xml
@@ -235,7 +235,7 @@
         </p>
       </subsection>
 
-        <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <subsection name="Fully Qualified Name" id="RegexpOnFilename_Fully_Qualified_Name">
           <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck</p>
           <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/regexp/regexponfilename.xml.template
+++ b/src/site/xdoc/checks/regexp/regexponfilename.xml.template
@@ -122,7 +122,7 @@
         </p>
       </subsection>
 
-        <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+        <subsection name="Fully Qualified Name" id="RegexpOnFilename_Fully_Qualified_Name">
           <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck</p>
           <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/regexp/regexpsingleline.xml
+++ b/src/site/xdoc/checks/regexp/regexpsingleline.xml
@@ -251,7 +251,7 @@ CREATE DATABASE MyDB;
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RegexpSingleline_Fully_Qualified_Name">
          <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck</p>
          <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/regexp/regexpsingleline.xml.template
+++ b/src/site/xdoc/checks/regexp/regexpsingleline.xml.template
@@ -143,7 +143,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RegexpSingleline_Fully_Qualified_Name">
          <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck</p>
          <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml
+++ b/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml
@@ -450,7 +450,7 @@ class Example7 {
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+  <subsection name="Fully Qualified Name" id="RegexpSinglelineJava_Fully_Qualified_Name">
       <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck</p>
       <p>
         Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml.template
+++ b/src/site/xdoc/checks/regexp/regexpsinglelinejava.xml.template
@@ -162,7 +162,7 @@
         </p>
       </subsection>
 
-  <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+  <subsection name="Fully Qualified Name" id="RegexpSinglelineJava_Fully_Qualified_Name">
       <p> com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck</p>
       <p>
         Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/anoninnerlength.xml
+++ b/src/site/xdoc/checks/sizes/anoninnerlength.xml
@@ -142,7 +142,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AnonInnerLength_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/anoninnerlength.xml.template
+++ b/src/site/xdoc/checks/sizes/anoninnerlength.xml.template
@@ -78,7 +78,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="AnonInnerLength_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/executablestatementcount.xml
+++ b/src/site/xdoc/checks/sizes/executablestatementcount.xml
@@ -183,7 +183,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ExecutableStatementCount_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/executablestatementcount.xml.template
+++ b/src/site/xdoc/checks/sizes/executablestatementcount.xml.template
@@ -94,7 +94,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ExecutableStatementCount_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/filelength.xml
+++ b/src/site/xdoc/checks/sizes/filelength.xml
@@ -135,7 +135,7 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FileLength_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/filelength.xml.template
+++ b/src/site/xdoc/checks/sizes/filelength.xml.template
@@ -96,7 +96,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FileLength_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/lambdabodylength.xml
+++ b/src/site/xdoc/checks/sizes/lambdabodylength.xml
@@ -164,7 +164,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LambdaBodyLength_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.LambdaBodyLengthCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/lambdabodylength.xml.template
+++ b/src/site/xdoc/checks/sizes/lambdabodylength.xml.template
@@ -86,7 +86,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LambdaBodyLength_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.LambdaBodyLengthCheck</p>
         <p>
               Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/linelength.xml
+++ b/src/site/xdoc/checks/sizes/linelength.xml
@@ -319,7 +319,7 @@ public class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LineLength_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/linelength.xml.template
+++ b/src/site/xdoc/checks/sizes/linelength.xml.template
@@ -168,7 +168,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="LineLength_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/methodcount.xml
+++ b/src/site/xdoc/checks/sizes/methodcount.xml
@@ -394,7 +394,7 @@ class Example6 { // no violations: there are no protected methods in this class
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MethodCount_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.MethodCountCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/methodcount.xml.template
+++ b/src/site/xdoc/checks/sizes/methodcount.xml.template
@@ -135,7 +135,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MethodCount_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.MethodCountCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/methodlength.xml
+++ b/src/site/xdoc/checks/sizes/methodlength.xml
@@ -284,7 +284,7 @@ public class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MethodLength_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.MethodLengthCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/methodlength.xml.template
+++ b/src/site/xdoc/checks/sizes/methodlength.xml.template
@@ -99,7 +99,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MethodLength_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.MethodLengthCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/outertypenumber.xml
+++ b/src/site/xdoc/checks/sizes/outertypenumber.xml
@@ -116,7 +116,7 @@ enum outer1 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OuterTypeNumber_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/outertypenumber.xml.template
+++ b/src/site/xdoc/checks/sizes/outertypenumber.xml.template
@@ -80,7 +80,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OuterTypeNumber_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/parameternumber.xml
+++ b/src/site/xdoc/checks/sizes/parameternumber.xml
@@ -269,7 +269,7 @@ class ExternalService4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ParameterNumber_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/parameternumber.xml.template
+++ b/src/site/xdoc/checks/sizes/parameternumber.xml.template
@@ -121,7 +121,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ParameterNumber_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/recordcomponentnumber.xml
+++ b/src/site/xdoc/checks/sizes/recordcomponentnumber.xml
@@ -163,7 +163,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RecordComponentNumber_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/sizes/recordcomponentnumber.xml.template
+++ b/src/site/xdoc/checks/sizes/recordcomponentnumber.xml.template
@@ -100,7 +100,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="RecordComponentNumber_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml
+++ b/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml
@@ -129,7 +129,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyForInitializerPad_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml.template
+++ b/src/site/xdoc/checks/whitespace/emptyforinitializerpad.xml.template
@@ -84,7 +84,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyForInitializerPad_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml
+++ b/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml
@@ -135,7 +135,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyForIteratorPad_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml.template
+++ b/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml.template
@@ -87,7 +87,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyForIteratorPad_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/emptylineseparator.xml
+++ b/src/site/xdoc/checks/whitespace/emptylineseparator.xml
@@ -546,7 +546,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator.pac
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyLineSeparator_Fully_Qualified_Name">
           <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</p>
           <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/emptylineseparator.xml.template
+++ b/src/site/xdoc/checks/whitespace/emptylineseparator.xml.template
@@ -232,7 +232,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="EmptyLineSeparator_Fully_Qualified_Name">
           <p> com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</p>
           <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/filetabcharacter.xml
+++ b/src/site/xdoc/checks/whitespace/filetabcharacter.xml
@@ -181,7 +181,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FileTabCharacter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/filetabcharacter.xml.template
+++ b/src/site/xdoc/checks/whitespace/filetabcharacter.xml.template
@@ -121,7 +121,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="FileTabCharacter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/genericwhitespace.xml
+++ b/src/site/xdoc/checks/whitespace/genericwhitespace.xml
@@ -128,7 +128,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="GenericWhitespace_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/genericwhitespace.xml.template
+++ b/src/site/xdoc/checks/whitespace/genericwhitespace.xml.template
@@ -73,7 +73,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="GenericWhitespace_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck</p>
         <p>
             Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/methodparampad.xml
+++ b/src/site/xdoc/checks/whitespace/methodparampad.xml
@@ -203,7 +203,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MethodParamPad_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/methodparampad.xml.template
+++ b/src/site/xdoc/checks/whitespace/methodparampad.xml.template
@@ -89,7 +89,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="MethodParamPad_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml
@@ -216,7 +216,7 @@ class // violation 'should not be line-wrapped'
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoLineWrap_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
@@ -123,7 +123,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoLineWrap_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml
+++ b/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml
@@ -232,7 +232,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoWhitespaceAfter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml.template
+++ b/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml.template
@@ -82,7 +82,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoWhitespaceAfter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml
+++ b/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml
@@ -237,7 +237,7 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoWhitespaceBefore_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml.template
+++ b/src/site/xdoc/checks/whitespace/nowhitespacebefore.xml.template
@@ -114,7 +114,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="NoWhitespaceBefore_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml
+++ b/src/site/xdoc/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml
@@ -89,7 +89,8 @@ class Example1 {
         </p>
       </subsection>
 
-<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+              id="NoWhitespaceBeforeCaseDefaultColon_Fully_Qualified_Name">
   <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCaseDefaultColonCheck</p>
   <p>
     Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml.template
+++ b/src/site/xdoc/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml.template
@@ -60,7 +60,8 @@
         </p>
       </subsection>
 
-<subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+<subsection name="Fully Qualified Name"
+              id="NoWhitespaceBeforeCaseDefaultColon_Fully_Qualified_Name">
   <p> com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCaseDefaultColonCheck</p>
   <p>
     Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/operatorwrap.xml
+++ b/src/site/xdoc/checks/whitespace/operatorwrap.xml
@@ -299,7 +299,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OperatorWrap_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/operatorwrap.xml.template
+++ b/src/site/xdoc/checks/whitespace/operatorwrap.xml.template
@@ -90,7 +90,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="OperatorWrap_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/parenpad.xml
+++ b/src/site/xdoc/checks/whitespace/parenpad.xml
@@ -298,7 +298,7 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ParenPad_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/parenpad.xml.template
+++ b/src/site/xdoc/checks/whitespace/parenpad.xml.template
@@ -100,7 +100,7 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="ParenPad_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/separatorwrap.xml
+++ b/src/site/xdoc/checks/whitespace/separatorwrap.xml
@@ -205,7 +205,7 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SeparatorWrap_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/separatorwrap.xml.template
+++ b/src/site/xdoc/checks/whitespace/separatorwrap.xml.template
@@ -104,7 +104,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SeparatorWrap_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/singlespaceseparator.xml
+++ b/src/site/xdoc/checks/whitespace/singlespaceseparator.xml
@@ -146,7 +146,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SingleSpaceSeparator_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/singlespaceseparator.xml.template
+++ b/src/site/xdoc/checks/whitespace/singlespaceseparator.xml.template
@@ -80,7 +80,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SingleSpaceSeparator_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/typecastparenpad.xml
+++ b/src/site/xdoc/checks/whitespace/typecastparenpad.xml
@@ -142,7 +142,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="TypecastParenPad_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/typecastparenpad.xml.template
+++ b/src/site/xdoc/checks/whitespace/typecastparenpad.xml.template
@@ -87,7 +87,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="TypecastParenPad_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/whitespaceafter.xml
+++ b/src/site/xdoc/checks/whitespace/whitespaceafter.xml
@@ -256,7 +256,7 @@ class Example2 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="WhitespaceAfter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/whitespaceafter.xml.template
+++ b/src/site/xdoc/checks/whitespace/whitespaceafter.xml.template
@@ -88,7 +88,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="WhitespaceAfter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml
@@ -697,7 +697,7 @@ class Example11 {
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="WhitespaceAround_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml.template
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml.template
@@ -219,7 +219,7 @@
         </p>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="WhitespaceAround_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml
+++ b/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml
@@ -197,7 +197,8 @@
         </ul>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="BeforeExecutionExclusionFileFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filefilters.BeforeExecutionExclusionFileFilter </p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml.template
+++ b/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml.template
@@ -108,7 +108,8 @@
         </ul>
       </subsection>
 
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="BeforeExecutionExclusionFileFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filefilters.BeforeExecutionExclusionFileFilter </p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/severitymatchfilter.xml
+++ b/src/site/xdoc/filters/severitymatchfilter.xml
@@ -86,7 +86,7 @@ public class Example1 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SeverityMatchFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SeverityMatchFilter </p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/severitymatchfilter.xml.template
+++ b/src/site/xdoc/filters/severitymatchfilter.xml.template
@@ -59,7 +59,7 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SeverityMatchFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SeverityMatchFilter </p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppressioncommentfilter.xml
+++ b/src/site/xdoc/filters/suppressioncommentfilter.xml
@@ -550,7 +550,7 @@ class Example8
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressionCommentFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter </p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppressioncommentfilter.xml.template
+++ b/src/site/xdoc/filters/suppressioncommentfilter.xml.template
@@ -175,7 +175,7 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressionCommentFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter </p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppressionfilter.xml
+++ b/src/site/xdoc/filters/suppressionfilter.xml
@@ -401,7 +401,7 @@ files=&quot;com[\\/]mycompany[\\/]app[\\/].*IT.java&quot;/&gt;
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressionFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressionFilter </p>
         <p>
               This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppressionfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionfilter.xml.template
@@ -201,7 +201,7 @@ files="com[\\/]mycompany[\\/]app[\\/].*IT.java"/&gt;
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressionFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressionFilter </p>
         <p>
               This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppressionsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionsinglefilter.xml
@@ -223,7 +223,7 @@ public class Example4 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressionSingleFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressionSingleFilter</p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppressionsinglefilter.xml.template
+++ b/src/site/xdoc/filters/suppressionsinglefilter.xml.template
@@ -107,7 +107,7 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressionSingleFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressionSingleFilter</p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppressionxpathfilter.xml
+++ b/src/site/xdoc/filters/suppressionxpathfilter.xml
@@ -1017,7 +1017,7 @@ public class Example14 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressionXpathFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter</p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppressionxpathfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionxpathfilter.xml.template
@@ -569,7 +569,7 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressionXpathFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter</p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
@@ -504,7 +504,8 @@ public class Example13 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="SuppressionXpathSingleFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter</p>
         <p>
               This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppressionxpathsinglefilter.xml.template
+++ b/src/site/xdoc/filters/suppressionxpathsinglefilter.xml.template
@@ -267,7 +267,8 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="SuppressionXpathSingleFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter</p>
         <p>
               This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppresswarningsfilter.xml
+++ b/src/site/xdoc/filters/suppresswarningsfilter.xml
@@ -114,7 +114,7 @@ public class Example2 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressWarningsFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter</p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppresswarningsfilter.xml.template
+++ b/src/site/xdoc/filters/suppresswarningsfilter.xml.template
@@ -68,7 +68,7 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name" id="SuppressWarningsFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter</p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
@@ -348,7 +348,8 @@ public class Example8 { // filtered violation 'Class Data Abstraction Coupling i
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="SuppressWithNearbyCommentFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilter</p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml.template
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml.template
@@ -177,7 +177,8 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="SuppressWithNearbyCommentFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilter</p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
@@ -313,7 +313,8 @@ public class Example9 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="SuppressWithNearbyTextFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter</p>
         <p>
               This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppresswithnearbytextfilter.xml.template
+++ b/src/site/xdoc/filters/suppresswithnearbytextfilter.xml.template
@@ -196,7 +196,8 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="SuppressWithNearbyTextFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter</p>
         <p>
               This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
@@ -483,7 +483,8 @@ public class Example9 {
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="SuppressWithPlainTextCommentFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter</p>
         <p>
             This is the fully qualified class name of the module.

--- a/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml.template
+++ b/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml.template
@@ -215,7 +215,8 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+                   id="SuppressWithPlainTextCommentFilter_Fully_Qualified_Name">
         <p> com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter</p>
         <p>
             This is the fully qualified class name of the module.


### PR DESCRIPTION
Fixes #19817
Changes `id="Fully_Qualified_Name"` to `id="{ModuleName}_Fully_Qualified_Name"` 
across all xdoc files to eliminate Doxia site warnings