### PR TITLE
Issue ##19993: Regexp check for unnecessary // ok comments is configu…

### DIFF
--- a/config/checkstyle-examples-checks.xml
+++ b/config/checkstyle-examples-checks.xml
@@ -91,6 +91,13 @@
     <property name="maximum" value="0"/>
   </module>
 
+  <module name="RegexpSingleline">
+    <property name="id" value="UnnecessaryOkComment"/>
+    <property name="format" value="(?i)//\s*ok\s*$"/>
+    <property name="message" value="'// ok' comments should have an explanation, or they are unnecessary."/>
+    <property name="maximum" value="0"/>
+  </module>
+
   <!-- Miscellaneous -->
   <module name="NewlineAtEndOfFile"/>
 

--- a/src/site/xdoc/checks/annotation/annotationlocation.xml
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml
@@ -167,13 +167,13 @@ public String getNameIfPresent() { ... }
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
   @Nonnull
-  private boolean field1; // ok
-  @Override public int hashCode() { return 1; } // ok
-  @Nonnull // ok
+  private boolean field1;
+  @Override public int hashCode() { return 1; }
+  @Nonnull
   private boolean field2;
-  @Override // ok
+  @Override
   public boolean equals(Object obj) { return true; }
-  @Mock DataLoader loader1; // ok
+  @Mock DataLoader loader1;
   @SuppressWarnings("deprecation") DataLoader loader2;
   // violation above, 'Annotation 'SuppressWarnings' should be alone on line'
   @SuppressWarnings("deprecation") public int foo() { return 1; }
