### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputAtclauseOrderRecords

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -90,8 +90,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderMethodReturningArrayType.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderRecords.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationCustomTags.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationIncorrect.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
@@ -231,14 +231,14 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
             + " @see, @since, @serial, @serialField, @serialData, @deprecated]";
 
         final String[] expected = {
-            "36: " + getCheckMessage(MSG_KEY, tagOrder),
-            "37: " + getCheckMessage(MSG_KEY, tagOrder),
-            "38: " + getCheckMessage(MSG_KEY, tagOrder),
-            "48: " + getCheckMessage(MSG_KEY, tagOrder),
-            "49: " + getCheckMessage(MSG_KEY, tagOrder),
-            "58: " + getCheckMessage(MSG_KEY, tagOrder),
-            "77: " + getCheckMessage(MSG_KEY, tagOrder),
-            "92: " + getCheckMessage(MSG_KEY, tagOrder),
+            "39: " + getCheckMessage(MSG_KEY, tagOrder),
+            "40: " + getCheckMessage(MSG_KEY, tagOrder),
+            "41: " + getCheckMessage(MSG_KEY, tagOrder),
+            "53: " + getCheckMessage(MSG_KEY, tagOrder),
+            "54: " + getCheckMessage(MSG_KEY, tagOrder),
+            "64: " + getCheckMessage(MSG_KEY, tagOrder),
+            "85: " + getCheckMessage(MSG_KEY, tagOrder),
+            "102: " + getCheckMessage(MSG_KEY, tagOrder),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAtclauseOrderRecords.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
@@ -9,7 +9,6 @@ tagOrder = (default)@author, @version, @param, @return, @throws, @exception, @se
 
 */
 
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 
 import java.io.Serializable;
@@ -21,41 +20,48 @@ public class InputAtclauseOrderRecords {
         /**
          * Some text.
          *
-         * @param aString Some text. // should be a violation, but doesn't work w/ anno
+         * @param aString Some text.
          * @return Some text.
          * @throws Exception Some text.
          */
+        // should be flagged, but doesn't work w/ anno
         String method(String aString) throws Exception {
             return "null";
         }
 
+        // violation 7 lines below
+        // violation 7 lines below
+        // violation 7 lines below
         /**
          * Some text.
          *
          * @since the other day
-         * @param aString Some text. // violation
-         * @return Some text. // violation
-         * @throws Exception Some text. // violation
+         * @param aString Some text.
+         * @return Some text.
+         * @throws Exception Some text.
          */
         String method1(String aString) throws Exception {
             return "null";
         }
 
+        // violation 6 lines below
+        // violation 6 lines below
         /**
          * Some text.
          *
          * @since some time
-         * @param aString Some text. // violation
-         * @throws Exception Some text. // violation
+         * @param aString Some text.
+         * @throws Exception Some text.
          * @serialData Some javadoc.
          */
         void method2(String aString) throws Exception {
         }
 
+        // violation 4 lines below
         /**
          * Some text.
          * @since since
-         * @throws Exception Some text. // violation
+         * @throws Exception Some text.
          * @since Some text.
          */
         void method3() throws Exception {
@@ -67,14 +73,16 @@ public class InputAtclauseOrderRecords {
 /**
  * Some javadoc.
  *
- * @author max // should be a violation
+ * @author max
  * @version 1.0
  * @since Some javadoc.
  */
+// should be flagged
 record myOtherOtherRecord() {
+    // violation 3 lines below
     /**
      * @since Some javadoc.
-     * @author max // violation
+     * @author max
      **/
     public myOtherOtherRecord{}
 }
@@ -82,15 +90,17 @@ record myOtherOtherRecord() {
 /**
  * Some javadoc.
  *
- * @author max // should be a violation
+ * @author max
  * @version 1.0
  * @since Some javadoc.
  */
+// should be flagged
 class myOtherOtherClass {
-        /**
-         * @since Some javadoc.
-         * @author max // violation
-         **/
+    // violation 3 lines below
+    /**
+     * @since Some javadoc.
+     * @author max
+     **/
     public myOtherOtherClass() {
     }
 }


### PR DESCRIPTION
Part of #19764.

Made with [Cursor](https://cursor.com)