### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - membername

### DIFF
--- a/src/site/xdoc/checks/naming/membername.xml
+++ b/src/site/xdoc/checks/naming/membername.xml
@@ -79,20 +79,13 @@
 class Example1 {
   public int num1;
   protected int num2;
-  final int num3 = 3;
+  int num3;
   private int num4;
 
-  static int num5;
-  public static final int CONSTANT = 1;
-
-  public int NUM1; // violation 'Name 'NUM1' must match pattern'
-
+  public int NUM1;    // violation 'Name 'NUM1' must match pattern'
   protected int NUM2; // violation 'Name 'NUM2' must match pattern'
-
-  int NUM3; // violation 'Name 'NUM3' must match pattern'
-
-  private int NUM4; // violation 'Name 'NUM4' must match pattern'
-
+  int NUM3;           // violation 'Name 'NUM3' must match pattern'
+  private int NUM4;   // violation 'Name 'NUM4' must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -116,12 +109,15 @@ class Example1 {
         <p id="Example2-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
-  public int num1; // violation 'Name 'num1' must match pattern'
-
+  public int num1;  // violation 'Name 'num1' must match pattern'
   protected int num2;
   int num3;
   private int num4; // violation 'Name 'num4' must match pattern'
 
+  public int NUM1;  // violation 'Name 'NUM1' must match pattern'
+  protected int NUM2;
+  int NUM3;
+  private int NUM4; // violation 'Name 'NUM4' must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -141,11 +137,14 @@ class Example2 {
         <p id="Example3-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 {
+  public int num1;
+  protected int num2;
+  int num3;
+  private int num4;
+
   public int NUM1;
   protected int NUM2; // violation 'Name 'NUM2' must match pattern'
-
-  int NUM3; // violation 'Name 'NUM3' must match pattern'
-
+  int NUM3;           // violation 'Name 'NUM3' must match pattern'
   private int NUM4;
 }
 </code></pre></div>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -163,8 +163,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/npathcomplexity/Example2",
             "checks/naming/lambdaparametername/Example2",
             "checks/naming/localfinalvariablename/Example3",
-            "checks/naming/membername/Example2",
-            "checks/naming/membername/Example3",
             "checks/naming/parametername/Example5",
             "checks/naming/patternvariablename/Example4",
             "checks/naming/typename/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckExamplesTest.java
@@ -34,10 +34,10 @@ public class MemberNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "21:14: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM1", "^[a-z][a-zA-Z0-9]*$"),
-            "23:17: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM2", "^[a-z][a-zA-Z0-9]*$"),
-            "25:7: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM3", "^[a-z][a-zA-Z0-9]*$"),
-            "27:15: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM4", "^[a-z][a-zA-Z0-9]*$"),
+            "17:14: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM1", "^[a-z][a-zA-Z0-9]*$"),
+            "18:17: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM2", "^[a-z][a-zA-Z0-9]*$"),
+            "19:7: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM3", "^[a-z][a-zA-Z0-9]*$"),
+            "20:15: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM4", "^[a-z][a-zA-Z0-9]*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -47,7 +47,9 @@ public class MemberNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     public void testExample2() throws Exception {
         final String[] expected = {
             "16:14: " + getCheckMessage(MSG_INVALID_PATTERN, "num1", "^m[A-Z][a-zA-Z0-9]*$"),
-            "20:15: " + getCheckMessage(MSG_INVALID_PATTERN, "num4", "^m[A-Z][a-zA-Z0-9]*$"),
+            "19:15: " + getCheckMessage(MSG_INVALID_PATTERN, "num4", "^m[A-Z][a-zA-Z0-9]*$"),
+            "21:14: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM1", "^m[A-Z][a-zA-Z0-9]*$"),
+            "24:15: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM4", "^m[A-Z][a-zA-Z0-9]*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -56,8 +58,8 @@ public class MemberNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "16:17: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM2", "^[a-z][a-zA-Z0-9]*$"),
-            "18:7: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM3", "^[a-z][a-zA-Z0-9]*$"),
+            "21:17: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM2", "^[a-z][a-zA-Z0-9]*$"),
+            "22:7: " + getCheckMessage(MSG_INVALID_PATTERN, "NUM3", "^[a-z][a-zA-Z0-9]*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/membername/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/membername/Example1.java
@@ -5,26 +5,18 @@
   </module>
 </module>
 */
-
 package com.puppycrawl.tools.checkstyle.checks.naming.membername;
 
 // xdoc section -- start
 class Example1 {
   public int num1;
   protected int num2;
-  final int num3 = 3;
+  int num3;
   private int num4;
 
-  static int num5;
-  public static final int CONSTANT = 1;
-
-  public int NUM1; // violation 'Name 'NUM1' must match pattern'
-
+  public int NUM1;    // violation 'Name 'NUM1' must match pattern'
   protected int NUM2; // violation 'Name 'NUM2' must match pattern'
-
-  int NUM3; // violation 'Name 'NUM3' must match pattern'
-
-  private int NUM4; // violation 'Name 'NUM4' must match pattern'
-
+  int NUM3;           // violation 'Name 'NUM3' must match pattern'
+  private int NUM4;   // violation 'Name 'NUM4' must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/membername/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/membername/Example2.java
@@ -13,11 +13,14 @@ package com.puppycrawl.tools.checkstyle.checks.naming.membername;
 
 // xdoc section -- start
 class Example2 {
-  public int num1; // violation 'Name 'num1' must match pattern'
-
+  public int num1;  // violation 'Name 'num1' must match pattern'
   protected int num2;
   int num3;
   private int num4; // violation 'Name 'num4' must match pattern'
 
+  public int NUM1;  // violation 'Name 'NUM1' must match pattern'
+  protected int NUM2;
+  int NUM3;
+  private int NUM4; // violation 'Name 'NUM4' must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/membername/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/membername/Example3.java
@@ -12,11 +12,14 @@ package com.puppycrawl.tools.checkstyle.checks.naming.membername;
 
 // xdoc section -- start
 class Example3 {
+  public int num1;
+  protected int num2;
+  int num3;
+  private int num4;
+
   public int NUM1;
   protected int NUM2; // violation 'Name 'NUM2' must match pattern'
-
-  int NUM3; // violation 'Name 'NUM3' must match pattern'
-
+  int NUM3;           // violation 'Name 'NUM3' must match pattern'
   private int NUM4;
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

membername:

Example1 (default config)
Example2 (format=^m[A-Z][a-zA-Z0-9]*$,  -> unique
applyToProtected=false,
applyToPackage=false)

Example3 (applyToPublic=false,
applyToPrivate=false) -> unique

Section1 -> Example1,2,3