### PR TITLE
Issue #20339 fix: use expandedTabsColumnNo in NewHandler.getIndentImpl for tab sup…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
@@ -121,7 +121,7 @@ public class NewHandler extends AbstractExpressionHandler {
         IndentLevel result;
         // if our expression isn't first on the line, just use the start
         // of the line
-        if (getLineStart(mainAst) == mainAst.getColumnNo()) {
+        if (isOnStartOfLine(mainAst)) {
             result = super.getIndentImpl();
 
             final boolean isLineWrappedNew = TokenUtil.isOfType(mainAst.getParent().getParent(),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1320,6 +1320,111 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testNewKeywordWithTab() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, getPath("InputIndentationNewWithTab.java"), expected);
+    }
+
+    @Test
+    public void testNewBlockWithoutAssignment() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        final String[] expected = {
+            "15:9: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
+                    "object def", 8, "12, 16"),
+            "17:9: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def modifier", 8, "12, 16"),
+            "19:13: " + getCheckMessage(MSG_ERROR_MULTI, "if", 12, "16, 20"),
+            "20:17: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "if", 16, "20, 24"),
+            "21:13: " + getCheckMessage(MSG_ERROR_MULTI, "if rcurly", 12, "16, 20"),
+            "22:9: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def rcurly", 8, "12, 16"),
+        };
+        verifyWarns(checkConfig,
+                getPath("InputIndentationNewBlockWithoutAssignment.java"), expected);
+    }
+
+    @Test
+    public void testNewKeywordWithTabRegression() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("basicOffset", "8");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "8");
+        final String[] expected = {
+            "16:33: " + getCheckMessage(MSG_ERROR, "new", 32, 36),
+            "27:33: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def modifier", 32, "20, 24, 28"),
+            "29:41: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
+                    "method def", 40, "28, 32, 36"),
+            "30:33: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def rcurly", 32, "20, 24, 28"),
+            "31:25: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "object def rcurly", 24, "12, 16, 20"),
+        };
+        verifyWarns(checkConfig, getPath("InputIndentationNewWithTabRegression.java"), expected);
+    }
+
+    @Test
+    public void testNewKeywordWithTabSpringRegression() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("basicOffset", "8");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "8");
+        final String[] expected = {
+            "16:33: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def modifier", 32, "20, 24, 28"),
+            "19:33: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def rcurly", 32, "20, 24, 28"),
+            "20:33: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def modifier", 32, "20, 24, 28"),
+            "23:33: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def rcurly", 32, "20, 24, 28"),
+            "24:33: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def modifier", 32, "20, 24, 28"),
+            "27:33: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def rcurly", 32, "20, 24, 28"),
+            "28:33: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def modifier", 32, "20, 24, 28"),
+            "30:41: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
+                    "method def", 40, "28, 32, 36"),
+            "31:33: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "method def rcurly", 32, "20, 24, 28"),
+            "32:25: " + getCheckMessage(MSG_ERROR_MULTI,
+                    "object def rcurly", 24, "12, 16, 20"),
+        };
+        verifyWarns(checkConfig,
+                getPath("InputIndentationNewWithTabSpring.java"), expected);
+    }
+
+    @Test
+    public void testNewKeywordWithTabStrict() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("forceStrictCondition", "true");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig, getPath("InputIndentationNewWithTabStrict.java"), expected);
+    }
+
+    @Test
     public void testNewKeywordChildren() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewBlockWithoutAssignment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewBlockWithoutAssignment.java
