### PR TITLE
Issue #20216: Fix NPE in MagicNumberCheck for compact source files

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -339,13 +339,24 @@ public class MagicNumberCheck extends AbstractCheck {
             node = node.getParent();
         }
 
-        // contains variable declaration
-        // and it is directly inside class or record declaration
-        return varDefAST != null
-                && (varDefAST.getParent().getParent().getType() == TokenTypes.CLASS_DEF
-                || varDefAST.getParent().getParent().getType() == TokenTypes.RECORD_DEF
-                || varDefAST.getParent().getParent().getType() == TokenTypes.LITERAL_NEW);
+        boolean result = false;
 
+        if (varDefAST != null) {
+            final DetailAST parent = varDefAST.getParent();
+
+            if (parent.getType() == TokenTypes.COMPACT_COMPILATION_UNIT) {
+                result = true;
+            }
+            else {
+                final DetailAST grandParent = parent.getParent();
+
+                result = grandParent.getType() == TokenTypes.CLASS_DEF
+                    || grandParent.getType() == TokenTypes.RECORD_DEF
+                    || grandParent.getType() == TokenTypes.LITERAL_NEW;
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
@@ -853,4 +853,14 @@ public class MagicNumberCheckTest
                 getPath("InputMagicNumberWithOperatorsWithIgnoreFieldsFalse.java"),
                 expected);
     }
+
+    @Test
+    public void testMagicNumberInCompactSourceFilesWithIgnoreFieldDeclaration() throws Exception {
+        final String[] expected = {
+            "21:24: " + getCheckMessage(MSG_KEY, "456"),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputMagicNumberCompactSourceFile.java"), expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberCompactSourceFile.java
@@ -1,0 +1,25 @@
+/*
+MagicNumber
+ignoreNumbers = (default)-1, 0, 1, 2
+ignoreHashCodeMethod = (default)false
+ignoreAnnotation = (default)false
+ignoreFieldDeclaration = true
+ignoreAnnotationElementDefaults = (default)true
+constantWaiverParentToken = (default)TYPECAST, METHOD_CALL, EXPR, ARRAY_INIT, UNARY_MINUS, \
+                            UNARY_PLUS, ELIST, STAR, ASSIGN, PLUS, MINUS, DIV, LITERAL_NEW, \
+                            SR, BSR, SL, BXOR, BOR, BAND, BNOT, QUESTION, COLON, EQUAL, NOT_EQUAL, \
+                            GE, GT, LE, LT, MOD
+tokens = (default)NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+int field = 123;
+
+void main() {
+    System.out.println(456);
+    // violation above, ''456' is a magic number.'
+
+    System.out.println(field);
+}


### PR DESCRIPTION
Issue: #20216

Adds null-safety handling for compact source files in MagicNumberCheck when ignoreFieldDeclaration is enabled.