### PR TITLE
Issue #19926: Add Documenting Default Constructors coverage

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -198,6 +198,7 @@ CNAME
 Cnt
 cobertura
 codacy
+codebases
 codeclimate
 codeconventions
 codecov
@@ -276,6 +277,7 @@ declaredwhenneeded
 Deconstruction
 defau
 defaultcomeslast
+defaultconstructors
 defaultlabelpresence
 defaultlogger
 delims
@@ -315,6 +317,7 @@ dnd
 Dnew
 doccheck
 doccomments
+docdefaultconstr
 Dockter
 doclet
 doclint

--- a/src/it/java/com/doccomments/checkstyle/test/writingdoccomments/docdefaultconstr/MissingCtorTest.java
+++ b/src/it/java/com/doccomments/checkstyle/test/writingdoccomments/docdefaultconstr/MissingCtorTest.java
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.doccomments.checkstyle.test.writingdoccomments.docdefaultconstr;
+
+import org.junit.jupiter.api.Test;
+
+import com.doccomments.checkstyle.test.base.AbstractDocCommentsModuleTestSupport;
+
+public class MissingCtorTest extends AbstractDocCommentsModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/doccomments/checkstyle/test/writingdoccomments/docdefaultconstr";
+    }
+
+    @Test
+    public void testMissingCtor() throws Exception {
+        verifyWithWholeConfig(getPath("InputMissingCtor.java"));
+    }
+
+    @Test
+    public void testPrivateMissingCtor() throws Exception {
+        verifyWithWholeConfig(getPath("InputPrivateMissingCtor.java"));
+    }
+
+}

--- a/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/docdefaultconstr/InputMissingCtor.java
+++ b/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/docdefaultconstr/InputMissingCtor.java
@@ -1,0 +1,35 @@
+package com.doccomments.checkstyle.test.writingdoccomments.docdefaultconstr;
+
+public class InputMissingCtor {
+
+    private int a;
+
+    InputMissingCtor(int a) {
+        this.a = a;
+    }
+
+}
+
+class ExampleDefaultCtor {
+
+    private String s;
+
+    ExampleDefaultCtor() {
+        s = "string";
+    }
+
+}
+// violation 3 lines below 'Class should define an explicit constructor.
+//      If this class was already released with an implicit constructor,
+//      preserve its generated access modifier for compatibility.'
+class InvalidExample {
+
+    public void test() {}
+
+}
+
+abstract class AbstractExample {
+
+    public abstract void test();
+
+}

--- a/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/docdefaultconstr/InputPrivateMissingCtor.java
+++ b/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/docdefaultconstr/InputPrivateMissingCtor.java
@@ -1,0 +1,30 @@
+package com.doccomments.checkstyle.test.writingdoccomments.docdefaultconstr;
+
+public class InputPrivateMissingCtor {
+
+    private int a;
+
+    private InputPrivateMissingCtor(int a) {
+        this.a = a;
+    }
+
+}
+
+class ExampleDefaultCtor1 {
+
+    private String s;
+
+    private ExampleDefaultCtor1() {
+        s = "string";
+    }
+
+}
+
+// violation 3 lines below 'Class should define an explicit constructor.
+//      If this class was already released with an implicit constructor,
+//      preserve its generated access modifier for compatibility.'
+class InvalidExample1 {
+
+    private void test() {}
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheck.java
@@ -30,6 +30,21 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * on the default one.
  * </div>
  *
+ * <p>
+ * Compatibility note: <b>when creating</b> an explicit constructor already
+ * in existing class that used by other in codebases that you do not own, it must match
+ * precisely the declaration of the automatically generated constructor;
+ * even if the constructor should logically be protected, it must be made
+ * public to match the declaration of the automatically generated
+ * constructor, for <b>compatibility</b>.
+ * </p>
+ *
+ * <p>
+ * See
+ * <a href="https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#defaultconstructors">
+ * Documentation Comments Style Guide</a>.
+ * </p>
+ *
  * @since 3.4
  */
 @StatelessCheck

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MissingCtorCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MissingCtorCheck.xml
@@ -7,7 +7,22 @@
          <description>&lt;div&gt;
  Checks that classes (except abstract ones) define a constructor and don't rely
  on the default one.
- &lt;/div&gt;</description>
+ &lt;/div&gt;
+
+ &lt;p&gt;
+ Compatibility note: &lt;b&gt;when creating&lt;/b&gt; an explicit constructor already
+ in existing class that used by other in codebases that you do not own, it must match
+ precisely the declaration of the automatically generated constructor;
+ even if the constructor should logically be protected, it must be made
+ public to match the declaration of the automatically generated
+ constructor, for &lt;b&gt;compatibility&lt;/b&gt;.
+ &lt;/p&gt;
+
+ &lt;p&gt;
+ See
+ &lt;a href="https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#defaultconstructors"&gt;
+ Documentation Comments Style Guide&lt;/a&gt;.
+ &lt;/p&gt;</description>
          <message-keys>
             <message-key key="missing.ctor"/>
          </message-keys>

--- a/src/main/resources/doc_comments_checks.xml
+++ b/src/main/resources/doc_comments_checks.xml
@@ -39,6 +39,13 @@
     <!-- Tag conventions -->
     <module name="AtclauseOrder"/>
 
+    <!-- Documenting default constructors -->
+    <module name="MissingCtor">
+      <message key="missing.ctor" value="Class should define an explicit constructor.
+      If this class was already released with an implicit constructor,
+      preserve its generated access modifier for compatibility."/>
+    </module>
+
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.openjdk.suppressionxpathfilter.config}"