@@ -1,0 +1,43 @@
+/* Config:                                                                     //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:    //indent:1 exp:1
+ *                                                                             //indent:1 exp:1
+ * basicOffset = 4                                                             //indent:1 exp:1
+ * forceStrictCondition = false                                                //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                 //indent:1 exp:1
+ * tabWidth = 4                                                                //indent:1 exp:1
+ */                                                                            //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;        //indent:0 exp:0
+
+public class InputIndentationNewBlockWithoutAssignment {                       //indent:0 exp:0
+    void violation() {                                                         //indent:4 exp:4
+        new Scanner() {                                                        //indent:8 exp:8
+        Object elementStack = new Object();                                    //indent:8 exp:12,16 warn
+
+        @Override                                                              //indent:8 exp:12,16 warn
+        void scan(Object value) {                                              //indent:8 exp:8
+            if (value == null) {                                               //indent:12 exp:16,20 warn
+                return;                                                        //indent:16 exp:20,24 warn
+            }                                                                  //indent:12 exp:16,20 warn
+        }                                                                      //indent:8 exp:12,16 warn
+        }.scan(new Object());                                                  //indent:8 exp:8
+    }                                                                          //indent:4 exp:4
+
+    void correct() {                                                           //indent:4 exp:4
+        new Scanner() {                                                        //indent:8 exp:8
+            Object elementStack = new Object();                                //indent:12 exp:12
+
+            @Override                                                          //indent:12 exp:12
+            void scan(Object value) {                                          //indent:12 exp:12
+                if (value == null) {                                           //indent:16 exp:16
+                    return;                                                    //indent:20 exp:20
+                }                                                              //indent:16 exp:16
+            }                                                                  //indent:12 exp:12
+        }.scan(new Object());                                                  //indent:8 exp:8
+    }                                                                          //indent:4 exp:4
+
+    static class Scanner {                                                     //indent:4 exp:4
+        void scan(Object value) {                                              //indent:8 exp:8
+        }                                                                      //indent:8 exp:8
+    }                                                                          //indent:4 exp:4
+}                                                                              //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTab.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTab.java
@@ -1,0 +1,39 @@
+/* Config:                                                                     //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:    //indent:1 exp:1
+ *                                                                             //indent:1 exp:1
+ * arrayInitIndent = 4                                                         //indent:1 exp:1
+ * basicOffset = 4                                                             //indent:1 exp:1
+ * braceAdjustment = 0                                                         //indent:1 exp:1
+ * caseIndent = 4                                                              //indent:1 exp:1
+ * forceStrictCondition = false                                                //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                 //indent:1 exp:1
+ * tabWidth = 4                                                                //indent:1 exp:1
+ * throwsIndent = 4                                                            //indent:1 exp:1
+ *                                                                             //indent:1 exp:1
+ */                                                                            //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;        //indent:0 exp:0
+
+public class InputIndentationNewWithTab {                                      //indent:0 exp:0
+	void method() {                                                            //indent:4 exp:4
+		throw new RuntimeException(                                            //indent:8 exp:8
+			"Exception");                                                      //indent:12 exp:12
+	}                                                                          //indent:4 exp:4
+
+	private static final class Test18614 {                                     //indent:4 exp:4
+		private Test18614 client;                                              //indent:8 exp:8
+
+		private Test18614(String string) {                                     //indent:8 exp:8
+		}                                                                      //indent:8 exp:8
+
+		private void test() {                                                  //indent:8 exp:8
+			try {                                                              //indent:12 exp:12
+				client = new Test18614(                                        //indent:16 exp:16
+					null                                                       //indent:20 exp:20
+				);                                                             //indent:16 exp:16
+			}                                                                  //indent:12 exp:12
+			catch (Exception exception) {                                      //indent:12 exp:12
+			}                                                                  //indent:12 exp:12
+		}                                                                      //indent:8 exp:8
+	}                                                                          //indent:4 exp:4
+}                                                                              //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTabRegression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTabRegression.java
@@ -1,0 +1,60 @@
+/* Config:                                                                     //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:    //indent:1 exp:1
+ *                                                                             //indent:1 exp:1
+ * basicOffset = 8                                                             //indent:1 exp:1
+ * forceStrictCondition = false                                                //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                 //indent:1 exp:1
+ * tabWidth = 8                                                                //indent:1 exp:1
+ */                                                                            //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;        //indent:0 exp:0
+
+public class InputIndentationNewWithTabRegression {                            //indent:0 exp:0
+	void javaDesignPatternsViolation() {                                       //indent:8 exp:8
+		Commander commander = new Commander(new Sergeant(new Soldier(),        //indent:16 exp:16
+				new Soldier(), new Soldier()), new Sergeant(new Soldier(),     //indent:32 exp:32
+				new Soldier(), new Soldier()));                                //indent:32 exp:36 warn
+	}                                                                          //indent:8 exp:8
+
+	void javaDesignPatternsCorrect() {                                         //indent:8 exp:8
+		Commander commander = new Commander(new Sergeant(new Soldier(),        //indent:16 exp:16
+				new Soldier(), new Soldier()), new Sergeant(new Soldier(),     //indent:32 exp:32
+				    new Soldier(), new Soldier()));                            //indent:36 exp:36
+	}                                                                          //indent:8 exp:8
+
+	private final ThreadLocal<Object> targetInThreadViolation =                //indent:8 exp:8
+			new NamedThreadLocal<>("Thread-local instance of bean") {          //indent:24 exp:24
+				@Override                                                      //indent:32 exp:20,24,28 warn
+				public String toString() {                                     //indent:32 exp:32
+					return super.toString() + " '" + targetBeanName + "'";     //indent:40 exp:28,32,36 warn
+				}                                                              //indent:32 exp:20,24,28 warn
+			};                                                                 //indent:24 exp:12,16,20 warn
+
+	private final ThreadLocal<Object> targetInThreadCorrect =                  //indent:8 exp:8
+		new NamedThreadLocal<>("Thread-local instance of bean") {              //indent:16 exp:16
+			@Override                                                          //indent:24 exp:24
+			public String toString() {                                         //indent:24 exp:24
+				return super.toString() + " '" + targetBeanName + "'";         //indent:32 exp:32
+			}                                                                  //indent:24 exp:24
+		};                                                                     //indent:16 exp:16
+
+	private String targetBeanName;                                             //indent:8 exp:8
+
+	private static final class Soldier {                                       //indent:8 exp:8
+	}                                                                          //indent:8 exp:8
+
+	private static final class Sergeant {                                      //indent:8 exp:8
+		Sergeant(Soldier... soldiers) {                                        //indent:16 exp:16
+		}                                                                      //indent:16 exp:16
+	}                                                                          //indent:8 exp:8
+
+	private static final class Commander {                                     //indent:8 exp:8
+		Commander(Sergeant... sergeants) {                                     //indent:16 exp:16
+		}                                                                      //indent:16 exp:16
+	}                                                                          //indent:8 exp:8
+
+	private static class NamedThreadLocal<T> extends ThreadLocal<T> {          //indent:8 exp:8
+		NamedThreadLocal(String name) {                                        //indent:16 exp:16
+		}                                                                      //indent:16 exp:16
+	}                                                                          //indent:8 exp:8
+}                                                                              //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTabSpring.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTabSpring.java
@@ -1,0 +1,81 @@
+/* Config:                                                                     //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:    //indent:1 exp:1
+ *                                                                             //indent:1 exp:1
+ * basicOffset = 8                                                             //indent:1 exp:1
+ * forceStrictCondition = false                                                //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                 //indent:1 exp:1
+ * tabWidth = 8                                                                //indent:1 exp:1
+ */                                                                            //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;        //indent:0 exp:0
+
+public class InputIndentationNewWithTabSpring {                                //indent:0 exp:0
+	private final LifecycleMetadata emptyLifecycleMetadataViolation =          //indent:8 exp:8
+			//below indent:24 exp:24
+			new LifecycleMetadata(Object.class, Collections.emptyList(), Collections.emptyList()) {
+				@Override                                                      //indent:32 exp:20,24,28 warn
+				//below indent:32 exp:32
+				public void checkInitDestroyMethods(RootBeanDefinition beanDefinition) {
+				}                                                              //indent:32 exp:20,24,28 warn
+				@Override                                                      //indent:32 exp:20,24,28 warn
+				//below indent:32 exp:32
+				public void invokeInitMethods(Object target, String beanName) {
+				}                                                              //indent:32 exp:20,24,28 warn
+				@Override                                                      //indent:32 exp:20,24,28 warn
+				//below indent:32 exp:32
+				public void invokeDestroyMethods(Object target, String beanName) {
+				}                                                              //indent:32 exp:20,24,28 warn
+				@Override                                                      //indent:32 exp:20,24,28 warn
+				public boolean hasDestroyMethods() {                           //indent:32 exp:32
+					return false;                                              //indent:40 exp:28,32,36 warn
+				}                                                              //indent:32 exp:20,24,28 warn
+			};                                                                 //indent:24 exp:12,16,20 warn
+
+	private final LifecycleMetadata emptyLifecycleMetadataCorrect =            //indent:8 exp:8
+		//below indent:16 exp:16
+		new LifecycleMetadata(Object.class, Collections.emptyList(), Collections.emptyList()) {
+			@Override                                                          //indent:24 exp:24
+			//below indent:24 exp:24
+			public void checkInitDestroyMethods(RootBeanDefinition beanDefinition) {
+			}                                                                  //indent:24 exp:24
+			@Override                                                          //indent:24 exp:24
+			public void invokeInitMethods(Object target, String beanName) {    //indent:24 exp:24
+			}                                                                  //indent:24 exp:24
+			@Override                                                          //indent:24 exp:24
+			public void invokeDestroyMethods(Object target, String beanName) { //indent:24 exp:24
+			}                                                                  //indent:24 exp:24
+			@Override                                                          //indent:24 exp:24
+			public boolean hasDestroyMethods() {                               //indent:24 exp:24
+				return false;                                                  //indent:32 exp:32
+			}                                                                  //indent:24 exp:24
+		};                                                                     //indent:16 exp:16
+
+	private static class LifecycleMetadata {                                   //indent:8 exp:8
+		//below indent:16 exp:16
+		LifecycleMetadata(Class<?> targetClass, Object initMethods, Object destroyMethods) {
+		}                                                                      //indent:16 exp:16
+
+		//below indent:16 exp:16
+		public void checkInitDestroyMethods(RootBeanDefinition beanDefinition) {
+		}                                                                      //indent:16 exp:16
+
+		public void invokeInitMethods(Object target, String beanName) {        //indent:16 exp:16
+		}                                                                      //indent:16 exp:16
+
+		public void invokeDestroyMethods(Object target, String beanName) {     //indent:16 exp:16
+		}                                                                      //indent:16 exp:16
+
+		public boolean hasDestroyMethods() {                                   //indent:16 exp:16
+			return true;                                                       //indent:24 exp:24
+		}                                                                      //indent:16 exp:16
+	}                                                                          //indent:8 exp:8
+
+	private static final class RootBeanDefinition {                            //indent:8 exp:8
+	}                                                                          //indent:8 exp:8
+
+	private static final class Collections {                                   //indent:8 exp:8
+		static Object emptyList() {                                            //indent:16 exp:16
+			return new Object();                                               //indent:24 exp:24
+		}                                                                      //indent:16 exp:16
+	}                                                                          //indent:8 exp:8
+}                                                                              //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTabStrict.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationNewWithTabStrict.java
@@ -1,0 +1,22 @@
+/* Config:                                                                     //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:    //indent:1 exp:1
+ *                                                                             //indent:1 exp:1
+ * arrayInitIndent = 4                                                         //indent:1 exp:1
+ * basicOffset = 4                                                             //indent:1 exp:1
+ * braceAdjustment = 0                                                         //indent:1 exp:1
+ * caseIndent = 4                                                              //indent:1 exp:1
+ * forceStrictCondition = true                                                 //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                 //indent:1 exp:1
+ * tabWidth = 4                                                                //indent:1 exp:1
+ * throwsIndent = 4                                                            //indent:1 exp:1
+ *                                                                             //indent:1 exp:1
+ */                                                                            //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;        //indent:0 exp:0
+
+public class InputIndentationNewWithTabStrict {                                //indent:0 exp:0
+	void method() {                                                            //indent:4 exp:4
+		throw new RuntimeException(                                            //indent:8 exp:8
+			"Exception");                                                      //indent:12 exp:12
+	}                                                                          //indent:4 exp:4
+}                                                                              //indent:0 exp:0


