### PR TITLE
dependency: bump plexus-utils from 3.3.0 to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,11 @@
         <version>1.18.8</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.6.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
**Related issue/PR:**
* Issue: https://github.com/checkstyle/checkstyle/issues/19772
* PR: https://github.com/checkstyle/checkstyle/pull/19771.

**Short summary:**
The related issue/PR excluded `plexus-utils` from `doxia-core` because of a CVE. However, `plexus-utils` is still pulled in through `doxia-module-xdoc`.

Excluding `plexus-utils` from `doxia-module-xdoc` does not work since the dependency must be present for build time.

Our next best option is to update it to the patched version - `3.6.1`