### PR TITLE
Issue #19803: move violation comments in InputCommentsIndentationCommentIsAtTheEndOfBlockFour

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -227,8 +227,6 @@
             files="[\\/]checks[\\/]coding[\\/]unusedlocalvariable[\\/]InputUnusedLocalVariableTestWarningSeverity\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationAfterAnnotation\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentIsAtTheEndOfBlockFour\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationCommentIsAtTheEndOfBlockSix\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"


### PR DESCRIPTION
Part of #19803.

Made with [Cursor](https://cursor.com)