### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputIllegalTokensCheckBlockCommentBegin

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -82,8 +82,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity[\\/]InputClassFanOutComplexityRemoveIncorrectAnnotationToken.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckBlockCommentBegin.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckCommentsContent.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationJavadoc.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
@@ -70,11 +70,8 @@ public class IllegalTokenCheckTest
         final String[] expected = {
             "1:3: " + getCheckMessage(MSG_KEY,
                         "\\nIllegalToken\\ntokens = COMMENT_CONTENT\\n\\n\\n"),
-            "10:3: " + getCheckMessage(MSG_KEY,
-                        "*\\n * // violation 10"
-                            + " lines above 'is not allowed'\\n"
-                            + " * // violation 2 lines above 'is not allowed'\\n"
-                            + " * Test for illegal tokens\\n "),
+            "12:3: " + getCheckMessage(MSG_KEY,
+                        "*\\n * Test for illegal tokens\\n "),
             "40:29: " + getCheckMessage(MSG_KEY,
                         " some comment href // violation, 'is not allowed'\\n"),
             "44:28: " + getCheckMessage(MSG_KEY,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/InputIllegalTokensCheckBlockCommentBegin.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/InputIllegalTokensCheckBlockCommentBegin.java
@@ -6,8 +6,8 @@ tokens = BLOCK_COMMENT_BEGIN
 */
 
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltoken;
-
-/** // violation, 'Using '\/\*' is not allowed'
+// violation below 'Using '\/\*' is not allowed'
+/**
  * Test for illegal tokens
  */
 public class InputIllegalTokensCheckBlockCommentBegin


### PR DESCRIPTION
Part of #19764.

Made with [Cursor](https://cursor.com)