### PR TITLE
Issue #19803: move violation comments in InputMissingDeprecatedBadJavadoc

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -403,8 +403,6 @@
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]annotationusestyle[\\/]InputAnnotationUseStyleWithTrailingCommaIgnore\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedBadDeprecated\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedBadJavadoc\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedClass\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"


### PR DESCRIPTION
## Summary
- Remove the `violationBetweenAnnotationAndMethod` suppression for `InputMissingDeprecatedBadJavadoc.java`.
- No source changes required.

Part of #19803.

Made with [Cursor](https://cursor.com)