### PR TITLE
Issue #19764: Move violation comments out of Javadoc for package-info

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -102,8 +102,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]InputJavadocContentLocationTrimOptionProperty.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoccontentlocation[\\/]package-info.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignIncorrect.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignTabs.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
@@ -77,7 +77,7 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPackage() throws Exception {
         final String[] expected = {
-            "8:1: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "9:1: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
         };
         verifyWithInlineConfigParser(
                 getPath("package-info.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/package-info.java
@@ -5,6 +5,7 @@ location = (default)SECOND_LINE
 
 */
 
-/** // violation 'Javadoc content should start from the next line after /\*\*.'
+// violation below 'Javadoc content should start from the next line after /\*\*.'
+/** package javadoc on same line as opening.
  */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoccontentlocation;


### PR DESCRIPTION
## Summary
- Move `// violation` comment outside Javadoc in `package-info.java`
- Remove `noViolationCommentsInJavadoc` suppression
- Update `JavadocContentLocationCheckTest#testPackage` expected line to **9:1**

## Test plan
- [x] `./mvnw clean test -Dtest=JavadocContentLocationCheckTest#testPackage`

Relates to #19764

Made with [Cursor](https://cursor.com)