### PR TITLE
Issue #19803: move violation comment out of annotation in finalclass

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -425,8 +425,6 @@
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]designforextension[\\/]InputDesignForExtensionOverridableMethods\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]finalclass[\\/]InputFinalClassPrivateCtor\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]hideutilityclassconstructor[\\/]InputHideUtilityClassConstructorIgnoreAnnotationByFullyQualifiedName\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocJavadocTagsWithoutArgs\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -294,9 +294,9 @@ public class FinalClassCheckTest
             "44:5: " + getCheckMessage(MSG_KEY, "Node"),
             "51:5: " + getCheckMessage(MSG_KEY, "Some1"),
             "55:1: " + getCheckMessage(MSG_KEY, "Some2"),
-            "105:5: " + getCheckMessage(MSG_KEY, "NewCheck"),
-            "108:5: " + getCheckMessage(MSG_KEY, "NewCheck2"),
-            "112:5: " + getCheckMessage(MSG_KEY, "OldCheck"),
+            "106:5: " + getCheckMessage(MSG_KEY, "NewCheck"),
+            "110:5: " + getCheckMessage(MSG_KEY, "NewCheck2"),
+            "115:5: " + getCheckMessage(MSG_KEY, "OldCheck"),
         };
         verifyWithInlineConfigParser(getPath("InputFinalClassPrivateCtor.java"),
                                      expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassPrivateCtor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassPrivateCtor.java
@@ -102,14 +102,17 @@ class IfAbstract {
 
 class Suppression {
 
-    @SuppressWarnings("uncheck") // violation 'Class NewCheck should be declared as final'
+    // violation below 'Class NewCheck should be declared as final'
+    @SuppressWarnings("uncheck")
     private static class NewCheck {}
 
-    @SuppressWarnings("uncheck") // violation 'Class NewCheck2 should be declared as final'
+    // violation below 'Class NewCheck2 should be declared as final'
+    @SuppressWarnings("uncheck")
     private class NewCheck2 {}
 
 
-    @SuppressWarnings("uncheck") // violation 'Class OldCheck should be declared as final'
+    // violation below 'Class OldCheck should be declared as final'
+    @SuppressWarnings("uncheck")
     private class OldCheck {
         private OldCheck(){}
     }


### PR DESCRIPTION
Moves the three `// violation` comments off the `@SuppressWarnings` annotations in `InputFinalClassPrivateCtor` to their own line above the annotation (`// violation below`), updates the expected violation lines in `FinalClassCheckTest`, and removes the corresponding `violationBetweenAnnotationAndMethod` suppression from `config/checkstyle-input-suppressions.xml`.

Part of #19803.