### PR TITLE
Issue #19803: move violation comments in InputNoWhitespaceBeforeAnnotations

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -318,8 +318,6 @@
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule412nonemptyblocks[\\/]InputNonemptyBlocksLeftRightCurly\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule462horizontalwhitespace[\\/]InputNoWhitespaceBeforeAnnotations\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule4821onevariableperline[\\/]InputFormattedOneVariablePerDeclaration\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule4821onevariableperline[\\/]InputOneVariablePerDeclaration\.java"/>


### PR DESCRIPTION
Part of #19803.

Made with [Cursor](https://cursor.com)