### PR TITLE
Issue #19764: Move violation comments out of Javadoc for IllegalToken and CommentsIndentation

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -82,11 +82,7 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity[\\/]InputClassFanOutComplexityRemoveIncorrectAnnotationToken.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckBlockCommentBegin.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckCommentsContent.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]indentation[\\/]commentsindentation[\\/]InputCommentsIndentationJavadoc.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderMethodReturningArrayType.java"/>
   <suppress id="noViolationCommentsInJavadoc"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
@@ -88,7 +88,7 @@ public class IllegalTokenCheckTest
 
         final String[] expected = {
             "1:1: " + getCheckMessage(MSG_KEY, "/*"),
-            "10:1: " + getCheckMessage(MSG_KEY, "/*"),
+            "11:1: " + getCheckMessage(MSG_KEY, "/*"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalTokensCheckBlockCommentBegin.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -293,10 +293,10 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testJavadoc() throws Exception {
         final String[] expected = {
-            "10:3: " + getCheckMessage(MSG_KEY_BLOCK, 13, 2, 0),
-            "16:1: " + getCheckMessage(MSG_KEY_BLOCK, 17, 0, 4),
-            "19:9: " + getCheckMessage(MSG_KEY_BLOCK, 22, 8, 4),
-            "26:11: " + getCheckMessage(MSG_KEY_BLOCK, 27, 10, 8),
+            "11:3: " + getCheckMessage(MSG_KEY_BLOCK, 14, 2, 0),
+            "17:1: " + getCheckMessage(MSG_KEY_BLOCK, 18, 0, 4),
+            "21:9: " + getCheckMessage(MSG_KEY_BLOCK, 24, 8, 4),
+            "28:11: " + getCheckMessage(MSG_KEY_BLOCK, 29, 10, 8),
         };
         final String testInputFile = "InputCommentsIndentationJavadoc.java";
         verifyWithInlineConfigParser(getPath(testInputFile), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/InputIllegalTokensCheckBlockCommentBegin.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/InputIllegalTokensCheckBlockCommentBegin.java
@@ -7,7 +7,8 @@ tokens = BLOCK_COMMENT_BEGIN
 
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltoken;
 
-/** // violation, 'Using '\/\*' is not allowed'
+// violation below 'Using '\/\*' is not allowed'
+/**
  * Test for illegal tokens
  */
 public class InputIllegalTokensCheckBlockCommentBegin

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationJavadoc.java
@@ -7,22 +7,24 @@ tokens = (default)SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN
 
 package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;
 
-  /** // violation '.* incorrect .* level 2, expected is 0, .* same .* as line 13.'
+// violation below '.* incorrect .* level 2, expected is 0, .* same .* as line 14.'
+  /**
    *
    */
 public class InputCommentsIndentationJavadoc {
 
-// violation below '.* incorrect .* level 0, expected is 4, .* same .* as line 17.'
+// violation below '.* incorrect .* level 0, expected is 4, .* same .* as line 18.'
 /** some comment */
     int i;
 
-        /** // violation '.* incorrect .* level 8, expected is 4, .* same .* as line 22.'
+        // violation below '.* incorrect .* level 8, expected is 4, .* same .* as line 24.'
+        /**
          *
          */
     void foo() {}
 
     enum Bar {
-        // violation below '.* incorrect .* level 10, expected is 8, .* same .* as line 27.'
+        // violation below '.* incorrect .* level 10, expected is 8, .* same .* as line 29.'
           /** some comment */
         A;
     }


### PR DESCRIPTION
Issue: #19764

Follow-up of #19756 / example #19766.

Moved violation comments out of Javadoc for the following input files and removed their `noViolationCommentsInJavadoc` suppressions:

- `InputIllegalTokensCheckBlockCommentBegin.java` (checks/coding/illegaltoken)
- `InputCommentsIndentationJavadoc.java` (checks/indentation/commentsindentation)

Updated violation line numbers in the corresponding unit tests:

- `IllegalTokenCheckTest`
- `CommentsIndentationCheckTest`

Notes:
- Violation comments were relocated above the Javadoc using `// violation below ...`,
  adjusting the line references accordingly so they still point at the same code.
- The remaining suppressed input files (e.g. the `rule711generalform`
  `InputCorrectJavadocLeadingAsteriskAlignment` files and
  `InputIllegalTokensCheckCommentsContent`) are intentionally left for separate PRs:
  they contain empty `/***/` Javadoc tokens (which the `noViolationCommentsInJavadoc`
  regex cannot close) or assert the `// violation` text as `COMMENT_CONTENT`,
  so they cannot be fixed by simply relocating comments.