### PR TITLE
Issue #19803: move violation comments in InputDeclarationOrderConstructor

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -376,8 +376,6 @@
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]sun[\\/]checkstyle[\\/]test[\\/]chapter3fileorganization[\\/]rule313classdeclarations[\\/]InputDeclarationOrderAccessModifiers\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]com[\\/]sun[\\/]checkstyle[\\/]test[\\/]chapter3fileorganization[\\/]rule313classdeclarations[\\/]InputDeclarationOrderConstructor\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]sun[\\/]checkstyle[\\/]test[\\/]chapter3fileorganization[\\/]rule313classdeclarations[\\/]InputDeclarationOrderDefault\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]sun[\\/]checkstyle[\\/]test[\\/]chapter3fileorganization[\\/]rule313classdeclarations[\\/]InputDeclarationOrderMultipleViolations\.java"/>


### PR DESCRIPTION
Part of #19803.

Made with [Cursor](https://cursor.com)