### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputIllegalTokensCheckCommentsContent

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -84,8 +84,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckBlockCommentBegin.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckCommentsContent.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationJavadoc.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderMethodReturningArrayType.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
@@ -71,8 +71,7 @@ public class IllegalTokenCheckTest
             "1:3: " + getCheckMessage(MSG_KEY,
                         "\\nIllegalToken\\ntokens = COMMENT_CONTENT\\n\\n\\n"),
             "10:3: " + getCheckMessage(MSG_KEY,
-                        "*\\n * // violation 10"
-                            + " lines above 'is not allowed'\\n"
+                        "\\n * // violation 10 lines above 'is not allowed'\\n"
                             + " * // violation 2 lines above 'is not allowed'\\n"
                             + " * Test for illegal tokens\\n "),
             "40:29: " + getCheckMessage(MSG_KEY,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/InputIllegalTokensCheckCommentsContent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/InputIllegalTokensCheckCommentsContent.java
@@ -7,7 +7,7 @@ tokens = COMMENT_CONTENT
 
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltoken;
 
-/**
+/*
  * // violation 10 lines above 'is not allowed'
  * // violation 2 lines above 'is not allowed'
  * Test for illegal tokens


### PR DESCRIPTION
Part of #19764.

Made with [Cursor](https://cursor.com)