### PR TITLE
Issue #18251: Fix Eclipse Static Analysis for latest ECJ preview level

### DIFF
--- a/.ci/eclipse-compiler-javac.sh
+++ b/.ci/eclipse-compiler-javac.sh
@@ -13,10 +13,9 @@ JAVA_RELEASE=${2:-$DEFAULT_JAVA_RELEASE}
 
 ECLIPSE_URL="http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/eclipse/downloads/drops4"
 
-# hard coded versions until #18251
-ECJ_MAVEN_VERSION="R-4.37-202509050730" 
-
-echo "Using pinned eclipse release: $ECJ_MAVEN_VERSION"
+ECJ_MAVEN_VERSION=$(curl --fail-with-body -s "$ECLIPSE_URL/?C=M;O=D" \
+    | grep -o "R-[^/]*" | head -n1)
+echo "Latest eclipse release is $ECJ_MAVEN_VERSION"
 
 ECJ_JAR=$(curl --fail-with-body -s "$ECLIPSE_URL/$ECJ_MAVEN_VERSION/" \
     | grep -o "ecj-[^\"]*" | head -n1)
@@ -76,7 +75,7 @@ if [[ $EXIT_CODE != 0 ]]; then
   cat $RESULT_FILE
   false
 else
-    JAVA_RELEASE=24
+    JAVA_RELEASE=26
     echo "In eclipse, Preview of features is supported only at the latest source level"
     echo "JAVA_RELEASE isset to ${JAVA_RELEASE}"
     echo "Executing eclipse compiler on generated resources with all warnings suppressed..."
@@ -102,4 +101,3 @@ else
       false
     fi
 fi
-

--- a/config/org.eclipse.jdt.core.prefs
+++ b/config/org.eclipse.jdt.core.prefs
@@ -108,6 +108,7 @@ org.eclipse.jdt.core.compiler.problem.varargsArgumentNeedCast=error
 org.eclipse.jdt.core.compiler.problem.autoboxing=ignore
 # We can not enforce this rule as we are library and we keep deprecated stuff for some time
 org.eclipse.jdt.core.compiler.problem.deprecation=ignore
+org.eclipse.jdt.core.compiler.problem.memberOfDeprecatedTypeNotDeprecated=ignore
 # Preview features can be enabled be enabled only at source level 14, we are using 8
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 # We don't document the tests. As we cannot exclude them, this check is muted.


### PR DESCRIPTION
Resolves issue:
- #18251

## Summary

- Restored `.ci/eclipse-compiler-javac.sh` to use the latest available ECJ release instead of the temporary pinned version from #18253.
- Updated the ECJ preview validation source level from Java 24 to Java 26.
- Added `org.eclipse.jdt.core.compiler.problem.memberOfDeprecatedTypeNotDeprecated=ignore` to `config/org.eclipse.jdt.core.prefs`.
- Restored the SemaphoreCI Eclipse Static Analysis validation that was failing on `master` and active PRs.