### PR TITLE
Issue #19803: move violation comments in InputMagicNumberRecordsDefault

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -424,8 +424,6 @@
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]magicnumber[\\/]InputMagicNumberIgnoreFieldDeclarationWithAnnotation\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]magicnumber[\\/]InputMagicNumberRecordsDefault\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]magicnumber[\\/]InputMagicNumberWaiverParentToken3\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]superfinalize[\\/]InputSuperFinalizeVariations\.java"/>


### PR DESCRIPTION
## Summary
- Remove the `violationBetweenAnnotationAndMethod` suppression for `InputMagicNumberRecordsDefault.java`.
- No source changes required.

Part of #19803.

Made with [Cursor](https://cursor.com)