### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - illegalsymbol

### DIFF
--- a/src/site/xdoc/checks/coding/illegalsymbol.xml
+++ b/src/site/xdoc/checks/coding/illegalsymbol.xml
@@ -109,8 +109,9 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
   // ✅ Enhancement completed // violation 'Illegal symbol detected: '✅''
-  // 😀 Happy coding // violation 'Illegal symbol detected: '😀''
-  int value = 1;
+  // 😀 Happy coding          // violation 'Illegal symbol detected: '😀''
+  int value1 = 1;
+  String value2 = "Hello 😀";
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -131,7 +132,33 @@ public class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
   // 🌟 Star // violation 'Illegal symbol detected: '🌟''
-  int value = 1;
+
+  int value1 = 1;
+  String value2 = "Hello 😀";
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure the check for ASCII-only mode:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="IllegalSymbol"&gt;
+      &lt;property name="symbolCodes" value="0x1F600-0x1F64F"/&gt;
+      &lt;property name="tokens" value="STRING_LITERAL"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code">
+            Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example4 {
+  // 😀 This emoji in comment is ok
+
+  int value1 = 1;
+  String value2 = "Hello 😀"; // violation 'Illegal symbol detected: '😀''
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -152,6 +179,31 @@ public class Example2 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example3 {
   // café // violation 'Illegal symbol detected: 'é''
+
+  int value1 = 1;
+  String value2 = "Hello 😀";
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check for ASCII-only mode:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="IllegalSymbol"&gt;
+      &lt;property name="symbolCodes" value="0x0080-0x10FFFF"/&gt;
+      &lt;message key="illegal.symbol"
+               value="Only ASCII characters are allowed."/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code">
+            Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example5 {
+  // café // violation 'Only ASCII characters are allowed.'
   int value = 1;
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/coding/illegalsymbol.xml.template
+++ b/src/site/xdoc/checks/coding/illegalsymbol.xml.template
@@ -60,6 +60,22 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example2.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure the check for ASCII-only mode:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">
+            Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
         <p id="Example3-config">
           To configure the check for ASCII-only mode:
         </p>
@@ -74,6 +90,22 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check for ASCII-only mode:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example5-code">
+            Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example5.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -90,7 +90,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/annotation/missingoverride/Example2",
             "checks/annotation/suppresswarningsholder/Example1",
             "checks/blocks/needbraces/Example6",
-            "checks/coding/illegalsymbol/Example4",
             "checks/coding/packagedeclaration/Example2",
             "checks/coding/requirethis/Example5",
             "checks/coding/requirethis/Example6",
@@ -274,7 +273,9 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/whitespace/nowhitespacebefore/Example4",
             "checks/whitespace/whitespacearound/Example2",
             "checks/blocks/emptycatchblock/Example4",
-            "checks/blocks/emptycatchblock/Example5"
+            "checks/blocks/emptycatchblock/Example5",
+            "checks/coding/illegalsymbol/Example3",
+            "checks/coding/illegalsymbol/Example5"
             );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalSymbolCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalSymbolCheckExamplesTest.java
@@ -68,7 +68,7 @@ public class IllegalSymbolCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "16:18: " + getCheckMessage(MSG_KEY, "😀"),
+            "18:19: " + getCheckMessage(MSG_KEY, "😀"),
         };
 
         verifyWithInlineConfigParser(

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example1.java
@@ -10,7 +10,8 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegalsymbol;
 // xdoc section -- start
 public class Example1 {
   // ✅ Enhancement completed // violation 'Illegal symbol detected: '✅''
-  // 😀 Happy coding // violation 'Illegal symbol detected: '😀''
-  int value = 1;
+  // 😀 Happy coding          // violation 'Illegal symbol detected: '😀''
+  int value1 = 1;
+  String value2 = "Hello 😀";
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example2.java
@@ -14,6 +14,8 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegalsymbol;
 // xdoc section -- start
 public class Example2 {
   // 🌟 Star // violation 'Illegal symbol detected: '🌟''
-  int value = 1;
+
+  int value1 = 1;
+  String value2 = "Hello 😀";
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example3.java
@@ -12,6 +12,8 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegalsymbol;
 // xdoc section -- start
 public class Example3 {
   // café // violation 'Illegal symbol detected: 'é''
-  int value = 1;
+
+  int value1 = 1;
+  String value2 = "Hello 😀";
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example4.java
@@ -13,7 +13,9 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegalsymbol;
 // xdoc section -- start
 public class Example4 {
   // 😀 This emoji in comment is ok
-  String value = "Hello 😀"; // violation 'Illegal symbol detected: '😀''
+
+  int value1 = 1;
+  String value2 = "Hello 😀"; // violation 'Illegal symbol detected: '😀''
 }
 // xdoc section -- end
 


### PR DESCRIPTION
#18435

IllegalSymbol :

- Example1 -> default configuration
- Example2 -> symbolCodes
- Example3 -> symbolCodes -> use case
- Example4 -> symbolCodes + tokens
- Example5 -> symbolCodes (additional use case)


Section1 -> Example1,2,4
UseCase -> Example 3,5