### PR TITLE
Issue #19803: move violation comments in InputHideUtilityClassConstructorIgnoreAnnotationByFullyQualifiedName

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -437,8 +437,6 @@
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]designforextension[\\/]InputDesignForExtensionOverridableMethods\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]finalclass[\\/]InputFinalClassPrivateCtor\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]hideutilityclassconstructor[\\/]InputHideUtilityClassConstructorIgnoreAnnotationByFullyQualifiedName\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocJavadocTagsWithoutArgs\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"


### PR DESCRIPTION
## Summary
- Remove the `violationBetweenAnnotationAndMethod` suppression for `InputHideUtilityClassConstructorIgnoreAnnotationByFullyQualifiedName.java`.
- No source changes required.

Part of #19803.

Made with [Cursor](https://cursor.com)