### PR TITLE
Issue #20093: Add checks for redundant paranthesis

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1201,6 +1201,7 @@ ruleliterals
 rulemethodnames
 rulepackagedeclaration
 rulepackagenames
+ruleredundantparenthesis
 ruleset
 rulesetfiles
 rulespecialcharacters

--- a/src/it/java/com/openjdk/checkstyle/test/chapterformatting/ruleredundantparenthesis/RedundantParenForReturnTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapterformatting/ruleredundantparenthesis/RedundantParenForReturnTest.java
@@ -1,0 +1,39 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapterformatting.ruleredundantparenthesis;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class RedundantParenForReturnTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapterformatting/"
+            + "ruleredundantparenthesis";
+    }
+
+    @Test
+    public void testForReturn() throws Exception {
+        verifyWithWholeConfig(getPath("InputRedundantParenForReturn.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleredundantparenthesis/InputRedundantParenForReturn.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleredundantparenthesis/InputRedundantParenForReturn.java
@@ -1,0 +1,31 @@
+package com.openjdk.checkstyle.test.chapterformatting.ruleredundantparenthesis;
+
+import java.util.List;
+
+/**
+ * Test input for the redundant parenthesis rule for return statement.
+ */
+public final class InputRedundantParenForReturn {
+
+    public int test() {
+        String val = "1";
+        return (val.equals("1") ? 1 : 0); // violation, 'Unnecessary parentheses*'
+    }
+
+    public List<Integer> test1(List<Integer> list) {
+
+        return (list  // violation, 'Unnecessary parentheses*'
+                .stream()
+                .filter(num -> num % 2 == 0)
+                .toList());
+    }
+
+    public int test2() {
+        return ((10 * 4) + 5); // violation, 'Unnecessary parentheses*'
+    }
+
+    public int test3() {
+        return 1 + 2;
+    }
+
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -104,6 +104,13 @@
     </module>
 
     <module name="UnusedImports"/>
+    <module name="MatchXpath">
+      <property name="id" value="unnecessaryParenthesesInReturn"/>
+      <property name="query"
+                value="//LITERAL_RETURN/EXPR[./LPAREN and ./RPAREN
+                       and not(./LPAREN/preceding-sibling::*)]"/>
+      <message key="matchxpath.match" value="Unnecessary parentheses in return statement."/>
+    </module>
 
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
     <module name="SuppressionXpathFilter">

--- a/src/site/xdoc/checks/coding/matchxpath.xml
+++ b/src/site/xdoc/checks/coding/matchxpath.xml
@@ -267,6 +267,10 @@ public class Example6 {
       <subsection name="Example of Usage" id="MatchXpath_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
+              OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
               Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/coding/matchxpath.xml.template
+++ b/src/site/xdoc/checks/coding/matchxpath.xml.template
@@ -166,6 +166,10 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
       <subsection name="Example of Usage" id="MatchXpath_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
+              OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
               Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -701,8 +701,28 @@
                     Redundant Parentheses
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/coding/matchxpath.html#MatchXpath">
+                    MatchXpath</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ban_red.png" alt="" />
+                  </span>
+                  Note: Automated enforcement of this rule is not supported, as determining
+                  whether redundant parentheses improve code readability requires human context
+                  and subjective judgment.
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleredundantparenthesis">
+                    samples
+                  </a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
Issue: #20093 


Added MatchXPath module to complete the coverage for Redundant Paranthesis section of style guide.