### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - visibilitymodifier

### DIFF
--- a/src/site/xdoc/checks/design/visibilitymodifier.xml
+++ b/src/site/xdoc/checks/design/visibilitymodifier.xml
@@ -202,6 +202,18 @@ class Example1 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  // violation below, annotation not configured 'must be private'
+  public final int someIntValue = 0;
+
+  // violation below, annotation not configured 'must be private'
+  public final ImmutableSet&lt;String&gt; includes = null;
+
+  // violation below, annotation not configured 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, annotation not configured 'must be private'
+  public final List list = null;
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -255,6 +267,18 @@ class Example2 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  // violation below, 'must be private'
+  public final int someIntValue = 0;
+
+  // violation below, 'must be private'
+  public final ImmutableSet&lt;String&gt; includes = null;
+
+  // violation below, 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, 'must be private'
+  public final List list = null;
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -309,6 +333,18 @@ class Example3 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  // violation below, 'must be private'
+  public final int someIntValue = 0;
+
+  // violation below, 'must be private'
+  public final ImmutableSet&lt;String&gt; includes = null;
+
+  // violation below, 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, 'must be private'
+  public final List list = null;
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -364,6 +400,18 @@ class Example4 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  // violation below, 'must be private'
+  public final int someIntValue = 0;
+
+  // violation below, 'must be private'
+  public final ImmutableSet&lt;String&gt; includes = null;
+
+  // violation below, 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, 'must be private'
+  public final List list = null;
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example5-config">
@@ -419,6 +467,17 @@ class Example5 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  public final int someIntValue = 0; // violation 'must be private'
+
+  // violation below, immutable type not in config 'must be private'
+  public final ImmutableSet&lt;String&gt; includes = null;
+
+  // violation below, immutable type not in config 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, mutable 'must be private'
+  public final List list = null;
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example6-config">
@@ -476,6 +535,16 @@ class Example6 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  public final int someIntValue = 0; // violation 'must be private'
+  // violation below, immutable type not in config 'must be private'
+  public final ImmutableSet&lt;String&gt; includes = null;
+
+  // violation below, immutable type not in config 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, mutable 'must be private'
+  public final List list = null;
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example7-config">
@@ -590,6 +659,18 @@ class Example8 {
   @com.google.common.annotations.VisibleForTesting
   // violation below, annotation not configured 'must be private'
   public String testString = "";
+
+  // violation below, 'must be private'
+  public final int someIntValue = 0;
+
+  // violation below, 'must be private'
+  public final ImmutableSet&lt;String&gt; includes = null;
+
+  // violation below, 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, 'must be private'
+  public final List list = null;
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example9-config">
@@ -748,11 +829,42 @@ class Example11 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example12 {
+  private int myPrivateField1;
+
+  int field1; // violation, 'must be private'
+
+  protected String field2; // violation, 'must be private'
+
+  // violation below, 'must be private'
+  public int field3 = 42;
+
+  public long serialVersionUID = 1L;
+
+  public static final int field4 = 42;
+
+  public final int field5 = 42;
+
+  public final java.lang.String notes = null;
+
+  public final Set&lt;String&gt; mySet1 = new HashSet&lt;&gt;();
+
+  public final ImmutableSet&lt;String&gt; mySet2 = null;
+
+  public final ImmutableMap&lt;String, Object&gt; objects1 = null;
+
+  @java.lang.Deprecated
+  String annotatedString; // violation, 'must be private'
+
+  @Deprecated
+  // violation below, 'must be private'
+  String shortCustomAnnotated;
+
+  @com.google.common.annotations.VisibleForTesting
+  public String testString = "";
+
   public final int someIntValue = 0;
 
   public final ImmutableSet&lt;String&gt; includes = null;
-
-  public final java.lang.String notes = "";
 
   public final BigDecimal value = null;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -117,8 +117,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/descendanttoken/Example7",
             "checks/descendanttoken/Example8",
             "checks/descendanttoken/Example9",
-            "checks/design/visibilitymodifier/Example11",
-            "checks/design/visibilitymodifier/Example12",
             "checks/finalparameters/Example4",
             "checks/imports/avoidstaticimport/Example2",
             "checks/imports/customimportorder/Example10",
@@ -301,7 +299,11 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/coding/matchxpath/Example4",
             "checks/coding/matchxpath/Example5",
             "checks/coding/matchxpath/Example6",
-            "filters/suppresswithplaintextcommentfilter/Example9"
+            "filters/suppresswithplaintextcommentfilter/Example9",
+            "checks/design/visibilitymodifier/Example7",
+            "checks/design/visibilitymodifier/Example9",
+            "checks/design/visibilitymodifier/Example10",
+            "checks/design/visibilitymodifier/Example11"
             );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckExamplesTest.java
@@ -24,7 +24,6 @@ import static com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCh
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
@@ -35,16 +34,20 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "23:7: " + getCheckMessage(MSG_KEY, "field1"),
-            "25:20: " + getCheckMessage(MSG_KEY, "field2"),
-            "27:14: " + getCheckMessage(MSG_KEY, "field3"),
-            "34:20: " + getCheckMessage(MSG_KEY, "field5"),
-            "37:33: " + getCheckMessage(MSG_KEY, "notes"),
-            "40:28: " + getCheckMessage(MSG_KEY, "mySet1"),
-            "43:37: " + getCheckMessage(MSG_KEY, "mySet2"),
-            "46:45: " + getCheckMessage(MSG_KEY, "objects1"),
-            "49:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
-            "53:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "25:7: " + getCheckMessage(MSG_KEY, "field1"),
+            "27:20: " + getCheckMessage(MSG_KEY, "field2"),
+            "29:14: " + getCheckMessage(MSG_KEY, "field3"),
+            "36:20: " + getCheckMessage(MSG_KEY, "field5"),
+            "39:33: " + getCheckMessage(MSG_KEY, "notes"),
+            "42:28: " + getCheckMessage(MSG_KEY, "mySet1"),
+            "45:37: " + getCheckMessage(MSG_KEY, "mySet2"),
+            "48:45: " + getCheckMessage(MSG_KEY, "objects1"),
+            "51:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
+            "55:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "61:20: " + getCheckMessage(MSG_KEY, "someIntValue"),
+            "64:37: " + getCheckMessage(MSG_KEY, "includes"),
+            "67:27: " + getCheckMessage(MSG_KEY, "value"),
+            "70:21: " + getCheckMessage(MSG_KEY, "list"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -53,13 +56,17 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "27:20: " + getCheckMessage(MSG_KEY, "field2"),
-            "30:14: " + getCheckMessage(MSG_KEY, "field3"),
-            "37:20: " + getCheckMessage(MSG_KEY, "field5"),
-            "40:33: " + getCheckMessage(MSG_KEY, "notes"),
-            "43:28: " + getCheckMessage(MSG_KEY, "mySet1"),
-            "46:37: " + getCheckMessage(MSG_KEY, "mySet2"),
-            "49:45: " + getCheckMessage(MSG_KEY, "objects1"),
+            "29:20: " + getCheckMessage(MSG_KEY, "field2"),
+            "32:14: " + getCheckMessage(MSG_KEY, "field3"),
+            "39:20: " + getCheckMessage(MSG_KEY, "field5"),
+            "42:33: " + getCheckMessage(MSG_KEY, "notes"),
+            "45:28: " + getCheckMessage(MSG_KEY, "mySet1"),
+            "48:37: " + getCheckMessage(MSG_KEY, "mySet2"),
+            "51:45: " + getCheckMessage(MSG_KEY, "objects1"),
+            "63:20: " + getCheckMessage(MSG_KEY, "someIntValue"),
+            "66:37: " + getCheckMessage(MSG_KEY, "includes"),
+            "69:27: " + getCheckMessage(MSG_KEY, "value"),
+            "72:21: " + getCheckMessage(MSG_KEY, "list"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -68,15 +75,19 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "25:7: " + getCheckMessage(MSG_KEY, "field1"),
-            "30:14: " + getCheckMessage(MSG_KEY, "field3"),
-            "37:20: " + getCheckMessage(MSG_KEY, "field5"),
-            "40:33: " + getCheckMessage(MSG_KEY, "notes"),
-            "43:28: " + getCheckMessage(MSG_KEY, "mySet1"),
-            "46:37: " + getCheckMessage(MSG_KEY, "mySet2"),
-            "49:45: " + getCheckMessage(MSG_KEY, "objects1"),
-            "52:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
-            "56:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "27:7: " + getCheckMessage(MSG_KEY, "field1"),
+            "32:14: " + getCheckMessage(MSG_KEY, "field3"),
+            "39:20: " + getCheckMessage(MSG_KEY, "field5"),
+            "42:33: " + getCheckMessage(MSG_KEY, "notes"),
+            "45:28: " + getCheckMessage(MSG_KEY, "mySet1"),
+            "48:37: " + getCheckMessage(MSG_KEY, "mySet2"),
+            "51:45: " + getCheckMessage(MSG_KEY, "objects1"),
+            "54:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
+            "58:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "64:20: " + getCheckMessage(MSG_KEY, "someIntValue"),
+            "67:37: " + getCheckMessage(MSG_KEY, "includes"),
+            "70:27: " + getCheckMessage(MSG_KEY, "value"),
+            "73:21: " + getCheckMessage(MSG_KEY, "list"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -85,17 +96,21 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "25:7: " + getCheckMessage(MSG_KEY, "field1"),
-            "27:20: " + getCheckMessage(MSG_KEY, "field2"),
-            "30:14: " + getCheckMessage(MSG_KEY, "field3"),
-            "33:15: " + getCheckMessage(MSG_KEY, "serialVersionUID"),
-            "38:20: " + getCheckMessage(MSG_KEY, "field5"),
-            "41:33: " + getCheckMessage(MSG_KEY, "notes"),
-            "44:28: " + getCheckMessage(MSG_KEY, "mySet1"),
-            "47:37: " + getCheckMessage(MSG_KEY, "mySet2"),
-            "50:45: " + getCheckMessage(MSG_KEY, "objects1"),
-            "53:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
-            "57:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "27:7: " + getCheckMessage(MSG_KEY, "field1"),
+            "29:20: " + getCheckMessage(MSG_KEY, "field2"),
+            "32:14: " + getCheckMessage(MSG_KEY, "field3"),
+            "35:15: " + getCheckMessage(MSG_KEY, "serialVersionUID"),
+            "40:20: " + getCheckMessage(MSG_KEY, "field5"),
+            "43:33: " + getCheckMessage(MSG_KEY, "notes"),
+            "46:28: " + getCheckMessage(MSG_KEY, "mySet1"),
+            "49:37: " + getCheckMessage(MSG_KEY, "mySet2"),
+            "52:45: " + getCheckMessage(MSG_KEY, "objects1"),
+            "55:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
+            "59:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "65:20: " + getCheckMessage(MSG_KEY, "someIntValue"),
+            "68:37: " + getCheckMessage(MSG_KEY, "includes"),
+            "71:27: " + getCheckMessage(MSG_KEY, "value"),
+            "74:21: " + getCheckMessage(MSG_KEY, "list"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
@@ -104,16 +119,20 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "25:7: " + getCheckMessage(MSG_KEY, "field1"),
-            "27:20: " + getCheckMessage(MSG_KEY, "field2"),
-            "30:14: " + getCheckMessage(MSG_KEY, "field3"),
-            "36:20: " + getCheckMessage(MSG_KEY, "field5"),
-            "38:33: " + getCheckMessage(MSG_KEY, "notes"),
-            "41:28: " + getCheckMessage(MSG_KEY, "mySet1"),
-            "44:37: " + getCheckMessage(MSG_KEY, "mySet2"),
-            "47:45: " + getCheckMessage(MSG_KEY, "objects1"),
-            "50:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
-            "54:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "27:7: " + getCheckMessage(MSG_KEY, "field1"),
+            "29:20: " + getCheckMessage(MSG_KEY, "field2"),
+            "32:14: " + getCheckMessage(MSG_KEY, "field3"),
+            "38:20: " + getCheckMessage(MSG_KEY, "field5"),
+            "40:33: " + getCheckMessage(MSG_KEY, "notes"),
+            "43:28: " + getCheckMessage(MSG_KEY, "mySet1"),
+            "46:37: " + getCheckMessage(MSG_KEY, "mySet2"),
+            "49:45: " + getCheckMessage(MSG_KEY, "objects1"),
+            "52:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
+            "56:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "61:20: " + getCheckMessage(MSG_KEY, "someIntValue"),
+            "64:37: " + getCheckMessage(MSG_KEY, "includes"),
+            "67:27: " + getCheckMessage(MSG_KEY, "value"),
+            "70:21: " + getCheckMessage(MSG_KEY, "list"),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
@@ -122,16 +141,20 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample6() throws Exception {
         final String[] expected = {
-            "28:7: " + getCheckMessage(MSG_KEY, "field1"),
-            "30:20: " + getCheckMessage(MSG_KEY, "field2"),
-            "33:14: " + getCheckMessage(MSG_KEY, "field3"),
-            "39:20: " + getCheckMessage(MSG_KEY, "field5"),
-            "41:33: " + getCheckMessage(MSG_KEY, "notes"),
-            "44:28: " + getCheckMessage(MSG_KEY, "mySet1"),
-            "47:37: " + getCheckMessage(MSG_KEY, "mySet2"),
-            "50:45: " + getCheckMessage(MSG_KEY, "objects1"),
-            "53:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
-            "57:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "30:7: " + getCheckMessage(MSG_KEY, "field1"),
+            "32:20: " + getCheckMessage(MSG_KEY, "field2"),
+            "35:14: " + getCheckMessage(MSG_KEY, "field3"),
+            "41:20: " + getCheckMessage(MSG_KEY, "field5"),
+            "43:33: " + getCheckMessage(MSG_KEY, "notes"),
+            "46:28: " + getCheckMessage(MSG_KEY, "mySet1"),
+            "49:37: " + getCheckMessage(MSG_KEY, "mySet2"),
+            "52:45: " + getCheckMessage(MSG_KEY, "objects1"),
+            "55:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
+            "59:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "64:20: " + getCheckMessage(MSG_KEY, "someIntValue"),
+            "66:37: " + getCheckMessage(MSG_KEY, "includes"),
+            "69:27: " + getCheckMessage(MSG_KEY, "value"),
+            "72:21: " + getCheckMessage(MSG_KEY, "list"),
         };
 
         verifyWithInlineConfigParser(getPath("Example6.java"), expected);
@@ -158,15 +181,19 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample8() throws Exception {
         final String[] expected = {
-            "26:7: " + getCheckMessage(MSG_KEY, "field1"),
-            "28:20: " + getCheckMessage(MSG_KEY, "field2"),
-            "31:14: " + getCheckMessage(MSG_KEY, "field3"),
-            "37:20: " + getCheckMessage(MSG_KEY, "field5"),
-            "39:33: " + getCheckMessage(MSG_KEY, "notes"),
-            "42:28: " + getCheckMessage(MSG_KEY, "mySet1"),
-            "45:37: " + getCheckMessage(MSG_KEY, "mySet2"),
-            "48:45: " + getCheckMessage(MSG_KEY, "objects1"),
-            "58:17: " + getCheckMessage(MSG_KEY, "testString"),
+            "28:7: " + getCheckMessage(MSG_KEY, "field1"),
+            "30:20: " + getCheckMessage(MSG_KEY, "field2"),
+            "33:14: " + getCheckMessage(MSG_KEY, "field3"),
+            "39:20: " + getCheckMessage(MSG_KEY, "field5"),
+            "41:33: " + getCheckMessage(MSG_KEY, "notes"),
+            "44:28: " + getCheckMessage(MSG_KEY, "mySet1"),
+            "47:37: " + getCheckMessage(MSG_KEY, "mySet2"),
+            "50:45: " + getCheckMessage(MSG_KEY, "objects1"),
+            "60:17: " + getCheckMessage(MSG_KEY, "testString"),
+            "63:20: " + getCheckMessage(MSG_KEY, "someIntValue"),
+            "66:37: " + getCheckMessage(MSG_KEY, "includes"),
+            "69:27: " + getCheckMessage(MSG_KEY, "value"),
+            "72:21: " + getCheckMessage(MSG_KEY, "list"),
         };
 
         verifyWithInlineConfigParser(getPath("Example8.java"), expected);
@@ -223,7 +250,13 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
 
     @Test
     public void testExample12() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "27:7: " + getCheckMessage(MSG_KEY, "field1"),
+            "29:20: " + getCheckMessage(MSG_KEY, "field2"),
+            "32:14: " + getCheckMessage(MSG_KEY, "field3"),
+            "49:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
+            "53:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+        };
 
         verifyWithInlineConfigParser(getPath("Example12.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example1.java
@@ -13,7 +13,9 @@ package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import java.math.BigDecimal;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 // xdoc section -- start
@@ -54,5 +56,17 @@ class Example1 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  // violation below, annotation not configured 'must be private'
+  public final int someIntValue = 0;
+
+  // violation below, annotation not configured 'must be private'
+  public final ImmutableSet<String> includes = null;
+
+  // violation below, annotation not configured 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, annotation not configured 'must be private'
+  public final List list = null;
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example12.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example12.java
@@ -12,18 +12,52 @@
 
 package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.math.BigDecimal;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 // xdoc section -- start
 class Example12 {
+  private int myPrivateField1;
+
+  int field1; // violation, 'must be private'
+
+  protected String field2; // violation, 'must be private'
+
+  // violation below, 'must be private'
+  public int field3 = 42;
+
+  public long serialVersionUID = 1L;
+
+  public static final int field4 = 42;
+
+  public final int field5 = 42;
+
+  public final java.lang.String notes = null;
+
+  public final Set<String> mySet1 = new HashSet<>();
+
+  public final ImmutableSet<String> mySet2 = null;
+
+  public final ImmutableMap<String, Object> objects1 = null;
+
+  @java.lang.Deprecated
+  String annotatedString; // violation, 'must be private'
+
+  @Deprecated
+  // violation below, 'must be private'
+  String shortCustomAnnotated;
+
+  @com.google.common.annotations.VisibleForTesting
+  public String testString = "";
+
   public final int someIntValue = 0;
 
   public final ImmutableSet<String> includes = null;
-
-  public final java.lang.String notes = "";
 
   public final BigDecimal value = null;
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example2.java
@@ -15,7 +15,9 @@ package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import java.math.BigDecimal;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 // xdoc section -- start
@@ -56,5 +58,17 @@ class Example2 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  // violation below, 'must be private'
+  public final int someIntValue = 0;
+
+  // violation below, 'must be private'
+  public final ImmutableSet<String> includes = null;
+
+  // violation below, 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, 'must be private'
+  public final List list = null;
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example3.java
@@ -15,7 +15,9 @@ package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import java.math.BigDecimal;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 // xdoc section -- start
@@ -57,5 +59,17 @@ class Example3 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  // violation below, 'must be private'
+  public final int someIntValue = 0;
+
+  // violation below, 'must be private'
+  public final ImmutableSet<String> includes = null;
+
+  // violation below, 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, 'must be private'
+  public final List list = null;
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example4.java
@@ -15,7 +15,9 @@ package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import java.math.BigDecimal;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 // xdoc section -- start
@@ -58,5 +60,17 @@ class Example4 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  // violation below, 'must be private'
+  public final int someIntValue = 0;
+
+  // violation below, 'must be private'
+  public final ImmutableSet<String> includes = null;
+
+  // violation below, 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, 'must be private'
+  public final List list = null;
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example5.java
@@ -15,7 +15,9 @@ package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import java.math.BigDecimal;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 // xdoc section -- start
@@ -55,5 +57,16 @@ class Example5 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  public final int someIntValue = 0; // violation 'must be private'
+
+  // violation below, immutable type not in config 'must be private'
+  public final ImmutableSet<String> includes = null;
+
+  // violation below, immutable type not in config 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, mutable 'must be private'
+  public final List list = null;
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example6.java
@@ -18,7 +18,9 @@ package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import java.math.BigDecimal;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 // xdoc section -- start
@@ -58,5 +60,15 @@ class Example6 {
 
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
+
+  public final int someIntValue = 0; // violation 'must be private'
+  // violation below, immutable type not in config 'must be private'
+  public final ImmutableSet<String> includes = null;
+
+  // violation below, immutable type not in config 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, mutable 'must be private'
+  public final List list = null;
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example8.java
@@ -16,7 +16,9 @@ package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import java.math.BigDecimal;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 // xdoc section -- start
@@ -56,5 +58,17 @@ class Example8 {
   @com.google.common.annotations.VisibleForTesting
   // violation below, annotation not configured 'must be private'
   public String testString = "";
+
+  // violation below, 'must be private'
+  public final int someIntValue = 0;
+
+  // violation below, 'must be private'
+  public final ImmutableSet<String> includes = null;
+
+  // violation below, 'must be private'
+  public final BigDecimal value = null;
+
+  // violation below, 'must be private'
+  public final List list = null;
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

https://www.diffchecker.com/MumZwdaJ/
https://www.diffchecker.com/PgtjvuCP/
https://www.diffchecker.com/A9fKZr3E/
https://www.diffchecker.com/YtKVZ7Xj/
https://www.diffchecker.com/N9EeOSCP/
https://www.diffchecker.com/OOiSC4GG/
https://www.diffchecker.com/CxS9thmh/

For each of the properties, examples 1,2,3,4,5,6,8,12 have identical AST ;  examples 7,9,10,11 have original structure and are marked as use-case examples as they have repeated properties from below.
packageAllowed 
protectedAllowed 
publicMemberPattern
allowPublicImmutableFields 
immutableClassCanonicalNames 
ignoreAnnotationCanonicalNames 
allowPublicFinalFields 
