### PR TITLE
Issue #20284: XdocsExamplesAstConsistencyTest: enhance code quality a…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -31,6 +31,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -518,7 +520,7 @@ public class XdocsExamplesAstConsistencyTest {
                     .sorted()
                     .forEach(path -> {
                         try {
-                            checkForBlockCommentMarkers(path, violations);
+                            violations.addAll(checkForBlockCommentMarkers(path));
                         }
                         catch (IOException exception) {
                             throw new IllegalStateException(
@@ -532,21 +534,7 @@ public class XdocsExamplesAstConsistencyTest {
             message = "";
         }
         else {
-            final StringBuilder builder = new StringBuilder(1024);
-            builder.append("Found ")
-                    .append(violations.size())
-                    .append(
-                            """
-                             example file(s) using block comments as ok/violation markers.
-                            Convert them to single-line comments, e.g.:
-                              BAD:  /* ok, allowMissingReturnTag is true */
-                              GOOD: // ok, allowMissingReturnTag is true
-
-                            """);
-            for (String violation : violations) {
-                builder.append(violation).append('\n');
-            }
-            message = builder.toString();
+            message = formatBlockCommentMarkerViolationsMessage(violations);
         }
 
         assertWithMessage(message)
@@ -555,49 +543,66 @@ public class XdocsExamplesAstConsistencyTest {
     }
 
     /**
+     * Formats the violation message for block comment markers.
+     *
+     * @param violations the list of violations
+     * @return formatted message
+     */
+    private static String formatBlockCommentMarkerViolationsMessage(List<String> violations) {
+        final StringBuilder builder = new StringBuilder(1024);
+        builder.append("Found ")
+                .append(violations.size())
+                .append(
+                        """
+                         example file(s) using block comments as ok/violation markers.
+                        Convert them to single-line comments, e.g.:
+                          BAD:  /* ok, allowMissingReturnTag is true */
+                          GOOD: // ok, allowMissingReturnTag is true
+
+                        """);
+
+        for (String violation : violations) {
+            builder.append(violation).append('\n');
+        }
+
+        return builder.toString();
+    }
+
+    /**
      * Checks a single example file for block comments used as ok/violation markers.
      *
-     * @param file       the example file to check
-     * @param violations the list to append violation messages to
+     * @param file the example file to check
+     * @return the list of violation messages
      * @throws IOException if an I/O error occurs
      */
-    private static void checkForBlockCommentMarkers(Path file, List<String> violations)
+    private static List<String> checkForBlockCommentMarkers(Path file)
             throws IOException {
-        final List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
-        boolean inBlockComment = false;
-        final StringBuilder commentContent = new StringBuilder(1000);
-        int commentStartLine = -1;
+        final List<String> fileViolations = new ArrayList<>();
+        final String content = Files.readString(file);
+        final Pattern blockCommentPattern = Pattern.compile("(?s)/\\*.*?\\*/");
+        final Matcher matcher = blockCommentPattern.matcher(content);
 
-        for (int index = 0; index < lines.size(); index++) {
-            final String stripped = lines.get(index).strip();
+        while (matcher.find()) {
+            final String block = matcher.group();
+            final String inner = block
+                    .replaceAll("^/\\*+", "")
+                    .replaceAll("\\*/$", "")
+                    .replace("*", "")
+                    .strip();
 
-            if (!inBlockComment && stripped.startsWith("/*")) {
-                inBlockComment = true;
-                commentStartLine = index + 1;
-                commentContent.setLength(0);
-            }
-
-            if (inBlockComment) {
-                commentContent.append(stripped).append(' ');
-
-                if (stripped.contains("*/")) {
-                    inBlockComment = false;
-
-                    final String content = commentContent.toString()
-                            .replaceAll("^/\\*+", "")
-                            .replaceAll("\\*/$", "")
-                            .replace("*", "")
-                            .strip();
-
-                    if (content.startsWith("ok")
-                            || content.startsWith("violation")) {
-                        violations.add(file + ":" + commentStartLine
-                                + " - use single-line comment instead: // "
-                                + content);
+            if (inner.startsWith("ok") || inner.startsWith("violation")) {
+                int lineNo = 1;
+                for (int index = 0; index < matcher.start(); index++) {
+                    if (content.charAt(index) == '\n') {
+                        lineNo++;
                     }
                 }
+                fileViolations.add(file + ":" + lineNo
+                        + " - use single-line comment instead: // "
+                        + inner);
             }
         }
+        return fileViolations;
     }
 
     /**
@@ -1041,6 +1046,8 @@ public class XdocsExamplesAstConsistencyTest {
 
                 if (!comment.startsWith("ok")
                         && !comment.startsWith("violation")
+                        && !comment.contains("// ok")
+                        && !comment.contains("// violation")
                         && !comment.startsWith("xdoc section")) {
                     comments.add(comment);
                 }


### PR DESCRIPTION
#20284 

## PR Improvements to `XdocsExamplesAstConsistencyTest`

This PR introduces several improvements to `XdocsExamplesAstConsistencyTest` to improve maintainability, readability, and the accuracy of comment-based consistency validation across xdoc examples.

### Key Changes

#### 1. Refactored `checkForBlockCommentMarkers` to Return Violations

Previously, `checkForBlockCommentMarkers` mutated a shared `List<String>` passed as an argument. Following review feedback, the method now returns its collected violations directly, and callers aggregate results using `violations.addAll(...)`.

---

#### 2. Extracted Block Comment Violation Message Formatting

The logic for constructing the failure message in `testNoBlockCommentMarkers` has been extracted into a dedicated helper method:

`formatBlockCommentMarkerViolationsMessage(List<String> violations)`

---

#### 3. Improved Detection of Block Comment Markers

The previous implementation only detected block comments that started at the beginning of a line using `startsWith("/*")`.

This missed valid cases such as:

```java
final int VAR1 = 5;  /* violation 'Name ''VAR1'' must match pattern' */
```

The implementation now uses regular-expression based block-comment detection to identify comment markers regardless of their position within a line.

**Benefits:**

* Detects inline block comments.
* Detects multi-line block comments.
* Detects Javadoc-style block comments.
* Provides more reliable enforcement of the rule that `ok` and `violation` markers must use single-line comments.

Examples now correctly detected:

```java
/* violation 'message' */
```

```java
final int VAR1 = 5; /* violation 'message' */
```

```java
/*
 * violation 'message'
 */
```

```java
/**
 * violation 'message'
 */
```

---

#### 4. Enhanced Marker Comment Filtering in `extractComments`

The comment filtering logic has been enhanced to better recognize documentation marker comments.

Previously, only comments beginning directly with:

```java
// ok
```

or

```java
// violation
```

were excluded from comparison.

The implementation now also ignores comments containing documentation markers later in the comment text, for example:

```java
// ✅ Enhancement completed // violation 'Illegal symbol detected'
```

```java
// 😀 Happy coding // violation 'Illegal symbol detected'
```

This prevents false-positive comment mismatches in examples where explanatory text is combined with a Checkstyle violation marker.
