### PR TITLE
Issue #19803: move violation comments in InputSuppressWarningsExpandedNonConstant4

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -194,8 +194,6 @@
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsExpandedNonConstant3\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsExpandedNonConstant4\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsExpandedNonConstant5\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsExpandedNonConstant6\.java"/>

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsExpandedNonConstant4.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsExpandedNonConstant4.java
@@ -71,8 +71,7 @@ public class InputSuppressWarningsExpandedNonConstant4
     }
 
     // violation below, 'The warning 'unchecked' cannot be suppressed at this location'
-    @SuppressWarnings(value={(false) ? "unchecked" : "", (false) ? "unchecked" : ""})
-    // violation above, 'The warning 'unchecked' cannot be suppressed at this location'
+    @SuppressWarnings(value={(false) ? "unchecked" : "", (false) ? "unchecked" : ""}) // violation, 'The warning 'unchecked' cannot be suppressed at this location'
     class Cond {
 
         @SuppressWarnings(value={(false) ? "" : "unchecked"})


### PR DESCRIPTION
Part of #19803.

Moves `// violation` comments out from between annotations and declarations in `InputSuppressWarningsExpandedNonConstant4.java`, removes the matching `violationBetweenAnnotationAndMethod` suppression entry. No test line number updates were required.