### PR TITLE
Issue #19803: move violation comments in InputFormattedIncorrectJavadocParagraph

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -342,8 +342,6 @@
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter7javadoc[\\/]rule711generalform[\\/]InputIncorrectJavadocLeadingAsteriskAlignment\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter7javadoc[\\/]rule712paragraphs[\\/]InputFormattedIncorrectJavadocParagraph\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter7javadoc[\\/]rule712paragraphs[\\/]InputIncorrectJavadocParagraph\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter7javadoc[\\/]rule712paragraphs[\\/]InputIncorrectRequireEmptyLineBeforeBlockTagGroup\.java"/>


### PR DESCRIPTION
Part of #19803.

Made with [Cursor](https://cursor.com)