### PR TITLE
Issue #15562: FinalClass: add ignoreAnnotatedBy property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ checkstyle.iws
 # Temp files
 *~
 
+# Personal notes
+NOTES.md
+
 # Java Virtual machine crash logs
 hs_err_pid*
 replay_pid*

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -20,12 +20,14 @@
 package com.puppycrawl.tools.checkstyle.checks.design;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;
 
@@ -33,6 +35,7 @@ import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
@@ -61,6 +64,10 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   </li>
  *   <li>
  *       Class is extended by another class in the same file.
+ *   </li>
+ *   <li>
+ *       Class is annotated with any of the specified annotations from
+ *       {@code ignoreAnnotatedBy} property.
  *   </li>
  * </ol>
  *
@@ -95,6 +102,33 @@ public class FinalClassCheck
 
     /** Full qualified name of the package. */
     private String packageName;
+
+    /**
+     * Ignore classes annotated with the specified annotation(s). Annotation names
+     * provided in this property must exactly match the annotation names on the classes.
+     * If the target class has annotations specified with their fully qualified names
+     * (including package), the annotations in this property should also be specified with
+     * their fully qualified names. Similarly, if the target class has annotations specified
+     * with their simple names, this property should contain the annotations with the same
+     * simple names.
+     */
+    private Set<String> ignoreAnnotatedBy = Collections.emptySet();
+
+    /**
+     * Setter to ignore classes annotated with the specified annotation(s). Annotation names
+     * provided in this property must exactly match the annotation names on the classes.
+     * If the target class has annotations specified with their fully qualified names
+     * (including package), the annotations in this property should also be specified with
+     * their fully qualified names. Similarly, if the target class has annotations specified
+     * with their simple names, this property should contain the annotations with the same
+     * simple names.
+     *
+     * @param annotationNames specified annotation(s)
+     * @since 13.6.0
+     */
+    public void setIgnoreAnnotatedBy(String... annotationNames) {
+        ignoreAnnotatedBy = Set.of(annotationNames);
+    }
 
     @Override
     public int[] getDefaultTokens() {
@@ -198,12 +232,23 @@ public class FinalClassCheck
             innerClasses.forEach(this::registerExtendedClass);
             // Second pass: report violation for all classes that should be declared as final
             innerClasses.forEach((qualifiedClassName, classDesc) -> {
-                if (shouldBeDeclaredAsFinal(classDesc)) {
+                if (shouldBeDeclaredAsFinal(classDesc)
+                        && !shouldIgnoreClass(classDesc.getTypeDeclarationAst())) {
                     final String className = CommonUtil.baseClassName(qualifiedClassName);
                     log(classDesc.getTypeDeclarationAst(), MSG_KEY, className);
                 }
             });
         }
+    }
+
+    /**
+     * Checks if class is annotated by specific annotation(s) to skip.
+     *
+     * @param ast class to check
+     * @return true if annotated by ignored annotations
+     */
+    private boolean shouldIgnoreClass(DetailAST ast) {
+        return AnnotationUtil.containsAnnotation(ast, ignoreAnnotatedBy);
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/design/FinalClassCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/design/FinalClassCheck.xml
@@ -27,7 +27,16 @@
    &lt;li&gt;
        Class is extended by another class in the same file.
    &lt;/li&gt;
+   &lt;li&gt;
+       Class is annotated with any of the specified annotations from
+       &lt;code&gt;ignoreAnnotatedBy&lt;/code&gt; property.
+   &lt;/li&gt;
  &lt;/ol&gt;</description>
+         <properties>
+            <property default-value="" name="ignoreAnnotatedBy" type="java.lang.String[]">
+               <description>Ignore classes annotated with the specified annotation(s). Annotation names provided in this property must exactly match the annotation names on the classes. If the target class has annotations specified with their fully qualified names (including package), the annotations in this property should also be specified with their fully qualified names. Similarly, if the target class has annotations specified with their simple names, this property should contain the annotations with the same simple names.</description>
+            </property>
+         </properties>
          <message-keys>
             <message-key key="final.class"/>
          </message-keys>

--- a/src/site/xdoc/checks/design/finalclass.xml
+++ b/src/site/xdoc/checks/design/finalclass.xml
@@ -32,7 +32,32 @@
         <li>
           Class is extended by another class in the same file.
         </li>
+        <li>
+          Class is annotated with any of the specified annotations from
+          <code>ignoreAnnotatedBy</code> property.
+        </li>
         </ol>
+      </subsection>
+
+      <subsection name="Properties" id="FinalClass_Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td><a id="ignoreAnnotatedBy"/><a href="#ignoreAnnotatedBy">ignoreAnnotatedBy</a></td>
+              <td>Ignore classes annotated with the specified annotation(s). Annotation names provided in this property must exactly match the annotation names on the classes. If the target class has annotations specified with their fully qualified names (including package), the annotations in this property should also be specified with their fully qualified names. Similarly, if the target class has annotations specified with their simple names, this property should contain the annotations with the same simple names.</td>
+              <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
+              <td><code>{}</code></td>
+              <td>13.6.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="FinalClass_Examples">
@@ -92,6 +117,42 @@ public class Example1 { // ok, since it has a public constructor
     public class Class3 {
     }
 
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example2-config">
+          To configure the check to ignore classes annotated with <code>Configuration</code>
+          or <code>java.lang.Deprecated</code>.
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="FinalClass"&gt;
+      &lt;property name="ignoreAnnotatedBy"
+        value="Configuration, java.lang.Deprecated" /&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example2-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+@java.lang.Deprecated // ok, skipped by annotation
+class Example2 {
+
+  private Example2() {
+  }
+}
+
+class Example2A { // violation, 'Class Example2A should be declared as final.'
+
+  private Example2A() {
+  }
+}
+
+@Configuration // ok, skipped by annotation
+class Example2B {
+
+  private Example2B() {
   }
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/design/finalclass.xml.template
+++ b/src/site/xdoc/checks/design/finalclass.xml.template
@@ -18,6 +18,15 @@
         </macro>
       </subsection>
 
+      <subsection name="Properties" id="FinalClass_Properties">
+        <div class="wrapper">
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java"/>
+          </macro>
+        </div>
+      </subsection>
+
       <subsection name="Examples" id="FinalClass_Examples">
         <p id="Example1-config">
           To configure the check:
@@ -31,6 +40,21 @@
         <macro name="example">
           <param name="path"
                    value="resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/Example1.java"/>
+            <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example2-config">
+          To configure the check to ignore classes annotated with <code>Configuration</code>
+          or <code>java.lang.Deprecated</code>.
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                   value="resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/Example2.java"/>
             <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -211,6 +211,17 @@ public class FinalClassCheckTest
     }
 
     @Test
+    public void testFinalClassIgnoreAnnotatedBy() throws Exception {
+        final String[] expected = {
+            "15:1: " + getCheckMessage(MSG_KEY, "InputFinalClassIgnoreAnnotatedByNoAnnotation"),
+            "26:1: " + getCheckMessage(MSG_KEY,
+                    "InputFinalClassIgnoreAnnotatedByOtherAnnotation"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputFinalClassIgnoreAnnotatedBy.java"), expected);
+    }
+
+    @Test
     public void testFinalClassAnonymousInnerClass() throws Exception {
         final String[] expected = {
             "11:9: " + getCheckMessage(MSG_KEY, "b"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -271,7 +271,8 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/blocks/emptycatchblock/Example4",
             "checks/blocks/emptycatchblock/Example5",
             "checks/coding/illegalsymbol/Example3",
-            "checks/coding/illegalsymbol/Example5"
+            "checks/coding/illegalsymbol/Example5",
+            "checks/design/finalclass/Example2"
             );
 
     /**

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassClassWithPrivateCtorWithNestedExtendingClass.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassClassWithPrivateCtorWithNestedExtendingClass.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassClassWithPrivateCtorWithNestedExtendingClassWithoutPackage.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassClassWithPrivateCtorWithNestedExtendingClassWithoutPackage.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClass.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClass2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClass2.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassAnnotation.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassAnonymousInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassAnonymousInnerClass.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassConstructorInRecord.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassConstructorInRecord.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassEnum.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassIgnoreAnnotatedBy.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassIgnoreAnnotatedBy.java
@@ -1,0 +1,34 @@
+/*
+FinalClass
+ignoreAnnotatedBy = AnnotConf, java.lang.Deprecated
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.design.finalclass;
+
+@java.lang.Deprecated
+class InputFinalClassIgnoreAnnotatedBy { // ok, skipped by annotation
+    private InputFinalClassIgnoreAnnotatedBy() {
+    }
+}
+
+class InputFinalClassIgnoreAnnotatedByNoAnnotation { // violation, 'should be declared as final'
+    private InputFinalClassIgnoreAnnotatedByNoAnnotation() {
+    }
+}
+
+@AnnotConf
+class InputFinalClassIgnoreAnnotatedByConfiguration { // ok, skipped by annotation
+    private InputFinalClassIgnoreAnnotatedByConfiguration() {
+    }
+}
+
+@OtherAnnotation // violation, 'should be declared as final'
+class InputFinalClassIgnoreAnnotatedByOtherAnnotation {
+    private InputFinalClassIgnoreAnnotatedByOtherAnnotation() {
+    }
+}
+
+@interface AnnotConf {}
+
+@interface OtherAnnotation {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassInnerAndNestedClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassInnerAndNestedClass.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassInterface.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedInEnumWithAnonInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedInEnumWithAnonInnerClass.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 package com.puppycrawl.tools.checkstyle.checks.design.finalclass;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedInInterfaceWithAnonInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedInInterfaceWithAnonInnerClass.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 package com.puppycrawl.tools.checkstyle.checks.design.finalclass;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedInRecord.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedInRecord.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedStaticClassInsideInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedStaticClassInsideInnerClass.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassPrivateCtor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassPrivateCtor.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassPrivateCtor2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassPrivateCtor2.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassPrivateCtor3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassPrivateCtor3.java
@@ -1,6 +1,6 @@
 /*
 FinalClass
-
+ignoreAnnotatedBy = (default)
 
 */
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckExamplesTest.java
@@ -40,4 +40,13 @@ public class FinalClassCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
+    @Test
+    public void testExample2() throws Exception {
+        final String[] expected = {
+            "22:1: " + getCheckMessage(MSG_KEY, "Example2A"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/Example2.java
@@ -1,0 +1,36 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="FinalClass">
+      <property name="ignoreAnnotatedBy"
+        value="Configuration, java.lang.Deprecated" />
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.design.finalclass;
+
+// xdoc section -- start
+@java.lang.Deprecated // ok, skipped by annotation
+class Example2 {
+
+  private Example2() {
+  }
+}
+
+class Example2A { // violation, 'Class Example2A should be declared as final.'
+
+  private Example2A() {
+  }
+}
+
+@Configuration // ok, skipped by annotation
+class Example2B {
+
+  private Example2B() {
+  }
+}
+// xdoc section -- end
+
+@interface Configuration {}


### PR DESCRIPTION
Issue: #15562

Added `ignoreAnnotatedBy` property to `FinalClassCheck`, identical to the
existing property in `HideUtilityClassConstructorCheck`.

This allows skipping the check for classes annotated with specific annotations
(e.g., Spring `@Configuration`), resolving the conflict where a class with only
a private constructor triggers `FinalClass`, but making it `final` breaks Spring
CGLIB proxying.