### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - suppresswithplaintextcommentfilter

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -288,8 +288,6 @@ public class XdocsExamplesAstConsistencyTest {
             "filters/suppresswithnearbytextfilter/Example7",
             "filters/suppresswithnearbytextfilter/Example8",
             "filters/suppresswithnearbytextfilter/Example9",
-            "filters/suppresswithplaintextcommentfilter/Example5",
-            "filters/suppresswithplaintextcommentfilter/Example9",
             "checks/indentation/indentation/Example2",
             "checks/indentation/indentation/Example3",
             "checks/indentation/indentation/Example4",
@@ -303,7 +301,8 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/coding/matchxpath/Example3",
             "checks/coding/matchxpath/Example4",
             "checks/coding/matchxpath/Example5",
-            "checks/coding/matchxpath/Example6"
+            "checks/coding/matchxpath/Example6",
+            "filters/suppresswithplaintextcommentfilter/Example9"
             );
 
     /**

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example5.java
@@ -20,12 +20,7 @@
 
 package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
 
+public class Example5 { }
+
 // xdoc section -- start
-public class Example5 {
-  // CHECKSTYLE_OFF: ALMOST_ALL
-  public static final int MAX_ITEMS = 100;
-  private String[] stringArray;
-  // CHECKSTYLE_ON: ALMOST_ALL
-  private int[] intArray;
-}
 // xdoc section -- end


### PR DESCRIPTION
#18435 

<img width="1742" height="710" alt="image" src="https://github.com/user-attachments/assets/37d991e7-f911-4836-94a4-136469d696cc" />

diff check links: 
https://www.diffchecker.com/Bl1cukrE/
https://www.diffchecker.com/xWK16dFe/
https://www.diffchecker.com/3wLm2oD0/
