### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputCorrectJavadocLeadingAsteriskAlignment

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -64,8 +64,6 @@
   <suppress id="noCheckstyleInInputs"
             files="[\\/]it[\\/]resources[\\/]com[\\/]google[\\/]checkstyle[\\/]test[\\/]chapter3filestructure[\\/]rule333orderingandspacing[\\/]InputFormattedOrderingAndSpacingValid2.java"/>
 
-  <!-- Input files with violation comments inside Javadoc, until https://github.com/checkstyle/checkstyle/issues/19764 -->
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]chapter7javadoc[\\/]rule711generalform[\\/]InputCorrectJavadocLeadingAsteriskAlignment.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]chapter7javadoc[\\/]rule711generalform[\\/]InputFormattedCorrectJavadocLeadingAsteriskAlignment.java"/>


### PR DESCRIPTION
Part of #19764.