### PR TITLE
Issue #16656: Fix JavadocTagContinuationIndentation for line break af…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -129,8 +129,11 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
      */
     private static List<DetailNode> getTargetedTextNodesInsideHtmlElement(DetailNode ast) {
         final List<DetailNode> textNodes = new ArrayList<>();
-
         if (!JavadocUtil.isTag(ast, PRE_TAG) && !isInsidePreTag(ast)) {
+            final DetailNode prevSibling = ast.getPreviousSibling();
+            if (prevSibling != null && isTargetTextNode(prevSibling)) {
+                textNodes.add(prevSibling);
+            }
             DetailNode node = ast.getFirstChild();
             while (node != null) {
                 if (node.getType() == JavadocCommentsTokenTypes.HTML_CONTENT) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -186,6 +186,9 @@ public class JavadocTagContinuationIndentationCheckTest
     public void testJavadocTagContinuationIndentationCheck1() throws Exception {
         final String[] expected = {
             "16: " + getCheckMessage(MSG_KEY, 4),
+            "26: " + getCheckMessage(MSG_KEY, 4),
+            "29: " + getCheckMessage(MSG_KEY, 4),
+            "30: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationCheck1.java"),
@@ -208,6 +211,8 @@ public class JavadocTagContinuationIndentationCheckTest
             "65: " + getCheckMessage(MSG_KEY, 4),
             "75: " + getCheckMessage(MSG_KEY, 4),
             "76: " + getCheckMessage(MSG_KEY, 4),
+            "83: " + getCheckMessage(MSG_KEY, 4),
+            "90: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationCheckHtml.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationCheck1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationCheck1.java
@@ -16,4 +16,18 @@ public class InputJavadocTagContinuationIndentationCheck1 {
      ****/
     // violation above 'Line continuation .* expected level should be 4'
     void foo1() {}
+
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
+    // violation 8 lines below 'Line continuation .* expected level should be 4'
+    // violation 8 lines below 'Line continuation .* expected level should be 4'
+    /**
+     *
+     * @see <a href="https://checkstyle.org/checks/javadoc">
+     *   JavadocTagContinuationIndentation: Checks the indentation.</a>
+     *
+     * @see
+     * <a href="https://checkstyle.org/checks/javadoc">
+     *   JavadocTagContinuationIndentation: Checks the indentation.</a>
+     */
+    void foo2() {}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationCheckHtml.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationCheckHtml.java
@@ -77,15 +77,17 @@ public class InputJavadocTagContinuationIndentationCheckHtml {
      */
     static class Test2 {}
 
+    // violation 3 lines below 'Line continuation .* expected level should be 4'
     /**
      * @see
-     * <a href="https://checkstyle.org"> Javadoc </a> // ok until #16656
+     * <a href="https://checkstyle.org"> Javadoc </a>
      */
     static class Test3 {}
 
+   // violation 3 lines below 'Line continuation .* expected level should be 4'
     /**
      * @see
-     *   <a href="https://checkstyle.org"> Javadoc </a> // ok until #16656
+     *   <a href="https://checkstyle.org"> Javadoc </a>
      */
     static class Test4 {}
 


### PR DESCRIPTION
Issue: #16656
fix `JavadocTagContinuationIndentation` for line break after block tag, 
When a block tag (e.g. @see) is followed by a line break before an HTML element, the continuation indentation on the next line was not checked.

