### PR TITLE
Issue #19764: Move violation comment out of Javadoc

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -112,7 +112,8 @@
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationOffset3.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationPreTag.java"/>
-
+  <suppress id="noViolationCommentsInJavadoc"
+            files="[\\/]filters[\\/]suppresswithnearbytextfilter[\\/]InputSuppressWithNearbyTextFilterNearbyTextPatternUrlLineLengthSuppression.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]summaryjavadoc[\\/]InputSummaryJavadocInlineReturn.java"/>
   <suppress id="noViolationCommentsInJavadoc"
@@ -125,8 +126,6 @@
             files="[\\/]checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorJavadocCommentAfterPackage.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorWithComments.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]filters[\\/]suppresswithnearbytextfilter[\\/]InputSuppressWithNearbyTextFilterNearbyTextPatternUrlLineLengthSuppression.java"/>
   <!-- until https://github.com/checkstyle/checkstyle/issues/19803 -->
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]annotation[\\/]annotationlocation[\\/]InputAnnotationLocationInterface\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterTest.java
@@ -316,13 +316,13 @@ public class SuppressWithNearbyTextFilterTest extends AbstractModuleTestSupport 
         final int expectedLineLength = 90;
 
         final String[] violationMessages = {
-            "32: " + getLineLengthCheckMessage(expectedLineLength, 98),
-            "39: " + getLineLengthCheckMessage(expectedLineLength, 97),
+            "31: " + getLineLengthCheckMessage(expectedLineLength, 98),
+            "38: " + getLineLengthCheckMessage(expectedLineLength, 97),
         };
 
         final String[] suppressedMessages = {
-            "32: " + getLineLengthCheckMessage(expectedLineLength, 98),
-            "39: " + getLineLengthCheckMessage(expectedLineLength, 97),
+            "31: " + getLineLengthCheckMessage(expectedLineLength, 98),
+            "38: " + getLineLengthCheckMessage(expectedLineLength, 97),
         };
 
         verifyFilterWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterNearbyTextPatternUrlLineLengthSuppression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterNearbyTextPatternUrlLineLengthSuppression.java
@@ -25,10 +25,9 @@ public class InputSuppressWithNearbyTextFilterNearbyTextPatternUrlLineLengthSupp
     public class SarifLogger{
     }
 
-
+    // filtered violation 3 lines below 'Line is longer than 90 characters (found 98).'
     /**
      *
-     * // filtered violation below 'Line is longer than 90 characters (found 98).'
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#CHDHJECF">
      * Oracle Docs</a>
      * @see #PARAM_LITERAL


### PR DESCRIPTION
Issue: #19764 

- Move out violation comment file InputSuppressWithNearbyTextFilterNearbyTextPatternUrlLineLengthSuppression.java
- update SuppressWithNearbyTextFilterTest.java
- remove suppressions