### PR TITLE
Issue #18361: pin byte-buddy and add JDK-conditional cacio-tta profiles

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,10 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\JDK21
       DESC: "site, without verify (JDK21)"
       CMD: "./.ci/validation.cmd site_without_verify"
+    # verify (JDK25)
+    - JAVA_HOME: C:\Program Files\Java\JDK25
+      DESC: "verify (JDK25)"
+      CMD: "./mvnw.cmd -e --no-transfer-progress verify"
 
 build_script:
   - ps: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,6 +95,16 @@ strategy:
       image: 'macOS-14'
       cmd: "JAVA_HOME=$JAVA_HOME_21_X64 ./mvnw -e --no-transfer-progress verify"
 
+    # OpenJDK25 verify
+    'OpenJDK25 verify':
+      image: 'ubuntu-24.04'
+      cmd: "JAVA_HOME=$JAVA_HOME_25_X64 ./mvnw -e --no-transfer-progress verify"
+
+    # MacOS JDK25 verify
+    'MacOS JDK25 verify':
+      image: 'macOS-14'
+      cmd: "JAVA_HOME=$JAVA_HOME_25_X64 ./mvnw -e --no-transfer-progress verify"
+
     # versions to update
     'versions':
       image: 'ubuntu-24.04'

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -136,6 +136,7 @@ buildkite
 Bunsubscribe
 bw
 BXOR
+bytebuddy
 bytecode
 Cacheable
 cachefile

--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,18 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.18.8</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>1.18.8</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -397,18 +409,6 @@
       <artifactId>archunit-junit5</artifactId>
       <version>1.4.2</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.github.caciocavallosilano</groupId>
-      <artifactId>cacio-tta</artifactId>
-      <version>1.18</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.jidesoft</groupId>
-          <artifactId>jide-oss</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
@@ -2503,6 +2503,48 @@
   </reporting>
 
   <profiles>
+
+    <profile>
+      <id>cacio-tta-pre-jdk25</id>
+      <activation>
+        <jdk>(,25)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.caciocavallosilano</groupId>
+          <artifactId>cacio-tta</artifactId>
+          <version>1.18</version>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.jidesoft</groupId>
+              <artifactId>jide-oss</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>cacio-tta-jdk25</id>
+      <activation>
+        <jdk>[25,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.caciocavallosilano</groupId>
+          <artifactId>cacio-tta-jdk25</artifactId>
+          <version>2.0</version>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.jidesoft</groupId>
+              <artifactId>jide-oss</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
 
     <profile>
       <!-- To be used during development. Run the command -->


### PR DESCRIPTION
Issue #18361

Two pom.xml changes to make `./mvnw clean verify` pass on JDK 25

1. **Pin `byte-buddy` 1.18.8 in `<dependencyManagement>`.**  Mockito 5.2.0 transitively bundles byte-buddy 1.14.1, which rejects JDK 25 class files (major 69) with `Java 25 (69) is not supported by the current version of Byte Buddy`. Pinning byte-buddy 1.18.8 raises the supported class-file ceiling for every transitive consumer.

2. **Split `cacio-tta` into two JDK-version-conditional profiles.** `cacio-tta:1.18` references `sun.java2d.SurfaceManagerFactory` which was removed in JDK 25, but its replacement `cacio-tta-jdk25:2.0` is  compiled targeting JDK 25 (class-file 69) and cannot be read on JDK 21.  Use `cacio-tta:1.18` on JDK < 25, `cacio-tta-jdk25:2.0` on JDK ≥ 25.

