### PR TITLE
Issue #19881: Add Implementation Independence, Automatic re-use of method comments coverage

### DIFF
--- a/src/site/xdoc/doc_comments_style.xml
+++ b/src/site/xdoc/doc_comments_style.xml
@@ -333,7 +333,7 @@
                     Implementation-Independence
                   </a>
                 </td>
-                <td>???</td>
+                <td>--</td>
                 <td/>
               </tr>
 
@@ -345,7 +345,16 @@
                     Automatic re-use of method comments
                   </a>
                 </td>
-                <td>???</td>
+                <td>
+                  <span class="wrapper inline">
+                    <img
+                        src="images/ban_red.png"
+                        alt="" />
+                  </span>
+                  Violations of this guideline cannot be detected by Checkstyle due to its
+                  <a href="writingchecks.html#Limitations">
+                    limitation</a>, multiple file checking is not supported.
+                </td>
                 <td/>
               </tr>
 


### PR DESCRIPTION
Issue #19881

| Documentation Comments Rule | Checkstyle Checks Used | Sample files |
|---|---|---|
| Implementation-Independence | -- | |
| Automatic re-use of method comments | 🚫 Violations of this guideline cannot be detected by Checkstyle due to its [limitation](https://checkstyle.sourceforge.io/writingchecks.html#Limitations), multiple file checking is not supported. | |