### PR TITLE
Issue #18435: Align TypecastParenPad xdoc example AST

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -163,7 +163,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/whitespace/separatorwrap/Example2",
             "checks/whitespace/separatorwrap/Example3",
             "checks/whitespace/singlespaceseparator/Example2",
-            "checks/whitespace/typecastparenpad/Example2",
+            
             "checks/whitespace/whitespaceafter/Example2",
             "filters/suppressionsinglefilter/Example2",
             "filters/suppressionsinglefilter/Example3",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -163,7 +163,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/whitespace/separatorwrap/Example2",
             "checks/whitespace/separatorwrap/Example3",
             "checks/whitespace/singlespaceseparator/Example2",
-            
             "checks/whitespace/whitespaceafter/Example2",
             "filters/suppressionsinglefilter/Example2",
             "filters/suppressionsinglefilter/Example3",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example2.java
@@ -14,16 +14,16 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.typecastparenpad;
 
 // xdoc section -- start
 class Example2 {
-  double d1 = 3.14;
+  float f1 = 3.14f;
 
-  int n = ( int ) d1;
+  int n = ( int ) f1;
 
-  int m = (int ) d1; // violation 'not followed by whitespace'
+  double d = 1.234567;
 
-  double d2 = 9.8;
+  float f2 = (float ) d; // violation 'not followed by whitespace'
 
-  int x = (int) d2; // 2 violations
+  float f3 = (float) d; // 2 violations
 
-  int y = ( int) d2; // violation 'not preceded with whitespace'
+  float f4 = ( float) d; // violation 'not preceded with whitespace'
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue #18435

Aligns the TypecastParenPad Example2 xdoc section with Example1 so the examples share the same AST structure while still documenting the `option=space` behavior.

Also removes the corresponding entry from `SUPPRESSED_EXAMPLES`.