### PR DESCRIPTION
Fixes #20339
Closes #18614

Hi, thanks for maintaining Checkstyle. I took a look at the false positive reported in #20339 and found the root cause.

## Problem

In `NewHandler.getIndentImpl()` line 124, the code checks if `new` is at the start of a line:

```java
if (getLineStart(mainAst) == mainAst.getColumnNo())
```

`getLineStart()` returns the tab-expanded column, but `getColumnNo()` returns the raw column. With tab-indented files these two values don't match, even when `new` is actually the first non-whitespace character on the line.

For example, with `tabWidth=4` and 2 tabs of indentation, `getLineStart()` returns 8 while `getColumnNo()` returns 2, so the check wrongly evaluates to `false`.

The reverse case is also broken: when `new` is NOT at the line start (e.g. after `throw`), the raw column can coincidentally equal the line start, producing a false `true`.

## Fix

Replace `mainAst.getColumnNo()` with `expandedTabsColumnNo(mainAst)` — the same pattern already used by `isOnStartOfLine()` at line 180 of the same file, and consistent with the fix in PR #18686.

## Additional note

While investigating, I noticed `MethodCallHandler.java` line 185 has the same pattern:

```java
if (getLineStart(rparen) == rparen.getColumnNo())
```

This would have the same tab-related issue. I kept this PR focused on `NewHandler` as described in the issue, but wanted to flag it for awareness.

## Test

Added two test cases in `IndentationCheckTest.java` with corresponding input files:

- `testNewKeywordWithTab` — non-strict mode (`forceStrictCondition=false`), `new` at the first nesting level with tab indentation
- `testNewKeywordWithTabStrict` — strict mode (`forceStrictCondition=true`), `new` inside an if block (deeper nesting) with tab indentation

Both input files use actual tab characters for indentation. Before the fix these would produce false positives; after the fix no warnings are expected.

## BungeeCord Diff Regression

Diff Regression config: https://gist.githubusercontent.com/BobSong-dev/26a6c8d6bc2f6b2fbf53b24de39ab7ac/raw/4c2f8ecb6cb1e2a441bf01ce8e5e7f4255fd29a1/bungeecord-indentation.xml
Diff Regression projects: https://gist.githubusercontent.com/BobSong-dev/e0e12b1681c2023dddd7aa6f4336d0a2/raw/67bc1dbaba119c31587bb14bf35da037de74887b/bungeecord-projects.properties
Report label: BungeeCord default Indentation
