### PR TITLE
Issue #19764: Move violation comments out of Javadoc in atclauseorder

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -84,10 +84,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckCommentsContent.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderMethodReturningArrayType.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderRecords.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationCustomTags.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationIncorrect.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
@@ -231,14 +231,14 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
             + " @see, @since, @serial, @serialField, @serialData, @deprecated]";
 
         final String[] expected = {
-            "36: " + getCheckMessage(MSG_KEY, tagOrder),
-            "37: " + getCheckMessage(MSG_KEY, tagOrder),
-            "38: " + getCheckMessage(MSG_KEY, tagOrder),
-            "48: " + getCheckMessage(MSG_KEY, tagOrder),
-            "49: " + getCheckMessage(MSG_KEY, tagOrder),
-            "58: " + getCheckMessage(MSG_KEY, tagOrder),
-            "77: " + getCheckMessage(MSG_KEY, tagOrder),
-            "92: " + getCheckMessage(MSG_KEY, tagOrder),
+            "40: " + getCheckMessage(MSG_KEY, tagOrder),
+            "41: " + getCheckMessage(MSG_KEY, tagOrder),
+            "42: " + getCheckMessage(MSG_KEY, tagOrder),
+            "54: " + getCheckMessage(MSG_KEY, tagOrder),
+            "55: " + getCheckMessage(MSG_KEY, tagOrder),
+            "65: " + getCheckMessage(MSG_KEY, tagOrder),
+            "86: " + getCheckMessage(MSG_KEY, tagOrder),
+            "103: " + getCheckMessage(MSG_KEY, tagOrder),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAtclauseOrderRecords.java"), expected);
@@ -249,9 +249,9 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         final String tagOrder = "[@author, @version, @param, @return, @throws, @exception, @see,"
                 + " @since, @serial, @serialField, @serialData, @deprecated]";
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_KEY, tagOrder),
-            "32: " + getCheckMessage(MSG_KEY, tagOrder),
-            "33: " + getCheckMessage(MSG_KEY, tagOrder),
+            "21: " + getCheckMessage(MSG_KEY, tagOrder),
+            "35: " + getCheckMessage(MSG_KEY, tagOrder),
+            "36: " + getCheckMessage(MSG_KEY, tagOrder),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAtclauseOrderMethodReturningArrayType.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderMethodReturningArrayType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderMethodReturningArrayType.java
@@ -6,7 +6,6 @@ target = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, \
 tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
            @see, @serial, @serialData, @serialField, @since, @throws, @version
 
-
 */
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
@@ -14,24 +13,27 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 import java.sql.SQLException;
 
 public interface InputAtclauseOrderMethodReturningArrayType {
+    // violation 5 lines below 'Block tags have to appear in the order'
     /**
      * @return int array
      * @exception SQLException
+     *
      * @throws java.sql.SQLTimeoutException
-     * @see #addBatch // violation above
+     * @see #addBatch
      * @see DatabaseMetaData#supportsBatchUpdates
      * @since 1.2
      */
     int[] executeBatch() throws SQLException;
 
+    // violation 7 lines below 'Block tags have to appear in the order'
+    // violation 7 lines below 'Block tags have to appear in the order'
     /**
       * {@code selected} is an array that will contain
       * the indices of items that have been selected.
       *
       * @serial
-      * @see #getSelectedIndexes() // violation
-      * @see #getSelectedIndex() // violation
+      * @see #getSelectedIndexes()
+      * @see #getSelectedIndex()
       */
     int selected[] = new int[0];
 }
-

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
@@ -18,10 +18,11 @@ public class InputAtclauseOrderRecords {
     public record MyRecord(int x) implements Serializable {
         private static final long serialVersionUID = 3928773301716751506L;
 
+        // should be a violatio\u006e, but doesn't work w/ anno
         /**
          * Some text.
          *
-         * @param aString Some text. // should be a violation, but doesn't work w/ anno
+         * @param aString Some text.
          * @return Some text.
          * @throws Exception Some text.
          */
@@ -29,33 +30,39 @@ public class InputAtclauseOrderRecords {
             return "null";
         }
 
+        // violation 7 lines below 'Block tags have to appear in the order'
+        // violation 7 lines below 'Block tags have to appear in the order'
+        // violation 7 lines below 'Block tags have to appear in the order'
         /**
          * Some text.
          *
          * @since the other day
-         * @param aString Some text. // violation
-         * @return Some text. // violation
-         * @throws Exception Some text. // violation
+         * @param aString Some text.
+         * @return Some text.
+         * @throws Exception Some text.
          */
         String method1(String aString) throws Exception {
             return "null";
         }
 
+        // violation 6 lines below 'Block tags have to appear in the order'
+        // violation 6 lines below 'Block tags have to appear in the order'
         /**
          * Some text.
          *
          * @since some time
-         * @param aString Some text. // violation
-         * @throws Exception Some text. // violation
+         * @param aString Some text.
+         * @throws Exception Some text.
          * @serialData Some javadoc.
          */
         void method2(String aString) throws Exception {
         }
 
+        // violation 4 lines below 'Block tags have to appear in the order'
         /**
          * Some text.
          * @since since
-         * @throws Exception Some text. // violation
+         * @throws Exception Some text.
          * @since Some text.
          */
         void method3() throws Exception {
@@ -64,32 +71,36 @@ public class InputAtclauseOrderRecords {
 
 }
 
+// should be a violatio\u006e
 /**
  * Some javadoc.
  *
- * @author max // should be a violation
+ * @author max
  * @version 1.0
  * @since Some javadoc.
  */
 record myOtherOtherRecord() {
+    // violation 3 lines below 'Block tags have to appear in the order'
     /**
      * @since Some javadoc.
-     * @author max // violation
+     * @author max
      **/
     public myOtherOtherRecord{}
 }
 
+// should be a violatio\u006e
 /**
  * Some javadoc.
  *
- * @author max // should be a violation
+ * @author max
  * @version 1.0
  * @since Some javadoc.
  */
 class myOtherOtherClass {
+        // violation 3 lines below 'Block tags have to appear in the order'
         /**
          * @since Some javadoc.
-         * @author max // violation
+         * @author max
          **/
     public myOtherOtherClass() {
     }


### PR DESCRIPTION
Issue: #19764

Moved violation comments out of Javadoc blocks for the
`checks/javadoc/atclauseorder` input files and removed the matching
`noViolationCommentsInJavadoc` suppressions.

Updated files:
- `InputAtclauseOrderMethodReturningArrayType.java`
- `InputAtclauseOrderRecords.java`
- `AtclauseOrderCheckTest.java`
- `config/checkstyle-input-suppressions.xml`

The moved markers now use `// violation N lines below ...` syntax so they
continue to point to the same target Javadoc tag lines. Expected violation
line numbers were updated in `AtclauseOrderCheckTest`.

Validation:
- `./mvnw -Dtest=AtclauseOrderCheckTest test`: passed
- `./mvnw clean verify`: passed
- `./mvnw -q clean verify`: passed