### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - parenpad

### DIFF
--- a/src/site/xdoc/checks/whitespace/parenpad.xml
+++ b/src/site/xdoc/checks/whitespace/parenpad.xml
@@ -167,25 +167,42 @@
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
-  int n;
-
-  public void fun() {
-    bar( 1);  // violation 'is followed by whitespace'
+  int x;
+  public Example1(int n) {
   }
 
-  public void bar(int k ) {  // violation 'is preceded with whitespace'
-    while (k &gt; 0) {
+  public void fun() {
+    try {
+      throw new IOException();
     }
-
-    StringBuilder obj = new StringBuilder(k);
+    catch( IOException e) { // violation 'is followed by whitespace'
+    }
+    catch(Exception e ) {}  // violation 'is preceded with whitespace'
+    for ( int i = 0; i &lt; x; i++ ) { // 2 violations
+      // ''(' is followed by whitespace'
+      // '')' is preceded with whitespace'
+    }
   }
 
   public void fun2() {
-    switch( n) {  // violation 'is followed by whitespace'
+    switch( x) { // violation 'is followed by whitespace'
       case 2:
-        bar(n);
+        break;
       default:
         break;
+    }
+  }
+
+  class Bar extends Example1 {
+    public Bar() {
+      super(1 ); // violation '')' is preceded with whitespace'
+    }
+    public Bar(int k) {
+      super( k ); // 2 violations
+      // ''(' is followed by whitespace'
+      // '')' is preceded with whitespace'
+      for ( int i = 0; i &lt; k; i++) { // violation ''(' is followed by whitespace'
+      }
     }
   }
 }
@@ -211,18 +228,28 @@ class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
   int x;
-
   public Example2(int n) {
   }
 
   public void fun() {
     try {
       throw new IOException();
-    } catch( IOException e) { // violation 'not preceded with whitespace'
-    } catch( Exception e ) {
     }
-
+    catch( IOException e) { // violation 'not preceded with whitespace'
+    }
+    catch(Exception e ) {}
     for ( int i = 0; i &lt; x; i++ ) {
+    // violation 2 lines above 'not followed by whitespace'
+
+    }
+  }
+
+  public void fun2() {
+    switch( x) {
+      case 2:
+        break;
+      default:
+        break;
     }
   }
 
@@ -230,11 +257,11 @@ class Example2 {
     public Bar() {
       super(1 ); // violation 'not followed by whitespace'
     }
-
     public Bar(int k) {
       super( k );
 
-      for ( int i = 0; i &lt; k; i++) { // violation 'not preceded with whitespace'
+      // violation below 'not preceded with whitespace'
+      for ( int i = 0; i &lt; k; i++) {
       }
     }
   }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -206,7 +206,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/whitespace/nolinewrap/Example4",
             "checks/whitespace/nolinewrap/Example5",
             "checks/whitespace/operatorwrap/Example2",
-            "checks/whitespace/parenpad/Example2",
             "checks/whitespace/separatorwrap/Example2",
             "checks/whitespace/separatorwrap/Example3",
             "checks/whitespace/singlespaceseparator/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadExamplesTest.java
@@ -37,9 +37,15 @@ public class ParenPadExamplesTest extends AbstractExamplesModuleTestSupport {
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "18:8: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
-            "21:25: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
-            "29:11: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
+            "25:10: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
+            "27:23: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
+            "28:9: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
+            "28:33: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
+            "35:11: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
+            "45:15: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
+            "48:12: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
+            "48:16: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
+            "51:11: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -48,9 +54,10 @@ public class ParenPadExamplesTest extends AbstractExamplesModuleTestSupport {
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "29:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
-            "39:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
-            "45:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "29:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "31:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
+            "49:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
+            "55:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example1.java
@@ -10,27 +10,46 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
 
+import java.io.IOException;
+
 // xdoc section -- start
 class Example1 {
-  int n;
-
-  public void fun() {
-    bar( 1);  // violation 'is followed by whitespace'
+  int x;
+  public Example1(int n) {
   }
 
-  public void bar(int k ) {  // violation 'is preceded with whitespace'
-    while (k > 0) {
+  public void fun() {
+    try {
+      throw new IOException();
     }
-
-    StringBuilder obj = new StringBuilder(k);
+    catch( IOException e) { // violation 'is followed by whitespace'
+    }
+    catch(Exception e ) {}  // violation 'is preceded with whitespace'
+    for ( int i = 0; i < x; i++ ) { // 2 violations
+      // ''(' is followed by whitespace'
+      // '')' is preceded with whitespace'
+    }
   }
 
   public void fun2() {
-    switch( n) {  // violation 'is followed by whitespace'
+    switch( x) { // violation 'is followed by whitespace'
       case 2:
-        bar(n);
+        break;
       default:
         break;
+    }
+  }
+
+  class Bar extends Example1 {
+    public Bar() {
+      super(1 ); // violation '')' is preceded with whitespace'
+    }
+    public Bar(int k) {
+      super( k ); // 2 violations
+      // ''(' is followed by whitespace'
+      // '')' is preceded with whitespace'
+      for ( int i = 0; i < k; i++) { // violation ''(' is followed by whitespace'
+      }
     }
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example2.java
@@ -19,18 +19,28 @@ import java.io.IOException;
 // xdoc section -- start
 class Example2 {
   int x;
-
   public Example2(int n) {
   }
 
   public void fun() {
     try {
       throw new IOException();
-    } catch( IOException e) { // violation 'not preceded with whitespace'
-    } catch( Exception e ) {
     }
-
+    catch( IOException e) { // violation 'not preceded with whitespace'
+    }
+    catch(Exception e ) {}
     for ( int i = 0; i < x; i++ ) {
+    // violation 2 lines above 'not followed by whitespace'
+
+    }
+  }
+
+  public void fun2() {
+    switch( x) {
+      case 2:
+        break;
+      default:
+        break;
     }
   }
 
@@ -38,11 +48,11 @@ class Example2 {
     public Bar() {
       super(1 ); // violation 'not followed by whitespace'
     }
-
     public Bar(int k) {
       super( k );
 
-      for ( int i = 0; i < k; i++) { // violation 'not preceded with whitespace'
+      // violation below 'not preceded with whitespace'
+      for ( int i = 0; i < k; i++) {
       }
     }
   }


### PR DESCRIPTION
#18435 

parenpad

Example1.java -> default config
Example2.java -> token property (unique)

Both in section1.