### PR TITLE
Issue #19764: move violation comments out of Javadoc in InputJavadocContentLocationTrimOptionProperty

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -100,8 +100,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationFirstLine.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationTrimOptionProperty.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]package-info.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignIncorrect.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
@@ -58,7 +58,7 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     public void testDefault() throws Exception {
         final String[] expected = {
             "17:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
-            "21:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "22:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocContentLocationDefault.java"), expected);
@@ -67,8 +67,8 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFirstLine() throws Exception {
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
-            "21:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "13:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "22:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocContentLocationFirstLine.java"), expected);
@@ -102,8 +102,8 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTrimOptionProperty() throws Exception {
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
-            "21:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "13:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "22:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocContentLocationTrimOptionProperty.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
@@ -57,8 +57,8 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDefault() throws Exception {
         final String[] expected = {
-            "17:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
-            "22:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "18:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocContentLocationDefault.java"), expected);
@@ -67,8 +67,8 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFirstLine() throws Exception {
         final String[] expected = {
-            "13:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
-            "22:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "12:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "21:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocContentLocationFirstLine.java"), expected);
@@ -77,7 +77,7 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPackage() throws Exception {
         final String[] expected = {
-            "8:1: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "9:1: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("package-info.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationTrimOptionProperty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationTrimOptionProperty.java
@@ -9,8 +9,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoccontentlocation;
 
 public interface InputJavadocContentLocationTrimOptionProperty {
 
+    // violation below 'Javadoc content should start from the same line as /\\*\\*.'
     /**
-     * Text. // violation above 'Javadoc content should start from the same line as /\*\*.'
+     * Text.
      */
     void violation();
 


### PR DESCRIPTION
Part of #19764.

Made with [Cursor](https://cursor.com)