### PR TITLE
Issue #19803: move violation comments in InputAnnotationUseStyleCompactNoArray

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -392,8 +392,6 @@
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheckTokensOnMethodAndVar\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]annotationusestyle[\\/]InputAnnotationUseStyleCompactNoArray\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]annotationusestyle[\\/]InputAnnotationUseStyleDifferentStyles\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]annotationusestyle[\\/]InputAnnotationUseStyleExpanded\.java"/>


### PR DESCRIPTION
## Summary
- Remove the `violationBetweenAnnotationAndMethod` suppression for `InputAnnotationUseStyleCompactNoArray.java`.
- No source changes required.

Part of #19803.

Made with [Cursor](https://cursor.com)