### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - emptyblock

### DIFF
--- a/src/site/xdoc/checks/blocks/emptyblock.xml
+++ b/src/site/xdoc/checks/blocks/emptyblock.xml
@@ -121,14 +121,44 @@
 public class Example1 {
   private void emptyLoop() {
     for (int i = 0; i &lt; 10; i++) { // violation 'Must have at least one statement'
+
     }
 
     try { // violation 'Must have at least one statement'
-
-    } catch (Exception e) {
-      // ignored
+    }
+    catch (Exception e) {
+      // ok, LITERAL_CATCH is not part of the tokens property.
     }
   }
+
+  private void testBadSwitchStatement(int a) {
+    switch (a) {
+      case 1: { }
+
+      case 2: {} {};
+
+      case 3: {} { System.out.println(); }
+
+      case 4: { System.out.println(); } {}
+      default: { }
+    }
+  }
+
+  private void testGoodSwitchStatement(int a) {
+    switch (a) {
+      case 1: { someMethod(); }
+      default: // ok, as there is no block
+    }
+  }
+
+  private void testBadSwitchRule(int a) {
+    switch (a) {
+      case 1 -&gt; { }
+      default -&gt; { }
+    }
+  }
+
+  void someMethod() { }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -154,11 +184,40 @@ public class Example2 {
     }
 
     try {
-    }  // violation above 'Empty try block'
+    } // violation above 'Empty try block'
     catch (Exception e) {
-      // ignored
+      // ok, LITERAL_CATCH is not part of the tokens property.
     }
   }
