### PR TITLE
Issue #19803: move violation comments in InputMagicNumberIgnoreFieldDeclarationRecords

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -420,8 +420,6 @@
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]magicnumber[\\/]InputMagicNumberIgnoreFieldDeclaration3\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]magicnumber[\\/]InputMagicNumberIgnoreFieldDeclarationRecords\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]magicnumber[\\/]InputMagicNumberIgnoreFieldDeclarationWithAnnotation\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]magicnumber[\\/]InputMagicNumberRecordsDefault\.java"/>


### PR DESCRIPTION
## Summary
- Remove the `violationBetweenAnnotationAndMethod` suppression for `InputMagicNumberIgnoreFieldDeclarationRecords.java`.
- No source changes required.

Part of #19803.

Made with [Cursor](https://cursor.com)