### PR TITLE
Issue #19803: move violation comments in InputAnnotationOnSameLineCheckTokensOnMethodAndVar

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -390,8 +390,6 @@
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]annotationlocation[\\/]InputAnnotationLocationIncorrectOne\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheckTokensOnMethodAndVar\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]annotationusestyle[\\/]InputAnnotationUseStyleCompactNoArray\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]annotationusestyle[\\/]InputAnnotationUseStyleDifferentStyles\.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckTokensOnMethodAndVar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckTokensOnMethodAndVar.java
@@ -14,12 +14,12 @@ public class InputAnnotationOnSameLineCheckTokensOnMethodAndVar {
     @Annotation3 int x;
 
     int y;
-
-
-
-    @Annotation3 // violation, "should be on the same line with its target."
-    @SomeClass2.Annotation // violation, "should be on the same line with its target."
-    @java.lang.Deprecated // violation, "should be on the same line with its target."
+    // violation 3 lines below "Annotation 'Annotation3' should be on the same line with its target."
+    // violation 3 lines below "Annotation 'Annotation' should be on the same line with its target."
+    // violation 3 lines below "Annotation 'Deprecated' should be on the same line with its target."
+    @Annotation3
+    @SomeClass2.Annotation
+    @java.lang.Deprecated
     public int getX() {
         return (int) x;
     }


### PR DESCRIPTION
Part of #19803.

Made with [Cursor](https://cursor.com)