### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - javadocmethod

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml
@@ -175,23 +175,34 @@ public class Example1 {
 
   /** */
   Example1(int x) {}
-  // violation above, 'Expected @param tag for 'x''
+  // violation above, 'Expected @param tag for 'x'.'
   /** */
-  public int m1(int p1) { return p1; }
-  // 2 violations above:
-  //    '@return tag should be present'
-  //    'Expected @param tag for 'p1''
+  public int m1(int p1) throws IOException {
+    // 2 violations above:
+    //    '@return tag should be present and have description.'
+    //    'Expected @param tag for 'p1'.'
+
+    throw new IOException();
+  }
 
   /**
    * @param p1 The first number
    */
   @Deprecated
-  private int m2(int p1) { return p1; }
-  // violation 2 lines above '@return tag should be present'
-
+  private int m2(int p1) {
+    return p1;
+  }
+  // violation 4 lines above '@return tag should be present and have description.'
   /** */
   void m3(int p1) {}
-  // violation above, 'Expected @param tag for 'p1''
+  // violation above, 'Expected @param tag for 'p1'.'
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+    // violation above, '@return tag should be present and have description.'
+    return 0;
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -217,21 +228,273 @@ public class Example2 {
   Example2(int x) {}
 
   /** */
-  public int m1(int p1) { return p1; }
-  // 1 violations above:
-  //    '@return tag should be present'
-  // ok, No missing param tag violation
+  public int m1(int p1) throws IOException {
+    // violation above, '@return tag should be present and have description.'
+    /*
+     ok, allowMissingParamTags is true
+    */
+    throw new IOException();
+  }
 
   /**
    * @param p1 The first number
    */
   @Deprecated
-  private int m2(int p1) { return p1; }
-  // ok, only public methods are checked
+  private int m2(int p1) {
+    return p1;
+  }
 
   /** */
   void m3(int p1) {}
 
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+    // violation above, '@return tag should be present and have description.'
+    return 0;
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-config">
+              To configure the check to ignore any missing return tags:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocMethod"&gt;
+        &lt;property name="allowMissingReturnTag" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code"> Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example4 {
+
+  /** */
+  Example4(int x) {}
+  // violation above, 'Expected @param tag for 'x'.'
+  /** */
+  public int m1(int p1) throws IOException {
+    // violation above, 'Expected @param tag for 'p1'.'
+    /*
+     ok, allowMissingReturnTag is true
+    */
+    throw new IOException();
+  }
+
+  /**
+   * @param p1 The first number
+   */
+  @Deprecated
+  private int m2(int p1) {
+    return p1;
+  }
+
+  /** */
+  void m3(int p1) {}
+  // violation above, 'Expected @param tag for 'p1'.'
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+
+    return 0;
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+              To configure the check to ignore Methods with annotation <code>Deprecated</code>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocMethod"&gt;
+        &lt;property name="allowedAnnotations" value="Deprecated"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code"> Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example5 {
+
+  /** */
+  Example5(int x) {}
+  // violation above, 'Expected @param tag for 'x'.'
+  /** */
+  public int m1(int p1) throws IOException {
+    // 2 violations above:
+    //    '@return tag should be present and have description.'
+    //    'Expected @param tag for 'p1'.'
+
+    throw new IOException();
+  }
+
+  /**
+   * @param p1 The first number
+   */
+  @Deprecated
+  private int m2(int p1) {
+    return p1;
+  }
+
+  /** */
+  void m3(int p1) {}
+  // violation above, 'Expected @param tag for 'p1'.'
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+    // violation above, '@return tag should be present and have description.'
+    return 0;
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example6-config">
+              To configure the check only for tokens which are Constructor Definitions:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocMethod"&gt;
+      &lt;property name="tokens" value="CTOR_DEF"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example6-code"> Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example6 {
+
+  /** */
+  Example6(int x) {}
+  // violation above, 'Expected @param tag for 'x''
+  /** */
+  public int m1(int p1) throws IOException {
+    /*
+     ok, only constructors are checked.
+     Method definitions are ignored for this token set.
+    */
+    throw new IOException();
+  }
+  // ok, only constructors are checked
+  /**
+   * @param p1 The first number
+   */
+  @Deprecated
+  private int m2(int p1) {
+    return p1;
+  }
+  // ok, only constructors are checked
+  /** */
+  void m3(int p1) {}
+  // ok, only constructors are checked
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+
+    return 0;
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example7-config">
+          To configure the check to validate <code>throws</code> tags, you can use following config.
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocMethod"&gt;
+      &lt;property name="validateThrows" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example7-code"> Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example7 {
+
+  /** */
+  Example7(int x) {}
+  // violation above, 'Expected @param tag for 'x'.'
+  /** */
+  public int m1(int p1) throws IOException {
+    // 3 violations above:
+    //    '@return tag should be present and have description.'
+    //    'Expected @param tag for 'p1'.'
+    //    'Expected @throws tag for 'IOException'.'
+    throw new IOException();
+  }
+
+  /**
+   * @param p1 The first number
+   */
+  @Deprecated
+  private int m2(int p1) {
+    return p1;
+  }
+  // violation 4 lines above '@return tag should be present and have description.'
+  /** */
+  void m3(int p1) {}
+  // violation above, 'Expected @param tag for 'p1'.'
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+    // violation above, '@return tag should be present and have description.'
+    return 0;
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example8-config">
+          To configure the check to allow inline <code>return</code> tags,
+          you can use following config.
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocMethod"&gt;
+        &lt;property name="allowInlineReturn" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example8-code"> Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example8 {
+
+  /** */
+  Example8(int x) {}
+  // violation above, 'Expected @param tag for 'x'.'
+  /** */
+  public int m1(int p1) throws IOException {
+    // 2 violations above:
+    //    '@return tag should be present and have description.'
+    //    'Expected @param tag for 'p1'.'
+
+    throw new IOException();
+  }
+
+  /**
+   * @param p1 The first number
+   */
+  @Deprecated
+  private int m2(int p1) {
+    return p1;
+  }
+  // violation 4 lines above '@return tag should be present and have description.'
+  /** */
+  void m3(int p1) {}
+  // violation above, 'Expected @param tag for 'p1'.'
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+    // ok, allowInlineReturn is true
+    return 0;
+  }
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -255,260 +518,32 @@ public class Example3 {
   Example3(int x) {}
 
   /** */
-  public int m1(int p1) { return p1; }
-  // ok, No missing param tag violation
-  // ok, No missing @return tag violation
-  // only private, package are checked
+  public int m1(int p1) throws IOException {
+    /*
+     ok, only private and package access modifiers are checked.
+     Public methods are not validated under this configuration.
+    */
+    throw new IOException();
+  }
 
   /**
    * @param p1 The first number
    */
   @Deprecated
-  private int m2(int p1) { return p1; }
-  // ok, No missing @return tag violation
+  private int m2(int p1) {
+    return p1;
+  }
 
   /** */
   void m3(int p1) {}
-
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example4-config">
-              To configure the check to ignore any missing return tags:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="JavadocMethod"&gt;
-        &lt;property name="allowMissingReturnTag" value="true"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example4-code"> Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example4 {
-
-  /** */
-  Example4(int x) {}
-  // violation above, 'Expected @param tag for 'x''
-  /** */
-  public int m1(int p1) { return p1; }
-  // 1 violations above:
-  //    'Expected @param tag for 'p1''
-  // ok, No missing @return tag violation
-
-  /**
-   * @param p1 The first number
-   */
-  @Deprecated
-  private int m2(int p1) { return p1; }
-  // ok, No missing @return tag violation
-
-  /** */
-  void m3(int p1) {}
-  // violation above, 'Expected @param tag for 'p1''
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example5-config">
-              To configure the check to ignore Methods with annotation <code>Deprecated</code>:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="JavadocMethod"&gt;
-        &lt;property name="allowedAnnotations" value="Deprecated"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example5-code"> Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example5 {
-
-  /** */
-  Example5(int x) {}
-  // violation above, 'Expected @param tag for 'x''
-  /** */
-  public int m1(int p1) { return p1; }
-  // 2 violations above:
-  //    '@return tag should be present'
-  //    'Expected @param tag for 'p1''
-
-  /**
-   * @param p1 The first number
-   */
-  @Deprecated
-  private int m2(int p1) { return p1; }
-  // ok, No missing @return tag violation
-
-  /** */
-  void m3(int p1) {}
-  // violation above, 'Expected @param tag for 'p1''
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example6-config">
-              To configure the check only for tokens which are Constructor Definitions:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="JavadocMethod"&gt;
-        &lt;property name="tokens" value="CTOR_DEF"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example6-code"> Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example6 {
-
-  /** */
-  Example6(int x) {}
-  // violation above, 'Expected @param tag for 'x''
-  /** */
-  public int m1(int p1) { return p1; }
-  // ok, No missing param tag violation
-  // ok, No missing @return tag violation
-  // only constructors are checked
-
-  /**
-   * @param p1 The first number
-   */
-  @Deprecated
-  private int m2(int p1) { return p1; }
-  // ok, No missing @return tag violation
-
-  /** */
-  void m3(int p1) {}
-
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example7-config">
-          To configure the check to validate <code>throws</code> tags, you can use following config.
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="JavadocMethod"&gt;
-      &lt;property name="validateThrows" value="true"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example7-code"> Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example7 {
-
-  /**
-   * Actual exception thrown is child class of class that is declared in throws.
-   * It is limitation of checkstyle (as checkstyle does not know type hierarchy).
-   * Javadoc is valid not declaring FileNotFoundException
-   * BUT checkstyle can not distinguish relationship between exceptions.
-   * @param file some file
-   * @throws IOException if some problem
-   */
-  public void doSomething8(File file) throws IOException {
-    if (file == null) {
-      // violation below, 'Expected @throws tag for 'FileNotFoundException''
-      throw new FileNotFoundException();
-    }
-  }
-
-  /**
-   * Exact throw type referencing in javadoc even first is parent of second type.
-   * It is a limitation of checkstyle (as checkstyle does not know type hierarchy).
-   * This javadoc is valid for checkstyle and for javadoc tool.
-   * @param file some file
-   * @throws IOException if some problem
-   * @throws FileNotFoundException if file is not found
-   */
-  public void doSomething9(File file) throws IOException {
-    if (file == null) {
-      throw new FileNotFoundException();
-    }
-  }
-
-  /**
-   * Ignore try block, but keep catch and finally blocks.
-   *
-   * @param s String to parse
-   * @return A positive integer
-   */
-  public int parsePositiveInt(String s) {
-    try {
-      int value = Integer.parseInt(s);
-      if (value &lt;= 0) {
-        throw new NumberFormatException(value + " is negative/zero"); // ok, try
-      }
-      return value;
-    } catch (NumberFormatException ex) {
-      // violation below, 'Expected @throws tag for 'IllegalArgumentException''
-      throw new IllegalArgumentException("Invalid number", ex);
-    } finally {
-      // violation below, 'Expected @throws tag for 'IllegalStateException''
-      throw new IllegalStateException("Should never reach here");
-    }
-  }
-
-  /**
-   * Try block without catch is not ignored.
-   *
-   * @return a String from standard input, if there is one
-   */
-  public String readLine() {
-    try (Scanner sc = new Scanner(System.in)) {
-      if (!sc.hasNext()) {
-        // violation below, 'Expected @throws tag for 'IllegalStateException''
-        throw new IllegalStateException("Empty input");
-      }
-      return sc.next();
-    }
-  }
-
-  /**
-   * Lambda expressions are ignored.
-   *
-   * @param s a String to be printed at some point in the future
-   * @return a Runnable to be executed when the string is to be printed
-   */
-  public Runnable printLater(String s) {
-    return () -&gt; {
-      if (s == null) {
-        throw new NullPointerException();
-      }
-      System.out.println(s);
-    };
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example8-config">
-          To configure the check to allow inline <code>return</code> tags,
-          you can use following config.
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="JavadocMethod"&gt;
-        &lt;property name="allowInlineReturn" value="true"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example8-code"> Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example8 {
 
   /**
    * {@return the foo}
    */
-  public int getFoo() { return 0; }
+  public int getFoo() {
 
-  /**
-   * Returns the bar
-   * @return the bar
-   */
-  public int getBar() { return 0; }
-
+    return 0;
+  }
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
@@ -59,21 +59,6 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example2.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example3-config">
-            To configure the check for methods which are in <code>private</code> and
-          <code>package</code>, but not any other modifier:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example3.java"/>
-          <param name="type" value="config"/>
-        </macro>
-        <p id="Example3-code"> Example:</p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example3.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
         <p id="Example4-config">
               To configure the check to ignore any missing return tags:
         </p>
@@ -143,6 +128,21 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example8.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example3-config">
+            To configure the check for methods which are in <code>private</code> and
+          <code>package</code>, but not any other modifier:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code"> Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example3.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -138,8 +138,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/imports/importorder/Example9",
             "checks/javadoc/javadocleadingasteriskalign/Example2",
             "checks/javadoc/javadocleadingasteriskalign/Example3",
-            "checks/javadoc/javadocmethod/Example7",
-            "checks/javadoc/javadocmethod/Example8",
             "checks/javadoc/javadocstyle/Example7",
             "checks/javadoc/javadoctagcontinuationindentation/Example4",
             "checks/javadoc/javadocvariable/Example5",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckExamplesTest.java
@@ -36,11 +36,12 @@ public class JavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "14:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "x"),
-            "17: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
-            "17:21: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
-            "25: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
-            "30:15: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+            "16:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "x"),
+            "19: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
+            "19:21: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+            "30: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
+            "36:15: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+            "41: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -49,7 +50,8 @@ public class JavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
+            "22: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
+            "44: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -64,9 +66,9 @@ public class JavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "16:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "x"),
-            "19:21: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
-            "32:15: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+            "18:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "x"),
+            "21:21: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+            "38:15: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
@@ -75,10 +77,11 @@ public class JavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "16:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "x"),
-            "19: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
-            "19:21: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
-            "32:15: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+            "18:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "x"),
+            "21: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
+            "21:21: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+            "38:15: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+            "43: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
@@ -87,7 +90,7 @@ public class JavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample6() throws Exception {
         final String[] expected = {
-            "16:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "x"),
+            "18:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "x"),
         };
 
         verifyWithInlineConfigParser(getPath("Example6.java"), expected);
@@ -96,10 +99,13 @@ public class JavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample7() throws Exception {
         final String[] expected = {
-            "31:17: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "FileNotFoundException"),
-            "64:17: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalArgumentException"),
-            "67:17: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalStateException"),
-            "80:19: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalStateException"),
+            "18:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "x"),
+            "21: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
+            "21:21: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+            "21:32: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IOException"),
+            "32: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
+            "38:15: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+            "43: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
         };
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
@@ -107,7 +113,13 @@ public class JavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSu
 
     @Test
     public void testExample8() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "18:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "x"),
