### PR TITLE
Issue #19995: Fix sdkman install failure by retrying download

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,7 +21,11 @@ blocks:
           - export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
           - export PATH=$JAVA_HOME/bin:$PATH
           - java -version
-          - curl --fail-with-body -s "https://get.sdkman.io" | bash
+          - |
+            for i in 1 2 3 4 5; do
+                curl --fail-with-body -s "https://get.sdkman.io?ci=true" | bash && break \
+                    || sleep 15s;
+            done
           - source "$HOME/.sdkman/bin/sdkman-init.sh"
           - sdk install groovy
           - groovy --version


### PR DESCRIPTION
Issue: #19995

https://sdkman.io/install/#ci-mode
Using ci specific mode
