### PR TITLE
Issue #19764: Move violation comments out of Javadoc for JavadocContentLocation

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -95,14 +95,7 @@
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationCustomTags.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationIncorrect.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationDefault.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationFirstLine.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationTrimOptionProperty.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]package-info.java"/>
+
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignIncorrect.java"/>
   <suppress id="noViolationCommentsInJavadoc"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
@@ -57,8 +57,8 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDefault() throws Exception {
         final String[] expected = {
-            "17:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
-            "21:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "18:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocContentLocationDefault.java"), expected);
@@ -67,8 +67,8 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFirstLine() throws Exception {
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
-            "21:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "13:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "22:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocContentLocationFirstLine.java"), expected);
@@ -77,7 +77,7 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPackage() throws Exception {
         final String[] expected = {
-            "8:1: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "9:1: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("package-info.java"), expected);
@@ -102,8 +102,8 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTrimOptionProperty() throws Exception {
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
-            "21:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "13:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "22:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocContentLocationTrimOptionProperty.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationDefault.java
@@ -14,11 +14,13 @@ public interface InputJavadocContentLocationDefault {
      */
     void ok();
 
-    /** Text. // violation 'Javadoc content should start from the next line after /\*\*.'
+    // violation below 'Javadoc content should start from the next line after /\*\*.'
+    /** Text.
      */
     void violation();
 
-    /** // violation 'Javadoc content should start from the next line after /\*\*.'
+    // violation below 'Javadoc content should start from the next line after /\*\*.'
+    /**
      *
      * Third line.
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationFirstLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationFirstLine.java
@@ -9,8 +9,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoccontentlocation;
 
 public interface InputJavadocContentLocationFirstLine {
 
+    // violation below 'Javadoc content should start from the same line as /\*\*.'
     /**
-     * Text. // violation above 'Javadoc content should start from the same line as /\*\*.'
+     * Text.
      */
     void violation();
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationTrimOptionProperty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationTrimOptionProperty.java
@@ -9,8 +9,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoccontentlocation;
 
 public interface InputJavadocContentLocationTrimOptionProperty {
 
+    // violation below 'Javadoc content should start from the same line as /\*\*.'
     /**
-     * Text. // violation above 'Javadoc content should start from the same line as /\*\*.'
+     * Text.
      */
     void violation();
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/package-info.java
@@ -5,6 +5,7 @@ location = (default)SECOND_LINE
 
 */
 
-/** // violation 'Javadoc content should start from the next line after /\*\*.'
+// violation below 'Javadoc content should start from the next line after /\*\*.'
+/** Text.
  */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoccontentlocation;


### PR DESCRIPTION
Issue: #19764

**Description:**
Moved `// violation` comments out of the Javadoc blocks for all input files related to `JavadocContentLocationCheck`. 
Updated the expected violation line numbers in `JavadocContentLocationCheckTest.java` to match the new offsets, and removed the corresponding suppression lines from `checkstyle-input-suppressions.xml`.

**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes (or test files were updated).
- [x] All new and existing tests passed.