### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputJavadocContentLocationFirstLine

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -98,9 +98,8 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationDefault.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationFirstLine.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationTrimOptionProperty.java"/>
+
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]package-info.java"/>
   <suppress id="noViolationCommentsInJavadoc"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
@@ -67,8 +67,8 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFirstLine() throws Exception {
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
-            "21:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "13:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "22:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocContentLocationFirstLine.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationFirstLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationFirstLine.java
@@ -9,8 +9,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoccontentlocation;
 
 public interface InputJavadocContentLocationFirstLine {
 
+    // violation below 'Javadoc content should start from the same line as /\\*\\*.'
     /**
-     * Text. // violation above 'Javadoc content should start from the same line as /\*\*.'
+     * Text.
      */
     void violation();
 


### PR DESCRIPTION
Part of #19764.

Made with [Cursor](https://cursor.com)