### PR TITLE
Issue #20273: fix Javadoc parsing error

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammar/javadoc/JavadocCommentsLexer.g4
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammar/javadoc/JavadocCommentsLexer.g4
@@ -105,12 +105,14 @@ import com.puppycrawl.tools.checkstyle.grammar.CrAwareLexerSimulator;
 
     public boolean isJavadocBlockTag() {
         int nextChar = _input.LA(1);
+        int tagStartChar = _input.LA(2);
 
         return (previousTokenType == WS
                 || previousTokenType == LEADING_ASTERISK
                 || previousToken == null
                 || previousTokenType == NEWLINE)
-                && nextChar == '@';
+                && nextChar == '@'
+                && tagStartChar != '@';
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
@@ -86,7 +86,7 @@ public class SingleLineJavadocCheckTest extends AbstractModuleTestSupport {
     public void testLexerError() throws Exception {
         final String[] expected = {
             "14: " + getCheckMessage(AbstractJavadocCheck.MSG_JAVADOC_PARSE_RULE_ERROR,
-                        4, "token recognition error at: '@'", "@"),
+                        3, "token recognition error at: '@'", "{@"),
             "19: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/javadoc/JavadocCommentsAstRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/javadoc/JavadocCommentsAstRegressionTest.java
@@ -75,6 +75,12 @@ public class JavadocCommentsAstRegressionTest extends AbstractTreeTestSupport {
     }
 
     @Test
+    public void testDoubleAtAsText() throws Exception {
+        verifyJavadocTree(getPath("ExpectedDoubleAtAsText.txt"),
+                getPath("InputDoubleAtAsText.javadoc"));
+    }
+
+    @Test
     public void testAuthorTag() throws Exception {
         verifyJavadocTree(getBlockTagsPath("ExpectedAuthorTag.txt"),
                 getBlockTagsPath("InputAuthorTags.javadoc"));

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/singlelinejavadoc/InputSingleLineJavadocLexerError.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/singlelinejavadoc/InputSingleLineJavadocLexerError.java
@@ -11,9 +11,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.singlelinejavadoc;
 
 class InputSingleLineJavadocLexerError {
 
-    /** @@{@return} */
+    /** {@@return} */
     void foo() {
-        // violation 2 lines above 'Javadoc comment at column 4 has parse error.'
+        // violation 2 lines above 'Javadoc comment at column 3 has parse error.'
     }
 
     /** @throws Exception if a problem occurs */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/javadoc/ExpectedDoubleAtAsText.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/javadoc/ExpectedDoubleAtAsText.txt
@@ -1,0 +1,7 @@
+JAVADOC_CONTENT -> JAVADOC_CONTENT [0:1]
+|--LEADING_ASTERISK -> * [0:1]
+|--TEXT ->  @@Example [0:2]
+|--NEWLINE -> \n [0:12]
+|--LEADING_ASTERISK -> * [1:1]
+|--TEXT ->    (value="text") [1:2]
+`--NEWLINE -> \n [1:19]

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/javadoc/InputDoubleAtAsText.javadoc
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/javadoc/InputDoubleAtAsText.javadoc
@@ -1,0 +1,2 @@
+* @@Example
+*   (value="text")


### PR DESCRIPTION
closes #20273

```
gianmarco@Gianmarcos-MacBook-Air ~/Documents/Projects/testing-checkstyle % cat Test.java
import java.util.Map;

/** Summary.
 */
public class Test {

  /** Summary.
   */
  public Test() {}

    /**
     * @@org.springframework.jmx.export.metadata.ManagedAttribute
     *   (description="The Age Attribute", currencyTimeLimit=15)
     */
  public void computeClassShortNames() {}

}


gianmarco@Gianmarcos-MacBook-Air ~/Documents/Projects/testing-checkstyle % java -jar ../checkstyle/target/checkstyle-13.6.0-SNAPSHOT-all.jar -J Test.java
COMPILATION_UNIT -> COMPILATION_UNIT [1:1]
|--IMPORT -> import [1:1]
|   |--DOT -> . [1:17]
|   |   |--DOT -> . [1:12]
|   |   |   |--IDENT -> java [1:8]
|   |   |   `--IDENT -> util [1:13]
|   |   `--IDENT -> Map [1:18]
|   `--SEMI -> ; [1:21]
`--CLASS_DEF -> CLASS_DEF [5:1]
    |--MODIFIERS -> MODIFIERS [5:1]
    |   |--BLOCK_COMMENT_BEGIN -> /* [3:1]
    |   |   |--COMMENT_CONTENT -> * Summary.\n  [3:3]
    |   |   |   `--JAVADOC_CONTENT -> JAVADOC_CONTENT [3:4]
    |   |   |       |--TEXT ->  Summary. [3:4]
    |   |   |       |--NEWLINE -> \n [3:13]
    |   |   |       `--TEXT ->   [4:1]
    |   |   `--BLOCK_COMMENT_END -> */ [4:2]
    |   `--LITERAL_PUBLIC -> public [5:1]
    |--LITERAL_CLASS -> class [5:8]
    |--IDENT -> Test [5:14]
    `--OBJBLOCK -> OBJBLOCK [5:19]
        |--LCURLY -> { [5:19]
        |--CTOR_DEF -> CTOR_DEF [9:3]
        |   |--MODIFIERS -> MODIFIERS [9:3]
        |   |   |--BLOCK_COMMENT_BEGIN -> /* [7:3]
        |   |   |   |--COMMENT_CONTENT -> * Summary.\n    [7:5]
        |   |   |   |   `--JAVADOC_CONTENT -> JAVADOC_CONTENT [7:6]
        |   |   |   |       |--TEXT ->  Summary. [7:6]
        |   |   |   |       |--NEWLINE -> \n [7:15]
        |   |   |   |       `--TEXT ->     [8:1]
        |   |   |   `--BLOCK_COMMENT_END -> */ [8:4]
        |   |   `--LITERAL_PUBLIC -> public [9:3]
        |   |--IDENT -> Test [9:10]
        |   |--LPAREN -> ( [9:14]
        |   |--PARAMETERS -> PARAMETERS [9:15]
        |   |--RPAREN -> ) [9:15]
        |   `--SLIST -> { [9:17]
        |       `--RCURLY -> } [9:18]
        |--METHOD_DEF -> METHOD_DEF [15:3]
        |   |--MODIFIERS -> MODIFIERS [15:3]
        |   |   |--BLOCK_COMMENT_BEGIN -> /* [11:5]
        |   |   |   |--COMMENT_CONTENT -> *\n     * @@org.springframework.jmx.export.metadata.ManagedAttribute\n     *   (description="The Age Attribute", currencyTimeLimit=15)\n      [11:7]
        |   |   |   |   `--JAVADOC_CONTENT -> JAVADOC_CONTENT [11:8]
        |   |   |   |       |--NEWLINE -> \n [11:8]
        |   |   |   |       |--LEADING_ASTERISK ->      * [12:1]
        |   |   |   |       |--TEXT ->  @@org.springframework.jmx.export.metadata.ManagedAttribute [12:7]
        |   |   |   |       |--NEWLINE -> \n [12:66]
        |   |   |   |       |--LEADING_ASTERISK ->      * [13:1]
        |   |   |   |       |--TEXT ->    (description="The Age Attribute", currencyTimeLimit=15) [13:7]
        |   |   |   |       |--NEWLINE -> \n [13:65]
        |   |   |   |       `--TEXT ->       [14:1]
        |   |   |   `--BLOCK_COMMENT_END -> */ [14:6]
        |   |   `--LITERAL_PUBLIC -> public [15:3]
        |   |--TYPE -> TYPE [15:10]
        |   |   `--LITERAL_VOID -> void [15:10]
        |   |--IDENT -> computeClassShortNames [15:15]
        |   |--LPAREN -> ( [15:37]
        |   |--PARAMETERS -> PARAMETERS [15:38]
        |   |--RPAREN -> ) [15:38]
        |   `--SLIST -> { [15:40]
        |       `--RCURLY -> } [15:41]
        `--RCURLY -> } [17:1]
```

Diff Regression config: https://gist.githubusercontent.com/gianmarcoschifone/01948aba0e83ee91d240fbddb2a2f054/raw/09963b347561fcf1f499215e996b42935215deb0/parser.xml