### PR TITLE
Issue #19803: remove violationBetween suppression for missingjavadocpackage/nojavadoc/annotation/blockcomment/package-info.java

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -292,8 +292,6 @@
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]checks[\\/]javadoc[\\/]javadocstyle[\\/]InputJavadocStyleCheck1\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]checks[\\/]javadoc[\\/]javadocstyle[\\/]InputJavadocStyleCheck2\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]javadoc[\\/]missingjavadocpackage[\\/]nojavadoc[\\/]annotation[\\/]blockcomment[\\/]package-info\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]javadoc[\\/]missingjavadocpackage[\\/]nojavadoc[\\/]annotation[\\/]package-info\.java"/>


### PR DESCRIPTION
Part of #19803.

Remove suppression entry for `missingjavadocpackage/nojavadoc/annotation/blockcomment/package-info.java`.

Made with [Cursor](https://cursor.com)