### PR TITLE
Add New OpenJDK Style 3.12 Lambda Expressions Rule 1 

### DIFF
--- a/src/it/java/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/LambdaBodyLengthTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/LambdaBodyLengthTest.java
@@ -40,4 +40,14 @@ public class LambdaBodyLengthTest extends AbstractOpenJdkModuleTestSupport {
         verifyWithWholeConfig(getPath("InputLambdaExpressionsBodyLengthValid.java"));
     }
 
+    @Test
+    public void expressionLambdaPreferredTest() throws Exception {
+        verifyWithWholeConfig(getPath("InputExpressionLambdaPreferred.java"));
+    }
+
+    @Test
+    public void expressionLambdaPreferredValidTest() throws Exception {
+        verifyWithWholeConfig(getPath("InputExpressionLambdaPreferredValid.java"));
+    }
+
 }

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/InputExpressionLambdaPreferred.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/InputExpressionLambdaPreferred.java
@@ -1,0 +1,35 @@
+package com.openjdk.checkstyle.test.chapterformatting.rulelambdaexpressions;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Test input for expression lambda preferred over single-line block lambda with violations.
+ */
+public class InputExpressionLambdaPreferred {
+
+    /**
+     * Single void statement block lambda - should be expression lambda.
+     */
+    public void testVoidBlockLambda() {
+        // violation below 'Expression lambdas are preferred over single-line block lambdas.'
+        Runnable a = () -> { System.out.println("hello"); };
+    }
+
+    /**
+     * Single return block lambda - should be expression lambda.
+     */
+    public void testReturnBlockLambda() {
+        // violation below 'Expression lambdas are preferred over single-line block lambdas.'
+        Function<Integer, Integer> b = x -> { return x + 1; };
+    }
+
+    /**
+     * Single return block lambda with multiple parameters.
+     */
+    public void testReturnBlockLambdaMultiParam() {
+        // violation below 'Expression lambdas are preferred over single-line block lambdas.'
+        BiFunction<Integer, Integer, Integer> c = (a, b) -> { return a + b; };
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/InputExpressionLambdaPreferredValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/InputExpressionLambdaPreferredValid.java
@@ -1,0 +1,60 @@
+package com.openjdk.checkstyle.test.chapterformatting.rulelambdaexpressions;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Test input for expression lambda preferred over single-line block lambda with no violations.
+ */
+public class InputExpressionLambdaPreferredValid {
+
+    /**
+     * Expression lambda - void call, no braces.
+     */
+    public void testExpressionLambdaVoid() {
+        Runnable a = () -> System.out.println("hello");
+    }
+
+    /**
+     * Expression lambda - return value, no braces.
+     */
+    public void testExpressionLambdaReturn() {
+        Function<Integer, Integer> b = x -> x + 1;
+    }
+
+    /**
+     * Expression lambda with multiple parameters.
+     */
+    public void testExpressionLambdaMultiParam() {
+        BiFunction<Integer, Integer, Integer> c = (a, b) -> a + b;
+    }
+
+    /**
+     * Void return block lambda - cannot be expression lambda.
+     */
+    public void testVoidReturn() {
+        Runnable d = () -> { return; };
+    }
+
+    /**
+     * Multi-statement block lambda - cannot be expression lambda.
+     */
+    public void testMultiStatementBlock() {
+        Runnable e = () -> {
+            System.out.println("first");
+            System.out.println("second");
+        };
+    }
+
+    /**
+     * Single-statement multi-line block lambda - NOT a single-line block lambda.
+     */
+    public void testSingleStatementMultiLineBlock() {
+        Runnable f = () -> {
+            System.out.println("hello");
+        };
+        Function<Integer, Integer> g = x -> {
+            return x + 1;
+        };
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/InputLambdaExpressionsBodyLength.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/InputLambdaExpressionsBodyLength.java
@@ -9,7 +9,7 @@ public class InputLambdaExpressionsBodyLength {
      * Illegal method - lambda expression body exceeds 10 lines.
      */
     public void doIllegal() {
-        Runnable r = () -> { // violation 'Lambda body length is 11 lines (max allowed is 10).'
+        Runnable r = () -> { // violation 'Lambda body length is 12 lines (max allowed is 10).'
             int a = 1;
             int b = 2;
             int c = 3;
@@ -36,7 +36,6 @@ public class InputLambdaExpressionsBodyLength {
             int f = 6;
             int g = 7;
             int h = 8;
-            int i = 9;
         };
     }
 }

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/InputLambdaExpressionsBodyLengthValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/InputLambdaExpressionsBodyLengthValid.java
@@ -42,7 +42,6 @@ public class InputLambdaExpressionsBodyLengthValid {
             int f = 6;
             int g = 7;
             int h = 8;
-            int i = 9;
         };
     }
 }

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -73,6 +73,16 @@
     </module>
     <module name="AvoidEscapedUnicodeCharacters"/>
 
+    <!-- §3.12: Expression lambdas are preferred over single-line block lambdas -->
+    <module name="MatchXpath">
+      <property name="query"
+        value="//LAMBDA[SLIST[EXPR][count(*)=3][RCURLY[@lineNo = ../@lineNo]]
+                 or SLIST[LITERAL_RETURN[EXPR]][count(*)=2][RCURLY[@lineNo = ../@lineNo]]]"/>
+
+      <message key="matchxpath.match"
+        value="Expression lambdas are preferred over single-line block lambdas."/>
+    </module>
+
     <!-- §3.12: Expression lambda body length check based on OpenJDK style guide -->
     <module name="LambdaBodyLength"/>
     <module name="NoLineWrap">

--- a/src/site/xdoc/checks/coding/matchxpath.xml
+++ b/src/site/xdoc/checks/coding/matchxpath.xml
@@ -278,6 +278,10 @@ public class Example6 {
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
             Google Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/coding/matchxpath.xml.template
+++ b/src/site/xdoc/checks/coding/matchxpath.xml.template
@@ -177,6 +177,10 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
             Google Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -676,6 +676,15 @@
                   <span class="wrapper inline">
                     <img src="images/ok_green.png" alt="" />
                   </span>
+                  <a href="checks/coding/matchxpath.html#MatchXpath">
+                    MatchXpath</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
                   <a href="checks/sizes/lambdabodylength.html#LambdaBodyLength">
                     LambdaBodyLength</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LambdaBodyLength">


### PR DESCRIPTION
Part1 of issue: https://github.com/checkstyle/checkstyle/issues/19662

Summary
---
1. Add integration test for rule: expression lambdas are preferred over single-line block lambdas.
2. Update `openjdk_style.xml`
3. Update config in `openjdk_checks.xml`
4. Add reference to OpenJDK example usage in `MatchXpath` check page.
5. Fix pre-existing test file breakage from upstream `LambdaBodyLength` line-count change.
                  
  