### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - operatorwrap

### DIFF
--- a/src/site/xdoc/checks/whitespace/operatorwrap.xml
+++ b/src/site/xdoc/checks/whitespace/operatorwrap.xml
@@ -197,15 +197,35 @@ class Example1 {
             20) {
     }
 
-    if (10
-            ==
-            20) { }
-
     int c = 10 /
             5; // violation above ''/' should be on a new line'
 
-    int d = c
-            + 10;
+    int b
+            = 10;
+    int e =
+            10;
+    b
+            += 10;
+    b +=
+            10;
+    c
+            *= 10;
+    c
+            -= 5;
+    c -=
+            5;
+    c
+            /= 2;
+    c
+            %= 1;
+    c
+            &gt;&gt;= 1;
+    c
+        &gt;&gt;&gt;= 1;
+    c
+            &amp;=1 ;
+    c
+            &lt;&lt;= 1;
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -231,9 +251,19 @@ class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
   void example() {
+    String s = "Hello" +
+      "World";
+
+    if (10 ==
+            20) {
+    }
+
+    int c = 10 /
+            5;
+
     int b
             = 10; // violation ''=' should be on the previous line'
-    int c =
+    int e =
             10;
     b
             += 10; // violation ''\+=' should be on the previous line'

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -205,7 +205,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/whitespace/nolinewrap/Example3",
             "checks/whitespace/nolinewrap/Example4",
             "checks/whitespace/nolinewrap/Example5",
-            "checks/whitespace/operatorwrap/Example2",
             "checks/whitespace/separatorwrap/Example2",
             "checks/whitespace/separatorwrap/Example3",
             "checks/whitespace/singlespaceseparator/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapExamplesTest.java
@@ -37,7 +37,7 @@ public class OperatorWrapExamplesTest extends AbstractExamplesModuleTestSupport 
         final String[] expected = {
             "16:24: " + getCheckMessage(MSG_LINE_NEW, "+"),
             "19:12: " + getCheckMessage(MSG_LINE_NEW, "=="),
-            "27:16: " + getCheckMessage(MSG_LINE_NEW, "/"),
+            "23:16: " + getCheckMessage(MSG_LINE_NEW, "/"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -46,16 +46,16 @@ public class OperatorWrapExamplesTest extends AbstractExamplesModuleTestSupport 
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "23:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "="),
-            "27:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "+="),
-            "31:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "*="),
-            "33:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "-="),
-            "37:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "/="),
-            "39:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "%="),
-            "41:13: " + getCheckMessage(MSG_LINE_PREVIOUS, ">>="),
-            "43:9: " + getCheckMessage(MSG_LINE_PREVIOUS, ">>>="),
-            "45:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "&="),
-            "47:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "<<="),
+            "33:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "="),
+            "37:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "+="),
+            "41:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "*="),
+            "43:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "-="),
+            "47:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "/="),
+            "49:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "%="),
+            "51:13: " + getCheckMessage(MSG_LINE_PREVIOUS, ">>="),
+            "53:9: " + getCheckMessage(MSG_LINE_PREVIOUS, ">>>="),
+            "55:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "&="),
+            "57:13: " + getCheckMessage(MSG_LINE_PREVIOUS, "<<="),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/Example1.java
@@ -20,15 +20,35 @@ class Example1 {
             20) {
     }
 
-    if (10
-            ==
-            20) { }
-
     int c = 10 /
             5; // violation above ''/' should be on a new line'
 
-    int d = c
-            + 10;
+    int b
+            = 10;
+    int e =
+            10;
+    b
+            += 10;
+    b +=
+            10;
+    c
+            *= 10;
+    c
+            -= 5;
+    c -=
+            5;
+    c
+            /= 2;
+    c
+            %= 1;
+    c
+            >>= 1;
+    c
+        >>>= 1;
+    c
+            &=1 ;
+    c
+            <<= 1;
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/Example2.java
@@ -19,9 +19,19 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.operatorwrap;
 // xdoc section -- start
 class Example2 {
   void example() {
+    String s = "Hello" +
+      "World";
+
+    if (10 ==
+            20) {
+    }
+
+    int c = 10 /
+            5;
+
     int b
             = 10; // violation ''=' should be on the previous line'
-    int c =
+    int e =
             10;
     b
             += 10; // violation ''\+=' should be on the previous line'


### PR DESCRIPTION
#18435 

operatorwrap: https://checkstyle.org/checks/whitespace/operatorwrap.html#OperatorWrap

Example1.java -> default config
Example2.java -> property (options + token)


Both in Section1