### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputJavadocTagContinuationIndentationPreTag

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -117,8 +117,6 @@
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationDescription.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationOffset3.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationPreTag.java"/>
 
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]summaryjavadoc[\\/]InputSummaryJavadocInlineReturn.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -181,7 +181,7 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testJavadocTagContinuationIndentationCheckPreTag() throws Exception {
         final String[] expected = {
-            "91: " + getCheckMessage(MSG_KEY, 4),
+            "92: " + getCheckMessage(MSG_KEY, 4),
             "100: " + getCheckMessage(MSG_KEY, 4),
             "101: " + getCheckMessage(MSG_KEY, 4),
             "102: " + getCheckMessage(MSG_KEY, 4),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag.java
@@ -80,6 +80,7 @@ public class InputJavadocTagContinuationIndentationPreTag {
      */
     public void test3() {}
 
+    // violation 9 lines below 'Line continuation have .* expected level should be 4'
     /**
      * Test class.
      *
@@ -91,12 +92,11 @@ public class InputJavadocTagContinuationIndentationPreTag {
      *   behaviour of the check.
      */
     public void test4() {}
-    // violation 3 lines above 'Line continuation have .* expected level should be 4'
 
     /**
      * Writes the object using a
      * <a href="{@docRoot}/serialized-form.html#ja">deserialized form</a>.
-     * @serialData // violation below 'Line continuation .* expected level should be 4'
+     * @serialData
      * Refer to the serialized form of
      * <a href="{@docRoot}/serialized-formRules">ZoneRules.writeReplace</a>
      * for the encoding of epoch seconds and offsets.
@@ -112,6 +112,7 @@ public class InputJavadocTagContinuationIndentationPreTag {
     private Object writeReplace() {
         return new Object();
     }
-    // violation 14 lines above 'Line continuation .* expected level should be 4'
-    // violation 14 lines above 'Line continuation .* expected level should be 4'
+    // violation 15 lines above 'Line continuation have .* expected level should be 4'
+    // violation 15 lines above 'Line continuation have .* expected level should be 4'
+    // violation 15 lines above 'Line continuation have .* expected level should be 4'
 }


### PR DESCRIPTION
Part of #19764.