### PR TITLE
Issue #19895: fix UnnecessaryInheritDoc Qodana warnings in Javadoc

### DIFF
--- a/config/qodana.yml
+++ b/config/qodana.yml
@@ -47,13 +47,3 @@ exclude:
       - src/test/java/com/puppycrawl/tools/checkstyle/grammar/javadoc/ParseTreeBuilder.java
 
       - docs/GRAMMAR_UPDATES.md
-
-  # until https://github.com/checkstyle/checkstyle/issues/19895
-  - name: UnnecessaryInheritDoc
-    paths:
-      - src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
-      - src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
-      - src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
-      - src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
-      - src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
-      - src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
@@ -939,13 +939,13 @@ public final class JavadocCommentsTokenTypes {
     public static final int SUMMARY_INLINE_TAG = JavadocCommentsLexer.SUMMARY_INLINE_TAG;
 
     /**
-     * {@code {@inheritDoc}} inline tag.
+     * {@code @inheritDoc} inline tag.
      *
-     * <p>This node models the inline {@code {@inheritDoc}} tag that instructs Javadoc
+     * <p>This node models the inline {@code @inheritDoc}tag that instructs Javadoc
      * to inherit documentation from the corresponding element in a parent class or interface.</p>
      *
      * <p><b>Example:</b></p>
-     * <pre>{@code * {@inheritDoc}}</pre>
+     * <pre>{@code * @inheritDoc}</pre>
      *
      * <b>Tree:</b>
      * <pre>{@code

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -85,12 +85,12 @@ import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
  * Javadoc is not required on a method that is tagged with the {@code @Override}
  * annotation. However, under Java 5 it is not possible to mark a method required
  * for an interface (this was <i>corrected</i> under Java 6). Hence, Checkstyle
- * supports using the convention of using a single {@code {@inheritDoc}} tag
+ * supports using the convention of using a single {@code @inheritDoc} tag
  * instead of all the other tags.
  * </p>
  *
  * <p>
- * Note that only inheritable items will allow the {@code {@inheritDoc}}
+ * Note that only inheritable items will allow the {@code @inheritDoc}
  * tag to be used in place of comments. Static methods at all visibilities,
  * private non-static methods and constructors are not inheritable.
  * </p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -57,7 +57,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * content.
  * Javadoc automatically places the first sentence in the method summary
  * table and index. Without proper punctuation the Javadoc may be malformed.
- * All items eligible for the {@code {@inheritDoc}} tag are exempt from this
+ * All items eligible for the {@code @inheritDoc} tag are exempt from this
  * requirement.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
@@ -137,7 +137,7 @@ public enum JavadocTagInfo {
     },
 
     /**
-     * {@code {@inheritDoc}}.
+     * {@code @inheritDoc} .
      */
     INHERIT_DOC("{@inheritDoc}", "inheritDoc", Type.INLINE) {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
@@ -45,7 +45,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * Javadoc is not required on a method that is tagged with the {@code @Override} annotation.
  * However, under Java 5 it is not possible to mark a method required for an interface (this
  * was <i>corrected</i> under Java 6). Hence, Checkstyle supports using the convention of using
- * a single {@code {@inheritDoc}} tag instead of all the other tags.
+ * a single {@code @inheritDoc} tag instead of all the other tags.
  * </p>
  *
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -37,9 +37,9 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * Checks that
  * <a href="https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#firstsentence">
  * Javadoc summary sentence</a> does not contain phrases that are not recommended to use.
- * Summaries that contain only the {@code {@inheritDoc}} tag are skipped.
- * Summaries that contain a non-empty {@code {@return}} are allowed.
- * Check also violate Javadoc that does not contain first sentence, though with {@code {@return}} a
+ * Summaries that contain only the {@code @inheritDoc} tag are skipped.
+ * Summaries that contain a non-empty {@code @return} are allowed.
+ * Check also violate Javadoc that does not contain first sentence, though with {@code @return} a
  * period is not required as the Javadoc tool adds it.
  * </div>
  *

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMethodCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMethodCheck.xml
@@ -47,12 +47,12 @@
  Javadoc is not required on a method that is tagged with the &lt;code&gt;@Override&lt;/code&gt;
  annotation. However, under Java 5 it is not possible to mark a method required
  for an interface (this was &lt;i&gt;corrected&lt;/i&gt; under Java 6). Hence, Checkstyle
- supports using the convention of using a single &lt;code&gt;{@inheritDoc}&lt;/code&gt; tag
+ supports using the convention of using a single &lt;code&gt;@inheritDoc&lt;/code&gt; tag
  instead of all the other tags.
  &lt;/p&gt;
 
  &lt;p&gt;
- Note that only inheritable items will allow the &lt;code&gt;{@inheritDoc}&lt;/code&gt;
+ Note that only inheritable items will allow the &lt;code&gt;@inheritDoc&lt;/code&gt;
  tag to be used in place of comments. Static methods at all visibilities,
  private non-static methods and constructors are not inheritable.
  &lt;/p&gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocStyleCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocStyleCheck.xml
@@ -20,7 +20,7 @@
  content.
  Javadoc automatically places the first sentence in the method summary
  table and index. Without proper punctuation the Javadoc may be malformed.
- All items eligible for the &lt;code&gt;{@inheritDoc}&lt;/code&gt; tag are exempt from this
+ All items eligible for the &lt;code&gt;@inheritDoc&lt;/code&gt; tag are exempt from this
  requirement.
  &lt;/li&gt;
  &lt;li&gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/MissingJavadocMethodCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/MissingJavadocMethodCheck.xml
@@ -15,7 +15,7 @@
  Javadoc is not required on a method that is tagged with the &lt;code&gt;@Override&lt;/code&gt; annotation.
  However, under Java 5 it is not possible to mark a method required for an interface (this
  was &lt;i&gt;corrected&lt;/i&gt; under Java 6). Hence, Checkstyle supports using the convention of using
- a single &lt;code&gt;{@inheritDoc}&lt;/code&gt; tag instead of all the other tags.
+ a single &lt;code&gt;@inheritDoc&lt;/code&gt; tag instead of all the other tags.
  &lt;/p&gt;
 
  &lt;p&gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SummaryJavadocCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SummaryJavadocCheck.xml
@@ -8,9 +8,9 @@
  Checks that
  &lt;a href="https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#firstsentence"&gt;
  Javadoc summary sentence&lt;/a&gt; does not contain phrases that are not recommended to use.
- Summaries that contain only the &lt;code&gt;{@inheritDoc}&lt;/code&gt; tag are skipped.
- Summaries that contain a non-empty &lt;code&gt;{@return}&lt;/code&gt; are allowed.
- Check also violate Javadoc that does not contain first sentence, though with &lt;code&gt;{@return}&lt;/code&gt; a
+ Summaries that contain only the &lt;code&gt;@inheritDoc&lt;/code&gt; tag are skipped.
+ Summaries that contain a non-empty &lt;code&gt;@return&lt;/code&gt; are allowed.
+ Check also violate Javadoc that does not contain first sentence, though with &lt;code&gt;@return&lt;/code&gt; a
  period is not required as the Javadoc tool adds it.
  &lt;/div&gt;
 

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml
@@ -52,12 +52,12 @@
           Javadoc is not required on a method that is tagged with the <code>@Override</code>
           annotation. However, under Java 5 it is not possible to mark a method required
           for an interface (this was <i>corrected</i> under Java 6). Hence, Checkstyle
-          supports using the convention of using a single <code>{@inheritDoc}</code> tag
+          supports using the convention of using a single <code>@inheritDoc</code> tag
           instead of all the other tags.
         </p>
 
         <p>
-          Note that only inheritable items will allow the <code>{@inheritDoc}</code>
+          Note that only inheritable items will allow the <code>@inheritDoc</code>
           tag to be used in place of comments. Static methods at all visibilities,
           private non-static methods and constructors are not inheritable.
         </p>

--- a/src/site/xdoc/checks/javadoc/javadocstyle.xml
+++ b/src/site/xdoc/checks/javadoc/javadocstyle.xml
@@ -25,7 +25,7 @@
           content.
           Javadoc automatically places the first sentence in the method summary
           table and index. Without proper punctuation the Javadoc may be malformed.
-          All items eligible for the <code>{@inheritDoc}</code> tag are exempt from this
+          All items eligible for the <code>@inheritDoc</code> tag are exempt from this
           requirement.
         </li>
         <li>

--- a/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml
@@ -20,7 +20,7 @@
           Javadoc is not required on a method that is tagged with the <code>@Override</code> annotation.
           However, under Java 5 it is not possible to mark a method required for an interface (this
           was <i>corrected</i> under Java 6). Hence, Checkstyle supports using the convention of using
-          a single <code>{@inheritDoc}</code> tag instead of all the other tags.
+          a single <code>@inheritDoc</code> tag instead of all the other tags.
         </p>
 
         <p>

--- a/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
+++ b/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
@@ -13,9 +13,9 @@
           Checks that
           <a href="https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#firstsentence">
           Javadoc summary sentence</a> does not contain phrases that are not recommended to use.
-          Summaries that contain only the <code>{@inheritDoc}</code> tag are skipped.
-          Summaries that contain a non-empty <code>{@return}</code> are allowed.
-          Check also violate Javadoc that does not contain first sentence, though with <code>{@return}</code> a
+          Summaries that contain only the <code>@inheritDoc</code> tag are skipped.
+          Summaries that contain a non-empty <code>@return</code> are allowed.
+          Check also violate Javadoc that does not contain first sentence, though with <code>@return</code> a
           period is not required as the Javadoc tool adds it.
         </div>
 


### PR DESCRIPTION
Issue: #19895
All `UnnecessaryInheritDoc` Qodana warnings in Javadoc in has been fixed.
