### PR TITLE
Issue #19707: Fixed false negative for TextBlockGoogleStyleFormatting

### DIFF
--- a/config/google-java-format/excluded/compilable-input-paths.txt
+++ b/config/google-java-format/excluded/compilable-input-paths.txt
@@ -74,6 +74,7 @@ src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputModifierOrderSealed.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule487modifiers/InputModifierOrderNonSealed.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksGeneralForm.java
+src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksTernary.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksInAnnotation.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksIndentation.java
 src/it/resources/com/google/checkstyle/test/chapter5naming/rule522classnames/InputClassNames.java

--- a/config/google-java-format/suppressions/suppress-diff-lte-100.txt
+++ b/config/google-java-format/suppressions/suppress-diff-lte-100.txt
@@ -5,3 +5,4 @@ InputTextBlocksGeneralForm.java
 InputCamelCaseDefined.java
 InputInvalidJavadocPosition.java
 InputSingleSwitchStatementWithoutCurly.java
+InputTextBlocksTernary.java

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule489textblocks/TextBlocksTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule489textblocks/TextBlocksTest.java
@@ -60,4 +60,14 @@ public class TextBlocksTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputFormattedTextBlocksInAnnotation.java"));
     }
 
+    @Test
+    public void testTextBlocksTernary() throws Exception {
+        verifyWithWholeConfig(getPath("InputTextBlocksTernary.java"));
+    }
+
+    @Test
+    public void testFormattedTextBlocksTernary() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedTextBlocksTernary.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputFormattedTextBlocksTernary.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputFormattedTextBlocksTernary.java
@@ -1,0 +1,175 @@
+package com.google.checkstyle.test.chapter4formatting.rule489textblocks;
+
+/** Some javadoc. */
+public class InputFormattedTextBlocksTernary {
+
+  /** Some javadoc. */
+  public void method() {
+    final boolean flag1 = true;
+
+    // until https://github.com/google/google-java-format/issues/1378
+    // 2 violations 6 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 5 lines below 'Text-block quotes are not vertically aligned'
+    final String a =
+        flag1
+            ? """
+            Text Block 1
+            """
+            : """
+            Text Block 2
+            """;
+    // 2 violations 3 lines above:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 4 lines above 'Text-block quotes are not vertically aligned'
+
+    // until https://github.com/google/google-java-format/issues/1378
+    // 2 violations 6 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 5 lines below 'Text-block quotes are not vertically aligned'
+    final String correctA =
+        flag1
+            ? """
+            Text Block 1
+            """
+            : """
+            Text Block 2
+            """;
+    // 2 violations 3 lines above:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 4 lines above 'Text-block quotes are not vertically aligned'
+
+    final boolean flag2 = false;
+
+    // until https://github.com/google/google-java-format/issues/1378
+    // 2 violations 10 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    //  violation 9 lines below 'Text-block quotes are not vertically aligned'
+    //  2 violations 10 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    //  violation 9 lines below 'Text-block quotes are not vertically aligned'
+    final String b =
+        !flag1
+            ? """
+            Text Block 1
+            """
+            : flag2
+                ? """
+                Text Block 2
+                """
+                : """
+                Text Block 3
+                """;
+    // 2 violations 3 lines above:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    //  violation 4 lines above 'Text-block quotes are not vertically aligned'
+
+    // until https://github.com/google/google-java-format/issues/1378
+    // 2 violations 10 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    //  violation 9 lines below 'Text-block quotes are not vertically aligned'
+    //  2 violations 10 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    //  violation 9 lines below 'Text-block quotes are not vertically aligned'
+    final String correctB =
+        !flag1
+            ? """
+            Text Block 1
+            """
+            : flag2
+                ? """
+                Text Block 2
+                """
+                : """
+                Text Block 3
+                """;
+    // 2 violations 3 lines above:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    //  violation 4 lines above 'Text-block quotes are not vertically aligned'
+
+    // until https://github.com/google/google-java-format/issues/1378
+    // 2 violations 6 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 5 lines below 'Text-block quotes are not vertically aligned'
+    final String c =
+        flag2
+            ? """
+            Text Block 1
+            """
+                + "Text"
+            : """
+            Text Block 2
+            """;
+    // 2 violations 3 lines above:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 4 lines above 'Text-block quotes are not vertically aligned'
+
+    // until https://github.com/google/google-java-format/issues/1378
+    // 2 violations 6 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 5 lines below 'Text-block quotes are not vertically aligned'
+    final String correctC =
+        flag2
+            ? """
+            Text Block 1
+            """
+                + "Text"
+            : """
+            Text Block 2
+            """;
+    // 2 violations 3 lines above:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 4 lines above 'Text-block quotes are not vertically aligned'
+
+    // until https://github.com/google/google-java-format/issues/1378
+    // 2 violations 6 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 5 lines below 'Text-block quotes are not vertically aligned'
+    final String d =
+        flag2 && flag2
+            ? """
+            Text Block 1
+            """
+            : """
+            Text Block 2
+            """;
+    // 2 violations 3 lines above:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 4 lines above 'Text-block quotes are not vertically aligned'
+
+    // until https://github.com/google/google-java-format/issues/1378
+    // 2 violations 6 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 5 lines below 'Text-block quotes are not vertically aligned'
+    final String correctD =
+        flag2 && flag2
+            ? """
+            Text
+            """
+            : """
+            Text Block 2
+            """;
+    // 2 violations 3 lines above:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 4 lines above 'Text-block quotes are not vertically aligned'
+
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksTernary.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksTernary.java
@@ -1,0 +1,112 @@
+package com.google.checkstyle.test.chapter4formatting.rule489textblocks;
+
+/** Some javadoc. */
+public class InputTextBlocksTernary {
+
+  /** Some javadoc. */
+  public void method() {
+    final boolean flag1 = true;
+
+    // 2 violations 4 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    final String a = flag1
+        ? """
+        Text Block 1
+        """ :
+        """
+        Text Block 2
+        """;
+    // violation 4 lines above 'Text-block quotes are not vertically aligned'
+
+    final String correctA = flag1
+        ?
+        """
+        Text Block 1
+        """
+        :
+        """
+        Text Block 2
+        """;
+
+    final boolean flag2 = false;
+
+    // 2 violations 6 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    //  violation 5 lines below 'Text-block quotes are not vertically aligned'
+    //  violation 5 lines below ''?' should be on a new line.'
+    final String b = !flag1
+        ? """
+        Text Block 1
+        """ :
+        flag2 ?
+        """
+        Text Block 2
+        """
+        : """
+          Text Block 3
+          """;
+    // violation 3 lines above 'Opening quotes (""") of text-block must be on the new line'
+
+    final String correctB = !flag1
+        ?
+        """
+        Text Block 1
+        """
+        : flag2
+        ?
+        """
+        Text Block 2
+        """
+        :
+        """
+        Text Block 3
+        """;
+
+    // violation 2 lines below 'Opening quotes (""") of text-block must be on the new line'
+    final String c = flag2
+        ? """
+          Text Block 1
+          """
+          + "Text"
+        :
+        """
+        Text Block 2
+        """;
+
+    final String correctC = flag2
+        ?
+        """
+        Text Block 1
+        """
+        + "Text"
+        :
+        """
+        Text Block 2
+        """;
+
+    // 2 violations 4 lines below:
+    // 'Opening quotes (""") of text-block must be on the new line'
+    // 'Each line of text in the text block must be indented'
+    // violation 3 lines below 'Text-block quotes are not vertically aligned'
+    final String d = flag2 && flag2 ? """
+        Text Block 1
+        """
+        :
+            """
+            Text Block 2
+            """;
+
+    final String correctD = flag2 && flag2
+        ?
+        """
+        Text
+        """
+        :
+        """
+        Text Block 2
+        """;
+
+  }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheck.java
@@ -140,7 +140,9 @@ public class TextBlockGoogleStyleFormattingCheck extends AbstractCheck {
      * @return true if the opening quotes are on the new line.
      */
     private static boolean openingQuotesAreAloneOnTheLine(DetailAST openingQuotes) {
-        boolean quotesAreNotPreceded = true;
+        final DetailAST previousSibling = openingQuotes.getPreviousSibling();
+        boolean quotesAreNotPreceded = previousSibling == null
+                || !TokenUtil.areOnSameLine(openingQuotes, previousSibling);
         for (DetailAST parent = openingQuotes.getParent(); parent != null;
              parent = parent.getParent()) {
             if (!quotesAreNotPreceded || parent.getType() == TokenTypes.ELIST
@@ -149,11 +151,6 @@ public class TextBlockGoogleStyleFormattingCheck extends AbstractCheck {
             }
             if (parent.getType() == TokenTypes.METHOD_DEF) {
                 quotesAreNotPreceded = !quotesArePrecededWithComma(openingQuotes);
-            }
-            else if (parent.getType() == TokenTypes.QUESTION
-                    && openingQuotes.getPreviousSibling() != null) {
-                quotesAreNotPreceded = !TokenUtil.areOnSameLine(openingQuotes,
-                        openingQuotes.getPreviousSibling());
             }
             else {
                 quotesAreNotPreceded = !TokenUtil.areOnSameLine(openingQuotes, parent);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/TextBlockGoogleStyleFormattingCheckTest.java
@@ -485,4 +485,19 @@ public class TextBlockGoogleStyleFormattingCheckTest extends AbstractModuleTestS
         );
     }
 
+    @Test
+    public void testDefaultTestBlockFormatWithTernary() throws Exception {
+        final String[] expected = {
+            "17:19: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+            "20:19: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+            "38:27: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+            "38:30: " + getCheckMessage(MSG_TEXT_BLOCK_CONTENT),
+            "40:19: " + getCheckMessage(MSG_VERTICALLY_UNALIGNED),
+            "41:19: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+            "60:19: " + getCheckMessage(MSG_OPEN_QUOTES_ERROR),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputTextBlockGoogleStyleFormattingTernary.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/textblockgooglestyleformatting/InputTextBlockGoogleStyleFormattingTernary.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/textblockgooglestyleformatting/InputTextBlockGoogleStyleFormattingTernary.java
@@ -1,0 +1,74 @@
+/*
+TextBlockGoogleStyleFormatting
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.textblockgooglestyleformatting;
+
+public class InputTextBlockGoogleStyleFormattingTernary {
+
+    boolean flag = true;
+
+    void method() {
+
+        // violation 2 lines below 'Opening quotes (""") of text-block must be on the new line'
+        String a = flag
+                ? """
+                  yes
+                  """
+                : """
+                  no
+                  """;
+        // violation 3 lines above 'Opening quotes (""") of text-block must be on the new line'
+
+        String correctA = flag
+                ?
+                """
+                yes
+                """
+                :
+                """
+                no
+                """;
+
+        // 2 violations 3 lines below:
+        // 'Opening quotes (""") of text-block must be on the new line'
+        // 'Each line of text in the text block must be indented'
+        String b = flag ? """
+                  yes
+                  """
+                : """
+                  no
+                  """;
+        // violation 4 lines above 'Text-block quotes are not vertically aligned'
+        // violation 4 lines above 'Opening quotes (""") of text-block must be on the new line'
+
+        String correctB = flag ?
+                """
+                yes
+                """
+                :
+                """
+                no
+                """;
+
+        String c = flag ?
+                """
+                yes
+                """
+                : """
+                  no
+                  """;
+        // violation 3 lines above 'Opening quotes (""") of text-block must be on the new line'
+
+        String coorectC = flag ?
+                """
+                yes
+                """
+                :
+                """
+                no
+                """;
+    }
+}


### PR DESCRIPTION
Issue: #19707 

```
atharv@atharv-IdeaPad-3-15IIL05:~/test$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="TextBlockGoogleStyleFormatting"/>
  </module>
</module>
```
```
atharv@atharv-IdeaPad-3-15IIL05:~/test$ cat Test.java
public class Test {

    boolean flag = true;

    void method() {
        String value = flag
            ? """
              good
              """
                : """
                  no
                  """;
    }
}
```
```
Starting audit...
[ERROR] /home/atharv/test/Test.java:7:15: Opening quotes (""") of text-block must be on the new line. [TextBlockGoogleStyleFormatting]
[ERROR] /home/atharv/test/Test.java:10:19: Opening quotes (""") of text-block must be on the new line. [TextBlockGoogleStyleFormatting]
Audit done.
Checkstyle ends with 2 errors.

```
