### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputJavadocBlockTagLocationCustomTags

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -92,8 +92,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderRecords.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationCustomTags.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationIncorrect.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationDefault.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
@@ -89,12 +89,12 @@ public class JavadocBlockTagLocationCheckTest extends AbstractModuleTestSupport 
     @Test
     public void testCustomTags() throws Exception {
         final String[] expected = {
-            "14: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
-            "14: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
-            "14: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
-            "16: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
-            "17: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
-            "18: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
+            "19: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
+            "19: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
+            "19: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
+            "21: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
+            "22: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
+            "23: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocBlockTagLocationCustomTags.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCustomTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCustomTags.java
@@ -10,12 +10,17 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
 public class InputJavadocBlockTagLocationCustomTags {
 
-    /**
-     * Text. @apiNote note @implNote note @implSpec spec // 3 violations
+    // violation 6 lines below
+    // violation 5 lines below
+    // violation 4 lines below
+    // violation 5 lines below
+    // violation 5 lines below
+    // violation 5 lines below
+    /** Text. @apiNote note @implNote note @implSpec spec
      * {@code @apiNote}
-     * text @apiNote note1 // violation
-     * text text @implNote note2  // violation
-     * text @implSpec  // violation
+     * text @apiNote note1
+     * text text @implNote note2
+     * text @implSpec
      * text @since 1.0
      */
     public void method(int param) {


### PR DESCRIPTION
Part of #19764.