### PR TITLE
minor: escape file name in generated suppression files

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListener.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListener.java
@@ -190,7 +190,7 @@ public final class ChecksAndFilesSuppressionFileGeneratorAuditListener
     private void suppressXmlWriter(Path fileName, String checkName, String moduleIdName) {
         writer.println("  <suppress");
         writer.print("      files=\"");
-        writer.print(fileName);
+        writer.print(XMLLogger.encode(fileName.toString()));
         writer.println(QUOTE_CHAR);
 
         if (moduleIdName == null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListener.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListener.java
@@ -105,7 +105,7 @@ public final class XpathFileGeneratorAuditListener
 
             writer.println("  <suppress-xpath");
             writer.print("       files=\"");
-            writer.print(path.getFileName());
+            writer.print(XMLLogger.encode(String.valueOf(path.getFileName())));
             writer.println(QUOTE_CHAR);
 
             if (event.getModuleId() == null) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ChecksAndFilesSuppressionFileGeneratorAuditListenerTest.java
@@ -221,6 +221,23 @@ public class ChecksAndFilesSuppressionFileGeneratorAuditListenerTest {
     }
 
     @Test
+    public void testFileNameWithXmlSpecialCharacter() {
+        final AuditEvent event = createAuditEvent(
+                "Input&SuppressionFileGenerator.java", FIRST_MESSAGE);
+
+        final String expected = SUPPRESSION_XML_HEADER
+                + "<suppressions>" + EOL
+                + "  <suppress" + EOL
+                + "      files=\"Input&amp;SuppressionFileGenerator.java\""
+                + EOL
+                + "      checks=\"LeftCurlyCheck\""
+                + "/>" + EOL
+                + "</suppressions>" + EOL;
+
+        verifyOutput(expected, event);
+    }
+
+    @Test
     public void testFileNameNullCase() {
         final AuditEvent event1 = new AuditEvent(this, "/", FIRST_MESSAGE);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
@@ -242,6 +242,30 @@ public class XpathFileGeneratorAuditListenerTest {
     }
 
     @Test
+    public void testFileNameWithXmlSpecialCharacter() {
+        final AuditEvent event = createAuditEvent("Input&XpathFileGenerator.java",
+                FIRST_MESSAGE);
+
+        final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + EOL
+                + "<!DOCTYPE suppressions PUBLIC" + EOL
+                + "    \"-//Checkstyle//DTD SuppressionXpathFilter Configuration 1.2"
+                + "//EN\"" + EOL
+                + "    \"https://checkstyle.org/dtds/suppressions_1_2_xpath.dtd\">"
+                + EOL
+                + "<suppressions>" + EOL
+                + "  <suppress-xpath" + EOL
+                + "       files=\"Input&amp;XpathFileGenerator.java\"" + EOL
+                + "       checks=\"LeftCurlyCheck\""
+                + EOL
+                + "       query=\"/COMPILATION_UNIT/CLASS_DEF[./IDENT"
+                + "[@text='InputXpathFileGeneratorAuditListener']]"
+                + "/OBJBLOCK/LCURLY\"/>" + EOL
+                + "</suppressions>" + EOL;
+
+        verifyOutput(expected, event);
+    }
+
+    @Test
     public void testCloseStream() {
         final XpathFileGeneratorAuditListener listener =
                 new XpathFileGeneratorAuditListener(outStream, OutputStreamOptions.CLOSE);


### PR DESCRIPTION
Hit this while running the generator mode (`-g` / `-G`) over a tree whose
file names came from an untrusted contributor. Pointed an XML parser at the
generated suppressions file:

    [Fatal Error] :1:30: The reference to entity "Bar" must end with
    the ';' delimiter.
        files="Foo&Bar.java"

`event.getFileName()` is taken from the scanned tree and printed straight
into the `files="..."` attribute. A name holding `&`, `<`, `>` or a double
quote (all legal on POSIX) breaks the file. A name like `a" checks=".*`
closes the attribute early and drops in an extra `suppress` element, so a
later run quietly suppresses more than intended.

Both classes are XML writers and `XMLLogger.encode` already does this
escaping for the XML report, so I routed the name through it. `checks` /
`id` come from the configuration and the xpath query is escaped already, so
only the name needed touching.

Found by walking the two `*FileGenerator*AuditListener` writers and feeding
each one a name with an ampersand.