--- a/src/site/xdoc/checks/coding/missingctor.xml
+++ b/src/site/xdoc/checks/coding/missingctor.xml
@@ -13,6 +13,21 @@
           Checks that classes (except abstract ones) define a constructor and don't rely
           on the default one.
         </div>
+
+        <p>
+          Compatibility note: <b>when creating</b> an explicit constructor already
+          in existing class that used by other in codebases that you do not own, it must match
+          precisely the declaration of the automatically generated constructor;
+          even if the constructor should logically be protected, it must be made
+          public to match the declaration of the automatically generated
+          constructor, for <b>compatibility</b>.
+        </p>
+
+        <p>
+          See
+          <a href="https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#defaultconstructors">
+          Documentation Comments Style Guide</a>.
+        </p>
       </subsection>
 
       <subsection name="Examples" id="MissingCtor_Examples">
@@ -51,6 +66,10 @@ abstract class AbstractExample {
 
       <subsection name="Example of Usage" id="MissingCtor_Example_of_Usage">
         <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fdoc_comments_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingCtor">
+            Documentation Comments Style</a>
+          </li>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingCtor">
             Checkstyle Style</a>

--- a/src/site/xdoc/checks/coding/missingctor.xml.template
+++ b/src/site/xdoc/checks/coding/missingctor.xml.template
@@ -38,6 +38,10 @@
       <subsection name="Example of Usage" id="MissingCtor_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fdoc_comments_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingCtor">
+            Documentation Comments Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingCtor">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/doc_comments_style.xml
+++ b/src/site/xdoc/doc_comments_style.xml
@@ -790,8 +790,30 @@
                     <strong><em>Documenting Default Constructors</em></strong>
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_blue.png" alt=""/>
+                  </span>
+                  <a href="checks/coding/missingctor.html#MissingCtor">
+                    MissingCtor</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fdoc_comments_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingCtor">
+                  config</a>)
+                  <br/>
+                  <br/>
+                  <span class="wrapper inline">
+                    <img
+                        src="images/ban_red.png"
+                        alt="" />
+                  </span>
+                  Cannot cover compatibility rule for replacing an implicit default constructor,
+                    as Checkstyle analyzes only the current source snapshot and cannot know whether
+                    the constructor was part of a previously released API.
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/docdefaultconstr">
+                    samples
+                  </a>
+                </td>
               </tr>
 
               <!-- EXCEPTIONS -->


### PR DESCRIPTION
closes #19926

This PR adds MissingCtor as check that covers the Doc Comments guidelines for Documenting Default Constructors.

Diff Regression config: https://gist.githubusercontent.com/gianmarcoschifone/7a7f5d5c6a112828202d97b3ed021c18/raw/b52a87e309b9deeb01b6c47bdc87937c9a8f7434/missingctorbase.xml

Diff Regression patch config: https://gist.githubusercontent.com/gianmarcoschifone/28bbcf191c9c895f0eee98991869aa9e/raw/f8f5624456c8e183ef80e59ec5391b4ac2dc3a50/missingctorpatch.xml