### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - abbreviationaswordinname

### DIFF
--- a/src/site/xdoc/checks/naming/abbreviationaswordinname.xml
+++ b/src/site/xdoc/checks/naming/abbreviationaswordinname.xml
@@ -164,22 +164,35 @@
         <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 extends SuperClass { // ok, camel case
-  int CURRENT_COUNTER; // violation 'no more than '4' consecutive capital letters'
-  static int GLOBAL_COUNTER; // ok, static is ignored
+  int CURRENT_COUNTER;  // violation 'no more than '4' consecutive capital letters'
+
+  static int GLOBAL_COUNTER;        // ok, static is ignored
+
   final Set&lt;String&gt; stringsFOUND = new HashSet&lt;&gt;(); // ok, final is ignored
+  int firstNum;
+  int secondNUM;
+  static int thirdNum;
+  static int fourthNUm;
+  String firstXML;
+  String firstURL;
+  final int TOTAL = 5;              // ok, final is ignored
+  static final int LIMIT = 10;      // ok, static final is ignored
+  int nextXYZ = 1;
+  final int countID = 2;
+
+  static int nextID = 3;
+  static final int MAX_ALLOWED = 4; // ok, static final is ignored
+
+  void newOAuth2Client() {}
+  void OAuth2() {}
+  void OAUth2() {}
 
   @Override
-  public void printCOUNTER() { // ok, overridden method is ignored
-    System.out.println(CURRENT_COUNTER);
-  }
+  public void printCOUNTER() {}     // ok, overridden method is ignored
   // violation below 'no more than '4' consecutive capital letters'
-  void incrementCOUNTER() {
-    CURRENT_COUNTER++; // ok, only definitions are checked
-  }
+  void incrementCOUNTER() {}
   // violation below 'no more than '4' consecutive capital letters'
-  static void incrementGLOBAL() {
-    GLOBAL_COUNTER++; // ok, only definitions are checked
-  }
+  static void incrementGLOBAL() {}
 }
 </code></pre></div>
         <hr class="example-separator"/>
