### PR TITLE
Issue #19764: move violation comments out of Javadoc in javadoccontentlocation package-info

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -90,8 +90,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderMethodReturningArrayType.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderRecords.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationCustomTags.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationIncorrect.java"/>
@@ -100,15 +98,17 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationFirstLine.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationTrimOptionProperty.java"/>
+            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationInterface.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]package-info.java"/>
+            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationTrimOptionProperty.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignIncorrect.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignTabs.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocmissingwhitespaceafterasterisk[\\/]InputJavadocMissingWhitespaceAfterAsteriskInvalid.java"/>
+  <suppress id="noViolationCommentsInJavadoc"
+            files="[\\/]checks[\\/]javadoc[\\/]javadocstyle[\\/]InputJavadocStyleCheck1.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentation.java"/>
   <suppress id="noViolationCommentsInJavadoc"
@@ -301,8 +301,6 @@
             files="[\\/]checks[\\/]javadoc[\\/]writetag[\\/]InputWriteTagEnumsAndAnnotations\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]checks[\\/]trailingcomment[\\/]InputTrailingComment\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]checks[\\/]trailingcomment[\\/]InputTrailingComment2\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]whitespace[\\/]emptylineseparator[\\/]InputEmptyLineSeparatorWithJavadoc2\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
@@ -77,7 +77,7 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPackage() throws Exception {
         final String[] expected = {
-            "8:1: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "9:1: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("package-info.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/package-info.java
@@ -5,6 +5,7 @@ location = (default)SECOND_LINE
 
 */
 
-/** // violation 'Javadoc content should start from the next line after /\*\*.'
+// violation below 'Javadoc content should start from the next line after /\*\*.'
+/** package javadoc on same line as opening.
  */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoccontentlocation;


### PR DESCRIPTION
Part of #19764.

Made with [Cursor](https://cursor.com)