### PR TITLE
 Resolve modernizer-maven violations after dependency bump from 3.3.0 to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -894,7 +894,7 @@
       <plugin>
         <groupId>org.gaul</groupId>
         <artifactId>modernizer-maven-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.0</version>
         <configuration>
           <javaVersion>${java.version}</javaVersion>
           <includeTestClasses>false</includeTestClasses>
@@ -5266,6 +5266,7 @@
               </targetTests>
               <avoidCallsTo>
                 <avoidCallsTo>com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil</avoidCallsTo>
+                <avoidCallsTo>java.util.Comparator</avoidCallsTo>
               </avoidCallsTo>
               <features>
                 <feature>+funmodifiablecollection</feature>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -843,7 +842,7 @@ public final class JavaAstVisitor extends JavaLanguageParserBaseVisitor<DetailAs
         final DetailAstImpl dummyNode = new DetailAstImpl();
         // Since the TYPE AST is built by visitAnnotationMethodOrConstantRest(), we skip it
         // here (child [0])
-        processChildren(dummyNode, Collections.singletonList(ctx.children.get(1)));
+        processChildren(dummyNode, List.of(ctx.children.get(1)));
         // We also append the SEMI token to the first child [size() - 1],
         // until https://github.com/checkstyle/checkstyle/issues/3151
         dummyNode.getFirstChild().addChild(create(ctx.SEMI()));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -141,7 +140,7 @@ public class PackageObjectFactory implements ModuleFactory {
             throw new IllegalArgumentException(NULL_PACKAGE_MESSAGE);
         }
 
-        packages = Collections.singleton(packageName);
+        packages = Set.of(packageName);
         this.moduleClassLoader = moduleClassLoader;
     }
 
@@ -312,7 +311,7 @@ public class PackageObjectFactory implements ModuleFactory {
                         Collectors.toCollection(HashSet::new))));
         }
         catch (IOException ignore) {
-            returnValue = Collections.emptyMap();
+            returnValue = Map.of();
         }
         return returnValue;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -346,7 +345,7 @@ public class SuppressWarningsHolder
      */
     private static List<String> getAllAnnotationValues(DetailAST ast) {
         // get values of annotation
-        List<String> values = Collections.emptyList();
+        List<String> values = List.of();
         final DetailAST lparenAST = ast.findFirstToken(TokenTypes.LPAREN);
         if (lparenAST != null) {
             final DetailAST nextAST = lparenAST.getNextSibling();
@@ -465,7 +464,7 @@ public class SuppressWarningsHolder
      */
     private static List<String> getAnnotationValues(DetailAST ast) {
         return switch (ast.getType()) {
-            case TokenTypes.EXPR -> Collections.singletonList(getStringExpr(ast));
+            case TokenTypes.EXPR -> List.of(getStringExpr(ast));
             case TokenTypes.ANNOTATION_ARRAY_INIT -> findAllExpressionsInChildren(ast);
             default -> throw new IllegalArgumentException(
                     "Expression or annotation array initializer AST expected: " + ast);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.ArrayDeque;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Set;
@@ -101,7 +100,7 @@ public final class ParameterAssignmentCheck extends AbstractCheck {
     public void beginTree(DetailAST rootAST) {
         // clear data
         parameterNamesStack.clear();
-        parameterNames = Collections.emptySet();
+        parameterNames = Set.of();
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.design;
 
-import java.util.Collections;
 import java.util.Set;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
@@ -78,7 +77,7 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
      * with their simple names, this property should contain the annotations with the same
      * simple names.
      */
-    private Set<String> ignoreAnnotatedBy = Collections.emptySet();
+    private Set<String> ignoreAnnotatedBy = Set.of();
 
     /**
      * Setter to ignore classes annotated with the specified annotation(s). Annotation names

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.metrics;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -82,7 +81,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
     );
 
     /** Package names to ignore. */
-    private static final Set<String> DEFAULT_EXCLUDED_PACKAGES = Collections.emptySet();
+    private static final Set<String> DEFAULT_EXCLUDED_PACKAGES = Set.of();
 
     /** Pattern to match brackets in a full type name. */
     private static final Pattern BRACKET_PATTERN = Pattern.compile("\\[[^]]*]");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.sizes;
 
-import java.util.Collections;
 import java.util.Set;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
@@ -58,7 +57,7 @@ public class ParameterNumberCheck
     /**
      * Ignore methods and constructors annotated with the specified annotation(s).
      */
-    private Set<String> ignoreAnnotatedBy = Collections.emptySet();
+    private Set<String> ignoreAnnotatedBy = Set.of();
 
     /**
      * Setter to specify the maximum number of parameters allowed.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -278,7 +278,7 @@ public class SuppressionCommentFilter
                     .getBlockComments().values();
             cComments.forEach(this::tagSuppressions);
         }
-        Collections.sort(tags);
+        tags.sort(Comparator.naturalOrder());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -302,7 +301,7 @@ public class SuppressionXpathFilter extends AbstractAutomaticBean implements
 
     @Override
     public Set<String> getExternalResourceLocations() {
-        return Collections.singleton(file);
+        return Set.of(file);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
@@ -67,7 +67,7 @@ public final class UnmodifiableCollectionUtil {
     public static <T> List<T> unmodifiableList(Collection<? extends T> collection) {
         final List<T> result;
         if (collection == null) {
-            result = Collections.emptyList();
+            result = List.of();
         }
         else {
             result = List.copyOf(collection);
@@ -110,6 +110,6 @@ public final class UnmodifiableCollectionUtil {
      * @return immutable set
      */
     public static <T> Set<T> singleton(T obj) {
-        return Collections.singleton(obj);
+        return Set.of(obj);
     }
 }


### PR DESCRIPTION
Pull #19888 : 
As in the error message provide in the above pr . The bump requires usage of newer Java 9+ immutable collection methods as the message has suggested the replacements.Removed `import java.util.Collections` package where there is no usage of it .
```
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java:826: Prefer java.util.List.of(Object)
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java:144: Prefer java.util.Set.of(Object)
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java:315: Prefer java.util.Map.of()
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java:308: Prefer java.util.Set.of(Object)
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java:280: Prefer java.util.List.sort(Comparator.naturalOrder())
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java:67: Prefer java.util.List.of()
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java:110: Prefer java.util.Set.of(Object)
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java:104: Prefer java.util.Set.of()
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java:85: Prefer java.util.Set.of()
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java:61: Prefer java.util.Set.of()
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java:81: Prefer java.util.Set.of()
[ERROR]src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java:349: Prefer java.util.List.of()
[ERROR] src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java:468: Prefer java.util.List.of(Object)
```
