### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputJavadocTagContinuationIndentationDescription

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -114,8 +114,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationBlockTag.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationDescription.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationOffset3.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationPreTag.java"/>
@@ -451,12 +449,6 @@
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadocmethod[\\/]InputJavadocMethodNoJavadocOnlyPrivateScope\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadocmethod[\\/]InputJavadocMethodNoJavadocProtectedScope\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentation1\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationBlockTag\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationDescription\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]missingjavadocmethod[\\/]InputMissingJavadocMethodExtendAnnotation\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -91,14 +91,14 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testCheckWithDescription() throws Exception {
         final String[] expected = {
-            "16: " + getCheckMessage(MSG_KEY, 4),
-            "17: " + getCheckMessage(MSG_KEY, 4),
-            "18: " + getCheckMessage(MSG_KEY, 4),
-            "47: " + getCheckMessage(MSG_KEY, 4),
-            "49: " + getCheckMessage(MSG_KEY, 4),
-            "50: " + getCheckMessage(MSG_KEY, 4),
-            "70: " + getCheckMessage(MSG_KEY, 4),
-            "71: " + getCheckMessage(MSG_KEY, 4),
+            "19: " + getCheckMessage(MSG_KEY, 4),
+            "20: " + getCheckMessage(MSG_KEY, 4),
+            "21: " + getCheckMessage(MSG_KEY, 4),
+            "53: " + getCheckMessage(MSG_KEY, 4),
+            "55: " + getCheckMessage(MSG_KEY, 4),
+            "56: " + getCheckMessage(MSG_KEY, 4),
+            "76: " + getCheckMessage(MSG_KEY, 4),
+            "77: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationDescription.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationDescription.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationDescription.java
@@ -9,13 +9,16 @@ offset = (default)4
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
 
 public class InputJavadocTagContinuationIndentationDescription {
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
     /**
      * General Description here.
      *
      * @param s
-     * Description 1. // violation, 'Line continuation .* expected level should be 4'
-     * Description 2. // violation, 'Line continuation .* expected level should be 4'
-     * Description 3. // violation, 'Line continuation .* expected level should be 4'
+     * Description 1.
+     * Description 2.
+     * Description 3.
      *                         Description 4 with extra indentation.
      *
      *
@@ -42,13 +45,16 @@ public class InputJavadocTagContinuationIndentationDescription {
      */
     public void testWithMissingAsterisk(int x) {}
 
+    // violation 5 lines below 'Line continuation .* expected level should be 4'
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
     /**
-     * @param s // violation below 'Line continuation .* expected level should be 4'
+     * @param s
      *Description with missing space.
-     * @param s2 // violation below 'Line continuation .* expected level should be 4'
+     * @param s2
      *****Description with multiple asterisk and missing space
      ***** Description with multiple asterisk and missing space
-     */ // violation above 'Line continuation .* expected level should be 4'
+     */
     public void testOtherCases(String s, String s2) {}
     
     /**


### PR DESCRIPTION
Part of #19764.