@@ -202,7 +202,7 @@ class Example1 {
 class Example2 {
   @Nonnull
   private boolean field1;
-  @Override public int hashCode() { return 1; } // ok
+  @Override public int hashCode() { return 1; }
   @Nonnull
   private boolean field2;
   @Override
@@ -210,7 +210,7 @@ class Example2 {
   @Mock
   DataLoader loader1;
   @SuppressWarnings("deprecation") DataLoader loader;
-  @SuppressWarnings("deprecation") public int foo() { return 1; } // ok
+  @SuppressWarnings("deprecation") public int foo() { return 1; }
   @Nonnull @Mock DataLoader loader2;
   // ok above as 'allowSamelineMultipleAnnotations' set to true
 }

--- a/src/site/xdoc/checks/annotation/missingdeprecated.xml
+++ b/src/site/xdoc/checks/annotation/missingdeprecated.xml
@@ -83,7 +83,7 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
   @Deprecated
-  public static final int MY_CONST = 13; // ok
+  public static final int MY_CONST = 13;
 
   /** This javadoc is missing deprecated tag. */
   // violation 2 lines below """Must include both @java.lang.Deprecated annotation
@@ -96,14 +96,14 @@ class Example1 {
    * &lt;p&gt;&lt;/p&gt;
    */
   @Deprecated
-    public static final int NUM = 123456; // ok
+    public static final int NUM = 123456;
 
   /**
    * @deprecated
    *  &lt;p&gt;
    */
   @Deprecated
-  public static final int CONST = 12; // ok
+  public static final int CONST = 12;
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -123,7 +123,7 @@ class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
   @Deprecated
-  public static final int MY_CONST = 13; // ok
+  public static final int MY_CONST = 13;
 
   /** This javadoc is missing deprecated tag. */
   // violation 2 lines below """Must include both @java.lang.Deprecated annotation
@@ -136,7 +136,7 @@ class Example2 {
    * &lt;p&gt;&lt;/p&gt;
    */
   @Deprecated
-  public static final int NUM = 123456; // ok
+  public static final int NUM = 123456;
 
   /**
    * @deprecated

--- a/src/site/xdoc/checks/design/mutableexception.xml
+++ b/src/site/xdoc/checks/design/mutableexception.xml
@@ -188,7 +188,7 @@ class ThirdException extends Exception {
 }
 
 class ThirdThrowable extends Throwable {
-  final int code; // ok
+  final int code;
   String message; // violation 'The field 'message' must be declared final'
 
   public ThirdThrowable(int code, String message) {

--- a/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
@@ -184,10 +184,10 @@ class Example3 {
 class Example4 {
   /** Javadoc.*/
   @SpringBootApplication
-  private class Application { } // ok
+  private class Application { }
 
   @Configuration
-  private class DatabaseConfiguration { } // ok
+  private class DatabaseConfiguration { }
 
   private class MissingDoc { } // violation, 'Missing a Javadoc comment'
 }
@@ -214,10 +214,10 @@ class Example4 {
 class Example5 {
   /** Javadoc.*/
   @Annotation
-  private class Class1 { } // ok
+  private class Class1 { }
 
   @MyClass.Annotation
-  private class Class2 { } // ok
+  private class Class2 { }
 
   private class Class3 { } // violation, 'Missing a Javadoc comment'
 }

--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -312,7 +312,7 @@ class Example4 {
       int a;               // violation, 'level 6, expected level should be 4'
 
     void method() {
-        int b = 0;         // ok
+        int b = 0;
           int c = 1;       // violation, 'level 10, expected level should be 8'
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example1.java
@@ -21,13 +21,13 @@ interface DataLoader {
 // xdoc section -- start
 class Example1 {
   @Nonnull
-  private boolean field1; // ok
-  @Override public int hashCode() { return 1; } // ok
-  @Nonnull // ok
+  private boolean field1;
+  @Override public int hashCode() { return 1; }
+  @Nonnull
   private boolean field2;
-  @Override // ok
+  @Override
   public boolean equals(Object obj) { return true; }
-  @Mock DataLoader loader1; // ok
+  @Mock DataLoader loader1;
   @SuppressWarnings("deprecation") DataLoader loader2;
   // violation above, 'Annotation 'SuppressWarnings' should be alone on line'
   @SuppressWarnings("deprecation") public int foo() { return 1; }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example2.java
@@ -22,7 +22,7 @@ import org.mockito.Mock;
 class Example2 {
   @Nonnull
   private boolean field1;
-  @Override public int hashCode() { return 1; } // ok
+  @Override public int hashCode() { return 1; }
   @Nonnull
   private boolean field2;
   @Override
@@ -30,7 +30,7 @@ class Example2 {
   @Mock
   DataLoader loader1;
   @SuppressWarnings("deprecation") DataLoader loader;
-  @SuppressWarnings("deprecation") public int foo() { return 1; } // ok
+  @SuppressWarnings("deprecation") public int foo() { return 1; }
   @Nonnull @Mock DataLoader loader2;
   // ok above as 'allowSamelineMultipleAnnotations' set to true
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example1.java
@@ -11,7 +11,7 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.missingdeprecated;
 // xdoc section -- start
 class Example1 {
   @Deprecated
-  public static final int MY_CONST = 13; // ok
+  public static final int MY_CONST = 13;
 
   /** This javadoc is missing deprecated tag. */
   // violation 2 lines below """Must include both @java.lang.Deprecated annotation
@@ -24,13 +24,13 @@ class Example1 {
    * <p></p>
    */
   @Deprecated
-    public static final int NUM = 123456; // ok
+    public static final int NUM = 123456;
 
   /**
    * @deprecated
    *  <p>
    */
   @Deprecated
-  public static final int CONST = 12; // ok
+  public static final int CONST = 12;
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example2.java
@@ -13,7 +13,7 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.missingdeprecated;
 // xdoc section -- start
 class Example2 {
   @Deprecated
-  public static final int MY_CONST = 13; // ok
+  public static final int MY_CONST = 13;
 
   /** This javadoc is missing deprecated tag. */
   // violation 2 lines below """Must include both @java.lang.Deprecated annotation
@@ -26,7 +26,7 @@ class Example2 {
    * <p></p>
    */
   @Deprecated
-  public static final int NUM = 123456; // ok
+  public static final int NUM = 123456;
 
   /**
    * @deprecated

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/mutableexception/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/mutableexception/Example3.java
@@ -28,7 +28,7 @@ class ThirdException extends Exception {
 }
 
 class ThirdThrowable extends Throwable {
-  final int code; // ok
+  final int code;
   String message; // violation 'The field 'message' must be declared final'
 
   public ThirdThrowable(int code, String message) {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example4.java
@@ -13,7 +13,7 @@ class Example4 {
       int a;               // violation, 'level 6, expected level should be 4'
 
     void method() {
-        int b = 0;         // ok
+        int b = 0;
           int c = 1;       // violation, 'level 10, expected level should be 8'
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example4.java
@@ -21,10 +21,10 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 class Example4 {
   /** Javadoc.*/
   @SpringBootApplication
-  private class Application { } // ok
+  private class Application { }
 
   @Configuration
-  private class DatabaseConfiguration { } // ok
+  private class DatabaseConfiguration { }
 
   private class MissingDoc { } // violation, 'Missing a Javadoc comment'
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example5.java
@@ -24,10 +24,10 @@ class MyClass {
 class Example5 {
   /** Javadoc.*/
   @Annotation
-  private class Class1 { } // ok
+  private class Class1 { }
 
   @MyClass.Annotation
-  private class Class2 { } // ok
+  private class Class2 { }
 
   private class Class3 { } // violation, 'Missing a Javadoc comment'
 }


### PR DESCRIPTION
#19993 

https://github.com/checkstyle/checkstyle/issues/19993#issuecomment-4577953244
config/checkstyle-examples-checks.xml : added RegexpSingleline , because this is the config that actually scans the xdocs example files where the // ok comments live