### PR TITLE
percent-encode double quote in SarifLogger file uri

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
@@ -101,6 +101,9 @@ public final class SarifLogger extends AbstractAutomaticBean implements AuditLis
     /** A pattern for two backslashes. */
     private static final Pattern A_SPACE_PATTERN = Pattern.compile(" ");
 
+    /** A pattern for a double quote. */
+    private static final Pattern A_QUOTE_PATTERN = Pattern.compile("\"");
+
     /** A pattern for two backslashes. */
     private static final Pattern TWO_BACKSLASHES_PATTERN = Pattern.compile(TWO_BACKSLASHES);
 
@@ -436,10 +439,11 @@ public final class SarifLogger extends AbstractAutomaticBean implements AuditLis
      * @return the rendered URI for the given file name
      */
     private static String renderFileNameUri(final String fileName) {
-        String normalized =
+        final String withoutSpaces =
                 A_SPACE_PATTERN
                         .matcher(TWO_BACKSLASHES_PATTERN.matcher(fileName).replaceAll("/"))
                         .replaceAll("%20");
+        String normalized = A_QUOTE_PATTERN.matcher(withoutSpaces).replaceAll("%22");
         if (WINDOWS_DRIVE_LETTER_PATTERN.matcher(normalized).find()) {
             normalized = '/' + normalized;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -317,6 +317,28 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
     }
 
     /**
+     * A file name can contain a double quote on POSIX filesystems, and that character is not
+     * produced by the normal Checker.process(...) file-auditing flow, so the event is built
+     * manually to assert the rendered URI stays inside its JSON string instead of breaking out.
+     */
+    @Test
+    public void testAddErrorWithQuoteInPath() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, "Test\".java", violation);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerQuoteInPath.sarif"), outStream);
+    }
+
+    /**
      * We keep this test for 100% coverage. Until #12873.
      */
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerQuoteInPath.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerQuoteInPath.sarif
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+            {
+              "id": "com.puppycrawl.tools.checkstyle.SarifLoggerTest",
+              "messageStrings": {
+
+              },
+              "shortDescription": {
+                "text": "SarifLoggerTest"
+              },
+              "fullDescription": {
+                "text": "No description available"
+              }
+            }
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:Test%22.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found an error"
+          },
+          "ruleId": "com.puppycrawl.tools.checkstyle.SarifLoggerTest"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Found while comparing the two file loggers: XMLLogger.encode() escapes the file
name, SarifLogger leaves it raw. A double quote in the name (legal on POSIX)
ends the JSON string early and the trailing bytes parse as new object keys.
SARIF is the format CI hands to code scanning, so a crafted file name can
inject or drop entries in the report.

CLI output as per issue template:

```bash
/var/tmp $ javac Test\".java
# successful compilation, no output

/var/tmp $ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
    "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="RegexpSingleline">
    <property name="format" value="class"/>
  </module>
</module>

/var/tmp $ cat Test\".java
class Test {
}

/var/tmp $ RUN_LOCALE="-Duser.language=en -Duser.country=US"
/var/tmp $ java $RUN_LOCALE -jar checkstyle-13.5.0-all.jar -c config.xml -f sarif -o report.sarif Test\".java
[main] INFO org.reflections.Reflections - Reflections took 17 ms to scan 1 urls, producing 215 keys and 215 values
Checkstyle ends with 1 errors.

/var/tmp $ grep '"uri"' report.sarif
                  "uri": "file:/private/var/tmp/Test".java"

/var/tmp $ python3 -m json.tool report.sarif
Expecting ',' delimiter: line 44 column 54 (char 1739)
```

The raw quote terminates the JSON string after `Test` and the rest of the line
parses as garbage. The whole report is rejected by any JSON parser.

---

**Describe what you expect in detail.**

The report should stay valid JSON whatever the file is named. The quote should
take the same route the method already uses for spaces (%20) and become %22.
Same run with this patch applied on top of 13.5.0:

```bash
/var/tmp $ javac -cp checkstyle-13.5.0-all.jar -d patched SarifLogger.java
/var/tmp $ java $RUN_LOCALE -cp patched:checkstyle-13.5.0-all.jar com.puppycrawl.tools.checkstyle.Main -c config.xml -f sarif -o report.sarif Test\".java
[main] INFO org.reflections.Reflections - Reflections took 14 ms to scan 1 urls, producing 215 keys and 215 values
Checkstyle ends with 1 errors.

/var/tmp $ grep '"uri"' report.sarif
                  "uri": "file:/private/var/tmp/Test%22.java"

/var/tmp $ python3 -m json.tool report.sarif > /dev/null && echo valid
valid
```

Slashes, spaces and Windows drive letters render byte for byte as before.
Regression test added: SarifLoggerTest#testAddErrorWithQuoteInPath.
