### PR TITLE
Issue #20267: Fix ModifiedControlVariable NPE on compact source files

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -126,6 +126,7 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
     public int[] getRequiredTokens() {
         return new int[] {
             TokenTypes.OBJBLOCK,
+            TokenTypes.COMPACT_COMPILATION_UNIT,
             TokenTypes.LITERAL_FOR,
             TokenTypes.FOR_ITERATOR,
             TokenTypes.FOR_EACH_CLAUSE,
@@ -162,7 +163,8 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         switch (ast.getType()) {
-            case TokenTypes.OBJBLOCK -> enterBlock();
+            case TokenTypes.OBJBLOCK,
+                 TokenTypes.COMPACT_COMPILATION_UNIT -> enterBlock();
             case TokenTypes.LITERAL_FOR,
                  TokenTypes.FOR_ITERATOR,
                  TokenTypes.FOR_EACH_CLAUSE -> {
@@ -200,7 +202,8 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
                 }
             }
             case TokenTypes.LITERAL_FOR -> leaveForDef(ast);
-            case TokenTypes.OBJBLOCK -> exitBlock();
+            case TokenTypes.OBJBLOCK,
+                 TokenTypes.COMPACT_COMPILATION_UNIT -> exitBlock();
             case TokenTypes.ASSIGN,
                  TokenTypes.PLUS_ASSIGN,
                  TokenTypes.MINUS_ASSIGN,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckTest.java
@@ -172,6 +172,32 @@ public class ModifiedControlVariableCheckTest
                 expected);
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "11:10: " + getCheckMessage(MSG_KEY, "i"),
+            "19:11: " + getCheckMessage(MSG_KEY, "k"),
+            "24:14: " + getCheckMessage(MSG_KEY, "a"),
+            "31:10: " + getCheckMessage(MSG_KEY, "i"),
+            "36:14: " + getCheckMessage(MSG_KEY, "item"),
+            "43:14: " + getCheckMessage(MSG_KEY, "i"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputModifiedControlVariableCompactSourceFile.java"),
+                expected);
+    }
+
+    @Test
+    public void testCompactSourceFileSkipEnhancedForLoop() throws Exception {
+        final String[] expected = {
+            "16:10: " + getCheckMessage(MSG_KEY, "i"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                    "InputModifiedControlVariableCompactSourceFileSkipEnhancedForLoop.java"),
+                expected);
+    }
+
     /**
      * We cannot reproduce situation when visitToken is called and leaveToken is not.
      * So, we have to use reflection to be sure that even in such situation

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableCompactSourceFile.java
@@ -1,0 +1,46 @@
+/*
+ModifiedControlVariable
+skipEnhancedForLoopVariable = (default)false
+
+
+*/
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+    for (int i = 0; i < 10; i++) {
+        i++; // violation, 'Control variable 'i' is modified'
+    }
+
+    for (int j = 0; j < 10; j++) {
+        System.out.println(j);
+    }
+
+    for (int k = 0; k < 10; k++) {
+        k += 2; // violation, 'Control variable 'k' is modified'
+    }
+
+    for (int a = 0; a < 10; a++) {
+        for (int b = 0; b < 10; b++) {
+            a++; // violation, 'Control variable 'a' is modified'
+        }
+    }
+}
+
+void second() {
+    for (int i = 0; i < 5; i++) {
+        i--; // violation, 'Control variable 'i' is modified'
+    }
+
+    String[] items = {"x", "y"};
+    for (String item : items) {
+        item = "z"; // violation, 'Control variable 'item' is modified'
+    }
+}
+
+class Inner {
+    void m() {
+        for (int i = 0; i < 3; i++) {
+            i++; // violation, 'Control variable 'i' is modified'
+        }
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableCompactSourceFileSkipEnhancedForLoop.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableCompactSourceFileSkipEnhancedForLoop.java
@@ -1,0 +1,18 @@
+/*
+ModifiedControlVariable
+skipEnhancedForLoopVariable = true
+
+
+*/
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+    String[] items = {"x", "y"};
+    for (String item : items) {
+        item = "z"; // ok, enhanced for-loop variable is skipped
+    }
+
+    for (int i = 0; i < 5; i++) {
+        i++; // violation, 'Control variable 'i' is modified'
+    }
+}


### PR DESCRIPTION
Fixes #20267

`ModifiedControlVariable` crashed with a `NullPointerException` on JEP 512 compact source files.

The check pushes a variable scope only on `OBJBLOCK` (a class body). In a compact source file, top-level methods hang directly off `COMPACT_COMPILATION_UNIT` with no `OBJBLOCK`, so the scope stack stayed empty and `getCurrentVariables()` returned `null` in `checkIdent`.

Fix: treat `COMPACT_COMPILATION_UNIT` as a block scope, the same as `OBJBLOCK`. The control variable is now tracked, so the modification is correctly flagged instead of throwing, matching the behavior for the equivalent loop inside an ordinary class.

