### PR TITLE
Issue #19892: support multiple config links per rule entry in XdocsPagesTest

### DIFF
--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -1621,7 +1621,11 @@
                   <span class="wrapper inline">
                     <img src="images/ok_green.png" alt="" />
                   </span>
-                  BoxComments
+                  <a href="checks/misc/todocomment.html#TodoComment"
+                     id="BoxComments">
+                    TodoComment</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TodoComment+BoxComments">
+                  config</a>)
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle">
@@ -1645,9 +1649,10 @@
                   <span class="wrapper inline">
                     <img src="images/ok_green.png" alt="" />
                   </span>
-                  <a href="checks/misc/todocomment.html#TodoComment">
+                  <a href="checks/misc/todocomment.html#TodoComment"
+                     id="TodoFormat">
                     TodoComment</a>
-                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TodoComment">
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TodoComment+TodoFormat">
                   config</a>)
                 </td>
                 <td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -2189,14 +2189,27 @@ public class XdocsPagesTest {
 
             hasChecks = true;
 
-            assertWithMessage(
-                "The module '%s' in the rule '%s' of the style guide '%s_style.xml'"
-                    + " should not appear more than once in the section.",
-                moduleName, ruleName, styleName)
-                .that(usedModules)
-                .doesNotContain(moduleName);
+            final Node idAttr = module.getAttributes().getNamedItem("id");
+            String moduleId = "";
+            if (idAttr != null) {
+                moduleId = idAttr.getTextContent();
+            }
+            final String moduleKey;
+            if (moduleId.isEmpty()) {
+                moduleKey = moduleName;
+            }
+            else {
+                moduleKey = moduleName + "#" + moduleId;
+            }
 
-            usedModules.add(moduleName);
+            assertWithMessage(
+                "Module ids should be unique. Duplicate id '%s' was found for "
+                    + "module '%s' in rule '%s' of style guide '%s_style.xml'",
+                moduleId, moduleName, ruleName, styleName)
+                .that(usedModules)
+                .doesNotContain(moduleKey);
+
+            usedModules.add(moduleKey);
 
             assertWithMessage("%s_style.xml rule '%s' module '%s' shouldn't end with 'Check'",
                 styleName, ruleName, moduleName)
@@ -2214,11 +2227,21 @@ public class XdocsPagesTest {
                 final String expectedUrl =
                     partialConfigUrl + "_checks.xml+repo%3Acheckstyle%2Fcheckstyle+" + moduleName;
 
-                assertWithMessage(
-                    "%s_style.xml rule '%s' module '%s' should have matching config url",
-                    styleName, ruleName, moduleName)
-                    .that(configUrl)
-                    .isEqualTo(expectedUrl);
+                if (moduleId.isEmpty()) {
+                    assertWithMessage(
+                            "%s_style.xml rule '%s' module '%s' should have matching config url",
+                            styleName, ruleName, moduleName)
+                            .that(configUrl)
+                            .isEqualTo(expectedUrl);
+                }
+                else {
+                    final String expectedUrlWithId = expectedUrl + "+" + moduleId;
+                    assertWithMessage(
+                            "%s_style.xml rule '%s' module '%s' should have matching config url",
+                            styleName, ruleName, moduleName)
+                            .that(configUrl)
+                            .isEqualTo(expectedUrlWithId);
+                }
             }
             else {
                 assertWithMessage("%s_style.xml rule '%s' module '%s' is missing the config link",


### PR DESCRIPTION
Issue: #19892
Allow duplicate check module names in style XML when they have distinct id attributes.