### PR TITLE
minor: restore site workflow failure comment reporting

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -30,6 +30,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.pr-number || github.event.issue.number || github.ref }}
@@ -175,6 +176,7 @@ jobs:
       - name: Get message
         env:
           MSG: ${{needs.publish_site.outputs.message}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p .ci-temp
           if [ -z  "$MSG" ]; then


### PR DESCRIPTION
Noticed in 
- https://github.com/checkstyle/checkstyle/pull/20331

[User wrote `Github, generate site`](https://github.com/checkstyle/checkstyle/pull/20331#issuecomment-4698683957) to trigger website generation workflow. The workflow ran at https://github.com/checkstyle/checkstyle/actions/runs/27468378870. The website generation failed but the workflow [failed to report that in the comments](https://github.com/checkstyle/checkstyle/actions/runs/27468378870/job/81194919972#step:3:29):
```
API_LINK=https://api.github.com/repos/checkstyle/checkstyle/actions/runs/27468378870/jobs
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   112    0   112    0     0   2983      0 --:--:-- --:--:-- --:--:--  3027
curl: (22) The requested URL returned error: 401
Error: Process completed with exit code 22.
```

The workflow already has logic to report failure, but it failed due to a permission error + incomplete secrets setup:
https://github.com/checkstyle/checkstyle/blob/4af663bdd0a9cc25ce6343c5665e1c70d9a0722c/.github/workflows/site.yml#L175-L199

This PR fixes that by:
- Making the `secrets.GITHUB_TOKEN` available to the job
- Allowing `read` permissions for the `actions` API

### Proof that it works

See https://github.com/stoyanK7/checkstyle/pull/5

<img width="923" height="404" alt="image" src="https://github.com/user-attachments/assets/d59aa7ba-cb60-4640-89ec-d82884cb817c" />
