### PR TITLE
Issue #19764: Move violation comments out of Javadoc for Default input

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -88,15 +88,11 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationJavadoc.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderMethodReturningArrayType.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderRecords.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationCustomTags.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationIncorrect.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationDefault.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationFirstLine.java"/>
   <suppress id="noViolationCommentsInJavadoc"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
@@ -57,8 +57,8 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDefault() throws Exception {
         final String[] expected = {
-            "17:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
-            "21:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "18:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocContentLocationDefault.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/InputJavadocContentLocationDefault.java
@@ -14,11 +14,13 @@ public interface InputJavadocContentLocationDefault {
      */
     void ok();
 
-    /** Text. // violation 'Javadoc content should start from the next line after /\*\*.'
+    // violation below 'Javadoc content should start from the next line after /\*\*.'
+    /** Text.
      */
     void violation();
 
-    /** // violation 'Javadoc content should start from the next line after /\*\*.'
+    // violation below 'Javadoc content should start from the next line after /\*\*.'
+    /**
      *
      * Third line.
      */


### PR DESCRIPTION
## Summary
- Move `// violation` comments outside Javadoc blocks in `InputJavadocContentLocationDefault.java`
- Remove corresponding `noViolationCommentsInJavadoc` suppression
- Update `JavadocContentLocationCheckTest#testDefault` expected line numbers (18:5, 23:5)

## Test plan
- [x] `./mvnw clean test -Dtest=JavadocContentLocationCheckTest#testDefault`

Relates to #19764

Made with [Cursor](https://cursor.com)