### PR TITLE
Issue #19803: move violation comments in InputTextBlockGoogleStyleFormatting9

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -220,8 +220,6 @@
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineSingleLineSmallTalkStyle\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]checks[\\/]coding[\\/]textblockgooglestyleformatting[\\/]InputTextBlockGoogleStyleFormatting9\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]coding[\\/]unusedlocalvariable[\\/]InputUnusedLocalVariableNestedClasses3\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]coding[\\/]unusedlocalvariable[\\/]InputUnusedLocalVariableTestWarningSeverity\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheckTest.java
@@ -411,17 +411,17 @@ public class TextBlockGoogleStyleFormattingCheckTest extends AbstractModuleTestS
     @Test
     public void testDefaultTextBlockFormatInAnnotations() throws Exception {
         final String[] expected = {
-            "13:22: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
-            "13:25: " + getCheckMessage(MSG_TEXT_BLOCK_CONTENT),
-            "14:19: " + getCheckMessage(MSG_CLOSE_QUOTES_ERROR),
-            "14:19: " + getCheckMessage(MSG_VERTICALLY_UNALIGNED),
-            "22:22: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
-            "22:25: " + getCheckMessage(MSG_TEXT_BLOCK_CONTENT),
-            "23:15: " + getCheckMessage(MSG_CLOSE_QUOTES_ERROR),
-            "23:15: " + getCheckMessage(MSG_VERTICALLY_UNALIGNED),
-            "33:22: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
-            "33:25: " + getCheckMessage(MSG_TEXT_BLOCK_CONTENT),
-            "35:9: " + getCheckMessage(MSG_VERTICALLY_UNALIGNED),
+            "12:22: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+            "12:25: " + getCheckMessage(MSG_TEXT_BLOCK_CONTENT),
+            "13:19: " + getCheckMessage(MSG_CLOSE_QUOTES_ERROR),
+            "13:19: " + getCheckMessage(MSG_VERTICALLY_UNALIGNED),
+            "21:22: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+            "21:25: " + getCheckMessage(MSG_TEXT_BLOCK_CONTENT),
+            "22:15: " + getCheckMessage(MSG_CLOSE_QUOTES_ERROR),
+            "22:15: " + getCheckMessage(MSG_VERTICALLY_UNALIGNED),
+            "32:22: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+            "32:25: " + getCheckMessage(MSG_TEXT_BLOCK_CONTENT),
+            "34:9: " + getCheckMessage(MSG_VERTICALLY_UNALIGNED),
         };
         verifyWithInlineConfigParser(
                 getPath("InputTextBlockGoogleStyleFormatting9.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/textblockgooglestyleformatting/InputTextBlockGoogleStyleFormatting9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/textblockgooglestyleformatting/InputTextBlockGoogleStyleFormatting9.java
@@ -8,8 +8,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.textblockgooglestyleformat
 
 public class InputTextBlockGoogleStyleFormatting9 {
 
-    @SuppressWarnings({"membername"})
-    // violation below 'Opening quotes (""") of text-block must be on the new line'
+    @SuppressWarnings({"membername"}) // violation below 'Opening quotes (""") of text-block must be on the new line'
     String STRING1 = """
             string""";
     // violation 2 lines above 'Each line of text in the text block must be indented'
@@ -29,8 +28,8 @@ public class InputTextBlockGoogleStyleFormatting9 {
     @SuppressWarnings({
         "checkstyle:membername"
     }) // violation 2 lines below 'Opening quotes (""") of text-block must be on the new line'
-    // violation below 'Each line of text in the text block must be indented'
-    String STRING3 = """
+
+    String STRING3 = """ // violation, 'Each line of text in the text block must be indented'
         string
         """; // violation 'Text-block quotes are not vertically aligned'
 


### PR DESCRIPTION
## Summary
- Move standalone `// violation below` on STRING1 to the `@SuppressWarnings` line.
- Remove standalone `// violation below` between `@SuppressWarnings` and `STRING3`; use `// violation,` on the text-block opening line instead.
- Remove the matching `violationBetweenAnnotationAndMethod` suppression and update expected line numbers in `TextBlockGoogleStyleFormattingCheckTest`.

Part of #19803.