### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - linelength

### DIFF
--- a/src/site/xdoc/checks/sizes/linelength.xml
+++ b/src/site/xdoc/checks/sizes/linelength.xml
@@ -108,6 +108,15 @@ class Example1 {
     System.out.println("This is a short line.");
     // violation below, 'Line is longer than 80 characters'
     System.out.println("This line is long and exceeds the default limit of 80 characters.");
+
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer than 80 characters'
+
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer than 80 characters'
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -141,6 +150,15 @@ class Example2 {
     System.out.println("This is a short line.");
 
     System.out.println("This line is long and exceeds the default limit of 80 characters.");
+
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error............
+        """;
+
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error............
+        """;
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -175,6 +193,15 @@ class Example3 {
     System.out.println("This is a short line.");
     // violation below, 'Line is longer than 80 characters'
     System.out.println("This line is long and exceeds the default limit of 80 characters.");
+
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer than 80 characters'
+
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer than 80 characters'
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -209,6 +236,15 @@ class Example4 {
     System.out.println("This is a short line.");
 
     System.out.println("This line is long and exceeds the default limit of 80 characters.");
+
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error............
+        """;
+
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error............
+        """;
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -244,6 +280,15 @@ class Example5 {
     System.out.println("This is a short line.");
     // violation below, 'Line is longer than 60 characters'
     System.out.println("This line is long and exceeds the default limit of 80 characters.");
+
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer'
+
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer'
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -270,13 +315,23 @@ class Example5 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
 
-public class Example6 {
-  void testMethod() {
+import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
+
+/**
+ * This is a short Javadoc comment.
+ * ThisJavadocCommentIsAReallyLongWordThatExceedsDefaultLineLimitOfEightyCharacters.
+ */
+class Example6 {
+
+  void testMethod(String str) {
+    str = MSG_KEY;
+    System.out.println("This is a short line.");
+    // violation below, 'Line is longer than 84 characters (found 92).'
+    System.out.println("This line is long and exceeds the default limit of 80 characters.");
     // filtered violation below 'Line length is 90, expected 84'
     String str1 = """
         This is a very really long string that exceeds the limit but no error............
         """; // SUPPRESS CHECKSTYLE LineLength
-
     // filtered violation below 'Line length is 90, expected 84'
     String str2 =
         """

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -200,7 +200,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/regexp/regexpsingleline/Example4",
             "checks/regexp/regexpmultiline/Example5",
             "checks/sizes/lambdabodylength/Example2",
-            "checks/sizes/linelength/Example6",
             "checks/todocomment/Example3",
             "checks/whitespace/nolinewrap/Example2",
             "checks/whitespace/nolinewrap/Example3",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckExamplesTest.java
@@ -37,6 +37,8 @@ public class LineLengthCheckExamplesTest extends AbstractExamplesModuleTestSuppo
         final String[] expected = {
             "13: " + getCheckMessage(MSG_KEY, 80, 84),
             "21: " + getCheckMessage(MSG_KEY, 80, 92),
+            "24: " + getCheckMessage(MSG_KEY, 80, 89),
+            "29: " + getCheckMessage(MSG_KEY, 80, 89),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -53,6 +55,8 @@ public class LineLengthCheckExamplesTest extends AbstractExamplesModuleTestSuppo
         final String[] expected = {
             "11: " + getCheckMessage(MSG_KEY, 80, 83),
             "23: " + getCheckMessage(MSG_KEY, 80, 92),
+            "26: " + getCheckMessage(MSG_KEY, 80, 89),
+            "31: " + getCheckMessage(MSG_KEY, 80, 89),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -70,6 +74,8 @@ public class LineLengthCheckExamplesTest extends AbstractExamplesModuleTestSuppo
             "11: " + getCheckMessage(MSG_KEY, 60, 64),
             "17: " + getCheckMessage(MSG_KEY, 60, 84),
             "25: " + getCheckMessage(MSG_KEY, 60, 92),
+            "28: " + getCheckMessage(MSG_KEY, 60, 89),
+            "33: " + getCheckMessage(MSG_KEY, 60, 89),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
@@ -77,7 +83,9 @@ public class LineLengthCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
     @Test
     public void testExample6() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "29: " + getCheckMessage(MSG_KEY, 84, 92),
+        };
         verifyWithInlineConfigParser(getPath("Example6.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example1.java
@@ -19,6 +19,15 @@ class Example1 {
     System.out.println("This is a short line.");
     // violation below, 'Line is longer than 80 characters'
     System.out.println("This line is long and exceeds the default limit of 80 characters.");
+
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer than 80 characters'
+
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer than 80 characters'
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example2.java
@@ -21,6 +21,15 @@ class Example2 {
     System.out.println("This is a short line.");
 
     System.out.println("This line is long and exceeds the default limit of 80 characters.");
+
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error............
+        """;
+
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error............
+        """;
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example3.java
@@ -21,6 +21,15 @@ class Example3 {
     System.out.println("This is a short line.");
     // violation below, 'Line is longer than 80 characters'
     System.out.println("This line is long and exceeds the default limit of 80 characters.");
+
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer than 80 characters'
+
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer than 80 characters'
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example4.java
@@ -21,6 +21,15 @@ class Example4 {
     System.out.println("This is a short line.");
 
     System.out.println("This line is long and exceeds the default limit of 80 characters.");
+
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error............
+        """;
+
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error............
+        """;
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example5.java
@@ -23,6 +23,15 @@ class Example5 {
     System.out.println("This is a short line.");
     // violation below, 'Line is longer than 60 characters'
     System.out.println("This line is long and exceeds the default limit of 80 characters.");
+
+    String str1 = """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer'
+
+    String str2 =
+        """
+        This is a very really long string that exceeds the limit but no error............
+        """;  // violation above 'Line is longer'
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java
@@ -14,13 +14,23 @@
 // xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
 
-public class Example6 {
-  void testMethod() {
+import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
+
+/**
+ * This is a short Javadoc comment.
+ * ThisJavadocCommentIsAReallyLongWordThatExceedsDefaultLineLimitOfEightyCharacters.
+ */
+class Example6 {
+
+  void testMethod(String str) {
+    str = MSG_KEY;
+    System.out.println("This is a short line.");
+    // violation below, 'Line is longer than 84 characters (found 92).'
+    System.out.println("This line is long and exceeds the default limit of 80 characters.");
     // filtered violation below 'Line length is 90, expected 84'
     String str1 = """
         This is a very really long string that exceeds the limit but no error............
         """; // SUPPRESS CHECKSTYLE LineLength
-
     // filtered violation below 'Line length is 90, expected 84'
     String str2 =
         """


### PR DESCRIPTION
#18435 

Example1.java → default config
Example2.java → max = 120
Example3.java → ignorePattern = "^ *\\* *[^ ]+$"
Example4.java → fileExtensions = "xml, properties"
Example5.java → ignorePattern = "^(import) ", max = 60
Example6.java → max = 84, with SuppressWithPlainTextCommentFilter

Example 1-4 Section1
Example 5-6 UseCase
Unified all as it was possible to, without any complex change