### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - finalparameters

### DIFF
--- a/src/site/xdoc/checks/misc/finalparameters.xml
+++ b/src/site/xdoc/checks/misc/finalparameters.xml
@@ -100,6 +100,17 @@ public class Example1 {
   public void methodOne(final int x) { }
   public void methodTwo(int x) { } // violation, 'x should be final'
   public static void main(String[] args) { } // violation, 'args should be final'
+
+  void testCatchParameters() {
+    try { } catch (Exception e) { }
+    try { } catch (Exception _) { }
+    try { } catch (final Exception _) { }
+  }
+
+  void testForEachParameters() {
+    for (int number: new int[] {1, 2, 3}) { }
+    for (int _: new int[] {1, 2, 3}) { }
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -126,6 +137,17 @@ public class Example2 {
   public void methodOne(final int x) { }
   public void methodTwo(int x) { }
   public static void main(String[] args) { }
+
+  void testCatchParameters() {
+    try { } catch (Exception e) { }
+    try { } catch (Exception _) { }
+    try { } catch (final Exception _) { }
+  }
+
+  void testForEachParameters() {
+    for (int number: new int[] {1, 2, 3}) { }
+    for (int _: new int[] {1, 2, 3}) { }
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -153,6 +175,17 @@ public class Example3 {
   public void methodOne(final int x) { }
   public void methodTwo(int x) { }
   public static void main(String[] args) { } // violation, 'args should be final'
+
+  void testCatchParameters() {
+    try { } catch (Exception e) { }
+    try { } catch (Exception _) { }
+    try { } catch (final Exception _) { }
+  }
+
+  void testForEachParameters() {
+    for (int number: new int[] {1, 2, 3}) { }
+    for (int _: new int[] {1, 2, 3}) { }
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -174,42 +207,23 @@ public class Example3 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example4 {
+  public Example4() { }
+  public Example4(final int m) { }
+  public Example4(final int m, int n) { }
+  public void methodOne(final int x) { }
+  public void methodTwo(int x) { }
+  public static void main(String[] args) { }
 
   void testCatchParameters() {
-    try {
-      int x = 1 / 0;
-    }
-    catch (Exception e) { // violation, 'Parameter e should be final'
-      System.out.println(e);
-    }
-    try {
-      int x = 1 / 0;
-    }
-    catch (Exception _) { // ok, unnamed catch parameter, it is implicitly final
-      System.out.println("infinity");
-    }
-    try {
-      int x = 1 / 0;
-    }
-    // it is ok to have unnamed final parameters
-    // but it is unnecessary as it is implicitly final
-    catch (final Exception _) {
-      System.out.println("infinity");
-    }
+    try { } catch (Exception e) { } // violation, 'e should be final'
+    try { } catch (Exception _) { } // ok, unnamed catch parameter
+    try { } catch (final Exception _) { }
   }
 
   void testForEachParameters() {
-    int[] l = {1, 2, 3};
-    int x = 0;
-    for (int number: l) { // violation, 'Parameter number should be final'
-      System.out.println(number);
-    }
-    // ok, unnamed enhanced for loop variable, it is implicitly final
-    for (int _: l) {
-      x++;
-    }
+    for (int number: new int[] {1, 2, 3}) { } // violation, 'number should be final'
+    for (int _: new int[] {1, 2, 3}) { }
   }
-
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -109,7 +109,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/descendanttoken/Example7",
             "checks/descendanttoken/Example8",
             "checks/descendanttoken/Example9",
-            "checks/finalparameters/Example4",
             "checks/imports/avoidstaticimport/Example2",
             "checks/imports/customimportorder/Example10",
             "checks/imports/customimportorder/Example11",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckExamplesTest.java
@@ -60,8 +60,8 @@ public class FinalParametersCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "22:12: " + getCheckMessage(MSG_KEY, "e"),
-            "44:10: " + getCheckMessage(MSG_KEY, "number"),
+            "24:20: " + getCheckMessage(MSG_KEY, "e"),
+            "30:10: " + getCheckMessage(MSG_KEY, "number"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("Example4.java"), expected);

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example1.java
@@ -16,5 +16,16 @@ public class Example1 {
   public void methodOne(final int x) { }
   public void methodTwo(int x) { } // violation, 'x should be final'
   public static void main(String[] args) { } // violation, 'args should be final'
+
+  void testCatchParameters() {
+    try { } catch (Exception e) { }
+    try { } catch (Exception _) { }
+    try { } catch (final Exception _) { }
+  }
+
+  void testForEachParameters() {
+    for (int number: new int[] {1, 2, 3}) { }
+    for (int _: new int[] {1, 2, 3}) { }
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example2.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example2.java
@@ -18,5 +18,16 @@ public class Example2 {
   public void methodOne(final int x) { }
   public void methodTwo(int x) { }
   public static void main(String[] args) { }
+
+  void testCatchParameters() {
+    try { } catch (Exception e) { }
+    try { } catch (Exception _) { }
+    try { } catch (final Exception _) { }
+  }
+
+  void testForEachParameters() {
+    for (int number: new int[] {1, 2, 3}) { }
+    for (int _: new int[] {1, 2, 3}) { }
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example3.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example3.java
@@ -18,5 +18,16 @@ public class Example3 {
   public void methodOne(final int x) { }
   public void methodTwo(int x) { }
   public static void main(String[] args) { } // violation, 'args should be final'
+
+  void testCatchParameters() {
+    try { } catch (Exception e) { }
+    try { } catch (Exception _) { }
+    try { } catch (final Exception _) { }
+  }
+
+  void testForEachParameters() {
+    for (int number: new int[] {1, 2, 3}) { }
+    for (int _: new int[] {1, 2, 3}) { }
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example4.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/Example4.java
@@ -9,46 +9,26 @@
 </module>
 */
 // non-compiled with javac: Compilable with Java25
-
 package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 
 // xdoc section -- start
 public class Example4 {
+  public Example4() { }
+  public Example4(final int m) { }
+  public Example4(final int m, int n) { }
+  public void methodOne(final int x) { }
+  public void methodTwo(int x) { }
+  public static void main(String[] args) { }
 
   void testCatchParameters() {
-    try {
-      int x = 1 / 0;
-    }
-    catch (Exception e) { // violation, 'Parameter e should be final'
-      System.out.println(e);
-    }
-    try {
-      int x = 1 / 0;
-    }
-    catch (Exception _) { // ok, unnamed catch parameter, it is implicitly final
-      System.out.println("infinity");
-    }
-    try {
-      int x = 1 / 0;
-    }
-    // it is ok to have unnamed final parameters
-    // but it is unnecessary as it is implicitly final
-    catch (final Exception _) {
-      System.out.println("infinity");
-    }
+    try { } catch (Exception e) { } // violation, 'e should be final'
+    try { } catch (Exception _) { } // ok, unnamed catch parameter
+    try { } catch (final Exception _) { }
   }
 
   void testForEachParameters() {
-    int[] l = {1, 2, 3};
-    int x = 0;
-    for (int number: l) { // violation, 'Parameter number should be final'
-      System.out.println(number);
-    }
-    // ok, unnamed enhanced for loop variable, it is implicitly final
-    for (int _: l) {
-      x++;
-    }
+    for (int number: new int[] {1, 2, 3}) { } // violation, 'number should be final'
+    for (int _: new int[] {1, 2, 3}) { }
   }
-
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

Properties:

Example1 — default config
Example2 — tokens=CTOR_DEF → unique (tokens)
Example3 — ignorePrimitiveTypes=true → unique
Example4 — tokens=FOR_EACH_CLAUSE,LITERAL_CATCH + ignoreUnnamedParameters=true → unique (both tokens value and ignoreUnnamedParameters)

All 4 are Section 1 — all unique properties!