### PR TITLE
Issue #19827: Complete removal of chapter numbers in Doc Comments

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1328,6 +1328,7 @@ sysextensions
 sysprop
 systemout
 tac
+tagconventions
 Taglib
 taglist
 taskdef

--- a/src/it/java/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/orderoftags/AtclauseOrderTest.java
+++ b/src/it/java/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/orderoftags/AtclauseOrderTest.java
@@ -17,7 +17,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-package com.doccomments.checkstyle.test.chapter2writingdoccomments.rule251orderoftags;
+package com.doccomments.checkstyle.test.writingdoccomments.tagconventions.orderoftags;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +27,7 @@ public class AtclauseOrderTest extends AbstractDocCommentsModuleTestSupport {
 
     @Override
     public String getPackageLocation() {
-        return "com/doccomments/checkstyle/test/chapter2writingdoccomments/rule251orderoftags";
+        return "com/doccomments/checkstyle/test/writingdoccomments/tagconventions/orderoftags";
     }
 
     @Test

--- a/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/orderoftags/InputAtclauseOrder.java
+++ b/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/orderoftags/InputAtclauseOrder.java
@@ -1,4 +1,4 @@
-package com.doccomments.checkstyle.test.chapter2writingdoccomments.rule251orderoftags;
+package com.doccomments.checkstyle.test.writingdoccomments.tagconventions.orderoftags;
 
 /**
  * Input for AtclauseOrderCheck examples.

--- a/src/site/xdoc/doc_comments_style.xml
+++ b/src/site/xdoc/doc_comments_style.xml
@@ -520,7 +520,7 @@
                   config</a>)
                 </td>
                 <td>
-                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/doccomments/checkstyle/test/chapter2writingdoccomments/rule251orderoftags">
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/orderoftags">
                     samples
                   </a>
                 </td>


### PR DESCRIPTION
Issue #19827
There was one last detail not addressed in PR https://github.com/checkstyle/checkstyle/pull/19828.

This PR concludes the refactor, renaming the package names of the samples showed in coverage table.