### PR TITLE
Issue #19803: move violation comments in InputNonemptyBlocksLeftRightCurly

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -315,8 +315,6 @@
             files="[\\/]checks[\\/]whitespace[\\/]whitespaceafter[\\/]example1[\\/]package-info\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule412nonemptyblocks[\\/]InputFormattedNonemptyBlocksLeftRightCurly\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule412nonemptyblocks[\\/]InputNonemptyBlocksLeftRightCurly\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter4formatting[\\/]rule462horizontalwhitespace[\\/]InputNoWhitespaceBeforeAnnotations\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"


### PR DESCRIPTION
Part of #19803.

Made with [Cursor](https://cursor.com)