### PR TITLE
Issue #19803: move violation comments in InputUnusedLocalVariableNestedClasses3

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -222,8 +222,6 @@
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]coding[\\/]textblockgooglestyleformatting[\\/]InputTextBlockGoogleStyleFormatting9\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]checks[\\/]coding[\\/]unusedlocalvariable[\\/]InputUnusedLocalVariableNestedClasses3\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]coding[\\/]unusedlocalvariable[\\/]InputUnusedLocalVariableTestWarningSeverity\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationAfterAnnotation\.java"/>


### PR DESCRIPTION
Part of #19803. Input already compliant; removes matching suppression entry.