### PR TITLE
Issue #19803: move violation comments in InputOverrideAlwaysUsedForRecord

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -354,8 +354,6 @@
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter5naming[\\/]rule523methodnames[\\/]InputMethodName2\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter6programpractice[\\/]rule61overridealwaysused[\\/]InputOverrideAlwaysUsedForRecord\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter6programpractice[\\/]rule61overridealwaysused[\\/]InputOverrideAlwaysUsedForRecordGeneric\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter6programpractice[\\/]rule61overridealwaysused[\\/]InputOverrideAlwaysUsedForRecordInClass\.java"/>


### PR DESCRIPTION
Part of #19803.

Made with [Cursor](https://cursor.com)