### PR TITLE
Issue #19935: Mark doc image source location as no validation

### DIFF
--- a/src/site/xdoc/doc_comments_style.xml
+++ b/src/site/xdoc/doc_comments_style.xml
@@ -911,7 +911,7 @@
                     Location of doc images in source tree
                   </a>
                 </td>
-                <td>???</td>
+                <td>--</td>
                 <td/>
               </tr>
 


### PR DESCRIPTION
Issue: #19935

Updated the Documentation Comments Style coverage table to mark the doc image source-tree location rule as having no Checkstyle validation, matching the confirmed issue guidance.

Testing:

- `git diff --check`
- `./mvnw -e --no-transfer-progress -Dtest=XdocsPagesTest#testDocCommentsStyleRules test`