### PR TITLE
Issue #19803: move violation comments in annotationonsameline

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -129,14 +129,6 @@
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]annotation[\\/]annotationlocation[\\/]inputs[\\/]package-info\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheckInterfaceAndEnum\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineRecordsAndCompactCtors\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]checks[\\/]annotation[\\/]annotationonsameline[\\/]InputAnnotationOnSameLineRecordsAndCompactCtors\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsCompact2\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsCompact3\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
@@ -101,10 +101,10 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAnnotationOnSameLineCheckPrivateAndDeprecatedVar() throws Exception {
         final String[] expected = {
-            "19:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "25:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "29:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "30:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "20:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "26:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "30:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "32:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar.java"), expected);
@@ -113,22 +113,22 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAnnotationOnSameLineCheckInterfaceAndEnum() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "17:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "21:8: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "23:71: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "26:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "27:35: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "31:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "34:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "39:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "43:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "45:28: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "47:33: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "50:15: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "56:17: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "65:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "68:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "15:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "19:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "25:8: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "26:71: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "30:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "32:35: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "36:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "40:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "46:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "50:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "52:28: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "54:33: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "58:15: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "65:17: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "75:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "79:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationOnSameLineCheckInterfaceAndEnum.java"), expected);
@@ -137,15 +137,15 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAnnotationOnSameLineRecordsAndCompactCtors() throws Exception {
         final String[] expected = {
-            "13:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "NonNull1"),
-            "18:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "24:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "29:9: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "35:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "41:13: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "NonNull1"),
-            "41:23: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "51:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "58:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "14:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "NonNull1"),
+            "19:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "25:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "30:9: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "36:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "42:13: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "NonNull1"),
+            "42:23: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "52:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "59:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationOnSameLineRecordsAndCompactCtors.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckInterfaceAndEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckInterfaceAndEnum.java
@@ -11,49 +11,58 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationonsameline;
 
 import java.util.List;
 
-@Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
+// violation below "Annotation 'Ann' should be on the same line with its target."
+@Ann
 @Ann2 interface TestInterface {
 
-    @Ann    // violation, "Annotation 'Ann' should be on the same line with its target."
+    // violation below "Annotation 'Ann' should be on the same line with its target."
+    @Ann
     @Ann2 Integer getX();
 }
 
-public @Ann     // violation, "Annotation 'Ann' should be on the same line with its target."
-                // violation below, "Annotation 'Ann' should be on the same line with its target."
+// violation 2 lines below "Annotation 'Ann' should be on the same line with its target."
+// violation 2 lines below "Annotation 'Ann' should be on the same line with its target."
+public @Ann
 @Ann2 class InputAnnotationOnSameLineCheckInterfaceAndEnum implements @Ann
         @Ann2 TestInterface {
 
-    @Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
-    @Ann2 private Integer x = new @Ann // violation, should be on the same line with its target."
+    // violation below "Annotation 'Ann' should be on the same line with its target."
+    @Ann
+    // violation below "Annotation 'Ann' should be on the same line with its target."
+    @Ann2 private Integer x = new @Ann
             @Ann2 Integer(0);
 
-            // violation below, "Annotation 'Ann' should be on the same line with its target."
+    // violation below "Annotation 'Ann' should be on the same line with its target."
     private List<@Ann
             @Ann2 Integer> integerList;
 
-    @Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
+    // violation below "Annotation 'Ann' should be on the same line with its target."
+    @Ann
     @Ann2 enum TestEnum {
         A1, A2
     }
 
-    @Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
-
+    // violation below "Annotation 'Ann' should be on the same line with its target."
+    @Ann
     @Ann2 public InputAnnotationOnSameLineCheckInterfaceAndEnum() {}
 
-    @Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
-                // violation below, "Annotation 'Ann' should be on the same line with its target."
+    // violation below "Annotation 'Ann' should be on the same line with its target."
+    @Ann
+    // violation below "Annotation 'Ann' should be on the same line with its target."
     @Ann2 public void setX(@Ann
-
-            @Ann2 int x) throws @Ann // violation, should be on the same line with its target."
+            // violation below "Annotation 'Ann' should be on the same line with its target."
+            @Ann2 int x) throws @Ann
                     @Ann2 Exception {
 
-        this.<@Ann // violation, "Annotation 'Ann' should be on the same line with its target."
+        // violation below "Annotation 'Ann' should be on the same line with its target."
+        this.<@Ann
                 @Ann2 Integer> getXAs();
         this.x = x;
     }
 
     @Override public Integer getX() {
-        return (@Ann // violation, "Annotation 'Ann' should be on the same line with its target."
+        // violation below "Annotation 'Ann' should be on the same line with its target."
+        return (@Ann
                 @Ann2 Integer) x;
     }
 
@@ -62,9 +71,11 @@ public @Ann     // violation, "Annotation 'Ann' should be on the same line with 
     }
 }
 
