### PR TITLE
Issue #19793: Anchor IndentationCheck regex in google_checks.xml SuppressWithPlainTextCommentFilter

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -468,6 +468,7 @@ forbiddenapis
 Foreach
 Fpuppycrawl
 fq
+Fqcn
 freemarker
 Fregexp
 Fresources

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -134,6 +134,7 @@ public class SuppressWithNearbyCommentFilter
 
     /**
      * Setter to specify check pattern to suppress.
+     * The pattern is matched against the fully qualified class name of the Check.
      *
      * @param format a {@code String} value
      * @since 5.0

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilter.java
@@ -114,6 +114,7 @@ public class SuppressWithNearbyTextFilter extends AbstractAutomaticBean implemen
      * Setter to specify check name pattern to suppress. Property can also
      * be a RegExp group index at {@code nearbyTextPattern} in
      * format of {@code $x} and be picked from line that matches {@code nearbyTextPattern}.
+     * The pattern is matched against the fully qualified class name of the Check.
      *
      * @param pattern a {@code String} value.
      * @since 10.10.0

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -137,6 +137,7 @@ public class SuppressWithPlainTextCommentFilter extends AbstractAutomaticBean im
 
     /**
      * Setter to specify check pattern to suppress.
+     * The pattern is matched against the fully qualified class name of the Check.
      *
      * @param format pattern for check format.
      * @since 8.6

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -169,6 +169,7 @@ public class SuppressionCommentFilter
 
     /**
      * Setter to specify check pattern to suppress.
+     * The pattern is matched against the fully qualified class name of the Check.
      *
      * @param format a {@code String} value
      * @since 3.5

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
@@ -103,6 +103,7 @@ public class SuppressionSingleFilter extends AbstractAutomaticBean implements Fi
     /**
      * Setter to define the RegExp for matching against the name of the check associated with an
      * audit event.
+     * The pattern is matched against the fully qualified class name of the Check.
      *
      * @param checks the name of the check
      * @since 8.23

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java
@@ -103,6 +103,7 @@ public class SuppressionXpathSingleFilter extends AbstractAutomaticBean implemen
     /**
      * Setter to define a Regular Expression matched against the name of the check
      * associated with an audit event.
+     * The pattern is matched against the fully qualified class name of the Check.
      *
      * @param checks the name of the check
      * @since 8.18

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithNearbyCommentFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithNearbyCommentFilter.xml
@@ -38,7 +38,7 @@
             <property default-value=".*"
                       name="checkFormat"
                       type="java.util.regex.Pattern">
-               <description>Specify check pattern to suppress.</description>
+               <description>Specify check pattern to suppress. The pattern is matched against the fully qualified class name of the Check.</description>
             </property>
             <property default-value="SUPPRESS CHECKSTYLE (\w+)"
                       name="commentFormat"

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithNearbyTextFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithNearbyTextFilter.xml
@@ -19,7 +19,7 @@
             <property default-value=".*"
                       name="checkPattern"
                       type="java.util.regex.Pattern">
-               <description>Specify check name pattern to suppress. Property can also be a RegExp group index at &lt;code&gt;nearbyTextPattern&lt;/code&gt; in format of &lt;code&gt;$x&lt;/code&gt; and be picked from line that matches &lt;code&gt;nearbyTextPattern&lt;/code&gt;.</description>
+               <description>Specify check name pattern to suppress. Property can also be a RegExp group index at &lt;code&gt;nearbyTextPattern&lt;/code&gt; in format of &lt;code&gt;$x&lt;/code&gt; and be picked from line that matches &lt;code&gt;nearbyTextPattern&lt;/code&gt;. The pattern is matched against the fully qualified class name of the Check.</description>
             </property>
             <property name="idPattern" type="java.util.regex.Pattern">
                <description>Specify check ID pattern to suppress.</description>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithPlainTextCommentFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithPlainTextCommentFilter.xml
@@ -44,7 +44,7 @@
             <property default-value=".*"
                       name="checkFormat"
                       type="java.util.regex.Pattern">
-               <description>Specify check pattern to suppress.</description>
+               <description>Specify check pattern to suppress. The pattern is matched against the fully qualified class name of the Check.</description>
             </property>
             <property name="idFormat" type="java.util.regex.Pattern">
                <description>Specify check ID pattern to suppress.</description>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionCommentFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionCommentFilter.xml
@@ -50,7 +50,7 @@
             <property default-value=".*"
                       name="checkFormat"
                       type="java.util.regex.Pattern">
-               <description>Specify check pattern to suppress.</description>
+               <description>Specify check pattern to suppress. The pattern is matched against the fully qualified class name of the Check.</description>
             </property>
             <property name="idFormat" type="java.util.regex.Pattern">
                <description>Specify check ID pattern to suppress.</description>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionSingleFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionSingleFilter.xml
@@ -31,7 +31,7 @@
  &lt;/p&gt;</description>
          <properties>
             <property name="checks" type="java.util.regex.Pattern">
-               <description>Define the RegExp for matching against the name of the check associated with an audit event.</description>
+               <description>Define the RegExp for matching against the name of the check associated with an audit event. The pattern is matched against the fully qualified class name of the Check.</description>
             </property>
             <property name="columns" type="java.lang.String">
                <description>Specify a comma-separated list of values, where each value is an integer or a range of integers denoted by integer-integer.</description>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionXpathSingleFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionXpathSingleFilter.xml
@@ -31,7 +31,7 @@
  &lt;/p&gt;</description>
          <properties>
             <property name="checks" type="java.util.regex.Pattern">
-               <description>Define a Regular Expression matched against the name of the check associated with an audit event.</description>
+               <description>Define a Regular Expression matched against the name of the check associated with an audit event. The pattern is matched against the fully qualified class name of the Check.</description>
             </property>
             <property name="files" type="java.util.regex.Pattern">
                <description>Define a Regular Expression matched against the file name associated with an audit event.</description>

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -65,7 +65,7 @@
     <property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/>
   </module>
   <module name="SuppressWithPlainTextCommentFilter">
-    <property name="checkFormat" value="IndentationCheck"/>
+    <property name="checkFormat" value="\.IndentationCheck$"/>
     <property name="offCommentFormat" value='^""".?'/>
     <property name="onCommentFormat" value='.'/>
   </module>

--- a/src/site/xdoc/filters/suppressioncommentfilter.xml
+++ b/src/site/xdoc/filters/suppressioncommentfilter.xml
@@ -73,7 +73,7 @@
             </tr>
             <tr>
               <td><a id="checkFormat"/><a href="#checkFormat">checkFormat</a></td>
-              <td>Specify check pattern to suppress.</td>
+              <td>Specify check pattern to suppress. The pattern is matched against the fully qualified class name of the Check.</td>
               <td><a href="../property_types.html#Pattern">Pattern</a></td>
               <td><code>.*</code></td>
               <td>3.5</td>

--- a/src/site/xdoc/filters/suppressionsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionsinglefilter.xml
@@ -48,7 +48,7 @@
             </tr>
             <tr>
               <td><a id="checks"/><a href="#checks">checks</a></td>
-              <td>Define the RegExp for matching against the name of the check associated with an audit event.</td>
+              <td>Define the RegExp for matching against the name of the check associated with an audit event. The pattern is matched against the fully qualified class name of the Check.</td>
               <td><a href="../property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>8.23</td>

--- a/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
@@ -53,7 +53,7 @@
             </tr>
             <tr>
               <td><a id="checks"/><a href="#checks">checks</a></td>
-              <td>Define a Regular Expression matched against the name of the check associated with an audit event.</td>
+              <td>Define a Regular Expression matched against the name of the check associated with an audit event. The pattern is matched against the fully qualified class name of the Check.</td>
               <td><a href="../property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>8.18</td>

--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
@@ -61,7 +61,7 @@
             </tr>
             <tr>
               <td><a id="checkFormat"/><a href="#checkFormat">checkFormat</a></td>
-              <td>Specify check pattern to suppress.</td>
+              <td>Specify check pattern to suppress. The pattern is matched against the fully qualified class name of the Check.</td>
               <td><a href="../property_types.html#Pattern">Pattern</a></td>
               <td><code>.*</code></td>
               <td>5.0</td>

--- a/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbytextfilter.xml
@@ -34,7 +34,7 @@
             </tr>
             <tr>
               <td><a id="checkPattern"/><a href="#checkPattern">checkPattern</a></td>
-              <td>Specify check name pattern to suppress. Property can also be a RegExp group index at <code>nearbyTextPattern</code> in format of <code>$x</code> and be picked from line that matches <code>nearbyTextPattern</code>.</td>
+              <td>Specify check name pattern to suppress. Property can also be a RegExp group index at <code>nearbyTextPattern</code> in format of <code>$x</code> and be picked from line that matches <code>nearbyTextPattern</code>. The pattern is matched against the fully qualified class name of the Check.</td>
               <td><a href="../property_types.html#Pattern">Pattern</a></td>
               <td><code>.*</code></td>
               <td>10.10.0</td>

--- a/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithplaintextcommentfilter.xml
@@ -59,7 +59,7 @@
             </tr>
             <tr>
               <td><a id="checkFormat"/><a href="#checkFormat">checkFormat</a></td>
-              <td>Specify check pattern to suppress.</td>
+              <td>Specify check pattern to suppress. The pattern is matched against the fully qualified class name of the Check.</td>
               <td><a href="../property_types.html#Pattern">Pattern</a></td>
               <td><code>.*</code></td>
               <td>8.6</td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck.MSG_KEY_SINGLE;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_EXPECTED_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_RETURN_EXPECTED;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_UNUSED_TAG;
@@ -40,12 +41,15 @@ import org.junit.jupiter.api.io.TempDir;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.api.Violation;
+import com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck;
+import com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck;
@@ -719,6 +723,33 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
             removeSuppressed(expectedViolationMessages, suppressedViolationMessages),
             filterCfg, regexpCheckCfg
         );
+    }
+
+    @Test
+    public void testCheckFormatAnchoredToIndentationCheckFqcn() throws Exception {
+        final DefaultConfiguration filterCfg =
+            createModuleConfig(SuppressWithPlainTextCommentFilter.class);
+        filterCfg.addProperty("checkFormat", "\\.IndentationCheck$");
+        filterCfg.addProperty("offCommentFormat", "CSOFF");
+        filterCfg.addProperty("onCommentFormat", "CSON");
+
+        final DefaultConfiguration twCfg =
+            createModuleConfig(TreeWalker.class);
+        twCfg.addChild(createModuleConfig(IndentationCheck.class));
+        twCfg.addChild(createModuleConfig(CommentsIndentationCheck.class));
+
+        final DefaultConfiguration checkerConfig = createRootConfig(null);
+        checkerConfig.addProperty("fileExtensions", "java");
+        checkerConfig.addChild(filterCfg);
+        checkerConfig.addChild(twCfg);
+
+        final String[] expected = {
+            "5:5: " + getCheckMessage(CommentsIndentationCheck.class, MSG_KEY_SINGLE, 6, 4, 0),
+        };
+
+        verify(checkerConfig,
+            getPath("InputSuppressWithPlainTextCommentFilterIndentationAnchored.java"),
+            expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterIndentationAnchored.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterIndentationAnchored.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
+
+// CSOFF
+@SuppressWarnings("all")
+    // misaligned
+public class InputSuppressWithPlainTextCommentFilterIndentationAnchored {
+   int wrongIndent;
+}
+// CSON


### PR DESCRIPTION
Issue: #19793

`SuppressWithPlainTextCommentFilter.checkFormat` is applied via `Matcher.find()` against the violation's source class FQCN (`Violation.getSourceName()`), so the previous unanchored `IndentationCheck` regex also matched `CommentsIndentationCheck` and `JavadocTagContinuationIndentationCheck`.

With the production-narrow `offCommentFormat="^\"\"\".?"` / `onCommentFormat="."` window the bug is latent — the suppression covers a single line at a time, so the over-broad regex never silences anything it should not. The check value is still fragile: any future widening of the window would silently suppress unrelated `*IndentationCheck` violations.

Anchored to `\.IndentationCheck$`, the regex matches only `com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck`.

Added regression test `testCheckFormatAnchoredToIndentationCheckFqcn` in `SuppressWithPlainTextCommentFilterTest` that wires `IndentationCheck` and `CommentsIndentationCheck` behind the anchored filter and asserts the `CommentsIndentationCheck` violation survives while the `IndentationCheck` one is suppressed. Without the anchor the new test fails.
