### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - whitespacearound

### DIFF
--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml
@@ -382,25 +382,453 @@ try {
 class Example1 {
   public Example1(){} // 3 violations
   // no space after ')' and '{', no space before '}'
-  public static void main(String[] args) {
-    if (true) { }
-    else{ // 2 violations
-         // no space after 'else', no space before '}'
-    }
+  int y = 0;
+  int a = 4;
 
-    for (int i = 1; i &gt; 1; i++) {} // 2 violations
-    // no space after '{', no space before '}'
-
+  void example() {
     Runnable noop = () -&gt;{}; // 4 violations
     // no space after '-&gt;' and '{', no space before '{' and '}'
     try { }
     catch (Exception e){} // 3 violations
     // no space after ')' and '{', no space before '}'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
-    for (char item: vowels) { // ok, ignoreEnhancedForColon is true by default
+    for (char item: vowels) { }
+    for (int i = 100;i &gt; 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
+  }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check for whitespace only around curly braces:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="WhitespaceAround"&gt;
+      &lt;property name="tokens" value="LCURLY, RCURLY"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example3 {
+  public Example3(){} // violation ''}' is not preceded with whitespace'
+
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () -&gt;{}; // violation ''}' is not preceded with whitespace'
+
+    try { }
+    catch (Exception e){} // violation ''}' is not preceded with whitespace'
+
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i &gt; 10; i--){}
+    // violation above ''}' is not preceded with whitespace'
+    do {} while (y == 1); // violation ''}' is not preceded with whitespace'
+
+    int i = 0;
+    switch (i) {
+      case 1: {} // violation ''}' is not preceded with whitespace'
 
     }
+    int a=4;
+
   }
+
+  void myFunction() {} // violation ''}' is not preceded with whitespace'
+
+  void myFunction2() { }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure the check to allow empty method bodies:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="WhitespaceAround"&gt;
+      &lt;property name="allowEmptyMethods" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example4 {
+  public Example4(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () -&gt;{}; // 4 violations
+    // no space after '-&gt;' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i &gt; 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
+  }
+
+  void myFunction() {}
+
+  void myFunction2() { }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check to allow empty constructor bodies:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="WhitespaceAround"&gt;
+      &lt;property name="allowEmptyConstructors" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example5 {
+  public Example5(){} // violation, no space after ')'
+
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () -&gt;{}; // 4 violations
+    // no space after '-&gt;' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i &gt; 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
+  }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example6-config">
+          To configure the check to allow empty type bodies:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="WhitespaceAround"&gt;
+      &lt;property name="allowEmptyTypes" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example6-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example6 {
+  public Example6(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () -&gt;{}; // 4 violations
+    // no space after '-&gt;' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i &gt; 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
+  }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example7-config">
+          To configure the check to allow empty loop bodies:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="WhitespaceAround"&gt;
+      &lt;property name="allowEmptyLoops" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example7-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example7 {
+  public Example7(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () -&gt;{}; // 4 violations
+    // no space after '-&gt;' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i &gt; 10; i--){}
+
+    do {} while (y == 1);
+
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
+  }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example8-config">
+          To configure the check to allow empty lambda bodies:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="WhitespaceAround"&gt;
+      &lt;property name="allowEmptyLambdas" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example8-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example8 {
+  public Example8(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () -&gt;{}; // violation, no space after '-&gt;'
+
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i &gt; 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
+  }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example9-config">
+          To configure the check to allow empty catch bodies:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="WhitespaceAround"&gt;
+      &lt;property name="allowEmptyCatches" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example9-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example9 {
+  public Example9(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () -&gt;{}; // 4 violations
+    // no space after '-&gt;' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){}
+
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i &gt; 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
+  }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
+}
+</code></pre></div>
+        <p>
+          Also, this check can be configured to ignore the colon in an enhanced for loop.
+          The colon in an enhanced for loop is ignored by default.
+        </p>
+        <hr class="example-separator"/>
+        <p id="Example10-config">
+          To configure the check to ignore the colon:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="WhitespaceAround"&gt;
+      &lt;property name="ignoreEnhancedForColon" value="false"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example10-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example10 {
+  public Example10(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () -&gt;{}; // 4 violations
+    // no space after '-&gt;' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { } // violation '':' is not preceded with whitespace'
+    for (int i = 100;i &gt; 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
+  }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
+}
+</code></pre></div>
+        <hr class="example-separator"/>
+        <p id="Example11-config">
+          To configure the check to allow empty switch block statements:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="WhitespaceAround"&gt;
+      &lt;property name="allowEmptySwitchBlockStatements" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example11-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example11 {
+  public Example11(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () -&gt;{}; // 4 violations
+    // no space after '-&gt;' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i &gt; 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {}
+
+    }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
+  }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -448,216 +876,7 @@ class Example2 {
     c &gt;&gt;&gt;= 1;
   }
 }
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example3-config">
-          To configure the check for whitespace only around curly braces:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="WhitespaceAround"&gt;
-      &lt;property name="tokens" value="LCURLY, RCURLY"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
 </code></pre></div>
-        <p id="Example3-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example3 {
-  void myFunction() {} // violation ''}' is not preceded with whitespace'
-  void myFunction2() { }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example4-config">
-          To configure the check to allow empty method bodies:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="WhitespaceAround"&gt;
-      &lt;property name="allowEmptyMethods" value="true"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example4 {
-  public void muFunction() {}
-  int a=4; // 2 violations
-  // no space before and after '='
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example5-config">
-          To configure the check to allow empty constructor bodies:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="WhitespaceAround"&gt;
-      &lt;property name="allowEmptyConstructors" value="true"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example5-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example5 {
-  public Example5() {}
-  public void myFunction() {} // 2 violations
-  // no space after '{', no space before '}'
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example6-config">
-          To configure the check to allow empty type bodies:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="WhitespaceAround"&gt;
-      &lt;property name="allowEmptyTypes" value="true"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example6-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example6 {
-  class Test {}
-  interface testInterface{}
-  class anotherTest {
-    int a=4; // 2 violations
-    // no space before and after '='
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example7-config">
-          To configure the check to allow empty loop bodies:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="WhitespaceAround"&gt;
-      &lt;property name="allowEmptyLoops" value="true"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example7-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example7 {
-  int y = 0;
-  void example() {
-    for (int i = 100;i &gt; 10; i--){}
-    do {} while (y == 1);
-    int a=4; // 2 violations
-    // no space before and after '='
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example8-config">
-          To configure the check to allow empty lambda bodies:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="WhitespaceAround"&gt;
-      &lt;property name="allowEmptyLambdas" value="true"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example8-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example8 {
-  void example() {
-    Runnable noop = () -&gt; {};
-    int a=4; // 2 violations
-    // no space before and after '='
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example9-config">
-          To configure the check to allow empty catch bodies:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="WhitespaceAround"&gt;
-      &lt;property name="allowEmptyCatches" value="true"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example9-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example9 {
-  void example() {
-    int a=4; // 2 violations
-    // no space before and after '='
-    try {
-    } catch (Exception e){}
-  }
-}
-</code></pre></div>
-        <p>
-          Also, this check can be configured to ignore the colon in an enhanced for loop.
-          The colon in an enhanced for loop is ignored by default.
-        </p>
-        <hr class="example-separator"/>
-        <p id="Example10-config">
-          To configure the check to ignore the colon:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="WhitespaceAround"&gt;
-      &lt;property name="ignoreEnhancedForColon" value="false"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example10-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example10 {
-  void example() {
-    int a=4; // 2 violations
-    // no space before and after '='
-    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
-    for (char item: vowels) { // violation '':' is not preceded with whitespace'
-    }
-  }
-}
-</code></pre></div>
-        <hr class="example-separator"/>
-        <p id="Example11-config">
-          To configure the check to allow empty switch block statements:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="WhitespaceAround"&gt;
-      &lt;property name="allowEmptySwitchBlockStatements" value="true"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example11-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example11 {
-  void example() {
-    int i = 0;
-    switch (i) {
-      case 1: {}
-    }
-
-    int a=4; // 2 violations
-    // ''=' is not preceded with whitespace.'
-    // ''=' is not followed by whitespace.'
-  }
-}
-</code></pre></div>
-
       </subsection>
 
       <subsection name="Example of Usage" id="WhitespaceAround_Example_of_Usage">

--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml.template
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml.template
@@ -42,20 +42,6 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example1.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example2-config">
-          To configure the check for whitespace only around assignment operators:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example2.java"/>
-          <param name="type" value="config"/>
-        </macro>
-        <p id="Example2-code">Example:</p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example2.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
         <p id="Example3-config">
           To configure the check for whitespace only around curly braces:
         </p>
@@ -187,8 +173,21 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example11.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example2-config">
+          To configure the check for whitespace only around assignment operators:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example2.java"/>
+          <param name="type" value="config"/>
         </macro>
-
+        <p id="Example2-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example2.java"/>
+          <param name="type" value="code"/>
+        </macro>
       </subsection>
 
       <subsection name="Example of Usage" id="WhitespaceAround_Example_of_Usage">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -212,16 +212,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/whitespace/singlespaceseparator/Example2",
             "checks/whitespace/typecastparenpad/Example2",
             "checks/whitespace/whitespaceafter/Example2",
-            "checks/whitespace/whitespacearound/Example10",
-            "checks/whitespace/whitespacearound/Example2",
-            "checks/whitespace/whitespacearound/Example3",
-            "checks/whitespace/whitespacearound/Example4",
-            "checks/whitespace/whitespacearound/Example5",
-            "checks/whitespace/whitespacearound/Example6",
-            "checks/whitespace/whitespacearound/Example7",
-            "checks/whitespace/whitespacearound/Example8",
-            "checks/whitespace/whitespacearound/Example9",
-            "checks/whitespace/whitespacearound/Example11",
             "filters/suppressionfilter/Example2",
             "filters/suppressionfilter/Example3",
             "filters/suppressionfilter/Example4",
@@ -288,7 +278,8 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/naming/abbreviationaswordinname/Example7",
             "checks/naming/localvariablename/Example3",
             "checks/naming/localvariablename/Example5",
-            "checks/whitespace/nowhitespacebefore/Example4"
+            "checks/whitespace/nowhitespacebefore/Example4",
+            "checks/whitespace/whitespacearound/Example2"
             );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundExamplesTest.java
@@ -38,17 +38,24 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
             "15:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
             "15:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
             "15:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "19:5: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "else"),
-            "19:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "23:33: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "23:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "26:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
-            "26:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "26:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "26:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "29:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "29:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "29:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "21:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "21:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "24:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "24:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "24:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "28:34: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "28:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "28:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "30:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "30:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "34:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "34:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "37:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "37:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "41:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "41:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -81,7 +88,13 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "17:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "23:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "26:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "30:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "32:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "36:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "43:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -90,8 +103,25 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "18:8: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "18:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "23:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "23:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "32:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "32:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "36:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "36:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
@@ -100,8 +130,25 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "18:28: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "18:29: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "23:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "23:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "32:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "32:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "36:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "36:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "43:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "43:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
@@ -110,8 +157,27 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample6() throws Exception {
         final String[] expected = {
-            "20:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "20:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "23:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "23:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "32:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "32:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "36:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "36:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "43:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "43:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
 
         verifyWithInlineConfigParser(getPath("Example6.java"), expected);
@@ -120,8 +186,22 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample7() throws Exception {
         final String[] expected = {
-            "21:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "21:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "23:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "23:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "36:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "36:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "43:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "43:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
@@ -130,8 +210,24 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample8() throws Exception {
         final String[] expected = {
-            "19:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "19:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "23:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "32:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "32:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "36:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "36:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "43:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "43:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
 
         verifyWithInlineConfigParser(getPath("Example8.java"), expected);
@@ -140,8 +236,24 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample9() throws Exception {
         final String[] expected = {
-            "18:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "18:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "23:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "23:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "32:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "32:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "36:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "36:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "43:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "43:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
 
         verifyWithInlineConfigParser(getPath("Example9.java"), expected);
@@ -150,9 +262,28 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample10() throws Exception {
         final String[] expected = {
-            "18:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "18:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
-            "21:19: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
+            "17:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "17:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "23:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "23:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "23:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "29:19: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "30:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "32:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "32:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "36:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "36:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "39:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "43:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "43:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
 
         verifyWithInlineConfigParser(getPath("Example10.java"), expected);
@@ -161,8 +292,25 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample11() throws Exception {
         final String[] expected = {
-            "21:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
-            "21:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "15:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "15:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "15:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "21:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "21:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "24:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "24:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "24:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "28:34: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "28:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "28:35: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "30:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "30:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "37:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "="),
+            "37:10: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "="),
+            "41:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "41:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
         };
 
         verifyWithInlineConfigParser(getPath("Example11.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example1.java
@@ -14,24 +14,32 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 class Example1 {
   public Example1(){} // 3 violations
   // no space after ')' and '{', no space before '}'
-  public static void main(String[] args) {
-    if (true) { }
-    else{ // 2 violations
-         // no space after 'else', no space before '}'
-    }
+  int y = 0;
+  int a = 4;
 
-    for (int i = 1; i > 1; i++) {} // 2 violations
-    // no space after '{', no space before '}'
-
+  void example() {
     Runnable noop = () ->{}; // 4 violations
     // no space after '->' and '{', no space before '{' and '}'
     try { }
     catch (Exception e){} // 3 violations
     // no space after ')' and '{', no space before '}'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
-    for (char item: vowels) { // ok, ignoreEnhancedForColon is true by default
-
+    for (char item: vowels) { }
+    for (int i = 100;i > 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
     }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
   }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example10.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example10.java
@@ -14,12 +14,34 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 // xdoc section -- start
 class Example10 {
+  public Example10(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
   void example() {
-    int a=4; // 2 violations
-    // no space before and after '='
+    Runnable noop = () ->{}; // 4 violations
+    // no space after '->' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
-    for (char item: vowels) { // violation '':' is not preceded with whitespace'
+    for (char item: vowels) { } // violation '':' is not preceded with whitespace'
+    for (int i = 100;i > 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
     }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
   }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example11.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example11.java
@@ -12,15 +12,34 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 // xdoc section -- start
 class Example11 {
+  public Example11(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
   void example() {
+    Runnable noop = () ->{}; // 4 violations
+    // no space after '->' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i > 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
     int i = 0;
     switch (i) {
       case 1: {}
-    }
 
+    }
     int a=4; // 2 violations
-    // ''=' is not preceded with whitespace.'
-    // ''=' is not followed by whitespace.'
+    // no space before '=', no space after '='
   }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example3.java
@@ -14,7 +14,34 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 // xdoc section -- start
 class Example3 {
+  public Example3(){} // violation ''}' is not preceded with whitespace'
+
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () ->{}; // violation ''}' is not preceded with whitespace'
+
+    try { }
+    catch (Exception e){} // violation ''}' is not preceded with whitespace'
+
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i > 10; i--){}
+    // violation above ''}' is not preceded with whitespace'
+    do {} while (y == 1); // violation ''}' is not preceded with whitespace'
+
+    int i = 0;
+    switch (i) {
+      case 1: {} // violation ''}' is not preceded with whitespace'
+
+    }
+    int a=4;
+
+  }
+
   void myFunction() {} // violation ''}' is not preceded with whitespace'
+
   void myFunction2() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example4.java
@@ -14,8 +14,34 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 // xdoc section -- start
 class Example4 {
-  public void muFunction() {}
-  int a=4; // 2 violations
-  // no space before and after '='
+  public Example4(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () ->{}; // 4 violations
+    // no space after '->' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i > 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
+  }
+
+  void myFunction() {}
+
+  void myFunction2() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example5.java
@@ -14,8 +14,34 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 // xdoc section -- start
 class Example5 {
-  public Example5() {}
-  public void myFunction() {} // 2 violations
+  public Example5(){} // violation, no space after ')'
+
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () ->{}; // 4 violations
+    // no space after '->' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i > 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
+    int a=4; // 2 violations
+    // no space before '=', no space after '='
+  }
+
+  void myFunction() {} // 2 violations
   // no space after '{', no space before '}'
+  void myFunction2() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example6.java
@@ -14,11 +14,34 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 // xdoc section -- start
 class Example6 {
-  class Test {}
-  interface testInterface{}
-  class anotherTest {
+  public Example6(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
+  void example() {
+    Runnable noop = () ->{}; // 4 violations
+    // no space after '->' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i > 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
     int a=4; // 2 violations
-    // no space before and after '='
+    // no space before '=', no space after '='
   }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example7.java
@@ -14,12 +14,34 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 // xdoc section -- start
 class Example7 {
+  public Example7(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
   int y = 0;
+  int a = 4;
+
   void example() {
+    Runnable noop = () ->{}; // 4 violations
+    // no space after '->' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
     for (int i = 100;i > 10; i--){}
+
     do {} while (y == 1);
+
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
     int a=4; // 2 violations
-    // no space before and after '='
+    // no space before '=', no space after '='
   }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example8.java
@@ -14,10 +14,34 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 // xdoc section -- start
 class Example8 {
+  public Example8(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
   void example() {
-    Runnable noop = () -> {};
+    Runnable noop = () ->{}; // violation, no space after '->'
+
+    try { }
+    catch (Exception e){} // 3 violations
+    // no space after ')' and '{', no space before '}'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i > 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
     int a=4; // 2 violations
-    // no space before and after '='
+    // no space before '=', no space after '='
   }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example9.java
@@ -14,11 +14,34 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 
 // xdoc section -- start
 class Example9 {
+  public Example9(){} // 3 violations
+  // no space after ')' and '{', no space before '}'
+  int y = 0;
+  int a = 4;
+
   void example() {
+    Runnable noop = () ->{}; // 4 violations
+    // no space after '->' and '{', no space before '{' and '}'
+    try { }
+    catch (Exception e){}
+
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 100;i > 10; i--){} // 3 violations
+    // no space before '{', no space after '{', no space before '}'
+    do {} while (y == 1); // 2 violations
+    // no space after '{', no space before '}'
+    int i = 0;
+    switch (i) {
+      case 1: {} // 2 violations
+      // no space after '{', no space before '}'
+    }
     int a=4; // 2 violations
-    // no space before and after '='
-    try {
-    } catch (Exception e){}
+    // no space before '=', no space after '='
   }
+
+  void myFunction() {} // 2 violations
+  // no space after '{', no space before '}'
+  void myFunction2() { }
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

whitespacearound : 
Example1 — default config (all allowEmpty=false, ignoreEnhancedForColon=true)
Example2 — tokens (specific assignment operators only)
Example3 — tokens (LCURLY, RCURLY only)
Example4 — allowEmptyMethods=true
Example5 — allowEmptyConstructors=true
Example6 — allowEmptyTypes=true
Example7 — allowEmptyLoops=true
Example8 — allowEmptyLambdas=true
Example9 — allowEmptyCatches=true
Example10 — ignoreEnhancedForColon=false
Example11 — allowEmptySwitchBlockStatements=true

Examples 2 and 3 — both demonstrate tokens property with different values
3 stays in section1, example 2 marked as a use case