+            "21: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
+            "21:21: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+            "32: " + getCheckMessage(MSG_RETURN_EXPECTED, "@return"),
+            "38:15: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "p1"),
+        };
         verifyWithInlineConfigParser(getPath("Example8.java"), expected);
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example1.java
@@ -7,27 +7,40 @@
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
+import java.io.IOException;
+
 // xdoc section -- start
 public class Example1 {
 
   /** */
   Example1(int x) {}
-  // violation above, 'Expected @param tag for 'x''
+  // violation above, 'Expected @param tag for 'x'.'
   /** */
-  public int m1(int p1) { return p1; }
-  // 2 violations above:
-  //    '@return tag should be present'
-  //    'Expected @param tag for 'p1''
+  public int m1(int p1) throws IOException {
+    // 2 violations above:
+    //    '@return tag should be present and have description.'
+    //    'Expected @param tag for 'p1'.'
+
+    throw new IOException();
+  }
 
   /**
    * @param p1 The first number
    */
   @Deprecated
-  private int m2(int p1) { return p1; }
-  // violation 2 lines above '@return tag should be present'
-
+  private int m2(int p1) {
+    return p1;
+  }
+  // violation 4 lines above '@return tag should be present and have description.'
   /** */
   void m3(int p1) {}
-  // violation above, 'Expected @param tag for 'p1''
+  // violation above, 'Expected @param tag for 'p1'.'
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+    // violation above, '@return tag should be present and have description.'
+    return 0;
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example2.java
@@ -10,6 +10,8 @@
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
+import java.io.IOException;
+
 // xdoc section -- start
 public class Example2 {
 
@@ -17,20 +19,31 @@ public class Example2 {
   Example2(int x) {}
 
   /** */
-  public int m1(int p1) { return p1; }
-  // 1 violations above:
-  //    '@return tag should be present'
-  // ok, No missing param tag violation
+  public int m1(int p1) throws IOException {
+    // violation above, '@return tag should be present and have description.'
+    /*
+     ok, allowMissingParamTags is true
+    */
+    throw new IOException();
+  }
 
   /**
    * @param p1 The first number
    */
   @Deprecated
-  private int m2(int p1) { return p1; }
-  // ok, only public methods are checked
+  private int m2(int p1) {
+    return p1;
+  }
 
   /** */
   void m3(int p1) {}
 
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+    // violation above, '@return tag should be present and have description.'
+    return 0;
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example3.java
@@ -9,6 +9,8 @@
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
+import java.io.IOException;
+
 // xdoc section -- start
 public class Example3 {
 
@@ -16,20 +18,31 @@ public class Example3 {
   Example3(int x) {}
 
   /** */
-  public int m1(int p1) { return p1; }
-  // ok, No missing param tag violation
-  // ok, No missing @return tag violation
-  // only private, package are checked
+  public int m1(int p1) throws IOException {
+    /*
+     ok, only private and package access modifiers are checked.
+     Public methods are not validated under this configuration.
+    */
+    throw new IOException();
+  }
 
   /**
    * @param p1 The first number
    */
   @Deprecated
-  private int m2(int p1) { return p1; }
-  // ok, No missing @return tag violation
+  private int m2(int p1) {
+    return p1;
+  }
 
   /** */
   void m3(int p1) {}
 
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+
+    return 0;
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example4.java
@@ -9,27 +9,40 @@
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
+import java.io.IOException;
+
 // xdoc section -- start
 public class Example4 {
 
   /** */
   Example4(int x) {}
-  // violation above, 'Expected @param tag for 'x''
+  // violation above, 'Expected @param tag for 'x'.'
   /** */
-  public int m1(int p1) { return p1; }
-  // 1 violations above:
-  //    'Expected @param tag for 'p1''
-  // ok, No missing @return tag violation
+  public int m1(int p1) throws IOException {
+    // violation above, 'Expected @param tag for 'p1'.'
+    /*
+     ok, allowMissingReturnTag is true
+    */
+    throw new IOException();
+  }
 
   /**
    * @param p1 The first number
    */
   @Deprecated
-  private int m2(int p1) { return p1; }
-  // ok, No missing @return tag violation
+  private int m2(int p1) {
+    return p1;
+  }
 
   /** */
   void m3(int p1) {}
-  // violation above, 'Expected @param tag for 'p1''
+  // violation above, 'Expected @param tag for 'p1'.'
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+
+    return 0;
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example5.java
@@ -9,27 +9,40 @@
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
+import java.io.IOException;
+
 // xdoc section -- start
 public class Example5 {
 
   /** */
   Example5(int x) {}
-  // violation above, 'Expected @param tag for 'x''
+  // violation above, 'Expected @param tag for 'x'.'
   /** */
-  public int m1(int p1) { return p1; }
-  // 2 violations above:
-  //    '@return tag should be present'
-  //    'Expected @param tag for 'p1''
+  public int m1(int p1) throws IOException {
+    // 2 violations above:
+    //    '@return tag should be present and have description.'
+    //    'Expected @param tag for 'p1'.'
+
+    throw new IOException();
+  }
 
   /**
    * @param p1 The first number
    */
   @Deprecated
-  private int m2(int p1) { return p1; }
-  // ok, No missing @return tag violation
+  private int m2(int p1) {
+    return p1;
+  }
 
   /** */
   void m3(int p1) {}
-  // violation above, 'Expected @param tag for 'p1''
+  // violation above, 'Expected @param tag for 'p1'.'
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+    // violation above, '@return tag should be present and have description.'
+    return 0;
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example6.java
@@ -2,12 +2,14 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="JavadocMethod">
-        <property name="tokens" value="CTOR_DEF"/>
+      <property name="tokens" value="CTOR_DEF"/>
     </module>
   </module>
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+import java.io.IOException;
 
 // xdoc section -- start
 public class Example6 {
@@ -16,20 +18,31 @@ public class Example6 {
   Example6(int x) {}
   // violation above, 'Expected @param tag for 'x''
   /** */
-  public int m1(int p1) { return p1; }
-  // ok, No missing param tag violation
-  // ok, No missing @return tag violation
-  // only constructors are checked
-
+  public int m1(int p1) throws IOException {
+    /*
+     ok, only constructors are checked.
+     Method definitions are ignored for this token set.
+    */
+    throw new IOException();
+  }
+  // ok, only constructors are checked
   /**
    * @param p1 The first number
    */
   @Deprecated
-  private int m2(int p1) { return p1; }
-  // ok, No missing @return tag violation
-
+  private int m2(int p1) {
+    return p1;
+  }
+  // ok, only constructors are checked
   /** */
   void m3(int p1) {}
+  // ok, only constructors are checked
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
 
+    return 0;
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example7.java
@@ -9,93 +9,40 @@
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.Scanner;
 
 // xdoc section -- start
 public class Example7 {
 
-  /**
-   * Actual exception thrown is child class of class that is declared in throws.
-   * It is limitation of checkstyle (as checkstyle does not know type hierarchy).
-   * Javadoc is valid not declaring FileNotFoundException
-   * BUT checkstyle can not distinguish relationship between exceptions.
-   * @param file some file
-   * @throws IOException if some problem
-   */
-  public void doSomething8(File file) throws IOException {
-    if (file == null) {
-      // violation below, 'Expected @throws tag for 'FileNotFoundException''
-      throw new FileNotFoundException();
-    }
+  /** */
+  Example7(int x) {}
+  // violation above, 'Expected @param tag for 'x'.'
+  /** */
+  public int m1(int p1) throws IOException {
+    // 3 violations above:
+    //    '@return tag should be present and have description.'
+    //    'Expected @param tag for 'p1'.'
+    //    'Expected @throws tag for 'IOException'.'
+    throw new IOException();
   }
 
   /**
-   * Exact throw type referencing in javadoc even first is parent of second type.
-   * It is a limitation of checkstyle (as checkstyle does not know type hierarchy).
-   * This javadoc is valid for checkstyle and for javadoc tool.
-   * @param file some file
-   * @throws IOException if some problem
-   * @throws FileNotFoundException if file is not found
+   * @param p1 The first number
    */
-  public void doSomething9(File file) throws IOException {
-    if (file == null) {
-      throw new FileNotFoundException();
-    }
+  @Deprecated
+  private int m2(int p1) {
+    return p1;
   }
-
+  // violation 4 lines above '@return tag should be present and have description.'
+  /** */
+  void m3(int p1) {}
+  // violation above, 'Expected @param tag for 'p1'.'
   /**
-   * Ignore try block, but keep catch and finally blocks.
-   *
-   * @param s String to parse
-   * @return A positive integer
+   * {@return the foo}
    */
-  public int parsePositiveInt(String s) {
-    try {
-      int value = Integer.parseInt(s);
-      if (value <= 0) {
-        throw new NumberFormatException(value + " is negative/zero"); // ok, try
-      }
-      return value;
-    } catch (NumberFormatException ex) {
-      // violation below, 'Expected @throws tag for 'IllegalArgumentException''
-      throw new IllegalArgumentException("Invalid number", ex);
-    } finally {
-      // violation below, 'Expected @throws tag for 'IllegalStateException''
-      throw new IllegalStateException("Should never reach here");
-    }
-  }
-
-  /**
-   * Try block without catch is not ignored.
-   *
-   * @return a String from standard input, if there is one
-   */
-  public String readLine() {
-    try (Scanner sc = new Scanner(System.in)) {
-      if (!sc.hasNext()) {
-        // violation below, 'Expected @throws tag for 'IllegalStateException''
-        throw new IllegalStateException("Empty input");
-      }
-      return sc.next();
-    }
-  }
-
-  /**
-   * Lambda expressions are ignored.
-   *
-   * @param s a String to be printed at some point in the future
-   * @return a Runnable to be executed when the string is to be printed
-   */
-  public Runnable printLater(String s) {
-    return () -> {
-      if (s == null) {
-        throw new NullPointerException();
-      }
-      System.out.println(s);
-    };
+  public int getFoo() {
+    // violation above, '@return tag should be present and have description.'
+    return 0;
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example8.java
@@ -9,19 +9,40 @@
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
+import java.io.IOException;
+
 // xdoc section -- start
 public class Example8 {
 
+  /** */
+  Example8(int x) {}
+  // violation above, 'Expected @param tag for 'x'.'
+  /** */
+  public int m1(int p1) throws IOException {
+    // 2 violations above:
+    //    '@return tag should be present and have description.'
+    //    'Expected @param tag for 'p1'.'
+
+    throw new IOException();
+  }
+
+  /**
+   * @param p1 The first number
+   */
+  @Deprecated
+  private int m2(int p1) {
+    return p1;
+  }
+  // violation 4 lines above '@return tag should be present and have description.'
+  /** */
+  void m3(int p1) {}
+  // violation above, 'Expected @param tag for 'p1'.'
   /**
    * {@return the foo}
    */
-  public int getFoo() { return 0; }
-
-  /**
-   * Returns the bar
-   * @return the bar
-   */
-  public int getBar() { return 0; }
-
+  public int getFoo() {
+    // ok, allowInlineReturn is true
+    return 0;
+  }
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

Example1.java -> default config
Example2.java -> accessModifiers="public"
Example3.java -> accessModifiers="private, package"
Example4.java -> allowMissingReturnTag="true"
Example5.java -> allowedAnnotations="Deprecated"
Example6.java -> tokens="CTOR_DEF"
Example7.java -> validateThrows=true
Example8.java -> allowInlineReturn=true

Section1 -> Example1,2,4,5,6,7,8 
UseCase -> Example3