### PR TITLE
Issue #19764: Move violation comment out of Javadoc

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorJavadocCommentAfterPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorJavadocCommentAfterPackage.java
@@ -1,5 +1,6 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
-/** // violation ''/\*' should be separated from previous line.'
+// violation below ''/\*' should be separated from previous line.'
+/**
  * Some javadoc here.
  */
 


### PR DESCRIPTION
Issue #19764

Moved violation comment out of Javadoc in `InputEmptyLineSeparatorJavadocCommentAfterPackage.java`.