-@Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
+// violation below "Annotation 'Ann' should be on the same line with its target."
+@Ann
 @Ann2 @interface TestAnnotation {
 
-    @Ann    // violation, "Annotation 'Ann' should be on the same line with its target."
+    // violation below "Annotation 'Ann' should be on the same line with its target."
+    @Ann
     @Ann2 int x();
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar.java
@@ -16,7 +16,8 @@ import java.util.ArrayList;
 
 public class InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar {
 
-    @Ann        // violation, "Annotation 'Ann' should be on the same line with its target."
+    // violation below "Annotation 'Ann' should be on the same line with its target."
+    @Ann
     private List<String> names = new ArrayList<>();
 
     @Ann private List<String> names2 = new ArrayList<>();
@@ -27,8 +28,8 @@ public class InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar {
 
     // violation below, "Annotation 'SuppressWarnings' should be on the same line with its target."
     @SuppressWarnings("deprecation")
+    // violation below, "Annotation 'Ann' should be on the same line with its target."
     @Ann
-    // violation above, "Annotation 'Ann' should be on the same line with its target."
     Integer x2;
 
     @SuppressWarnings("deprecation") @Ann @Ann2 @Ann3 @Ann4 Integer x3;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineRecordsAndCompactCtors.java
@@ -10,7 +10,8 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, \
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationonsameline;
 
 public class InputAnnotationOnSameLineRecordsAndCompactCtors {
-    @NonNull1 // violation, "Annotation 'NonNull1' should be on the same line with its target."
+    // violation below "Annotation 'NonNull1' should be on the same line with its target."
+    @NonNull1
     public record MyRecord1() {
     }
 
@@ -44,10 +45,10 @@ public class InputAnnotationOnSameLineRecordsAndCompactCtors {
         }
     }
 
+    // violation 4 lines below "Annotation 'SuppressWarnings' should be on the same line"
     /**
      * @return
      */
-    // violation below, "Annotation 'SuppressWarnings' should be on the same line with its target."
     @SuppressWarnings("deprecation")
     public record MyRecord6() {
         record MyInnerRecord() {@SuppressWarnings("Annotation")public MyInnerRecord {}


### PR DESCRIPTION
Issue: #19803

Part of #19803 — `annotation/annotationonsameline` package (3 input files).

## Summary

Move violation comments so they appear **before** annotation blocks, not between an annotation and its target (method, field, etc.). This aligns with Checkstyle’s input file conventions and removes the need for suppressions in `checkstyle-input-suppressions.xml`.

## Changes

- `InputAnnotationOnSameLineCheckInterfaceAndEnum.java` — moved violation comments above annotations
- `InputAnnotationOnSameLineCheckPrivateAndDeprecatedVar.java` — same
- `InputAnnotationOnSameLineRecordsAndCompactCtors.java` — same
- `AnnotationOnSameLineCheckTest.java` — updated expected line numbers
- `config/checkstyle-input-suppressions.xml` — removed suppressions for the 3 files above

## Test plan

- [x] `mvn test -Dtest=AnnotationOnSameLineCheckTest`
- [x] `mvn clean verify` (local)
