### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - emptycatchblock

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -90,8 +90,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/annotation/missingoverride/Example2",
             "checks/annotation/suppresswarningsholder/Example1",
             "checks/blocks/emptyblock/Example3",
-            "checks/blocks/emptycatchblock/Example4",
-            "checks/blocks/emptycatchblock/Example5",
             "checks/blocks/needbraces/Example6",
             "checks/coding/illegaltokentext/Example3",
             "checks/coding/illegaltokentext/Example4",
@@ -277,7 +275,9 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/naming/localvariablename/Example3",
             "checks/naming/localvariablename/Example5",
             "checks/whitespace/nowhitespacebefore/Example4",
-            "checks/whitespace/whitespacearound/Example2"
+            "checks/whitespace/whitespacearound/Example2",
+            "checks/blocks/emptycatchblock/Example4",
+            "checks/blocks/emptycatchblock/Example5"
             );
 
     /**


### PR DESCRIPTION
#18435 

emptycatchblock

Example1.java -> default config
Example2.java -> exceptionVariableName (unique property)
Example3.java -> commentFormat (unique property)
Example4.java -> commentFormat (use-case)
Example5.java -> exceptionVariableName (use-case)

Example 1,2,3 -> section1
Example 4,5 -> use case