### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputJavaDocTagContinuationIndentation

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -76,8 +76,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]chapter7javadoc[\\/]rule713atclauses[\\/]InputIncorrectAtClauseOrderCheck3.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]chapter7javadoc[\\/]rule713atclauses[\\/]InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]chapter7javadoc[\\/]rule713atclauses[\\/]InputJavaDocTagContinuationIndentation.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity[\\/]InputClassFanOutComplexityRemoveIncorrectAnnotationToken.java"/>


### PR DESCRIPTION
Part of #19764.