### PR TITLE
Issue #19803: move violation comments in InputDeclarationOrderAccessModifiers

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -374,8 +374,6 @@
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter7javadoc[\\/]rule734nonrequiredjavadoc[\\/]InputInvalidJavadocPositionRecord\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]com[\\/]sun[\\/]checkstyle[\\/]test[\\/]chapter3fileorganization[\\/]rule313classdeclarations[\\/]InputDeclarationOrderAccessModifiers\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]sun[\\/]checkstyle[\\/]test[\\/]chapter3fileorganization[\\/]rule313classdeclarations[\\/]InputDeclarationOrderConstructor\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]sun[\\/]checkstyle[\\/]test[\\/]chapter3fileorganization[\\/]rule313classdeclarations[\\/]InputDeclarationOrderDefault\.java"/>


### PR DESCRIPTION
Part of #19803.

Made with [Cursor](https://cursor.com)