### PR TITLE
minor: add rocket reaction to site generation comments

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -47,6 +47,19 @@ jobs:
       commit_sha: ${{ steps.branch.outputs.commit_sha }}
 
     steps:
+      - name: React to comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            })
+
       - name: Getting PR description
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Noticed in:
- https://github.com/checkstyle/checkstyle/pull/20331

We write `GitHub, generate site` to trigger the site generation workflow. But there is no indication if the job ever started or failed:
<img width="930" height="758" alt="image" src="https://github.com/user-attachments/assets/e50f3a90-6497-468c-bebe-03567bd4f449" />

This PR adds the rocket emoji reaction to the trigger comment. It's a good first step that shows us that the job started. Simply so that we have some feedback and not feel left in the dark. Just like we do with the `regression-report`:
https://github.com/checkstyle/checkstyle/blob/4af663bdd0a9cc25ce6343c5665e1c70d9a0722c/.github/workflows/regression-report.yml#L142-L154

**Note: It's even better if we add a comment with a link to the job logs. This already exists but it's broken. I will send a fix in a separate PR**

### Proof that it works

See https://github.com/stoyanK7/checkstyle/pull/4

<img width="888" height="463" alt="image" src="https://github.com/user-attachments/assets/abb5b6ab-4511-4554-a13d-0bbed7528db1" />