+
+  private void testBadSwitchStatement(int a) {
+    switch (a) {
+      case 1: { }
+
+      case 2: {} {};
+
+      case 3: {} { System.out.println(); }
+
+      case 4: { System.out.println(); } {}
+      default: { }
+    }
+  }
+
+  private void testGoodSwitchStatement(int a) {
+    switch (a) {
+      case 1: { someMethod(); }
+      default: // ok, as there is no block
+    }
+  }
+
+  private void testBadSwitchRule(int a) {
+    switch (a) {
+      case 1 -&gt; { }
+      default -&gt; { }
+    }
+  }
+
+  void someMethod() { }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -176,26 +235,32 @@ public class Example2 {
         <p id="Example3-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example3 {
+  private void emptyLoop() {
+    for (int i = 0; i &lt; 10; i++) {
+
+    }
+
+    try {
+    }
+    catch (Exception e) {
+      // ok, LITERAL_CATCH is not part of the tokens property.
+    }
+  }
 
   private void testBadSwitchStatement(int a) {
     switch (a) {
-      case 1 : { }  // violation, 'Must have at least one statement'
+      case 1: { } // violation 'Must have at least one statement'
       // the second empty block is 'sequential', skipped.
+      case 2: {} {}; // violation 'Must have at least one statement'
       // violation below, 'Must have at least one statement'
-      case 2: {} {};
-      // violation below, 'Must have at least one statement'
-      case 3: {} {System.out.println();}
+      case 3: {} { System.out.println(); }
       // the second empty block is 'sequential', skipped.
-      case 4: {System.out.println();} {}
-      default : { }  // violation, 'Must have at least one statement'
+      case 4: { System.out.println(); } {}
+      default: { } // violation 'Must have at least one statement'
     }
   }
 
   private void testGoodSwitchStatement(int a) {
-    switch (a) {
-      case 1: { someMethod(); }
-      default: { someMethod(); }
-    }
     switch (a) {
       case 1: { someMethod(); }
       default: // ok, as there is no block
@@ -204,15 +269,8 @@ public class Example3 {
 
   private void testBadSwitchRule(int a) {
     switch (a) {
-      case 1 -&gt; { } // violation, 'Must have at least one statement'
-      default -&gt; { } // violation, 'Must have at least one statement'
-    }
-  }
-
-  private void testGoodSwitchRule(int a) {
-    switch (a) {
-      case 1 -&gt; { someMethod(); }
-      default -&gt; { someMethod(); }
+      case 1 -&gt; { } // violation 'Must have at least one statement'
+      default -&gt; { } // violation 'Must have at least one statement'
     }
   }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -89,7 +89,6 @@ public class XdocsExamplesAstConsistencyTest {
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
             "checks/annotation/missingoverride/Example2",
             "checks/annotation/suppresswarningsholder/Example1",
-            "checks/blocks/emptyblock/Example3",
             "checks/blocks/needbraces/Example6",
             "checks/coding/illegaltokentext/Example3",
             "checks/coding/illegaltokentext/Example4",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckExamplesTest.java
@@ -35,8 +35,8 @@ public class EmptyBlockCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "14:34: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "for"),
-            "17:9: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "try"),
+            "15:34: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "for"),
+            "19:9: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "try"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -45,7 +45,7 @@ public class EmptyBlockCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "21:9: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "try"),
+            "22:9: " + getCheckMessage(MSG_KEY_BLOCK_EMPTY, "try"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -54,12 +54,12 @@ public class EmptyBlockCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "19:16: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
-            "22:15: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
-            "24:15: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
-            "27:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
-            "44:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
-            "45:18: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "30:15: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "32:15: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "34:15: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "37:16: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "50:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "51:18: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example1.java
@@ -6,19 +6,50 @@
 </module>
 */
 
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.emptyblock;
 
 // xdoc section -- start
 public class Example1 {
   private void emptyLoop() {
     for (int i = 0; i < 10; i++) { // violation 'Must have at least one statement'
+
     }
 
     try { // violation 'Must have at least one statement'
-
-    } catch (Exception e) {
-      // ignored
+    }
+    catch (Exception e) {
+      // ok, LITERAL_CATCH is not part of the tokens property.
     }
   }
+
+  private void testBadSwitchStatement(int a) {
+    switch (a) {
+      case 1: { }
+
+      case 2: {} {};
+
+      case 3: {} { System.out.println(); }
+
+      case 4: { System.out.println(); } {}
+      default: { }
+    }
+  }
+
+  private void testGoodSwitchStatement(int a) {
+    switch (a) {
+      case 1: { someMethod(); }
+      default: // ok, as there is no block
+    }
+  }
+
+  private void testBadSwitchRule(int a) {
+    switch (a) {
+      case 1 -> { }
+      default -> { }
+    }
+  }
+
+  void someMethod() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example2.java
@@ -9,6 +9,7 @@
 </module>
 */
 
+
 package com.puppycrawl.tools.checkstyle.checks.blocks.emptyblock;
 
 // xdoc section -- start
@@ -19,10 +20,39 @@ public class Example2 {
     }
 
     try {
-    }  // violation above 'Empty try block'
+    } // violation above 'Empty try block'
     catch (Exception e) {
-      // ignored
+      // ok, LITERAL_CATCH is not part of the tokens property.
     }
   }
+
+  private void testBadSwitchStatement(int a) {
+    switch (a) {
+      case 1: { }
+
+      case 2: {} {};
+
+      case 3: {} { System.out.println(); }
+
+      case 4: { System.out.println(); } {}
+      default: { }
+    }
+  }
+
+  private void testGoodSwitchStatement(int a) {
+    switch (a) {
+      case 1: { someMethod(); }
+      default: // ok, as there is no block
+    }
+  }
+
+  private void testBadSwitchRule(int a) {
+    switch (a) {
+      case 1 -> { }
+      default -> { }
+    }
+  }
+
+  void someMethod() { }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example3.java
@@ -13,26 +13,32 @@ package com.puppycrawl.tools.checkstyle.checks.blocks.emptyblock;
 
 // xdoc section -- start
 public class Example3 {
+  private void emptyLoop() {
+    for (int i = 0; i < 10; i++) {
+
+    }
+
+    try {
+    }
+    catch (Exception e) {
+      // ok, LITERAL_CATCH is not part of the tokens property.
+    }
+  }
 
   private void testBadSwitchStatement(int a) {
     switch (a) {
-      case 1 : { }  // violation, 'Must have at least one statement'
+      case 1: { } // violation 'Must have at least one statement'
       // the second empty block is 'sequential', skipped.
+      case 2: {} {}; // violation 'Must have at least one statement'
       // violation below, 'Must have at least one statement'
-      case 2: {} {};
-      // violation below, 'Must have at least one statement'
-      case 3: {} {System.out.println();}
+      case 3: {} { System.out.println(); }
       // the second empty block is 'sequential', skipped.
-      case 4: {System.out.println();} {}
-      default : { }  // violation, 'Must have at least one statement'
+      case 4: { System.out.println(); } {}
+      default: { } // violation 'Must have at least one statement'
     }
   }
 
   private void testGoodSwitchStatement(int a) {
-    switch (a) {
-      case 1: { someMethod(); }
-      default: { someMethod(); }
-    }
     switch (a) {
       case 1: { someMethod(); }
       default: // ok, as there is no block
@@ -41,15 +47,8 @@ public class Example3 {
 
   private void testBadSwitchRule(int a) {
     switch (a) {
-      case 1 -> { } // violation, 'Must have at least one statement'
-      default -> { } // violation, 'Must have at least one statement'
-    }
-  }
-
-  private void testGoodSwitchRule(int a) {
-    switch (a) {
-      case 1 -> { someMethod(); }
-      default -> { someMethod(); }
+      case 1 -> { } // violation 'Must have at least one statement'
+      default -> { } // violation 'Must have at least one statement'
     }
   }
 


### PR DESCRIPTION
#18435 

module empty-block
Properties:

Example1 — default config
Example2 — option=text + tokens=LITERAL_TRY → unique (option)
Example3 — tokens=LITERAL_CASE,LITERAL_DEFAULT → unique (tokens)

All 3 examples in section1