### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - localvariable…

### DIFF
--- a/src/site/xdoc/checks/naming/localvariablename.xml
+++ b/src/site/xdoc/checks/naming/localvariablename.xml
@@ -66,12 +66,29 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
   void MyMethod() {
+    int good = 1;
+    int g = 0;
     for (int var = 1; var &lt; 10; var++) {}
     for (int VAR = 1; VAR &lt; 10; VAR++) {}
     // violation above, 'Name 'VAR' must match pattern*'
     for (int i = 1; i &lt; 10; i++) {}
     for (int var_1 = 0; var_1 &lt; 10; var_1++) {}
     // violation above, 'Name 'var_1' must match pattern*'
+    for (int v = 1; v &lt; 10; v++) {
+      int a = 1;
+    }
+    for (int V = 1; V &lt; 10; V++) {
+      // violation above, 'Name 'V' must match pattern*'
+      int I = 1; // violation, 'Name 'I' must match pattern*'
+    }
+    List list = new ArrayList();
+    for (Object o : list) {
+      String a = "";
+    }
+    for (Object O : list) {
+      // violation above, 'Name 'O' must match pattern*'
+      String A = ""; // violation, 'Name 'A' must match pattern*'
+    }
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -92,26 +109,29 @@ class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
   void MyMethod() {
+    int good = 1;
+    int g = 0;
     for (int var = 1; var &lt; 10; var++) {}
     for (int VAR = 1; VAR &lt; 10; VAR++) {}
     // violation above, 'Name 'VAR' must match pattern*'
     for (int i = 1; i &lt; 10; i++) {}
     for (int var_1 = 0; var_1 &lt; 10; var_1++) {}
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example3-code">
-          An example of one character variable name in initialization expression(like &quot;i&quot;)
-          in FOR loop:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example3 {
-  void myMethod () {
-    for(int i = 1; i &lt; 10; i++) {}
-    for(int K = 1; K &lt; 10; K++) {} // violation, 'Name 'K' must match pattern*'
+
+    for (int v = 1; v &lt; 10; v++) {
+      int a = 1;
+    }
+    for (int V = 1; V &lt; 10; V++) {
+      // violation above, 'Name 'V' must match pattern*'
+      int I = 1; // violation, 'Name 'I' must match pattern*'
+    }
     List list = new ArrayList();
-    for (Object o : list) {}
-    for (Object O : list) {} // violation, 'Name 'O' must match pattern*'
+    for (Object o : list) {
+      String a = "";
+    }
+    for (Object O : list) {
+      // violation above, 'Name 'O' must match pattern*'
+      String A = ""; // violation, 'Name 'A' must match pattern*'
+    }
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -137,10 +157,17 @@ class Example4 {
   void MyMethod() {
     int good = 1;
     int g = 0; // violation, 'Name 'g' must match pattern*'
+    for (int var = 1; var &lt; 10; var++) {}
+    for (int VAR = 1; VAR &lt; 10; VAR++) {}
+    // violation above, 'Name 'VAR' must match pattern*'
+    for (int i = 1; i &lt; 10; i++) {}
+    for (int var_1 = 0; var_1 &lt; 10; var_1++) {}
+
     for (int v = 1; v &lt; 10; v++) {
       int a = 1; // violation, 'Name 'a' must match pattern*'
     }
     for (int V = 1; V &lt; 10; V++) {
+
       int I = 1; // violation, 'Name 'I' must match pattern*'
     }
     List list = new ArrayList();
@@ -148,8 +175,24 @@ class Example4 {
       String a = ""; // violation, 'Name 'a' must match pattern*'
     }
     for (Object O : list) {
+
       String A = ""; // violation, 'Name 'A' must match pattern*'
     }
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example3-code">
+          An example of one character variable name in initialization expression(like &quot;i&quot;)
+          in FOR loop:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example3 {
+  void myMethod () {
+    for(int i = 1; i &lt; 10; i++) {}
+    for(int K = 1; K &lt; 10; K++) {} // violation, 'Name 'K' must match pattern*'
+    List list = new ArrayList();
+    for (Object o : list) {}
+    for (Object O : list) {} // violation, 'Name 'O' must match pattern*'
   }
 }
 </code></pre></div><hr class="example-separator"/>

--- a/src/site/xdoc/checks/naming/localvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/localvariablename.xml.template
@@ -58,15 +58,6 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/Example2.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example3-code">
-          An example of one character variable name in initialization expression(like "i")
-          in FOR loop:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/Example3.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
 
         <p id="Example4-config">
           An example of how to configure the check to allow one character variable name in
@@ -82,6 +73,15 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example3-code">
+          An example of one character variable name in initialization expression(like "i")
+          in FOR loop:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/Example3.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example5-config">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -177,9 +177,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/npathcomplexity/Example2",
             "checks/naming/lambdaparametername/Example2",
             "checks/naming/localfinalvariablename/Example3",
-            "checks/naming/localvariablename/Example3",
-            "checks/naming/localvariablename/Example4",
-            "checks/naming/localvariablename/Example5",
             "checks/naming/membername/Example2",
             "checks/naming/membername/Example3",
             "checks/naming/parametername/Example5",
@@ -292,7 +289,9 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/trailingcomment/Example6",
             "checks/naming/abbreviationaswordinname/Example4",
             "checks/naming/abbreviationaswordinname/Example6",
-            "checks/naming/abbreviationaswordinname/Example7"
+            "checks/naming/abbreviationaswordinname/Example7",
+            "checks/naming/localvariablename/Example3",
+            "checks/naming/localvariablename/Example5"
             );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckExamplesTest.java
@@ -35,8 +35,12 @@ public class LocalVariableNameCheckExamplesTest extends AbstractExamplesModuleTe
     public void testExample1() throws Exception {
         final String pattern = "^([a-z][a-zA-Z0-9]*|_)$";
         final String[] expected = {
-            "15:14: " + getCheckMessage(MSG_INVALID_PATTERN, "VAR", pattern),
-            "18:14: " + getCheckMessage(MSG_INVALID_PATTERN, "var_1", pattern),
+            "20:14: " + getCheckMessage(MSG_INVALID_PATTERN, "VAR", pattern),
+            "23:14: " + getCheckMessage(MSG_INVALID_PATTERN, "var_1", pattern),
+            "28:14: " + getCheckMessage(MSG_INVALID_PATTERN, "V", pattern),
+            "30:11: " + getCheckMessage(MSG_INVALID_PATTERN, "I", pattern),
+            "36:17: " + getCheckMessage(MSG_INVALID_PATTERN, "O", pattern),
+            "38:14: " + getCheckMessage(MSG_INVALID_PATTERN, "A", pattern),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -46,7 +50,11 @@ public class LocalVariableNameCheckExamplesTest extends AbstractExamplesModuleTe
     public void testExample2() throws Exception {
         final String pattern = "^[a-z](_?[a-zA-Z0-9]+)*$";
         final String[] expected = {
-            "17:14: " + getCheckMessage(MSG_INVALID_PATTERN, "VAR", pattern),
+            "22:14: " + getCheckMessage(MSG_INVALID_PATTERN, "VAR", pattern),
+            "30:14: " + getCheckMessage(MSG_INVALID_PATTERN, "V", pattern),
+            "32:11: " + getCheckMessage(MSG_INVALID_PATTERN, "I", pattern),
+            "38:17: " + getCheckMessage(MSG_INVALID_PATTERN, "O", pattern),
+            "40:14: " + getCheckMessage(MSG_INVALID_PATTERN, "A", pattern),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -68,10 +76,11 @@ public class LocalVariableNameCheckExamplesTest extends AbstractExamplesModuleTe
         final String pattern = "^[a-z][_a-zA-Z0-9]+$";
         final String[] expected = {
             "21:9: " + getCheckMessage(MSG_INVALID_PATTERN, "g", pattern),
-            "23:11: " + getCheckMessage(MSG_INVALID_PATTERN, "a", pattern),
-            "26:11: " + getCheckMessage(MSG_INVALID_PATTERN, "I", pattern),
-            "30:14: " + getCheckMessage(MSG_INVALID_PATTERN, "a", pattern),
-            "33:14: " + getCheckMessage(MSG_INVALID_PATTERN, "A", pattern),
+            "23:14: " + getCheckMessage(MSG_INVALID_PATTERN, "VAR", pattern),
+            "29:11: " + getCheckMessage(MSG_INVALID_PATTERN, "a", pattern),
+            "33:11: " + getCheckMessage(MSG_INVALID_PATTERN, "I", pattern),
+            "37:14: " + getCheckMessage(MSG_INVALID_PATTERN, "a", pattern),
+            "41:14: " + getCheckMessage(MSG_INVALID_PATTERN, "A", pattern),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
@@ -88,4 +97,3 @@ public class LocalVariableNameCheckExamplesTest extends AbstractExamplesModuleTe
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
 }
-

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/Example1.java
@@ -8,17 +8,35 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.localvariablename;
 
+import java.util.ArrayList;
+import java.util.List;
+
 // xdoc section -- start
 class Example1 {
   void MyMethod() {
+    int good = 1;
+    int g = 0;
     for (int var = 1; var < 10; var++) {}
     for (int VAR = 1; VAR < 10; VAR++) {}
     // violation above, 'Name 'VAR' must match pattern*'
     for (int i = 1; i < 10; i++) {}
     for (int var_1 = 0; var_1 < 10; var_1++) {}
     // violation above, 'Name 'var_1' must match pattern*'
+    for (int v = 1; v < 10; v++) {
+      int a = 1;
+    }
+    for (int V = 1; V < 10; V++) {
+      // violation above, 'Name 'V' must match pattern*'
+      int I = 1; // violation, 'Name 'I' must match pattern*'
+    }
+    List list = new ArrayList();
+    for (Object o : list) {
+      String a = "";
+    }
+    for (Object O : list) {
+      // violation above, 'Name 'O' must match pattern*'
+      String A = ""; // violation, 'Name 'A' must match pattern*'
+    }
   }
 }
 // xdoc section -- end
-
-

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/Example2.java
@@ -10,15 +10,35 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming.localvariablename;
 
+import java.util.ArrayList;
+import java.util.List;
+
 // xdoc section -- start
 class Example2 {
   void MyMethod() {
+    int good = 1;
+    int g = 0;
     for (int var = 1; var < 10; var++) {}
     for (int VAR = 1; VAR < 10; VAR++) {}
     // violation above, 'Name 'VAR' must match pattern*'
     for (int i = 1; i < 10; i++) {}
     for (int var_1 = 0; var_1 < 10; var_1++) {}
+
+    for (int v = 1; v < 10; v++) {
+      int a = 1;
+    }
+    for (int V = 1; V < 10; V++) {
+      // violation above, 'Name 'V' must match pattern*'
+      int I = 1; // violation, 'Name 'I' must match pattern*'
+    }
+    List list = new ArrayList();
+    for (Object o : list) {
+      String a = "";
+    }
+    for (Object O : list) {
+      // violation above, 'Name 'O' must match pattern*'
+      String A = ""; // violation, 'Name 'A' must match pattern*'
+    }
   }
 }
 // xdoc section -- end
-

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/Example4.java
@@ -19,10 +19,17 @@ class Example4 {
   void MyMethod() {
     int good = 1;
     int g = 0; // violation, 'Name 'g' must match pattern*'
+    for (int var = 1; var < 10; var++) {}
+    for (int VAR = 1; VAR < 10; VAR++) {}
+    // violation above, 'Name 'VAR' must match pattern*'
+    for (int i = 1; i < 10; i++) {}
+    for (int var_1 = 0; var_1 < 10; var_1++) {}
+
     for (int v = 1; v < 10; v++) {
       int a = 1; // violation, 'Name 'a' must match pattern*'
     }
     for (int V = 1; V < 10; V++) {
+
       int I = 1; // violation, 'Name 'I' must match pattern*'
     }
     List list = new ArrayList();
@@ -30,10 +37,9 @@ class Example4 {
       String a = ""; // violation, 'Name 'a' must match pattern*'
     }
     for (Object O : list) {
+
       String A = ""; // violation, 'Name 'A' must match pattern*'
     }
   }
 }
 // xdoc section -- end
-
-


### PR DESCRIPTION
#18435 

localvariablename: 
Example1 — default config (format=`^[a-z][a-zA-Z0-9]*$`)
Example2 — format=`^[a-z](_?[a-zA-Z0-9]+)*$ `→ unique property value
Example3 — same format as Example2 + uses enhanced-for loop → same property as Example2, different code → Use Case
Example4 — format=`^[a-z][_a-zA-Z0-9]+$` + allowOneCharVarInForLoop=true → unique (allowOneCharVarInForLoop)
Example5 — format=`^[a-z][_a-zA-Z0-9]{2,}$` → different format value → Use Case (same format property as Example2, just different regex)

Section 1: Example1, Example2, Example4
Use Cases: Example3 (same format as Example2), Example5 (same format property, different value)