### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - trailingcomment

### DIFF
--- a/src/site/xdoc/checks/misc/trailingcomment.xml
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml
@@ -111,6 +111,11 @@ d = e / f;      /* Some insightful block comment &#42;/
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
+  int a;
+  int b;
+  int c;
+  int d; // violation
+
   public static void main(String[] args) {
     int x = 10;
 
@@ -145,14 +150,20 @@ public class Example1 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
+  int a; // violation, line content before comment should match pattern "^\s*$"
+  int b; // violation, line content before comment should match pattern "^\s*$"
+  int c; // violation, line content before comment should match pattern "^\s*$"
+  int d; // violation, line content before comment should match pattern "^\s*$"
+
   public static void main(String[] args) {
-    int x = new Random().nextInt(100);
+    int x = 10;
 
     if (/* OK, this comment does not end the line */ x &gt; 5) {}
     int a = 5; // violation, line content before comment should match pattern "^\s*$"
     doSomething(
             "param1"
     ); // violation, line content before comment should match pattern "^\s*$"
+
   }
 
   private static void doSomething(String param) {
@@ -184,6 +195,20 @@ public class Example3 {
   int b; // NOPMD
   int c; // NOSONAR
   int d; // violation, not suppressed
+
+  public static void main(String[] args) {
+    int x = 10;
+
+    if (/* OK */ x &gt; 5) {}
+    int a = 5; // violation
+    doSomething(
+            "param1"
+    ); // ok, by default such trailing of method/code-block ending is allowed
+
+  }
+
+  private static void doSomething(String param) {
+  }
 }
 </code></pre></div><hr class="example-separator"/>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -210,11 +210,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/sizes/lambdabodylength/Example2",
             "checks/sizes/linelength/Example6",
             "checks/todocomment/Example3",
-            "checks/trailingcomment/Example2",
-            "checks/trailingcomment/Example3",
-            "checks/trailingcomment/Example4",
-            "checks/trailingcomment/Example5",
-            "checks/trailingcomment/Example6",
             "checks/whitespace/nolinewrap/Example2",
             "checks/whitespace/nolinewrap/Example3",
             "checks/whitespace/nolinewrap/Example4",
@@ -303,7 +298,10 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/design/visibilitymodifier/Example7",
             "checks/design/visibilitymodifier/Example9",
             "checks/design/visibilitymodifier/Example10",
-            "checks/design/visibilitymodifier/Example11"
+            "checks/design/visibilitymodifier/Example11",
+            "checks/trailingcomment/Example4",
+            "checks/trailingcomment/Example5",
+            "checks/trailingcomment/Example6"
             );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
@@ -34,7 +34,8 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "17:16: " + getCheckMessage(MSG_KEY),
+            "16:10: " + getCheckMessage(MSG_KEY),
+            "22:16: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -43,8 +44,12 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "21:16: " + getCheckMessage(MSG_KEY),
-            "24:8: " + getCheckMessage(MSG_KEY),
+            "15:10: " + getCheckMessage(MSG_KEY),
+            "16:10: " + getCheckMessage(MSG_KEY),
+            "17:10: " + getCheckMessage(MSG_KEY),
+            "18:10: " + getCheckMessage(MSG_KEY),
+            "24:16: " + getCheckMessage(MSG_KEY),
+            "27:8: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -54,6 +59,7 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
     public void testExample3() throws Exception {
         final String[] expected = {
             "18:10: " + getCheckMessage(MSG_KEY),
+            "24:16: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example1.java
@@ -10,6 +10,11 @@ package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
 
 // xdoc section -- start
 public class Example1 {
+  int a;
+  int b;
+  int c;
+  int d; // violation
+
   public static void main(String[] args) {
     int x = 10;
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example2.java
@@ -10,18 +10,22 @@
 
 package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
 
-import java.util.Random;
-
 // xdoc section -- start
 public class Example2 {
+  int a; // violation, line content before comment should match pattern "^\s*$"
+  int b; // violation, line content before comment should match pattern "^\s*$"
+  int c; // violation, line content before comment should match pattern "^\s*$"
+  int d; // violation, line content before comment should match pattern "^\s*$"
+
   public static void main(String[] args) {
-    int x = new Random().nextInt(100);
+    int x = 10;
 
     if (/* OK, this comment does not end the line */ x > 5) {}
     int a = 5; // violation, line content before comment should match pattern "^\s*$"
     doSomething(
             "param1"
     ); // violation, line content before comment should match pattern "^\s*$"
+
   }
 
   private static void doSomething(String param) {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
@@ -16,5 +16,19 @@ public class Example3 {
   int b; // NOPMD
   int c; // NOSONAR
   int d; // violation, not suppressed
+
+  public static void main(String[] args) {
+    int x = 10;
+
+    if (/* OK */ x > 5) {}
+    int a = 5; // violation
+    doSomething(
+            "param1"
+    ); // ok, by default such trailing of method/code-block ending is allowed
+
+  }
+
+  private static void doSomething(String param) {
+  }
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

trailingcomment:

Example1 — default config
Example2 — format property (different from default)
Example3 — legalComment property with exact match pattern $
Example4 — legalComment property with prefix match .*
Example5 — legalComment property with TODO/FIXME pattern
Example6 — legalComment + SuppressionXpathSingleFilter (completely different structure with block comments)

Examples 3, 4, 5 — all demonstrate legalComment property with different patterns:

Example3: exact match ($)
Example4: prefix match (.*) — same property as Example3, different regex value → Use Case
Example5: TODO/FIXME pattern — same property as Example3, different regex value → Use Case

Example6 — legalComment + SuppressionXpathSingleFilter + uses block comments (/* */) instead of line comments (//) → completely different structure ( Use Case )
Example2 — format property ( unique property, Section 1 )
So:

Section 1: Examples 1, 2, 3
Use Cases: Examples 4, 5, 6