### PR TITLE
Issue #20221: Validate JavadocMethod tags in compact source files

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -684,7 +684,7 @@ public class JavadocMethodCheck extends AbstractJavadocCheck {
                 continue;
             }
             // backtrack to parent if last child, stopping at root
-            while (curNode.getNextSibling() == null) {
+            while (!curNode.equals(root) && curNode.getNextSibling() == null) {
                 curNode = curNode.getParent();
             }
             // explore siblings if not root

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -375,14 +375,22 @@ public final class CheckUtil {
              returnValue.isEmpty() && !TokenUtil.isRootNode(token);
              token = token.getParent()) {
             final int type = token.getType();
-            if (type == TokenTypes.CLASS_DEF
-                || type == TokenTypes.INTERFACE_DEF
-                || type == TokenTypes.ANNOTATION_DEF
-                || type == TokenTypes.ENUM_DEF) {
-                returnValue = Optional.ofNullable(getAccessModifierFromModifiersToken(token));
+            if (TokenUtil.isOfType(type,
+                    TokenTypes.CLASS_DEF,
+                    TokenTypes.INTERFACE_DEF,
+                    TokenTypes.ANNOTATION_DEF,
+                    TokenTypes.ENUM_DEF)) {
+                returnValue = Optional.ofNullable(
+                        getAccessModifierFromModifiersToken(token));
             }
             else if (type == TokenTypes.LITERAL_NEW) {
                 break;
+            }
+            else if (TokenUtil.isOfType(token.getParent(),
+                    TokenTypes.COMPACT_COMPILATION_UNIT)
+                    && !TokenUtil.isOfType(token, TokenTypes.IMPORT,
+                            TokenTypes.STATIC_IMPORT, TokenTypes.MODULE_IMPORT)) {
+                returnValue = Optional.of(AccessModifierOption.PACKAGE);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -366,7 +366,8 @@ public final class CheckUtil {
     /**
      * Returns the access modifier of the surrounding "block".
      *
-     * @param node the node to return the access modifier for
+     * @param node method, constructor, annotation field, or compact constructor declaration
+     *        to return the surrounding access modifier for
      * @return the access modifier of the surrounding block
      */
     public static Optional<AccessModifierOption> getSurroundingAccessModifier(DetailAST node) {
@@ -375,14 +376,20 @@ public final class CheckUtil {
              returnValue.isEmpty() && !TokenUtil.isRootNode(token);
              token = token.getParent()) {
             final int type = token.getType();
-            if (type == TokenTypes.CLASS_DEF
-                || type == TokenTypes.INTERFACE_DEF
-                || type == TokenTypes.ANNOTATION_DEF
-                || type == TokenTypes.ENUM_DEF) {
-                returnValue = Optional.ofNullable(getAccessModifierFromModifiersToken(token));
+            if (TokenUtil.isOfType(type,
+                    TokenTypes.CLASS_DEF,
+                    TokenTypes.INTERFACE_DEF,
+                    TokenTypes.ANNOTATION_DEF,
+                    TokenTypes.ENUM_DEF)) {
+                returnValue = Optional.ofNullable(
+                        getAccessModifierFromModifiersToken(token));
             }
             else if (type == TokenTypes.LITERAL_NEW) {
                 break;
+            }
+            else if (TokenUtil.isOfType(token.getParent(),
+                    TokenTypes.COMPACT_COMPILATION_UNIT)) {
+                returnValue = Optional.of(AccessModifierOption.PACKAGE);
             }
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -366,8 +366,7 @@ public final class CheckUtil {
     /**
      * Returns the access modifier of the surrounding "block".
      *
-     * @param node method, constructor, annotation field, or compact constructor declaration
-     *        to return the surrounding access modifier for
+     * @param node the node to return the access modifier for
      * @return the access modifier of the surrounding block
      */
     public static Optional<AccessModifierOption> getSurroundingAccessModifier(DetailAST node) {
@@ -381,8 +380,7 @@ public final class CheckUtil {
                     TokenTypes.INTERFACE_DEF,
                     TokenTypes.ANNOTATION_DEF,
                     TokenTypes.ENUM_DEF)) {
-                returnValue = Optional.ofNullable(
-                        getAccessModifierFromModifiersToken(token));
+                returnValue = Optional.ofNullable(getAccessModifierFromModifiersToken(token));
             }
             else if (type == TokenTypes.LITERAL_NEW) {
                 break;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -655,4 +655,49 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             .contains("EQUALS");
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "19:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "msg"),
+            "21:37: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "recipient"),
+            "21:55: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "message"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputJavadocMethodCompactSourceFile.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFileReturn() throws Exception {
+        final String[] expected = {
+            "19: " + getCheckMessage(MSG_RETURN_EXPECTED),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputJavadocMethodCompactSourceFileReturn.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFileThrows() throws Exception {
+        final String[] expected = {
+            "19:20: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "Exception"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputJavadocMethodCompactSourceFileThrows.java"), expected);
+    }
+
+    @Test
+    public void testPublicScopeUnusedTag() throws Exception {
+        final String[] expected = {
+            "20:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethodPublicScopeUnusedTag.java"), expected);
+    }
+
+    @Test
+    public void testPrivateScopePublicClass() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethodPrivateScopePublicClass.java"), expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -676,4 +676,49 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             .contains("EQUALS");
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "19:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "msg"),
+            "21:37: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "recipient"),
+            "21:55: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "message"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputJavadocMethodCompactSourceFile.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFileReturn() throws Exception {
+        final String[] expected = {
+            "19: " + getCheckMessage(MSG_RETURN_EXPECTED),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputJavadocMethodCompactSourceFileReturn.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFileThrows() throws Exception {
+        final String[] expected = {
+            "24:20: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "Exception"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputJavadocMethodCompactSourceFileThrows.java"), expected);
+    }
+
+    @Test
+    public void testPublicScopeUnusedTag() throws Exception {
+        final String[] expected = {
+            "20:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethodPublicScopeUnusedTag.java"), expected);
+    }
+
+    @Test
+    public void testPrivateScopePublicClass() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethodPrivateScopePublicClass.java"), expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompactSourceFile.java
@@ -1,0 +1,28 @@
+/*
+JavadocMethod
+allowedAnnotations = (default)Override
+validateThrows = (default)false
+accessModifiers = (default)public, protected, package, private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+allowInlineReturn = (default)false
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+// violation 3 lines below 'Unused @param tag for 'msg'.'
+/**
+ * Sends a notification.
+ * @param msg the message content
+ */
+public void sendNotification(String recipient, String message) {
+    // 2 violations above:
+    //  'Expected @param tag for 'recipient'.'
+    //  'Expected @param tag for 'message'.'
+    System.out.println(recipient + ": " + message);
+}
+
+void main() { }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompactSourceFileReturn.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompactSourceFileReturn.java
@@ -1,0 +1,24 @@
+/*
+JavadocMethod
+allowedAnnotations = (default)Override
+validateThrows = (default)false
+accessModifiers = (default)public, protected, package, private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+allowInlineReturn = (default)false
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+/**
+ * Calculates value.
+ */
+int value() {
+    // violation above '@return tag should be present and have description.'
+    return 1;
+}
+
+void main() { }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompactSourceFileThrows.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompactSourceFileThrows.java
@@ -1,0 +1,24 @@
+/*
+JavadocMethod
+allowedAnnotations = (default)Override
+validateThrows = true
+accessModifiers = (default)public, protected, package, private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+allowInlineReturn = (default)false
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+/**
+ * Fails.
+ */
+void fail() throws Exception {
+    // violation above 'Expected @throws tag for 'Exception'.'
+    throw new Exception();
+}
+
+void main() { }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompactSourceFileThrows.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompactSourceFileThrows.java
@@ -1,0 +1,27 @@
+/*
+JavadocMethod
+allowedAnnotations = (default)Override
+validateThrows = true
+accessModifiers = (default)public, protected, package, private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+allowInlineReturn = (default)false
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+/**
+ * Entry point.
+ */
+void main() { }
+
+/**
+ * Fails.
+ */
+void fail() throws Exception {
+    // violation above 'Expected @throws tag for 'Exception'.'
+    throw new Exception();
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPrivateScopePublicClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPrivateScopePublicClass.java
@@ -1,0 +1,24 @@
+/*
+JavadocMethod
+allowedAnnotations = (default)Override
+validateThrows = (default)false
+accessModifiers = private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+allowInlineReturn = (default)false
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public class InputJavadocMethodPrivateScopePublicClass {
+
+    /**
+     * Does something.
+     * @param x unused parameter tag
+     */
+    private void method() {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicScopeUnusedTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicScopeUnusedTag.java
@@ -1,0 +1,24 @@
+/*
+JavadocMethod
+allowedAnnotations = (default)Override
+validateThrows = (default)false
+accessModifiers = public
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+allowInlineReturn = (default)false
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public class InputJavadocMethodPublicScopeUnusedTag {
+    // violation 3 lines below 'Unused @param tag for 'x'.'
+    /**
+     * Does something.
+     * @param x unused parameter tag
+     */
+    public void method() {
+    }
+}


### PR DESCRIPTION
Fixes #20221

This change updates `JavadocMethodCheck` so top-level methods in JEP 512 compact source files are considered during Javadoc tag validation.

Previously, these methods were skipped because `CheckUtil.getSurroundingAccessModifier` returned `Optional.empty()` when no explicit enclosing class, interface, enum, or annotation declaration existed. As a result, `shouldCheck` returned `false` before `@param`, `@return`, and `@throws` validation could run.

The fix keeps the behavior local to `JavadocMethodCheck` and treats top-level compact-source methods as members of the implicit package-access class for surrounding access checks.

Added regression coverage for compact-source top-level methods, including:

* unused `@param`
* missing `@param`
* missing `@return`
* missing `@throws` with `validateThrows=true`

Tests:

* `./mvnw clean -Dtest=JavadocMethodCheckTest test`
* `./mvnw clean verify`
* `git diff --check upstream/master...HEAD`