### PR TITLE
Issue #8312: Add control flow tokens to NoWhiteSpaceAfterCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -110,8 +110,13 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
             TokenTypes.TYPECAST,
             TokenTypes.ARRAY_DECLARATOR,
             TokenTypes.INDEX_OP,
+            TokenTypes.DO_WHILE,
+            TokenTypes.LITERAL_IF,
             TokenTypes.LITERAL_SYNCHRONIZED,
             TokenTypes.METHOD_REF,
+            TokenTypes.LITERAL_FOR,
+            TokenTypes.LITERAL_WHILE,
+            TokenTypes.LITERAL_CATCH,
         };
     }
 

--- a/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml
+++ b/src/site/xdoc/checks/whitespace/nowhitespaceafter.xml
@@ -91,10 +91,20 @@
                     ARRAY_DECLARATOR</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">
                     INDEX_OP</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DO_WHILE">
+                    DO_WHILE</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                    LITERAL_IF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
                     LITERAL_SYNCHRONIZED</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
                     METHOD_REF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                    LITERAL_FOR</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                    LITERAL_WHILE</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                    LITERAL_CATCH</a>
                   .
               </td>
               <td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -179,12 +179,60 @@ public class NoWhitespaceAfterCheckTest
     }
 
     @Test
+    public void testDoWhile() throws Exception {
+        final String[] expected = {
+            "16:11: " + getCheckMessage(MSG_KEY, "while"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceAfterDoWhile.java"), expected);
+    }
+
+    @Test
+    public void testLiteralIf() throws Exception {
+        final String[] expected = {
+            "15:9: " + getCheckMessage(MSG_KEY, "if"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceAfterLiteralIf.java"), expected);
+    }
+
+    @Test
     public void testSynchronized() throws Exception {
         final String[] expected = {
             "22:9: " + getCheckMessage(MSG_KEY, "synchronized"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputNoWhitespaceAfterTestSynchronized.java"), expected);
+    }
+
+    @Test
+    public void testLiteralFor() throws Exception {
+        final String[] expected = {
+            "14:9: " + getCheckMessage(MSG_KEY, "for"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceAfterFor.java"), expected);
+    }
+
+    @Test
+    public void testLiteralWhile() throws Exception {
+        final String[] expected = {
+            "16:9: " + getCheckMessage(MSG_KEY, "while"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceAfterWhile.java"), expected);
+    }
+
+    @Test
+    public void testLiteralCatch() throws Exception {
+        final String[] expected = {
+            "15:11: " + getCheckMessage(MSG_KEY, "catch"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceAfterCatch.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -164,7 +164,8 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 .collect(Collectors.toUnmodifiableSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("NoWhitespaceAfter", Stream.of(
                 // whitespace after is preferred
-                "TYPECAST", "LITERAL_SYNCHRONIZED").collect(Collectors.toUnmodifiableSet()));
+                "TYPECAST", "LITERAL_SYNCHRONIZED", "LITERAL_FOR", "LITERAL_WHILE",
+                "LITERAL_CATCH", "LITERAL_IF", "DO_WHILE").collect(Collectors.toUnmodifiableSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("SeparatorWrap", Stream.of(
                 // needs context to decide what type of parentheses should be separated or not
                 // which this check does not provide

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterCatch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterCatch.java
@@ -1,0 +1,24 @@
+/*
+NoWhitespaceAfter
+allowLineBreaks = (default)true
+tokens = LITERAL_CATCH
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
+
+public class InputNoWhitespaceAfterCatch {
+
+    void test() {
+
+        try {
+        } catch (Exception e) {
+        // violation above, ''catch' is followed by whitespace.'
+        }
+
+        try {
+        } catch(Exception e) {
+        }
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterDoWhile.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterDoWhile.java
@@ -1,0 +1,22 @@
+/*
+NoWhitespaceAfter
+allowLineBreaks = (default)true
+tokens = DO_WHILE
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
+
+public class InputNoWhitespaceAfterDoWhile {
+    void test() {
+        do {
+        } while(false);
+        do {
+        } while (false);
+        // violation above, ''while' is followed by whitespace.'
+        do {
+        } while
+            (false);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterFor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterFor.java
@@ -1,0 +1,22 @@
+/*
+NoWhitespaceAfter
+allowLineBreaks = (default)true
+tokens = LITERAL_FOR
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
+
+public class InputNoWhitespaceAfterFor {
+
+    void test() {
+
+        for (int i = 0; i < 10; i++) {
+        // violation above, ''for' is followed by whitespace.'
+        }
+
+        for(int i = 0; i < 10; i++) {
+        }
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterLiteralIf.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterLiteralIf.java
@@ -1,0 +1,22 @@
+/*
+NoWhitespaceAfter
+allowLineBreaks = (default)true
+tokens = LITERAL_IF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
+
+public class InputNoWhitespaceAfterLiteralIf {
+    void test(boolean condition) {
+        if(condition) {
+        }
+        if (condition) {
+        // violation above, ''if' is followed by whitespace.'
+        }
+        if
+            (condition) {
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterWhile.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterWhile.java
@@ -1,0 +1,23 @@
+/*
+NoWhitespaceAfter
+allowLineBreaks = (default)true
+tokens = LITERAL_WHILE
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
+
+public class InputNoWhitespaceAfterWhile {
+
+    boolean condition = false;
+
+    void test() {
+
+        while (condition) {
+        // violation above, ''while' is followed by whitespace.'
+        }
+
+        while(condition) {
+        }
+    }
+}


### PR DESCRIPTION
Issue: checkstyle#8312
Co-authored-by: Diogo Pereira <diogo.g.pereira@tecnico.ulisboa.pt>

This PR extends `NoWhitespaceAfter` so it can be configured with additional control-flow tokens.

Previously, tokens such as `DO_WHILE`, `LITERAL_CATCH`, `LITERAL_FOR`, `LITERAL_IF`, and `LITERAL_WHILE` were rejected when used in the `tokens` property because they were not part of the acceptable token list. With this change, the check accepts these tokens and can report whitespace violations between the keyword and the following opening parenthesis.

The change adds support for checking cases such as:

- `do { ... } while (...)`
- `catch (...)`
- `for (...)`
- `if (...)`
- `while (...)`

Regression tests and input files were added for each new token to verify that the tokens are accepted and that whitespace violations are reported correctly.

Testing:

```bash
./mvnw -e --no-transfer-progress clean test -Dtest='NoWhitespaceAfterCheckTest#testDoWhile+testLiteralIf+testLiteralFor+testLiteralWhile+testLiteralCatch'
