### PR TITLE
Issue #19803: move violation comments in InputCommentsIndentationAfterAnnotation

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -220,13 +220,9 @@
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]checks[\\/]coding[\\/]onestatementperline[\\/]InputOneStatementPerLineSingleLineSmallTalkStyle\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]checks[\\/]coding[\\/]textblockgooglestyleformatting[\\/]InputTextBlockGoogleStyleFormatting9\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]coding[\\/]unusedlocalvariable[\\/]InputUnusedLocalVariableNestedClasses3\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]coding[\\/]unusedlocalvariable[\\/]InputUnusedLocalVariableTestWarningSeverity\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationAfterAnnotation\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentIsAtTheEndOfBlockFour\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
@@ -409,8 +405,6 @@
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedClass\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]missingoverride[\\/]InputMissingOverrideBadOverrideFromObject\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsSingle1\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]illegalthrows[\\/]InputIllegalThrowsNotIgnoreOverriddenMethod\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -339,11 +339,11 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testCommentsAfterAnnotation() throws Exception {
         final String[] expected = {
-            "21:5: " + getCheckMessage(MSG_KEY_SINGLE, 22, 4, 0),
-            "25:9: " + getCheckMessage(MSG_KEY_SINGLE, 26, 8, 4),
-            "43:5: " + getCheckMessage(MSG_KEY_SINGLE, 44, 4, 0),
-            "48:9: " + getCheckMessage(MSG_KEY_SINGLE, 49, 8, 4),
-            "57:3: " + getCheckMessage(MSG_KEY_SINGLE, 58, 2, 4),
+            "22:5: " + getCheckMessage(MSG_KEY_SINGLE, 23, 4, 0),
+            "27:9: " + getCheckMessage(MSG_KEY_SINGLE, 28, 8, 4),
+            "46:5: " + getCheckMessage(MSG_KEY_SINGLE, 47, 4, 0),
+            "52:9: " + getCheckMessage(MSG_KEY_SINGLE, 53, 8, 4),
+            "62:3: " + getCheckMessage(MSG_KEY_SINGLE, 63, 2, 4),
         };
         final String testInputFile = "InputCommentsIndentationAfterAnnotation.java";
         verifyWithInlineConfigParser(getPath(testInputFile), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationAfterAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationAfterAnnotation.java
@@ -17,12 +17,14 @@ public class InputCommentsIndentationAfterAnnotation {
 
 }
 
+// violation 2 lines below '.* incorrect .* level 4, expected is 0, .* same .* as line 23.'
 @AfterAnnotationCommentsAnnotation1
-    // violation '.* incorrect .* level 4, expected is 0, .* same .* as line 22.'
+    // Comment after annotation
 class InputCommentsIndentationAfterAnnotation1 {
 
+    // violation 2 lines below '.* incorrect .* level 8, expected is 4, .* same .* as line 28.'
     @AfterAnnotationCommentsAnnotation1
-        // violation '.* incorrect .* level 8, expected is 4, .* same .* as line 26.'
+        // Comment after annotation
     public int input;
 
 }
@@ -39,13 +41,15 @@ class InputCommentsIndentationAfterAnnotation3 {
 
 }
 
+// violation 2 lines below '.* incorrect .* level 4, expected is 0, .* same .* as line 47.'
 @AfterAnnotationCommentsAnnotation1
-    // violation '.* incorrect .* level 4, expected is 0, .* same .* as line 44.'
+    // Comment after annotation
 @AfterAnnotationCommentsAnnotation2
 class InputCommentsIndentationAfterAnnotation4 {
 
+    // violation 2 lines below '.* incorrect .* level 8, expected is 4, .* same .* as line 53.'
     @AfterAnnotationCommentsAnnotation1
-        // violation '.* incorrect .* level 8, expected is 4, .* same .* as line 49.'
+        // Comment after annotation
     @AfterAnnotationCommentsAnnotation2
     public int input;
 
@@ -53,8 +57,9 @@ class InputCommentsIndentationAfterAnnotation4 {
 
 class InputCommentsIndentationAfterAnnotation5 {
 
+    // violation 2 lines below '.* incorrect .* level 2, expected is 4, .* same .* as line 63.'
     @AfterAnnotationCommentsAnnotation1
-  // violation '.* incorrect .* level 2, expected is 4, .* same .* as line 58.'
+  // Comment after annotation
     @AfterAnnotationCommentsAnnotation2
     public int input;
 


### PR DESCRIPTION
## Summary
- Move `// violation` markers from between annotations and declarations to lines before annotation blocks using `// violation 2 lines below`.
- Replace inline violation comments with plain wrongly-indented `// Comment after annotation` lines for the indentation check under test.
- Remove matching suppression and update expected line numbers in `CommentsIndentationCheckTest#testCommentsAfterAnnotation`.

Part of #19803.

Made with [Cursor](https://cursor.com)