### PR TITLE
Issue #19764 : move violation comments out of javadoc for InputTrailingComment3

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment3.java
@@ -1,7 +1,7 @@
 /* // violation
 TrailingComment
 format = NOT MATCH
-legalComment = (default)(null)
+legalComment = violation below
 
 
 */
@@ -30,8 +30,8 @@ public class InputTrailingComment3 {
         /* comment before text */int z;
         /* int y */int y/**/;
     }
-
-    /** // violation
+    // violation below
+    /**
      * comment with trailing space.
      */
     final static public String NAME="Some Name"; // NOI18N // violation
@@ -47,8 +47,8 @@ public class InputTrailingComment3 {
         /* ok */ final String operation = null;
         /* ok */ final long start = 0L;
     }
-
-    /** // violation
+    // violation below
+    /**
      * violation above this line.
      **/
     /* package */ void addError() {


### PR DESCRIPTION
# Issue: #19764

Moved violation comments out of Javadoc-style comments (/**) to regular block comments (/*) in "InputTrailingComment3.java"