### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - parametername

### DIFF
--- a/src/site/xdoc/checks/naming/parametername.xml
+++ b/src/site/xdoc/checks/naming/parametername.xml
@@ -77,39 +77,15 @@
         <p id="Example1-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
+  void method0(int v) {}
   void method1(int v1) {}
-  void method2(int V2) {} // violation 'Name 'V2' must match pattern'
-  @Override
-  public boolean equals(Object v3) {
-    return true;
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example2-config">
-          An example of how to configure the check for names that begin with a lower case letter,
-          followed by letters, digits, and underscores:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="ParameterName"&gt;
-      &lt;property name="format" value="^[a-z][_a-zA-Z0-9]+$"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example2-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example2 {
-  void method1(int v1) {}
-  void method2(int v_2) {}
+  void method2(int V2) {}            // violation 'Name 'V2' must match pattern'
   @Override
   public boolean equals(Object V3) { // violation 'Name 'V3' must match pattern'
     return true;
   }
 }
 </code></pre></div><hr class="example-separator"/>
-
         <p id="Example3-config">
             An example of how to configure the check to skip methods with Override annotation from
             validation:
@@ -126,6 +102,7 @@ class Example2 {
         <p id="Example3-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 {
+  void method0(int v) {}
   void method1(int v1) {}
   void method2(int V2) {} // violation 'Name 'V2' must match pattern'
   @Override
@@ -150,8 +127,9 @@ class Example3 {
         <p id="Example4-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example4 {
+  void method0(int v) {}             // violation 'Name 'v' must match pattern'
   void method1(int v1) {}
-  void method2(int v_2) {} // violation 'Name 'v_2' must match pattern'
+  void method2(int V2) {}            // violation 'Name 'V2' must match pattern'
   @Override
   public boolean equals(Object V3) { // violation 'Name 'V3' must match pattern'
     return true;
@@ -184,10 +162,38 @@ class Example4 {
         <p id="Example5-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example5 {
-  void fn1(int v1) {}
-  protected void fn2(int V2) {} // violation "Parameter name 'V2' must match pattern"
-  private void fn3(int a) {}
-  public void fn4(int b) {} // violation "Parameter name 'b' must match pattern"
+  void method0(int v) {}
+  void method1(int v1) {}
+  void method2(int V2) {}
+  @Override              // violation above "Parameter name 'V2' must match pattern"
+  public boolean equals(Object V3) {
+    return true;         // violation above "Parameter name 'V3' must match pattern"
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example2-config">
+          An example of how to configure the check for names that begin with a lower case letter,
+          followed by letters, digits, and underscores:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ParameterName"&gt;
+      &lt;property name="format" value="^[a-z][_a-zA-Z0-9]+$"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example2-code">Code Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example2 {
+  void method0(int v) {}             // violation 'Name 'v' must match pattern'
+  void method1(int v1) {}
+  void method2(int V2) {}            // violation 'Name 'V2' must match pattern'
+  @Override
+  public boolean equals(Object V3) { // violation 'Name 'V3' must match pattern'
+    return true;
+  }
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/naming/parametername.xml.template
+++ b/src/site/xdoc/checks/naming/parametername.xml.template
@@ -42,22 +42,6 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example1.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example2-config">
-          An example of how to configure the check for names that begin with a lower case letter,
-          followed by letters, digits, and underscores:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example2.java"/>
-          <param name="type" value="config"/>
-        </macro>
-        <p id="Example2-code">Code Example:</p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example2.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-
         <p id="Example3-config">
             An example of how to configure the check to skip methods with Override annotation from
             validation:
@@ -102,6 +86,21 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example5.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example2-config">
+          An example of how to configure the check for names that begin with a lower case letter,
+          followed by letters, digits, and underscores:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code">Code Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example2.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -151,7 +151,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
             "checks/metrics/npathcomplexity/Example2",
             "checks/naming/lambdaparametername/Example2",
-            "checks/naming/parametername/Example5",
             "checks/naming/patternvariablename/Example4",
             "checks/naming/typename/Example2",
             "checks/naming/typename/Example3",
@@ -292,9 +291,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/naming/catchparametername/Example2",
             "checks/naming/methodname/Example4",
             "checks/naming/packagename/Example2",
-            "checks/naming/parametername/Example2",
-            "checks/naming/parametername/Example3",
-            "checks/naming/parametername/Example4",
             "checks/naming/patternvariablename/Example2",
             "checks/naming/patternvariablename/Example3",
             "checks/newlineatendoffile/Example3",
@@ -432,6 +428,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/naming/localfinalvariablename/Example2",
             "checks/blocks/emptycatchblock/Example4",
             "checks/blocks/emptycatchblock/Example5",
+            "checks/naming/parametername/Example4",
             "checks/coding/illegalsymbol/Example3",
             "checks/coding/illegalsymbol/Example5"
             );

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckExamplesTest.java
@@ -34,7 +34,8 @@ public class ParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "14:20: " + getCheckMessage(MSG_INVALID_PATTERN, "V2", "^[a-z][a-zA-Z0-9]*$"),
+            "15:20: " + getCheckMessage(MSG_INVALID_PATTERN, "V2", "^[a-z][a-zA-Z0-9]*$"),
+            "17:32: " + getCheckMessage(MSG_INVALID_PATTERN, "V3", "^[a-z][a-zA-Z0-9]*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -43,7 +44,9 @@ public class ParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "18:32: " + getCheckMessage(MSG_INVALID_PATTERN, "V3", "^[a-z][_a-zA-Z0-9]+$"),
+            "15:20: " + getCheckMessage(MSG_INVALID_PATTERN, "v", "^[a-z][_a-zA-Z0-9]+$"),
+            "17:20: " + getCheckMessage(MSG_INVALID_PATTERN, "V2", "^[a-z][_a-zA-Z0-9]+$"),
+            "19:32: " + getCheckMessage(MSG_INVALID_PATTERN, "V3", "^[a-z][_a-zA-Z0-9]+$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -52,7 +55,7 @@ public class ParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "16:20: " + getCheckMessage(MSG_INVALID_PATTERN, "V2", "^[a-z][a-zA-Z0-9]*$"),
+            "17:20: " + getCheckMessage(MSG_INVALID_PATTERN, "V2", "^[a-z][a-zA-Z0-9]*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -61,8 +64,9 @@ public class ParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "16:20: " + getCheckMessage(MSG_INVALID_PATTERN, "v_2", "^[a-z][a-zA-Z0-9]+$"),
-            "18:32: " + getCheckMessage(MSG_INVALID_PATTERN, "V3", "^[a-z][a-zA-Z0-9]+$"),
+            "15:20: " + getCheckMessage(MSG_INVALID_PATTERN, "v", "^[a-z][a-zA-Z0-9]+$"),
+            "17:20: " + getCheckMessage(MSG_INVALID_PATTERN, "V2", "^[a-z][a-zA-Z0-9]+$"),
+            "19:32: " + getCheckMessage(MSG_INVALID_PATTERN, "V3", "^[a-z][a-zA-Z0-9]+$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
@@ -71,8 +75,10 @@ public class ParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "25:26: " + "Parameter name 'V2' must match pattern '^[a-z]([a-z0-9][a-zA-Z0-9]*)?$'",
-            "27:23: " + "Parameter name 'b' must match pattern '^[a-z][a-z0-9][a-zA-Z0-9]*$'",
+            "26:20: Parameter name 'V2' must match pattern "
+                + "'^[a-z]([a-z0-9][a-zA-Z0-9]*)?$'",
+            "28:32: Parameter name 'V3' must match pattern "
+                + "'^[a-z][a-z0-9][a-zA-Z0-9]*$'",
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example1.java
@@ -10,10 +10,11 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 
 // xdoc section -- start
 class Example1 {
+  void method0(int v) {}
   void method1(int v1) {}
-  void method2(int V2) {} // violation 'Name 'V2' must match pattern'
+  void method2(int V2) {}            // violation 'Name 'V2' must match pattern'
   @Override
-  public boolean equals(Object v3) {
+  public boolean equals(Object V3) { // violation 'Name 'V3' must match pattern'
     return true;
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example2.java
@@ -12,8 +12,9 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 
 // xdoc section -- start
 class Example2 {
+  void method0(int v) {}             // violation 'Name 'v' must match pattern'
   void method1(int v1) {}
-  void method2(int v_2) {}
+  void method2(int V2) {}            // violation 'Name 'V2' must match pattern'
   @Override
   public boolean equals(Object V3) { // violation 'Name 'V3' must match pattern'
     return true;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example3.java
@@ -12,6 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 
 // xdoc section -- start
 class Example3 {
+  void method0(int v) {}
   void method1(int v1) {}
   void method2(int V2) {} // violation 'Name 'V2' must match pattern'
   @Override

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example4.java
@@ -12,8 +12,9 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 
 // xdoc section -- start
 class Example4 {
+  void method0(int v) {}             // violation 'Name 'v' must match pattern'
   void method1(int v1) {}
-  void method2(int v_2) {} // violation 'Name 'v_2' must match pattern'
+  void method2(int V2) {}            // violation 'Name 'V2' must match pattern'
   @Override
   public boolean equals(Object V3) { // violation 'Name 'V3' must match pattern'
     return true;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/Example5.java
@@ -21,9 +21,12 @@ package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
 
 // xdoc section -- start
 class Example5 {
-  void fn1(int v1) {}
-  protected void fn2(int V2) {} // violation "Parameter name 'V2' must match pattern"
-  private void fn3(int a) {}
-  public void fn4(int b) {} // violation "Parameter name 'b' must match pattern"
+  void method0(int v) {}
+  void method1(int v1) {}
+  void method2(int V2) {}
+  @Override              // violation above "Parameter name 'V2' must match pattern"
+  public boolean equals(Object V3) {
+    return true;         // violation above "Parameter name 'V3' must match pattern"
+  }
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

Example1 | Default configuration
Example2 | format="^[a-z][_a-zA-Z0-9]+$" 
Example3 | ignoreOverridden="true" 
Example4 | format="^[a-z][a-zA-Z0-9]+$"
Example5 | accessModifiers and custom message configuration 

Section1 -> 1,3,4,5
UseCase -> 2