### PR TITLE
Issue #19764: Move LineLength violation comment out of Javadoc

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -131,8 +131,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]summaryjavadoc[\\/]InputSummaryJavadocInlineReturnForbidden.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]sizes[\\/]linelength[\\/]InputLineLengthLongLink.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorEmptyLineAfterPackageForPackageAst.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorJavadocCommentAfterPackage.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
@@ -98,7 +98,7 @@ public class LineLengthCheckTest extends AbstractModuleTestSupport {
     @Test
     public void shouldNotLogLongLinks() throws Exception {
         final String[] expected = {
-            "13: " + getCheckMessage(MSG_KEY, 80, 161),
+            "14: " + getCheckMessage(MSG_KEY, 80, 98),
         };
         verifyWithInlineConfigParser(
                 getPath("InputLineLengthLongLink.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthLongLink.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthLongLink.java
@@ -9,8 +9,9 @@ tabWidth = (default)0
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
 
+// violation 2 lines below 'Line is longer than 80 characters (found 98).'
 /**
- * <a href="a long string that has exceeded the 80 character per line limit">with inline title</a> // violation, 'Line is longer than 80 characters (found 161).'
+ * <a href="a long string that has exceeded the 80 character per line limit">with inline title</a>
  * <a href="another long string that has exceeded the 80 character per line limit">
  * with wrapped title</a>
  */


### PR DESCRIPTION
Issue: #19764

This PR handles the `LineLengthCheck` input-file slice for `InputLineLengthLongLink`.

Moved the violation marker out of the Javadoc block, removed the now-unneeded input suppression, and updated the expected `LineLength` violation location and measured line length for the changed input.

Testing:

- `git diff --check`
- `mvn clean -Dtest=LineLengthCheckTest#shouldNotLogLongLinks test`
- `mvn clean -Dtest=LineLengthCheckTest test`
