### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputSuppressWithNearbyTextFilterNearbyTextPatternUrlLineLengthSuppression

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -131,8 +131,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorJavadocCommentAfterPackage.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorWithComments.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]filters[\\/]suppresswithnearbytextfilter[\\/]InputSuppressWithNearbyTextFilterNearbyTextPatternUrlLineLengthSuppression.java"/>
   <!-- until https://github.com/checkstyle/checkstyle/issues/19803 -->
   <suppress id="violationBetweenAnnotationAndMethod"


### PR DESCRIPTION
Part of #19764.