### PR TITLE
Issue #19803: move violation comments in InputSuppressWarningsFilterWithoutFilter

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -499,6 +499,4 @@
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]filters[\\/]suppresswarningsfilter[\\/]InputSuppressWarningsFilter\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]filters[\\/]suppresswarningsfilter[\\/]InputSuppressWarningsFilterById\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]filters[\\/]suppresswarningsfilter[\\/]InputSuppressWarningsFilterWithoutFilter\.java"/>
 </suppressions>


### PR DESCRIPTION
Part of #19803.

Made with [Cursor](https://cursor.com)