### PR TITLE
Issue #19803: move violation comments in InputCommentsIndentationSurroundingCode

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -329,8 +329,6 @@
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule4853methodsandconstructorsannotations[\\/]InputMethodsAndConstructorsAnnotations\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule4854fieldannotations[\\/]InputFieldAnnotations\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule4861blockcommentstyle[\\/]InputCommentsIndentationSurroundingCode\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule487modifiers[\\/]InputModifierOrder\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"


### PR DESCRIPTION
Part of #19803.

Made with [Cursor](https://cursor.com)