### PR TITLE
Issue #19916: Mark doc comments author rule as no validation

### DIFF
--- a/src/site/xdoc/doc_comments_style.xml
+++ b/src/site/xdoc/doc_comments_style.xml
@@ -570,7 +570,7 @@
                     @author
                   </a>
                 </td>
-                <td>???</td>
+                <td>--</td>
                 <td/>
               </tr>
 


### PR DESCRIPTION
Issue: #19916

Updated the Documentation Comments Style coverage table to mark the `@author` rule as having no Checkstyle validation, matching the confirmed issue guidance.

Testing:

- `git diff --check`
- `./mvnw -e --no-transfer-progress -Dtest=XdocsPagesTest#testDocCommentsStyleRules test`