### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputJavadocContentLocationDefault

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -96,8 +96,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationIncorrect.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationDefault.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationFirstLine.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationTrimOptionProperty.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationDefault.java
@@ -13,12 +13,12 @@ public interface InputJavadocContentLocationDefault {
      * Text.
      */
     void ok();
-
-    /** Text. // violation 'Javadoc content should start from the next line after /\*\*.'
+    // violation below 'Javadoc content should start from the next line after /\*\*.'
+    /** Text.
      */
     void violation();
-
-    /** // violation 'Javadoc content should start from the next line after /\*\*.'
+    // violation below 'Javadoc content should start from the next line after /\*\*.'
+    /**
      *
      * Third line.
      */


### PR DESCRIPTION
Part of #19764.

Made with [Cursor](https://cursor.com)