### PR TITLE
Issue #19973: Fix FinalLocalVariable NullPointerException on compact …

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -142,6 +142,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
             TokenTypes.METHOD_DEF,
             TokenTypes.SLIST,
             TokenTypes.OBJBLOCK,
+            TokenTypes.COMPACT_COMPILATION_UNIT,
             TokenTypes.LITERAL_BREAK,
             TokenTypes.LITERAL_FOR,
             TokenTypes.EXPR,
@@ -156,6 +157,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
             TokenTypes.METHOD_DEF,
             TokenTypes.SLIST,
             TokenTypes.OBJBLOCK,
+            TokenTypes.COMPACT_COMPILATION_UNIT,
             TokenTypes.LITERAL_BREAK,
             TokenTypes.LITERAL_FOR,
             TokenTypes.VARIABLE_DEF,
@@ -171,6 +173,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
             TokenTypes.METHOD_DEF,
             TokenTypes.SLIST,
             TokenTypes.OBJBLOCK,
+            TokenTypes.COMPACT_COMPILATION_UNIT,
             TokenTypes.LITERAL_BREAK,
             TokenTypes.LITERAL_FOR,
             TokenTypes.VARIABLE_DEF,
@@ -184,8 +187,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         switch (ast.getType()) {
-            case TokenTypes.OBJBLOCK, TokenTypes.METHOD_DEF,
-                 TokenTypes.CTOR_DEF, TokenTypes.LITERAL_FOR ->
+            case TokenTypes.COMPACT_COMPILATION_UNIT, TokenTypes.OBJBLOCK,
+                 TokenTypes.METHOD_DEF, TokenTypes.CTOR_DEF, TokenTypes.LITERAL_FOR ->
                 scopeStack.push(new ScopeData());
 
             case TokenTypes.SLIST -> {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -462,4 +462,16 @@ public class FinalLocalVariableCheckTest
             getPath("InputFinalLocalVariableInterface.java"),
             expected);
     }
+
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "18:9: " + getCheckMessage(MSG_KEY, "lambdaLocal"),
+            "24:13: " + getCheckMessage(MSG_KEY, "branchLocal"),
+            "31:9: " + getCheckMessage(MSG_KEY, "local"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputFinalLocalVariableCompactSourceFile.java"),
+            expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCompactSourceFile.java
@@ -1,0 +1,36 @@
+/*
+FinalLocalVariable
+validateEnhancedForLoopVariable = (default)false
+validateUnnamedVariables = (default)false
+tokens = (default)VARIABLE_DEF
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+import java.util.function.Supplier;
+
+int field = 1;
+
+final int constField = 2;
+
+Supplier<Integer> supplier = () -> {
+    int lambdaLocal = 5; // violation, 'Variable 'lambdaLocal' should be declared final'
+    return lambdaLocal;
+};
+
+int categorized = switch (field) {
+    case 1 -> {
+        int branchLocal = 10; // violation, 'Variable 'branchLocal' should be declared final'
+        yield branchLocal;
+    }
+    default -> 0;
+};
+
+void main() {
+    int local = 2; // violation, 'Variable 'local' should be declared final'
+    int reassigned = 0;
+    reassigned = 9;
+    System.out.println(field + constField + local + categorized + reassigned);
+    supplier.get();
+}


### PR DESCRIPTION
Fixes #19973. FinalLocalVariableCheck threw a NullPointerException on JEP 512 compact source files with top-level members. The check pushes a scope when entering a class body (OBJBLOCK), method, etc., but a compact file's implicit class has no OBJBLOCK, so no scope was pushed at the top level and scopeStack was empty there. Any top-level member then dereferenced scopeStack.peek() and crashed.

The fix treats the implicit class like a normal class body: register COMPACT_COMPILATION_UNIT and push a scope for it on entry, just like OBJBLOCK. The stack is no longer empty at the top level, so the crash is gone with no defensive null-checks. Top-level fields go into that scope (never logged, so never flagged), and locals inside top-level methods are still analyzed as before. 