### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputJavadocTagContinuationIndentation

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -82,15 +82,9 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity[\\/]InputClassFanOutComplexityRemoveIncorrectAnnotationToken.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckBlockCommentBegin.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckCommentsContent.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationJavadoc.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderMethodReturningArrayType.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderRecords.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationCustomTags.java"/>
   <suppress id="noViolationCommentsInJavadoc"
@@ -100,9 +94,9 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationFirstLine.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationTrimOptionProperty.java"/>
+            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationInterface.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]package-info.java"/>
+            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationTrimOptionProperty.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignIncorrect.java"/>
   <suppress id="noViolationCommentsInJavadoc"
@@ -110,7 +104,7 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocmissingwhitespaceafterasterisk[\\/]InputJavadocMissingWhitespaceAfterAsteriskInvalid.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentation.java"/>
+            files="[\\/]checks[\\/]javadoc[\\/]javadocstyle[\\/]InputJavadocStyleCheck1.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationBlockTag.java"/>
   <suppress id="noViolationCommentsInJavadoc"
@@ -301,8 +295,6 @@
             files="[\\/]checks[\\/]javadoc[\\/]writetag[\\/]InputWriteTagEnumsAndAnnotations\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]checks[\\/]trailingcomment[\\/]InputTrailingComment\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]checks[\\/]trailingcomment[\\/]InputTrailingComment2\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorWithJavadoc2\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -57,20 +57,20 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testCheck() throws Exception {
         final String[] expected = {
-            "55: " + getCheckMessage(MSG_KEY, 4),
-            "117: " + getCheckMessage(MSG_KEY, 4),
+            "56: " + getCheckMessage(MSG_KEY, 4),
             "120: " + getCheckMessage(MSG_KEY, 4),
-            "211: " + getCheckMessage(MSG_KEY, 4),
-            "214: " + getCheckMessage(MSG_KEY, 4),
-            "229: " + getCheckMessage(MSG_KEY, 4),
-            "231: " + getCheckMessage(MSG_KEY, 4),
-            "293: " + getCheckMessage(MSG_KEY, 4),
-            "296: " + getCheckMessage(MSG_KEY, 4),
-            "298: " + getCheckMessage(MSG_KEY, 4),
-            "318: " + getCheckMessage(MSG_KEY, 4),
-            "330: " + getCheckMessage(MSG_KEY, 4),
-            "332: " + getCheckMessage(MSG_KEY, 4),
-            "350: " + getCheckMessage(MSG_KEY, 4),
+            "123: " + getCheckMessage(MSG_KEY, 4),
+            "216: " + getCheckMessage(MSG_KEY, 4),
+            "219: " + getCheckMessage(MSG_KEY, 4),
+            "236: " + getCheckMessage(MSG_KEY, 4),
+            "238: " + getCheckMessage(MSG_KEY, 4),
+            "303: " + getCheckMessage(MSG_KEY, 4),
+            "306: " + getCheckMessage(MSG_KEY, 4),
+            "308: " + getCheckMessage(MSG_KEY, 4),
+            "329: " + getCheckMessage(MSG_KEY, 4),
+            "343: " + getCheckMessage(MSG_KEY, 4),
+            "345: " + getCheckMessage(MSG_KEY, 4),
+            "364: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentation.java"),
@@ -80,8 +80,8 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testCheckWithOffset3() throws Exception {
         final String[] expected = {
-            "15: " + getCheckMessage(MSG_KEY, 3),
-            "27: " + getCheckMessage(MSG_KEY, 3),
+            "16: " + getCheckMessage(MSG_KEY, 3),
+            "29: " + getCheckMessage(MSG_KEY, 3),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationOffset3.java"),
@@ -91,14 +91,14 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testCheckWithDescription() throws Exception {
         final String[] expected = {
-            "16: " + getCheckMessage(MSG_KEY, 4),
-            "17: " + getCheckMessage(MSG_KEY, 4),
-            "18: " + getCheckMessage(MSG_KEY, 4),
-            "47: " + getCheckMessage(MSG_KEY, 4),
-            "49: " + getCheckMessage(MSG_KEY, 4),
-            "50: " + getCheckMessage(MSG_KEY, 4),
-            "70: " + getCheckMessage(MSG_KEY, 4),
-            "71: " + getCheckMessage(MSG_KEY, 4),
+            "19: " + getCheckMessage(MSG_KEY, 4),
+            "20: " + getCheckMessage(MSG_KEY, 4),
+            "21: " + getCheckMessage(MSG_KEY, 4),
+            "53: " + getCheckMessage(MSG_KEY, 4),
+            "55: " + getCheckMessage(MSG_KEY, 4),
+            "56: " + getCheckMessage(MSG_KEY, 4),
+            "76: " + getCheckMessage(MSG_KEY, 4),
+            "77: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationDescription.java"),
@@ -181,7 +181,7 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testJavadocTagContinuationIndentationCheckPreTag() throws Exception {
         final String[] expected = {
-            "91: " + getCheckMessage(MSG_KEY, 4),
+            "92: " + getCheckMessage(MSG_KEY, 4),
             "100: " + getCheckMessage(MSG_KEY, 4),
             "101: " + getCheckMessage(MSG_KEY, 4),
             "102: " + getCheckMessage(MSG_KEY, 4),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentation.java
@@ -45,6 +45,7 @@ class InputJavadocTagContinuationIndentation implements Serializable
      */
     private String tThirdName;
 
+    // violation 8 lines below 'Line continuation .* expected level should be 4'
     /**
      * Some text.
      * @param aString Some javadoc.
@@ -52,7 +53,7 @@ class InputJavadocTagContinuationIndentation implements Serializable
      * @return Some text.
      * @serialData Some javadoc.
      * @see Some text.
-     *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+     *    Some javadoc.
      * @throws Exception Some text.
      */
     String method(String aString) throws Exception
@@ -110,14 +111,16 @@ class InputJavadocTagContinuationIndentation implements Serializable
         return "null";
     }
 
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
+    // violation 8 lines below 'Line continuation .* expected level should be 4'
     /**
      * Some text.
      * @param aString Some text.
      * @return Some text.
-     *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+     *    Some javadoc.
      * @serialData Some javadoc.
      * @param aInt Some text.
-     *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+     *    Some javadoc.
      * @throws Exception Some text.
      * @param aBoolean Some text.
      * @see Some text.
@@ -203,15 +206,17 @@ class InputJavadocTagContinuationIndentation implements Serializable
             return "null";
         }
 
+        // violation 7 lines below 'Line continuation .* expected level should be 4'
+        // violation 9 lines below 'Line continuation .* expected level should be 4'
         /**
          * Some text.
          * @param aString Some text.
          * @return Some text.
          * @param aInt Some text.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @throws Exception Some text.
          * @param aBoolean Some text.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @see Some text.
          */
         String method6(String aString, int aInt, boolean aBoolean) throws Exception
@@ -222,13 +227,15 @@ class InputJavadocTagContinuationIndentation implements Serializable
 
     InnerClassWithAnnotations anon = new InnerClassWithAnnotations()
     {
+        // violation 6 lines below 'Line continuation .* expected level should be 4'
+        // violation 7 lines below 'Line continuation .* expected level should be 4'
         /**
          * Some text.
          * @throws Exception Some text.
          * @param aString Some text.
-         *   Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *   Some javadoc.
          * @serialData Some javadoc.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @see Some text.
          * @return Some text.
          */
@@ -286,16 +293,19 @@ class InputJavadocTagContinuationIndentation implements Serializable
             return "null";
         }
 
+        // violation 7 lines below 'Line continuation .* expected level should be 4'
+        // violation 9 lines below 'Line continuation .* expected level should be 4'
+        // violation 10 lines below 'Line continuation .* expected level should be 4'
         /**
          * Some text.
          *       Some javadoc.
          * @param aString Some text.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @return Some text.
          * @param aInt Some text.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @throws Exception Some text.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @param aBoolean Some text.
          * @see Some text.
          */
@@ -306,6 +316,7 @@ class InputJavadocTagContinuationIndentation implements Serializable
     };
 }
 
+// violation 10 lines below 'Line continuation .* expected level should be 4'
 /**
  * Some javadoc.
  *
@@ -315,11 +326,13 @@ class InputJavadocTagContinuationIndentation implements Serializable
  *     Some javadoc.
  *     Some javadoc.
  * @see Some javadoc.
- *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+ *    Some javadoc.
  * @author max
  */
 enum Foo1 {}
 
+// violation 9 lines below 'Line continuation .* expected level should be 4'
+// violation 10 lines below 'Line continuation .* expected level should be 4'
 /**
  * Some javadoc.
  *
@@ -328,8 +341,8 @@ enum Foo1 {}
  *     Some javadoc.
  * @serialData Some javadoc.
  *   Line below is empty on purpose.
- * @see Some Text. // violation above 'Line continuation .* expected level should be 4'
- * L. // violation, 'Line continuation .* expected level should be 4'
+ * @see Some Text.
+ * L.
  *
  * @author max
  * @customTag {@link com.puppycrawl.tools.checkstyle.AllChecksPresentOnAvailableChecksPageTest
@@ -343,11 +356,12 @@ interface FooIn1 {}
  */
 interface FooIn2 {}
 class ShortNextLine {
+    // violation 5 lines below 'Line continuation .* expected level should be 4'
     /**
      * Test.
      *
      * @return Test
-     * tt <code>null</code>. // violation, 'Line continuation .* expected level should be 4'
+     * tt <code>null</code>.
      */
     public void example() {
     }


### PR DESCRIPTION
Part of #19764.