@@ -201,23 +214,35 @@ class Example1 extends SuperClass { // ok, camel case
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 extends SuperClass { // ok, camel case
-  int CURRENT_COUNTER; // violation 'no more than '4' consecutive capital letters'
+  int CURRENT_COUNTER;  // violation 'no more than '4' consecutive capital letters'
   // violation below 'no more than '4' consecutive capital letters'
   static int GLOBAL_COUNTER;
+
   final Set&lt;String&gt; stringsFOUND = new HashSet&lt;&gt;(); // ok, final is ignored
+  int firstNum;
+  int secondNUM;
+  static int thirdNum;
+  static int fourthNUm;
+  String firstXML;
+  String firstURL;
+  final int TOTAL = 5;              // ok, final is ignored
+  static final int LIMIT = 10;      // ok, static final is ignored
+  int nextXYZ = 1;
+  final int countID = 2;
+
+  static int nextID = 3;
+  static final int MAX_ALLOWED = 4; // ok, static final is ignored
+
+  void newOAuth2Client() {}
+  void OAuth2() {}
+  void OAUth2() {}
 
   @Override // violation below 'no more than '4' consecutive capital letters'
-  public void printCOUNTER() {
-    System.out.println(CURRENT_COUNTER); // ok, only definitions are checked
-  }
+  public void printCOUNTER() {}
   // violation below 'no more than '4' consecutive capital letters'
-  void incrementCOUNTER() {
-    CURRENT_COUNTER++; // ok, only definitions are checked
-  }
+  void incrementCOUNTER() {}
   // violation below 'no more than '4' consecutive capital letters'
-  static void incrementGLOBAL() {
-    GLOBAL_COUNTER++; // ok, only definitions are checked
-  }
+  static void incrementGLOBAL() {}
 }
 </code></pre></div>
         <hr class="example-separator"/>
@@ -242,18 +267,36 @@ class Example2 extends SuperClass { // ok, camel case
 </code></pre></div>
         <p id="Example3-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example3 {
+class Example3 extends SuperClass {
+  int CURRENT_COUNTER;  // violation 'no more than '1' consecutive capital letters'
+  // violation below 'no more than '1' consecutive capital letters'
+  static int GLOBAL_COUNTER;
+
+  final Set&lt;String&gt; stringsFOUND = new HashSet&lt;&gt;(); // ok, final is ignored
   int firstNum;
-  int secondNUM; // violation 'no more than '1' consecutive capital letters'
-  static int thirdNum; // ok, the static modifier would be checked
+  int secondNUM;        // violation 'no more than '1' consecutive capital letters'
+  static int thirdNum;  // ok, the static modifier would be checked
   static int fourthNUm; // violation 'no more than '1' consecutive capital letters'
-  String firstXML; // ok, XML abbreviation is allowed
-  String firstURL; // ok, URL abbreviation is allowed
-  final int TOTAL = 5; // ok, final is ignored
-  static final int LIMIT = 10; // ok, static final is ignored
+  String firstXML;      // ok, XML abbreviation is allowed
+  String firstURL;      // ok, URL abbreviation is allowed
+  final int TOTAL = 5;              // ok, final is ignored
+  static final int LIMIT = 10;      // ok, static final is ignored
+  int nextXYZ = 1;      // violation 'no more than '1' consecutive capital letters'
+  final int countID = 2;            // ok, final is ignored
+  // violation below 'no more than '1' consecutive capital letters'
+  static int nextID = 3;
+  static final int MAX_ALLOWED = 4; // ok, static final is ignored
+
   void newOAuth2Client() {} // ok, O abbreviation is allowed
-  void OAuth2() {} // ok, O abbreviation is allowed
+  void OAuth2() {}          // ok, O abbreviation is allowed
   void OAUth2() {}
+
+  @Override
+  public void printCOUNTER() {}
+
+  void incrementCOUNTER() {}
+
+  static void incrementGLOBAL() {}
 }
 </code></pre></div>
         <hr class="example-separator"/>
@@ -310,12 +353,36 @@ class Example4 { // ok, ignore checking the class name
 </code></pre></div>
         <p id="Example5-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example5 {
-  int counterXYZ = 1; // violation 'no more than '1' consecutive capital letters'
+class Example5 extends SuperClass {
+  int CURRENT_COUNTER;  // violation 'no more than '1' consecutive capital letters'
   // violation below 'no more than '1' consecutive capital letters'
-  final int customerID = 2;
+  static int GLOBAL_COUNTER;
+  // violation below 'no more than '1' consecutive capital letters'
+  final Set&lt;String&gt; stringsFOUND = new HashSet&lt;&gt;();
+  int firstNum;
+  int secondNUM;        // violation 'no more than '1' consecutive capital letters'
+  static int thirdNum;
+  static int fourthNUm; // violation 'no more than '1' consecutive capital letters'
+  String firstXML;      // violation 'no more than '1' consecutive capital letters'
+  String firstURL;      // violation 'no more than '1' consecutive capital letters'
+  final int TOTAL = 5;  // violation 'no more than '1' consecutive capital letters'
+  static final int LIMIT = 10;
+  int nextXYZ = 1;       // violation 'no more than '1' consecutive capital letters'
+  final int countID = 2; // violation 'no more than '1' consecutive capital letters'
+
   static int nextID = 3; // violation 'no more than '1' consecutive capital letters'
-  static final int MAX_ALLOWED = 4; // ok, ignored
+  static final int MAX_ALLOWED = 4;
+
+  void newOAuth2Client() {} // ok, O abbreviation is allowed
+  void OAuth2() {}          // ok, O abbreviation is allowed
+  void OAUth2() {}
+
+  @Override
+  public void printCOUNTER() {}
+
+  void incrementCOUNTER() {}
+
+  static void incrementGLOBAL() {}
 }
 </code></pre></div>
         <hr class="example-separator"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -175,11 +175,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
             "checks/metrics/javancss/Example5",
             "checks/metrics/npathcomplexity/Example2",
-            "checks/naming/abbreviationaswordinname/Example3",
-            "checks/naming/abbreviationaswordinname/Example4",
-            "checks/naming/abbreviationaswordinname/Example5",
-            "checks/naming/abbreviationaswordinname/Example6",
-            "checks/naming/abbreviationaswordinname/Example7",
             "checks/naming/lambdaparametername/Example2",
             "checks/naming/localfinalvariablename/Example3",
             "checks/naming/localvariablename/Example3",
@@ -301,7 +296,10 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/design/visibilitymodifier/Example11",
             "checks/trailingcomment/Example4",
             "checks/trailingcomment/Example5",
-            "checks/trailingcomment/Example6"
+            "checks/trailingcomment/Example6",
+            "checks/naming/abbreviationaswordinname/Example4",
+            "checks/naming/abbreviationaswordinname/Example6",
+            "checks/naming/abbreviationaswordinname/Example7"
             );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameExamplesTest.java
@@ -38,8 +38,8 @@ public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModule
     public void testExample1() throws Exception {
         final String[] expected = {
             "18:7: " + getCheckMessage(MSG_KEY, "CURRENT_COUNTER", DEFAULT_EXPECTED_CAPITAL_COUNT),
-            "27:8: " + getCheckMessage(MSG_KEY, "incrementCOUNTER", DEFAULT_EXPECTED_CAPITAL_COUNT),
-            "31:15: " + getCheckMessage(MSG_KEY, "incrementGLOBAL", DEFAULT_EXPECTED_CAPITAL_COUNT),
+            "44:8: " + getCheckMessage(MSG_KEY, "incrementCOUNTER", DEFAULT_EXPECTED_CAPITAL_COUNT),
+            "46:15: " + getCheckMessage(MSG_KEY, "incrementGLOBAL", DEFAULT_EXPECTED_CAPITAL_COUNT),
         };
 
         verifyWithInlineXmlConfig(getPath("Example1.java"), expected);
@@ -50,9 +50,9 @@ public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModule
         final String[] expected = {
             "21:7: " + getCheckMessage(MSG_KEY, "CURRENT_COUNTER", DEFAULT_EXPECTED_CAPITAL_COUNT),
             "23:14: " + getCheckMessage(MSG_KEY, "GLOBAL_COUNTER", DEFAULT_EXPECTED_CAPITAL_COUNT),
-            "27:15: " + getCheckMessage(MSG_KEY, "printCOUNTER", DEFAULT_EXPECTED_CAPITAL_COUNT),
-            "31:8: " + getCheckMessage(MSG_KEY, "incrementCOUNTER", DEFAULT_EXPECTED_CAPITAL_COUNT),
-            "35:15: " + getCheckMessage(MSG_KEY, "incrementGLOBAL", DEFAULT_EXPECTED_CAPITAL_COUNT),
+            "45:15: " + getCheckMessage(MSG_KEY, "printCOUNTER", DEFAULT_EXPECTED_CAPITAL_COUNT),
+            "47:8: " + getCheckMessage(MSG_KEY, "incrementCOUNTER", DEFAULT_EXPECTED_CAPITAL_COUNT),
+            "49:15: " + getCheckMessage(MSG_KEY, "incrementGLOBAL", DEFAULT_EXPECTED_CAPITAL_COUNT),
         };
 
         verifyWithInlineXmlConfig(getPath("Example2.java"), expected);
@@ -63,8 +63,12 @@ public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModule
         final int expectedCapitalCount = 1;
 
         final String[] expected = {
-            "21:7: " + getCheckMessage(MSG_KEY, "secondNUM", expectedCapitalCount),
-            "23:14: " + getCheckMessage(MSG_KEY, "fourthNUm", expectedCapitalCount),
+            "23:7: " + getCheckMessage(MSG_KEY, "CURRENT_COUNTER", expectedCapitalCount),
+            "25:14: " + getCheckMessage(MSG_KEY, "GLOBAL_COUNTER", expectedCapitalCount),
+            "29:7: " + getCheckMessage(MSG_KEY, "secondNUM", expectedCapitalCount),
+            "31:14: " + getCheckMessage(MSG_KEY, "fourthNUm", expectedCapitalCount),
+            "36:7: " + getCheckMessage(MSG_KEY, "nextXYZ", expectedCapitalCount),
+            "39:14: " + getCheckMessage(MSG_KEY, "nextID", expectedCapitalCount),
         };
 
         verifyWithInlineXmlConfig(getPath("Example3.java"), expected);
@@ -88,9 +92,17 @@ public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModule
         final int expectedCapitalCount = 1;
 
         final String[] expected = {
-            "21:7: " + getCheckMessage(MSG_KEY, "counterXYZ", expectedCapitalCount),
-            "23:13: " + getCheckMessage(MSG_KEY, "customerID", expectedCapitalCount),
-            "24:14: " + getCheckMessage(MSG_KEY, "nextID", expectedCapitalCount),
+            "24:7: " + getCheckMessage(MSG_KEY, "CURRENT_COUNTER", expectedCapitalCount),
+            "26:14: " + getCheckMessage(MSG_KEY, "GLOBAL_COUNTER", expectedCapitalCount),
+            "28:21: " + getCheckMessage(MSG_KEY, "stringsFOUND", expectedCapitalCount),
+            "30:7: " + getCheckMessage(MSG_KEY, "secondNUM", expectedCapitalCount),
+            "32:14: " + getCheckMessage(MSG_KEY, "fourthNUm", expectedCapitalCount),
+            "33:10: " + getCheckMessage(MSG_KEY, "firstXML", expectedCapitalCount),
+            "34:10: " + getCheckMessage(MSG_KEY, "firstURL", expectedCapitalCount),
+            "35:13: " + getCheckMessage(MSG_KEY, "TOTAL", expectedCapitalCount),
+            "37:7: " + getCheckMessage(MSG_KEY, "nextXYZ", expectedCapitalCount),
+            "38:13: " + getCheckMessage(MSG_KEY, "countID", expectedCapitalCount),
+            "40:14: " + getCheckMessage(MSG_KEY, "nextID", expectedCapitalCount),
         };
 
         verifyWithInlineXmlConfig(getPath("Example5.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example1.java
@@ -15,21 +15,34 @@ import java.util.Set;
 
 // xdoc section -- start
 class Example1 extends SuperClass { // ok, camel case
-  int CURRENT_COUNTER; // violation 'no more than '4' consecutive capital letters'
-  static int GLOBAL_COUNTER; // ok, static is ignored
+  int CURRENT_COUNTER;  // violation 'no more than '4' consecutive capital letters'
+
+  static int GLOBAL_COUNTER;        // ok, static is ignored
+
   final Set<String> stringsFOUND = new HashSet<>(); // ok, final is ignored
+  int firstNum;
+  int secondNUM;
+  static int thirdNum;
+  static int fourthNUm;
+  String firstXML;
+  String firstURL;
+  final int TOTAL = 5;              // ok, final is ignored
+  static final int LIMIT = 10;      // ok, static final is ignored
+  int nextXYZ = 1;
+  final int countID = 2;
+
+  static int nextID = 3;
+  static final int MAX_ALLOWED = 4; // ok, static final is ignored
+
+  void newOAuth2Client() {}
+  void OAuth2() {}
+  void OAUth2() {}
 
   @Override
-  public void printCOUNTER() { // ok, overridden method is ignored
-    System.out.println(CURRENT_COUNTER);
-  }
+  public void printCOUNTER() {}     // ok, overridden method is ignored
   // violation below 'no more than '4' consecutive capital letters'
-  void incrementCOUNTER() {
-    CURRENT_COUNTER++; // ok, only definitions are checked
-  }
+  void incrementCOUNTER() {}
   // violation below 'no more than '4' consecutive capital letters'
-  static void incrementGLOBAL() {
-    GLOBAL_COUNTER++; // ok, only definitions are checked
-  }
+  static void incrementGLOBAL() {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example2.java
@@ -18,22 +18,34 @@ import java.util.Set;
 
 // xdoc section -- start
 class Example2 extends SuperClass { // ok, camel case
-  int CURRENT_COUNTER; // violation 'no more than '4' consecutive capital letters'
+  int CURRENT_COUNTER;  // violation 'no more than '4' consecutive capital letters'
   // violation below 'no more than '4' consecutive capital letters'
   static int GLOBAL_COUNTER;
+
   final Set<String> stringsFOUND = new HashSet<>(); // ok, final is ignored
+  int firstNum;
+  int secondNUM;
+  static int thirdNum;
+  static int fourthNUm;
+  String firstXML;
+  String firstURL;
+  final int TOTAL = 5;              // ok, final is ignored
+  static final int LIMIT = 10;      // ok, static final is ignored
+  int nextXYZ = 1;
+  final int countID = 2;
+
+  static int nextID = 3;
+  static final int MAX_ALLOWED = 4; // ok, static final is ignored
+
+  void newOAuth2Client() {}
+  void OAuth2() {}
+  void OAUth2() {}
 
   @Override // violation below 'no more than '4' consecutive capital letters'
-  public void printCOUNTER() {
-    System.out.println(CURRENT_COUNTER); // ok, only definitions are checked
-  }
+  public void printCOUNTER() {}
   // violation below 'no more than '4' consecutive capital letters'
-  void incrementCOUNTER() {
-    CURRENT_COUNTER++; // ok, only definitions are checked
-  }
+  void incrementCOUNTER() {}
   // violation below 'no more than '4' consecutive capital letters'
-  static void incrementGLOBAL() {
-    GLOBAL_COUNTER++; // ok, only definitions are checked
-  }
+  static void incrementGLOBAL() {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example3.java
@@ -15,18 +15,39 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
+import java.util.HashSet;
+import java.util.Set;
+
 // xdoc section -- start
-class Example3 {
+class Example3 extends SuperClass {
+  int CURRENT_COUNTER;  // violation 'no more than '1' consecutive capital letters'
+  // violation below 'no more than '1' consecutive capital letters'
+  static int GLOBAL_COUNTER;
+
+  final Set<String> stringsFOUND = new HashSet<>(); // ok, final is ignored
   int firstNum;
-  int secondNUM; // violation 'no more than '1' consecutive capital letters'
-  static int thirdNum; // ok, the static modifier would be checked
+  int secondNUM;        // violation 'no more than '1' consecutive capital letters'
+  static int thirdNum;  // ok, the static modifier would be checked
   static int fourthNUm; // violation 'no more than '1' consecutive capital letters'
-  String firstXML; // ok, XML abbreviation is allowed
-  String firstURL; // ok, URL abbreviation is allowed
-  final int TOTAL = 5; // ok, final is ignored
-  static final int LIMIT = 10; // ok, static final is ignored
+  String firstXML;      // ok, XML abbreviation is allowed
+  String firstURL;      // ok, URL abbreviation is allowed
+  final int TOTAL = 5;              // ok, final is ignored
+  static final int LIMIT = 10;      // ok, static final is ignored
+  int nextXYZ = 1;      // violation 'no more than '1' consecutive capital letters'
+  final int countID = 2;            // ok, final is ignored
+  // violation below 'no more than '1' consecutive capital letters'
+  static int nextID = 3;
+  static final int MAX_ALLOWED = 4; // ok, static final is ignored
+
   void newOAuth2Client() {} // ok, O abbreviation is allowed
-  void OAuth2() {} // ok, O abbreviation is allowed
+  void OAuth2() {}          // ok, O abbreviation is allowed
   void OAUth2() {}
+
+  @Override
+  public void printCOUNTER() {}
+
+  void incrementCOUNTER() {}
+
+  static void incrementGLOBAL() {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/Example5.java
@@ -16,12 +16,39 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
+import java.util.HashSet;
+import java.util.Set;
+
 // xdoc section -- start
-class Example5 {
-  int counterXYZ = 1; // violation 'no more than '1' consecutive capital letters'
+class Example5 extends SuperClass {
+  int CURRENT_COUNTER;  // violation 'no more than '1' consecutive capital letters'
   // violation below 'no more than '1' consecutive capital letters'
-  final int customerID = 2;
+  static int GLOBAL_COUNTER;
+  // violation below 'no more than '1' consecutive capital letters'
+  final Set<String> stringsFOUND = new HashSet<>();
+  int firstNum;
+  int secondNUM;        // violation 'no more than '1' consecutive capital letters'
+  static int thirdNum;
+  static int fourthNUm; // violation 'no more than '1' consecutive capital letters'
+  String firstXML;      // violation 'no more than '1' consecutive capital letters'
+  String firstURL;      // violation 'no more than '1' consecutive capital letters'
+  final int TOTAL = 5;  // violation 'no more than '1' consecutive capital letters'
+  static final int LIMIT = 10;
+  int nextXYZ = 1;       // violation 'no more than '1' consecutive capital letters'
+  final int countID = 2; // violation 'no more than '1' consecutive capital letters'
+
   static int nextID = 3; // violation 'no more than '1' consecutive capital letters'
-  static final int MAX_ALLOWED = 4; // ok, ignored
+  static final int MAX_ALLOWED = 4;
+
+  void newOAuth2Client() {} // ok, O abbreviation is allowed
+  void OAuth2() {}          // ok, O abbreviation is allowed
+  void OAUth2() {}
+
+  @Override
+  public void printCOUNTER() {}
+
+  void incrementCOUNTER() {}
+
+  static void incrementGLOBAL() {}
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

https://www.diffchecker.com/9gzfJ6NX/
https://www.diffchecker.com/5k1GjGri/
https://www.diffchecker.com/SIxksyQb/


Examples unified (Section 1 — identical AST)
Examples 1, 2, 3, 5 now share identical AST structure. Each demonstrates distinct properties:

Example1 — default configuration
Example2 — ignoreStatic=false, ignoreOverriddenMethods=false
Example3 — allowedAbbreviations, tokens=VARIABLE_DEF,CLASS_DEF
Example5 — ignoreFinal, ignoreStatic, ignoreStaticFinal combination

Examples marked as Use Cases (until #XXXXX)
Examples 4, 6, 7 are marked with // until #XXXXX as they demonstrate the same properties as existing Section 1 examples with different values, making forced unification unnecessary:

Example4 — same property intent as Example3 (allowedAbbreviations + tokens) with different values
Example6 — same property intent as Example5 (ignoreFinal, ignoreStatic, ignoreStaticFinal) with swapped values
Example7 — similar to Example3 (allowedAbbreviations) with different config