### PR TITLE
Issue #19936: Mark doc image destination rules as no validation

### DIFF
--- a/src/site/xdoc/doc_comments_style.xml
+++ b/src/site/xdoc/doc_comments_style.xml
@@ -935,7 +935,7 @@
                     Naming of doc images in HTML destination
                   </a>
                 </td>
-                <td>???</td>
+                <td>--</td>
                 <td/>
               </tr>
 
@@ -947,7 +947,7 @@
                     Location of doc images in HTML destination
                   </a>
                 </td>
-                <td>???</td>
+                <td>--</td>
                 <td/>
               </tr>
 


### PR DESCRIPTION
Issue: #19936

Updated the Documentation Comments Style coverage table to mark both doc image HTML-destination rules as having no Checkstyle validation, matching the confirmed issue guidance.

Testing:

- `git diff --check`
- `./mvnw -e --no-transfer-progress -Dtest=XdocsPagesTest#testDocCommentsStyleRules test`