### PR TITLE
Issue #19148: update MissingJavadocMethodCheck to use AST of javadoc

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -6369,20 +6369,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java</fileName>
-    <specifier>not.interned</specifier>
-    <message>attempting to use a non-@Interned comparison operand</message>
-    <lineContent>if (lcurly.getFirstChild() == rcurly) {</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java</fileName>
-    <specifier>not.interned</specifier>
-    <message>attempting to use a non-@Interned comparison operand</message>
-    <lineContent>if (lcurly.getFirstChild() == rcurly) {</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field excludeScope</message>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -135,8 +135,6 @@
   <suppress id="noUsageOfGetFileContentsMethod" files="JavadocTypeCheck.java"/>
   <!-- until #19147 -->
   <suppress id="noUsageOfGetFileContentsMethod" files="JavadocVariableCheck.java"/>
-  <!-- until #19148 -->
-  <suppress id="noUsageOfGetFileContentsMethod" files="MissingJavadocMethodCheck.java"/>
   <!-- permanent suppression to allow regexp on content of the line -->
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpCheck.java"/>
   <suppress id="noUsageOfGetFileContentsMethod" files="RegexpSinglelineJavaCheck.java"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
@@ -26,12 +26,11 @@ import java.util.regex.Pattern;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.Scope;
-import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 
 /**
@@ -198,16 +197,17 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
         };
     }
 
-    // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/19148
     @Override
-    @SuppressWarnings("deprecation")
+    public boolean isCommentNodesRequired() {
+        return true;
+    }
+
+    @Override
     public final void visitToken(DetailAST ast) {
         final Scope theScope = ScopeUtil.getScope(ast);
         if (shouldCheck(ast, theScope)) {
-            final FileContents contents = getFileContents();
-            final TextBlock textBlock = contents.getJavadocBefore(ast.getLineNo());
-
-            if (textBlock == null && !isMissingJavadocAllowed(ast)) {
+            final DetailAST blockCommentNode = JavadocUtil.getAttachedJavadocComment(ast);
+            if (blockCommentNode == null && !isMissingJavadocAllowed(ast)) {
                 log(ast, MSG_JAVADOC_MISSING);
             }
         }
@@ -220,16 +220,13 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
      * @return Some javadoc.
      */
     private static int getMethodsNumberOfLine(DetailAST methodDef) {
-        final int numberOfLines;
+        int numberOfLines = 1;
         final DetailAST lcurly = methodDef.getLastChild();
         final DetailAST rcurly = lcurly.getLastChild();
-
-        if (lcurly.getFirstChild() == rcurly) {
-            numberOfLines = 1;
-        }
-        else {
+        if (rcurly != null && lcurly.getLineNo() != rcurly.getLineNo()) {
             numberOfLines = rcurly.getLineNo() - lcurly.getLineNo() - 1;
         }
+
         return numberOfLines;
     }
 
@@ -311,7 +308,7 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
         // is allowed in a proper getter method which does not throw any
         // exceptions.
         if (ast.getType() == TokenTypes.METHOD_DEF
-                && ast.getChildCount() == SETTER_GETTER_MAX_CHILDREN) {
+                && getChildCount(ast) == SETTER_GETTER_MAX_CHILDREN) {
             final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
             final String name = type.getNextSibling().getText();
             final boolean matchesGetterFormat = GETTER_PATTERN.matcher(name).matches();
@@ -326,7 +323,10 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
                 final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
 
                 if (slist != null) {
-                    final DetailAST expr = slist.getFirstChild();
+                    DetailAST expr = slist.getFirstChild();
+                    while (expr.getType() == TokenTypes.SINGLE_LINE_COMMENT) {
+                        expr = expr.getNextSibling();
+                    }
                     getterMethod = expr.getType() == TokenTypes.LITERAL_RETURN;
                 }
             }
@@ -347,7 +347,7 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
         // is allowed in a proper setter method which does not throw any
         // exceptions.
         if (ast.getType() == TokenTypes.METHOD_DEF
-                && ast.getChildCount() == SETTER_GETTER_MAX_CHILDREN) {
+                && getChildCount(ast) == SETTER_GETTER_MAX_CHILDREN) {
             final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
             final String name = type.getNextSibling().getText();
             final boolean matchesSetterFormat = SETTER_PATTERN.matcher(name).matches();
@@ -362,12 +362,31 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
                 // RCURLY
                 final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
 
-                if (slist != null && slist.getChildCount() == SETTER_BODY_SIZE) {
+                if (slist != null && getChildCount(slist) == SETTER_BODY_SIZE) {
                     final DetailAST expr = slist.getFirstChild();
                     setterMethod = expr.getFirstChild().getType() == TokenTypes.ASSIGN;
                 }
             }
         }
         return setterMethod;
+    }
+
+    /**
+     * Returns the number of children without counting comments.
+     *
+     * @param detailAst parent ast
+     * @return the number of children
+     */
+    private static int getChildCount(DetailAST detailAst) {
+        int childCount = 0;
+        DetailAST child = detailAst.getFirstChild();
+
+        while (child != null) {
+            if (child.getType() != TokenTypes.SINGLE_LINE_COMMENT) {
+                childCount += 1;
+            }
+            child = child.getNextSibling();
+        }
+        return childCount;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -79,6 +79,7 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
     public void newTest() throws Exception {
         final String[] expected = {
             "70:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "82:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodSmallMethods.java"), expected);
@@ -437,6 +438,8 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
             "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "29:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "31:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "34:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodJavadocInMethod.java"), expected);
@@ -446,6 +449,7 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
     public void testConstructor() throws Exception {
         final String[] expected = {
             "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodConstructor.java"), expected);
@@ -582,5 +586,20 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodAboveComments.java"),
                 expected);
+    }
+
+    @Test
+    public void testNewCasesAfterAstMigration() throws Exception {
+        final String[] expected = {
+            "27:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "31:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "35:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "47:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "68:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "71:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMissingJavadocMethodNewCasesAfterAstMigration.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodConstructor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodConstructor.java
@@ -19,6 +19,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
 public class InputMissingJavadocMethodConstructor {
     private int field;
     public InputMissingJavadocMethodConstructor() {} // violation 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
     public InputMissingJavadocMethodConstructor(Runnable p1) { this.field = 0; }
     /** */
     public InputMissingJavadocMethodConstructor(String p1) { this.field = 0; }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodJavadocInMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodJavadocInMethod.java
@@ -28,10 +28,10 @@ public class InputMissingJavadocMethodJavadocInMethod {
 
     public void foo4() { /** */ } // violation 'Missing a Javadoc comment.'
 
-    @Deprecated
+    @Deprecated // violation 'Missing a Javadoc comment.'
     public void foo5() { /** */ }
 
-    @Deprecated
+    @Deprecated // violation 'Missing a Javadoc comment.'
     /** */
     public void foo6() { /** */ }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNewCasesAfterAstMigration.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodNewCasesAfterAstMigration.java
@@ -1,0 +1,72 @@
+/*
+MissingJavadocMethod
+minLineCount = (default)-1
+allowedAnnotations = (default)Override
+scope = private
+excludeScope = (default)null
+allowMissingPropertyJavadoc = (default)false
+ignoreMethodNamesRegex = (default)null
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
+
+public class InputMissingJavadocMethodNewCasesAfterAstMigration {
+
+    /**
+     * Some javadoc.
+     *
+     * @return some value.
+     */ final String hasJavadocWithClosingTagOnMethodLine() {
+        return "value";
+    }
+
+    // violation below 'Missing a Javadoc comment.'
+    @Test
+    public void annotatedSingleLineMethod() { }
+
+    // violation below 'Missing a Javadoc comment.'
+    @Benchmark
+    public Object annotatedBenchmarkMethod() { return new Object(); }
+
+    // violation below 'Missing a Javadoc comment.'
+    @AnnotationWithValue(Level.Invocation)
+    public void annotatedMethodWithAnnotationValue() { }
+
+    private static class Nested {
+        private static int map(int v) { return v + 1; } // violation 'Missing a Javadoc comment.'
+    }
+
+    private enum Includes {
+        VALUE("value");
+
+        private final String value;
+
+        Includes(String value) { this.value = value; } // violation 'Missing a Javadoc comment.'
+    }
+}
+
+@interface Test {
+}
+
+@interface Benchmark {
+}
+
+@interface AnnotationWithValue {
+    /** Some javadoc. */
+    Level value();
+}
+
+enum Level {
+    Invocation
+}
+
+interface DiffReportInterfaceRegression {
+    // violation below 'Missing a Javadoc comment.'
+    @SuppressWarnings("unchecked")
+    static Object oneLineStaticMethod(Object value) { return value; }
+
+    default Object get() { return new Object(); } // violation 'Missing a Javadoc comment.'
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSetterGetter4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSetterGetter4.java
@@ -30,4 +30,18 @@ public class InputMissingJavadocMethodSetterGetter4 {
     {
         return 666;
     }
+
+    public Object getObject1() { // comment
+        return null;
+    }
+
+    public int getNumber() {
+        return 1;
+    }
+
+    public int getNumberTwo() // comment
+    {
+        return 2;
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSmallMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodSmallMethods.java
@@ -79,7 +79,7 @@ public class InputMissingJavadocMethodSmallMethods extends Some
         foo2();
     }
 
-    void foo9() {
+    void foo9() { // violation 'Missing a Javadoc comment.'
 
 
 


### PR DESCRIPTION
closes #19148

It is not necessary to extend AbstractJavadocCheck in this case.
The following override is enough:

```java
@Override
public boolean isCommentNodesRequired() {
        return true;
}
```
