### PR TITLE
Issue #19803: move violation comments in InputWriteTagEnumsAndAnnotations

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -301,8 +301,6 @@
             files="[\\/]checks[\\/]javadoc[\\/]missingjavadocpackage[\\/]nojavadoc[\\/]annotation[\\/]blockcomment[\\/]package-info\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]javadoc[\\/]missingjavadocpackage[\\/]nojavadoc[\\/]annotation[\\/]package-info\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]checks[\\/]javadoc[\\/]writetag[\\/]InputWriteTagEnumsAndAnnotations\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]checks[\\/]trailingcomment[\\/]InputTrailingComment\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"


### PR DESCRIPTION
Part of #19803.

Made with [Cursor](https://cursor.com)