### PR TITLE
Issue #19764: Move violation comments out of Javadoc for InputIllegalTokensCheckCommentsContent

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -100,8 +100,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationFirstLine.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationInterface.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationTrimOptionProperty.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]package-info.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
@@ -86,7 +86,7 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testInterface() throws Exception {
         final String[] expected = {
-            "10:1: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "11:1: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocContentLocationInterface.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationInterface.java
@@ -7,8 +7,9 @@ location = FIRST_LINE
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoccontentlocation;
 
+// violation below 'Javadoc content should start from the same line as /\\*\\*.'
 /**
- * // violation above 'Javadoc content should start from the same line as /\*\*.'
+ * Text
  */
 public interface InputJavadocContentLocationInterface {
 


### PR DESCRIPTION
Issue: #19764

Moved violation comments out of Javadoc block for `InputIllegalTokensCheckCommentsContent`.