### PR TITLE
Issue #19909: Fix OuterTypeFilename false positive on JEP 512 compact…

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -95,14 +95,8 @@
     files="java25[\\/]InputCompactSourceFileWithModifiers\.java"/>
   <suppress checks="PackageDeclarationCheck"
     files="redundantmodifier[\\/]InputRedundantModifierCompactSourceFile\.java"/>
-
-  <!-- until https://github.com/checkstyle/checkstyle/issues/19909 -->
-  <suppress checks="OuterTypeFilename"
-    files="java25[\\/]InputCompactSourceFile\.java"/>
-  <suppress checks="OuterTypeFilename"
-    files="java25[\\/]InputCompactSourceFileWithModifiers\.java"/>
-  <suppress checks="OuterTypeFilename"
-    files="redundantmodifier[\\/]InputRedundantModifierCompactSourceFile\.java"/>
+  <suppress checks="PackageDeclarationCheck"
+    files="outertypefilename[\\/]InputOuterTypeFilenameCompactSourceFile\.java"/>
 
   <!-- intentional problem for testing -->
   <suppress checks="RegexpSingleline"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
@@ -60,6 +60,13 @@ public class OuterTypeFilenameCheck extends AbstractCheck {
     /** Outer type with mismatched file name. */
     private DetailAST wrongType;
 
+    /**
+     * Indicates whether the file is a compact source file. Its outer type is an
+     * implicit unnamed class that is not declared with a name in the source, so
+     * there is no type name to compare against the file name.
+     */
+    private boolean isCompactSourceFile;
+
     @Override
     public int[] getDefaultTokens() {
         return getRequiredTokens();
@@ -87,25 +94,29 @@ public class OuterTypeFilenameCheck extends AbstractCheck {
         seenFirstToken = false;
         hasPublic = false;
         wrongType = null;
+        isCompactSourceFile = rootAST != null
+                && rootAST.getType() == TokenTypes.COMPACT_COMPILATION_UNIT;
     }
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (seenFirstToken) {
-            final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
-            if (modifiers.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null
-                    && TokenUtil.isRootNode(ast.getParent())) {
-                hasPublic = true;
+        if (!isCompactSourceFile) {
+            if (seenFirstToken) {
+                final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
+                if (modifiers.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null
+                        && TokenUtil.isRootNode(ast.getParent())) {
+                    hasPublic = true;
+                }
             }
-        }
-        else {
-            final String outerTypeName = TokenUtil.getIdent(ast).getText();
+            else {
+                final String outerTypeName = TokenUtil.getIdent(ast).getText();
 
-            if (!fileName.equals(outerTypeName)) {
-                wrongType = ast;
+                if (!fileName.equals(outerTypeName)) {
+                    wrongType = ast;
+                }
             }
+            seenFirstToken = true;
         }
-        seenFirstToken = true;
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -58,7 +58,8 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
                  "InputNoCodeInFile1.java",
                  "InputNoCodeInFile2.java",
                  "InputNoCodeInFile3.java",
-                 "InputNoCodeInFile5.java"
+                 "InputNoCodeInFile5.java",
+                 "InputOuterTypeFilenameEmpty.java"
         );
 
     @TempDir

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
@@ -171,6 +171,20 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testEmptyFile() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputOuterTypeFilenameEmpty.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputOuterTypeFilenameCompactSourceFile.java"), expected);
+    }
+
+    @Test
     public void testStateIsClearedOnBeginTree2() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(OuterTypeFilenameCheck.class);
         final String file1 = getPath(

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameCompactSourceFile.java
@@ -1,0 +1,15 @@
+/*
+OuterTypeFilename
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+    System.out.println("Hello!");
+}
+
+// implicit unnamed class is the outer type, not Helper
+class Helper {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameEmpty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameEmpty.java
@@ -1,0 +1,7 @@
+/*
+OuterTypeFilename
+
+
+*/
+
+/* Comment only */


### PR DESCRIPTION
Fixes #19909

`OuterTypeFilename` reports a false positive on JEP 512 compact source files.
