### PR TITLE
Pull #20336: use quoteReplacement in fillTemplateWithStringsByRegexp

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -9352,17 +9352,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter replacement of String.replaceAll.</message>
-    <lineContent>result = result.replaceAll(&quot;\\$&quot; + i, matcher.group(i));</lineContent>
-    <details>
-      found   : @Initialized @Nullable String
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
     <lineContent>return uri;</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -468,8 +468,11 @@ public final class CommonUtil {
         String result = template;
         if (matcher.find()) {
             for (int i = 0; i <= matcher.groupCount(); i++) {
-                // $n expands comment match like in Pattern.subst().
-                result = result.replaceAll("\\$" + i, matcher.group(i));
+                final String group = matcher.group(i);
+                if (group != null) {
+                    // $n expands comment match like in Pattern.subst().
+                    result = result.replaceAll("\\$" + i, Matcher.quoteReplacement(group));
+                }
             }
         }
         return result;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -275,6 +275,19 @@ public class SuppressionCommentFilterTest
         verifySuppressedWithParser("InputSuppressionCommentFilter9.java", suppressed);
     }
 
+    @Test
+    public void testDollarSignInMatchedText() throws Exception {
+        final String[] messages = {
+            "29:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "low$price", "^[a-z][a-zA-Z0-9]*$"),
+        };
+        final String[] suppressed = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifySuppressedWithParser(getPath("InputSuppressionCommentFilter12.java"),
+                messages, suppressed);
+    }
+
     private void verifySuppressedWithParser(String fileName, String... suppressed)
             throws Exception {
         verifyFilterWithInlineConfigParser(getPath(fileName), ALL_MESSAGES,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
@@ -332,6 +332,18 @@ public class CommonUtilTest extends AbstractPathTestSupport {
             .that(CommonUtil.fillTemplateWithStringsByRegexp("before $0 after1 $1 after2 $2 after3",
                         "word 123", Pattern.compile("(\\w+) (\\d+)")))
             .isEqualTo("before word 123 after1 word after2 123 after3");
+        assertWithMessage("dollar sign in match must be treated literally")
+            .that(CommonUtil.fillTemplateWithStringsByRegexp("before $0 after",
+                        "a$b", Pattern.compile(".+")))
+            .isEqualTo("before a$b after");
+        assertWithMessage("backslash in match must be treated literally")
+            .that(CommonUtil.fillTemplateWithStringsByRegexp("before $0 after",
+                        "a\\b", Pattern.compile(".+")))
+            .isEqualTo("before a\\b after");
+        assertWithMessage("non-matching optional group must be left untouched")
+            .that(CommonUtil.fillTemplateWithStringsByRegexp("x $1 y $2 z",
+                        "a", Pattern.compile("(a)(b)?")))
+            .isEqualTo("x a y $2 z");
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/InputSuppressionCommentFilter12.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/InputSuppressionCommentFilter12.java
@@ -1,0 +1,31 @@
+/*
+SuppressionCommentFilter
+offCommentFormat = SUPPRESS NAME (.*)
+onCommentFormat = (default)CHECKSTYLE:ON
+checkFormat = MemberName
+messageFormat = $1
+idFormat = (default)(null)
+checkCPP = (default)true
+checkC = false
+
+
+com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck
+id = (null)
+format = (default)^[a-z][a-zA-Z0-9]*$
+applyToPublic = (default)true
+applyToProtected = (default)true
+applyToPackage = (default)true
+applyToPrivate = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.filters.suppressioncommentfilter;
+
+/** Test input for a suppression comment whose matched text contains a dollar sign. */
+class InputSuppressionCommentFilter12 {
+
+    // SUPPRESS NAME low$price
+    private int low$price; // violation, 'Name 'low\$price' must match pattern'
+
+}


### PR DESCRIPTION
`CommonUtil.fillTemplateWithStringsByRegexp` expands the `$n` placeholders in a
suppression filter's check/message/id format. The text captured from the
analysed-source comment is passed to `String.replaceAll` as the replacement
string, unescaped. `replaceAll` reads `$` and `\` in a replacement as group
references and escapes, so a captured group that holds a `$` (legal in a Java
identifier) or a trailing `\` throws `IllegalArgumentException: Illegal group
reference`.

The filter only catches `PatternSyntaxException`. `IllegalArgumentException` is
its parent, so the throw is not contained and the whole file audit aborts. The
same helper backs `SuppressionCommentFilter`, `SuppressWithNearbyCommentFilter`,
`SuppressWithPlainTextCommentFilter` and `SuppressWithNearbyTextFilter`, so all
four are affected.

Found it while reading the `$n` expansion. The matched text crosses the trust
boundary from analysed source, yet lands in the replacement slot unescaped.
Routing it through `Matcher.quoteReplacement` inserts it literally. Ordinary
`$n` expansion is unchanged.

### How to reproduce

`config.xml`:

```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
    "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="SuppressionCommentFilter">
      <property name="offCommentFormat" value="SUPPRESS NAME (.*)"/>
      <property name="checkFormat" value="MemberName"/>
      <property name="messageFormat" value="$1"/>
    </module>
    <module name="MemberName"/>
  </module>
</module>
```

`Example.java`:

```java
class Example {
    // SUPPRESS NAME pri$ce
    int pri$ce;
}
```

CLI on the latest release (13.6.0):

```bash
$ javac Example.java
# compiles fine, '$' is legal in a Java identifier

$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar checkstyle-13.6.0-all.jar -c config.xml Example.java
Starting audit...
com.puppycrawl.tools.checkstyle.api.CheckstyleException: Exception was thrown while processing Example.java
	at com.puppycrawl.tools.checkstyle.Checker.processFiles(Checker.java:313)
	...
Caused by: java.lang.IllegalArgumentException: Illegal group reference
	at java.base/java.util.regex.Matcher.appendExpandedReplacement(Matcher.java:1113)
	at java.base/java.util.regex.Matcher.appendReplacement(Matcher.java:1043)
	at java.base/java.util.regex.Matcher.replaceAll(Matcher.java:1229)
	at java.base/java.lang.String.replaceAll(String.java:3058)
	at com.puppycrawl.tools.checkstyle.utils.CommonUtil.fillTemplateWithStringsByRegexp(CommonUtil.java:472)
	at com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter$Tag.<init>(SuppressionCommentFilter.java:400)
	at com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter.addTag(SuppressionCommentFilter.java:331)
	...
Checkstyle ends with 1 errors.
```

A trailing `\` in the captured text fails the same way (`character to be escaped is missing`).

Built from this branch the same command completes, no exception, the file is audited as usual:

```bash
$ java $RUN_LOCALE -jar checkstyle-<this-branch>-all.jar -c config.xml Example.java
Starting audit...
[ERROR] Example.java:3:9: Name 'pri$ce' must match pattern '^[a-z][a-zA-Z0-9]*$'. [MemberName]
Audit done.
```

Regression test added in `CommonUtilTest` for `$` and `\` in the match.
