### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - lambdaparamet…

### DIFF
--- a/src/site/xdoc/checks/naming/lambdaparametername.xml
+++ b/src/site/xdoc/checks/naming/lambdaparametername.xml
@@ -49,9 +49,18 @@
         <p id="Example1-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
-  Function&lt;String, String&gt; function1 = s -&gt; s.toLowerCase();
+  Function&lt;String, String&gt; function1 = str1 -&gt; str1.toUpperCase().trim();
+
   Function&lt;String, String&gt; function2 =
-          S -&gt; S.toLowerCase(); // violation 'Name 'S' must match pattern'
+          S -&gt; S.trim();
+  // violation above 'Name 'S' must match pattern'
+
+  public boolean myMethod(String sentence) {
+    return Stream.of(sentence.split(" "))
+            .map(word -&gt; word.trim())
+            .anyMatch(Word -&gt; "in".equals(Word));
+    // violation above 'Name 'Word' must match pattern'
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -70,9 +79,11 @@ class Example1 {
         <p id="Example2-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
-  Function&lt;String, String&gt; function1 = str -&gt; str.toUpperCase().trim();
-  Function&lt;String, String&gt; function2 = _s -&gt; _s.trim();
-  // violation above 'Name '_s' must match pattern'
+  Function&lt;String, String&gt; function1 = str1 -&gt; str1.toUpperCase().trim();
+  // violation above 'Name 'str1' must match pattern'
+  Function&lt;String, String&gt; function2 =
+          S -&gt; S.trim();
+  // violation above 'Name 'S' must match pattern'
 
   public boolean myMethod(String sentence) {
     return Stream.of(sentence.split(" "))

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -140,7 +140,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/Example9",
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5",
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
-            "checks/naming/lambdaparametername/Example2",
             "checks/naming/patternvariablename/Example4",
             "checks/naming/typename/Example2",
             "checks/naming/typename/Example3",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LambdaParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LambdaParameterNameCheckExamplesTest.java
@@ -34,7 +34,8 @@ public class LambdaParameterNameCheckExamplesTest extends AbstractExamplesModule
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "17:11: " + getCheckMessage(MSG_INVALID_PATTERN, "S", "^([a-z][a-zA-Z0-9]*|_)$"),
+            "19:11: " + getCheckMessage(MSG_INVALID_PATTERN, "S", "^([a-z][a-zA-Z0-9]*|_)$"),
+            "25:23: " + getCheckMessage(MSG_INVALID_PATTERN, "Word", "^([a-z][a-zA-Z0-9]*|_)$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -43,8 +44,9 @@ public class LambdaParameterNameCheckExamplesTest extends AbstractExamplesModule
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "20:40: " + getCheckMessage(MSG_INVALID_PATTERN, "_s", "^[a-z]([a-zA-Z]+)*$"),
-            "26:23: " + getCheckMessage(MSG_INVALID_PATTERN, "Word", "^[a-z]([a-zA-Z]+)*$"),
+            "18:40: " + getCheckMessage(MSG_INVALID_PATTERN, "str1", "^[a-z]([a-zA-Z]+)*$"),
+            "21:11: " + getCheckMessage(MSG_INVALID_PATTERN, "S", "^[a-z]([a-zA-Z]+)*$"),
+            "27:23: " + getCheckMessage(MSG_INVALID_PATTERN, "Word", "^[a-z]([a-zA-Z]+)*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/lambdaparametername/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/lambdaparametername/Example1.java
@@ -9,11 +9,21 @@
 package com.puppycrawl.tools.checkstyle.checks.naming.lambdaparametername;
 
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 // xdoc section -- start
 class Example1 {
-  Function<String, String> function1 = s -> s.toLowerCase();
+  Function<String, String> function1 = str1 -> str1.toUpperCase().trim();
+
   Function<String, String> function2 =
-          S -> S.toLowerCase(); // violation 'Name 'S' must match pattern'
+          S -> S.trim();
+  // violation above 'Name 'S' must match pattern'
+
+  public boolean myMethod(String sentence) {
+    return Stream.of(sentence.split(" "))
+            .map(word -> word.trim())
+            .anyMatch(Word -> "in".equals(Word));
+    // violation above 'Name 'Word' must match pattern'
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/lambdaparametername/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/lambdaparametername/Example2.java
@@ -11,14 +11,15 @@
 package com.puppycrawl.tools.checkstyle.checks.naming.lambdaparametername;
 
 import java.util.function.Function;
-
 import java.util.stream.Stream;
 
 // xdoc section -- start
 class Example2 {
-  Function<String, String> function1 = str -> str.toUpperCase().trim();
-  Function<String, String> function2 = _s -> _s.trim();
-  // violation above 'Name '_s' must match pattern'
+  Function<String, String> function1 = str1 -> str1.toUpperCase().trim();
+  // violation above 'Name 'str1' must match pattern'
+  Function<String, String> function2 =
+          S -> S.trim();
+  // violation above 'Name 'S' must match pattern'
 
   public boolean myMethod(String sentence) {
     return Stream.of(sentence.split(" "))


### PR DESCRIPTION
#18435 

Example1 | Default configuration
Example2 | format="^[a-z]([a-zA-Z]+)*$"

Section1 - > Example1,2 both unique