### PR TITLE
supplemental: fix Constructor order violations

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -128,6 +128,26 @@ public class PackageObjectFactory implements ModuleFactory {
     /**
      * Creates a new {@code PackageObjectFactory} instance.
      *
+     * @param packageName The package name to use
+     * @param moduleClassLoader class loader used to load Checkstyle
+     *          core and custom modules
+     * @throws IllegalArgumentException if moduleClassLoader is null or packageNames is null
+     */
+    public PackageObjectFactory(String packageName, ClassLoader moduleClassLoader) {
+        if (moduleClassLoader == null) {
+            throw new IllegalArgumentException(NULL_LOADER_MESSAGE);
+        }
+        if (packageName == null) {
+            throw new IllegalArgumentException(NULL_PACKAGE_MESSAGE);
+        }
+
+        packages = Collections.singleton(packageName);
+        this.moduleClassLoader = moduleClassLoader;
+    }
+
+    /**
+     * Creates a new {@code PackageObjectFactory} instance.
+     *
      * @param packageNames package names to use
      * @param moduleClassLoader class loader used to load Checkstyle
      *          core and custom modules
@@ -147,26 +167,6 @@ public class PackageObjectFactory implements ModuleFactory {
         packages = new LinkedHashSet<>(packageNames);
         this.moduleClassLoader = moduleClassLoader;
         this.moduleLoadOption = moduleLoadOption;
-    }
-
-    /**
-     * Creates a new {@code PackageObjectFactory} instance.
-     *
-     * @param packageName The package name to use
-     * @param moduleClassLoader class loader used to load Checkstyle
-     *          core and custom modules
-     * @throws IllegalArgumentException if moduleClassLoader is null or packageNames is null
-     */
-    public PackageObjectFactory(String packageName, ClassLoader moduleClassLoader) {
-        if (moduleClassLoader == null) {
-            throw new IllegalArgumentException(NULL_LOADER_MESSAGE);
-        }
-        if (packageName == null) {
-            throw new IllegalArgumentException(NULL_PACKAGE_MESSAGE);
-        }
-
-        packages = Collections.singleton(packageName);
-        this.moduleClassLoader = moduleClassLoader;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
@@ -76,114 +76,27 @@ public final class Violation
     private final String customMessage;
 
     /**
-     * Creates a new {@code Violation} instance.
+     * Creates a new {@code Violation} instance. The column number
+     * defaults to 0.
      *
      * @param lineNo line number associated with the violation
-     * @param columnNo column number associated with the violation
-     * @param columnCharIndex column char index associated with the violation
-     * @param tokenType token type of the event associated with violation. See {@link TokenTypes}
-     * @param bundle resource bundle name
+     * @param bundle name of a resource bundle that contains audit event violations
      * @param key the key to locate the translation
      * @param args arguments for the translation
-     * @param severityLevel severity level for the violation
      * @param moduleId the id of the module the violation is associated with
-     * @param sourceClass the Class that is the source of the violation
+     * @param sourceClass the name of the source for the violation
      * @param customMessage optional custom violation overriding the default
-     * @noinspection ConstructorWithTooManyParameters
-     * @noinspectionreason ConstructorWithTooManyParameters - immutable class requires a large
-     *      number of arguments
      */
-    // -@cs[ParameterNumber] Class is immutable, we need that amount of arguments.
-    public Violation(int lineNo,
-                            int columnNo,
-                            int columnCharIndex,
-                            int tokenType,
-                            String bundle,
-                            String key,
-                            Object[] args,
-                            SeverityLevel severityLevel,
-                            String moduleId,
-                            Class<?> sourceClass,
-                            @Nullable String customMessage) {
-        this.lineNo = lineNo;
-        this.columnNo = columnNo;
-        this.columnCharIndex = columnCharIndex;
-        this.tokenType = tokenType;
-        this.key = key;
-
-        if (args == null) {
-            this.args = null;
-        }
-        else {
-            this.args = UnmodifiableCollectionUtil.copyOfArray(args, args.length);
-        }
-        this.bundle = bundle;
-        this.severityLevel = severityLevel;
-        this.moduleId = moduleId;
-        this.sourceClass = sourceClass;
-        this.customMessage = customMessage;
-    }
-
-    /**
-     * Creates a new {@code Violation} instance.
-     *
-     * @param lineNo line number associated with the violation
-     * @param columnNo column number associated with the violation
-     * @param tokenType token type of the event associated with violation. See {@link TokenTypes}
-     * @param bundle resource bundle name
-     * @param key the key to locate the translation
-     * @param args arguments for the translation
-     * @param severityLevel severity level for the violation
-     * @param moduleId the id of the module the violation is associated with
-     * @param sourceClass the Class that is the source of the violation
-     * @param customMessage optional custom violation overriding the default
-     * @noinspection ConstructorWithTooManyParameters
-     * @noinspectionreason ConstructorWithTooManyParameters - immutable class requires a large
-     *      number of arguments
-     */
-    // -@cs[ParameterNumber] Class is immutable, we need that amount of arguments.
-    public Violation(int lineNo,
-                            int columnNo,
-                            int tokenType,
-                            String bundle,
-                            String key,
-                            Object[] args,
-                            SeverityLevel severityLevel,
-                            String moduleId,
-                            Class<?> sourceClass,
-                            @Nullable String customMessage) {
-        this(lineNo, columnNo, columnNo, tokenType, bundle, key, args, severityLevel, moduleId,
+    public Violation(
+        int lineNo,
+        String bundle,
+        String key,
+        Object[] args,
+        String moduleId,
+        Class<?> sourceClass,
+        @Nullable String customMessage) {
+        this(lineNo, 0, bundle, key, args, DEFAULT_SEVERITY, moduleId,
                 sourceClass, customMessage);
-    }
-
-    /**
-     * Creates a new {@code Violation} instance.
-     *
-     * @param lineNo line number associated with the violation
-     * @param columnNo column number associated with the violation
-     * @param bundle resource bundle name
-     * @param key the key to locate the translation
-     * @param args arguments for the translation
-     * @param severityLevel severity level for the violation
-     * @param moduleId the id of the module the violation is associated with
-     * @param sourceClass the Class that is the source of the violation
-     * @param customMessage optional custom violation overriding the default
-     * @noinspection ConstructorWithTooManyParameters
-     * @noinspectionreason ConstructorWithTooManyParameters - immutable class requires a large
-     *      number of arguments
-     */
-    // -@cs[ParameterNumber] Class is immutable, we need that amount of arguments.
-    public Violation(int lineNo,
-                            int columnNo,
-                            String bundle,
-                            String key,
-                            Object[] args,
-                            SeverityLevel severityLevel,
-                            String moduleId,
-                            Class<?> sourceClass,
-                            @Nullable String customMessage) {
-        this(lineNo, columnNo, 0, bundle, key, args, severityLevel, moduleId, sourceClass,
-                customMessage);
     }
 
     /**
@@ -250,27 +163,114 @@ public final class Violation
     }
 
     /**
-     * Creates a new {@code Violation} instance. The column number
-     * defaults to 0.
+     * Creates a new {@code Violation} instance.
      *
      * @param lineNo line number associated with the violation
-     * @param bundle name of a resource bundle that contains audit event violations
+     * @param columnNo column number associated with the violation
+     * @param bundle resource bundle name
      * @param key the key to locate the translation
      * @param args arguments for the translation
+     * @param severityLevel severity level for the violation
      * @param moduleId the id of the module the violation is associated with
-     * @param sourceClass the name of the source for the violation
+     * @param sourceClass the Class that is the source of the violation
      * @param customMessage optional custom violation overriding the default
+     * @noinspection ConstructorWithTooManyParameters
+     * @noinspectionreason ConstructorWithTooManyParameters - immutable class requires a large
+     *      number of arguments
      */
-    public Violation(
-        int lineNo,
-        String bundle,
-        String key,
-        Object[] args,
-        String moduleId,
-        Class<?> sourceClass,
-        @Nullable String customMessage) {
-        this(lineNo, 0, bundle, key, args, DEFAULT_SEVERITY, moduleId,
+    // -@cs[ParameterNumber] Class is immutable, we need that amount of arguments.
+    public Violation(int lineNo,
+                            int columnNo,
+                            String bundle,
+                            String key,
+                            Object[] args,
+                            SeverityLevel severityLevel,
+                            String moduleId,
+                            Class<?> sourceClass,
+                            @Nullable String customMessage) {
+        this(lineNo, columnNo, 0, bundle, key, args, severityLevel, moduleId, sourceClass,
+                customMessage);
+    }
+
+    /**
+     * Creates a new {@code Violation} instance.
+     *
+     * @param lineNo line number associated with the violation
+     * @param columnNo column number associated with the violation
+     * @param tokenType token type of the event associated with violation. See {@link TokenTypes}
+     * @param bundle resource bundle name
+     * @param key the key to locate the translation
+     * @param args arguments for the translation
+     * @param severityLevel severity level for the violation
+     * @param moduleId the id of the module the violation is associated with
+     * @param sourceClass the Class that is the source of the violation
+     * @param customMessage optional custom violation overriding the default
+     * @noinspection ConstructorWithTooManyParameters
+     * @noinspectionreason ConstructorWithTooManyParameters - immutable class requires a large
+     *      number of arguments
+     */
+    // -@cs[ParameterNumber] Class is immutable, we need that amount of arguments.
+    public Violation(int lineNo,
+                            int columnNo,
+                            int tokenType,
+                            String bundle,
+                            String key,
+                            Object[] args,
+                            SeverityLevel severityLevel,
+                            String moduleId,
+                            Class<?> sourceClass,
+                            @Nullable String customMessage) {
+        this(lineNo, columnNo, columnNo, tokenType, bundle, key, args, severityLevel, moduleId,
                 sourceClass, customMessage);
+    }
+
+    /**
+     * Creates a new {@code Violation} instance.
+     *
+     * @param lineNo line number associated with the violation
+     * @param columnNo column number associated with the violation
+     * @param columnCharIndex column char index associated with the violation
+     * @param tokenType token type of the event associated with violation. See {@link TokenTypes}
+     * @param bundle resource bundle name
+     * @param key the key to locate the translation
+     * @param args arguments for the translation
+     * @param severityLevel severity level for the violation
+     * @param moduleId the id of the module the violation is associated with
+     * @param sourceClass the Class that is the source of the violation
+     * @param customMessage optional custom violation overriding the default
+     * @noinspection ConstructorWithTooManyParameters
+     * @noinspectionreason ConstructorWithTooManyParameters - immutable class requires a large
+     *      number of arguments
+     */
+    // -@cs[ParameterNumber] Class is immutable, we need that amount of arguments.
+    public Violation(int lineNo,
+                            int columnNo,
+                            int columnCharIndex,
+                            int tokenType,
+                            String bundle,
+                            String key,
+                            Object[] args,
+                            SeverityLevel severityLevel,
+                            String moduleId,
+                            Class<?> sourceClass,
+                            @Nullable String customMessage) {
+        this.lineNo = lineNo;
+        this.columnNo = columnNo;
+        this.columnCharIndex = columnCharIndex;
+        this.tokenType = tokenType;
+        this.key = key;
+
+        if (args == null) {
+            this.args = null;
+        }
+        else {
+            this.args = UnmodifiableCollectionUtil.copyOfArray(args, args.length);
+        }
+        this.bundle = bundle;
+        this.severityLevel = severityLevel;
+        this.moduleId = moduleId;
+        this.sourceClass = sourceClass;
+        this.customMessage = customMessage;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -896,21 +896,6 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          * Create a new VariableDesc instance.
          *
          * @param name name of the variable
-         * @param typeAst ast of type {@link TokenTypes#TYPE}
-         * @param scope ast of type {@link TokenTypes#SLIST} or
-         *              {@link TokenTypes#LITERAL_FOR} or {@link TokenTypes#OBJBLOCK}
-         *              which is enclosing the variable
-         */
-        private VariableDesc(String name, DetailAST typeAst, DetailAST scope) {
-            this.name = name;
-            this.typeAst = typeAst;
-            this.scope = scope;
-        }
-
-        /**
-         * Create a new VariableDesc instance.
-         *
-         * @param name name of the variable
          */
         private VariableDesc(String name) {
             this(name, null, null);
@@ -926,6 +911,21 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          */
         private VariableDesc(String name, DetailAST scope) {
             this(name, null, scope);
+        }
+
+        /**
+         * Create a new VariableDesc instance.
+         *
+         * @param name name of the variable
+         * @param typeAst ast of type {@link TokenTypes#TYPE}
+         * @param scope ast of type {@link TokenTypes#SLIST} or
+         *              {@link TokenTypes#LITERAL_FOR} or {@link TokenTypes#OBJBLOCK}
+         *              which is enclosing the variable
+         */
+        private VariableDesc(String name, DetailAST typeAst, DetailAST scope) {
+            this.name = name;
+            this.typeAst = typeAst;
+            this.scope = scope;
         }
 
         /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java
@@ -39,13 +39,9 @@ public class JavadocTag {
      * @param line the line number of the tag
      * @param column the column number of the tag
      * @param tag the tag string
-     * @param firstArg the tag argument
      **/
-    public JavadocTag(int line, int column, String tag, String firstArg) {
-        lineNo = line;
-        columnNo = column;
-        this.firstArg = firstArg;
-        tagInfo = JavadocTagInfo.fromName(tag);
+    public JavadocTag(int line, int column, String tag) {
+        this(line, column, tag, null);
     }
 
     /**
@@ -54,9 +50,13 @@ public class JavadocTag {
      * @param line the line number of the tag
      * @param column the column number of the tag
      * @param tag the tag string
+     * @param firstArg the tag argument
      **/
-    public JavadocTag(int line, int column, String tag) {
-        this(line, column, tag, null);
+    public JavadocTag(int line, int column, String tag, String firstArg) {
+        lineNo = line;
+        columnNo = column;
+        this.firstArg = firstArg;
+        tagInfo = JavadocTagInfo.fromName(tag);
     }
 
     /**


### PR DESCRIPTION
Issue: #19813 

Order constructors according to increasing arity for given files  - 

          src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
          src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
          src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
          src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java
          src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java