### PR TITLE
Issue #20228: Add to OverloadMethodsDeclarationOrder support for Java 25 compact source files

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
@@ -82,14 +82,13 @@ public class OverloadMethodsDeclarationOrderCheck extends AbstractCheck {
     public int[] getRequiredTokens() {
         return new int[] {
             TokenTypes.OBJBLOCK,
+            TokenTypes.COMPACT_COMPILATION_UNIT,
         };
     }
 
     @Override
     public void visitToken(DetailAST ast) {
-        final int parentType = ast.getParent().getType();
-
-        final int[] tokenTypes = {
+        final int[] objectBlockParentTypes = {
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.INTERFACE_DEF,
@@ -97,7 +96,8 @@ public class OverloadMethodsDeclarationOrderCheck extends AbstractCheck {
             TokenTypes.RECORD_DEF,
         };
 
-        if (TokenUtil.isOfType(parentType, tokenTypes)) {
+        if (ast.getType() == TokenTypes.COMPACT_COMPILATION_UNIT
+            || TokenUtil.isOfType(ast.getParent().getType(), objectBlockParentTypes)) {
             checkOverloadMethodsGrouping(ast);
         }
     }
@@ -107,7 +107,8 @@ public class OverloadMethodsDeclarationOrderCheck extends AbstractCheck {
      * separated from each other.
      *
      * @param objectBlock
-     *        is a class, interface or enum object block.
+     *        is a class, interface, enum object block, or a compact
+     *        compilation unit for a JEP 512 compact source file.
      */
     private void checkOverloadMethodsGrouping(DetailAST objectBlock) {
         final int allowedDistance = 1;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckTest.java
@@ -116,6 +116,37 @@ public class OverloadMethodsDeclarationOrderCheckTest
     }
 
     @Test
+    public void testCompactSourceFileOverloads() throws Exception {
+        final String[] expected = {
+            "13:1: " + getCheckMessage(MSG_KEY, 8),
+        };
+        verifyWithInlineConfigParser(
+            getNonCompilablePath(
+                "InputOverloadMethodsDeclarationOrderCompactSourceFile.java"),
+            expected);
+    }
+
+    @Test
+    public void testCompactSourceFileValid() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+            getNonCompilablePath(
+                "InputOverloadMethodsDeclarationOrderCompactSourceFileValid.java"),
+            expected);
+    }
+
+    @Test
+    public void testCompactSourceFileFirstMethodOverload() throws Exception {
+        final String[] expected = {
+            "11:1: " + getCheckMessage(MSG_KEY, 8),
+        };
+        verifyWithInlineConfigParser(
+            getNonCompilablePath(
+                "InputOverloadMethodsDeclarationOrderCompactSourceFileFirstMethodOverload.java"),
+            expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final OverloadMethodsDeclarationOrderCheck check =
             new OverloadMethodsDeclarationOrderCheck();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderCompactSourceFile.java
@@ -1,0 +1,15 @@
+/*
+OverloadMethodsDeclarationOrder
+orderByIncreasingParameterCount = (default)false
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+void process(int x) { }
+
+void helper() { }
+
+// violation below 'All overloaded methods should be placed next to each other.'
+void process(String s) { }
+
+void main() { }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderCompactSourceFileFirstMethodOverload.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderCompactSourceFileFirstMethodOverload.java
@@ -1,0 +1,12 @@
+/*
+OverloadMethodsDeclarationOrder
+orderByIncreasingParameterCount = (default)false
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+void helper() { }
+void process(int x) { }
+void process(String s) { }
+void helper(int x) { } // violation 'All overloaded methods should be placed next to each other.'
+void main() { }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderCompactSourceFileValid.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderCompactSourceFileValid.java
@@ -1,0 +1,11 @@
+/*
+OverloadMethodsDeclarationOrder
+orderByIncreasingParameterCount = (default)false
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void process(int x) { }
+void process(String s) { }
+void main() { }


### PR DESCRIPTION
Fixes #20228

### Description
This PR adds support for JEP 512 (Java 25) compact source files to `OverloadMethodsDeclarationOrderCheck`. 

Previously, the check only looked for top-level methods inside `COMPILATION_UNIT` and `OBJBLOCK`. Because compact source files implicitly declare an unnamed class, their root node is represented as `COMPACT_COMPILATION_UNIT` instead. 

**Changes made:**
- Added `TokenTypes.COMPACT_COMPILATION_UNIT` to `getRequiredTokens()`
- Handled `COMPACT_COMPILATION_UNIT` in `visitToken()` to apply the same grouping validation to top-level methods in compact source files.
- Added a new unit test `testCompactSourceFileOverloads` along with a compact source test input file `InputOverloadMethodsDeclarationOrderCompact.java` to verify the fix.

All tests have been run locally and pass successfully.