### PR TITLE
Issue #11741: Fix Indentation when switch expression is invocation ta…

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -5714,6 +5714,20 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java</fileName>
+    <specifier>not.interned</specifier>
+    <message>attempting to use a non-@Interned comparison operand</message>
+    <lineContent>while (node != null &amp;&amp; node != getMainAst()) {</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java</fileName>
+    <specifier>not.interned</specifier>
+    <message>attempting to use a non-@Interned comparison operand</message>
+    <lineContent>while (node != null &amp;&amp; node != getMainAst()) {</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter ast of AbstractExpressionHandler.isOnStartOfLine.</message>

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundArrow.java
@@ -71,8 +71,8 @@ public class InputWhitespaceAroundArrow {
     //     ''{' is not preceded with whitespace.'
     new LinkedList<Integer>().stream()
         .map(t ->{
-            return t * 2;
-          }
+          return t * 2;
+        }
         )
         .filter(t -> {
           return false;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -174,7 +174,8 @@ public class MethodCallHandler extends AbstractExpressionHandler {
         final DetailAST ident = getMethodIdentAst();
         final DetailAST rparen = getMainAst().findFirstToken(TokenTypes.RPAREN);
         IndentLevel suggestedLevel = new IndentLevel(getLineStart(ident));
-        if (!TokenUtil.areOnSameLine(child.getMainAst().getFirstChild(), ident)) {
+        if (!TokenUtil.areOnSameLine(child.getMainAst().getFirstChild(), ident)
+                && !isInvocationTarget(child)) {
             suggestedLevel = new IndentLevel(suggestedLevel,
                     getBasicOffset(),
                     getIndentCheck().getLineWrappingIndentation());
@@ -190,6 +191,27 @@ public class MethodCallHandler extends AbstractExpressionHandler {
         }
 
         return suggestedLevel;
+    }
+
+    /**
+     * Returns true if the given child handler represents the invocation target
+     * of this method call (the expression before the dot), rather than one of
+     * the call's arguments.
+     *
+     * @param child the child handler to classify
+     * @return true if the child is the invocation target, not an argument
+     */
+    private boolean isInvocationTarget(AbstractExpressionHandler child) {
+        boolean crossedElist = false;
+        DetailAST node = child.getMainAst().getParent();
+        while (node != null && node != getMainAst()) {
+            if (node.getType() == TokenTypes.ELIST) {
+                crossedElist = true;
+                break;
+            }
+            node = node.getParent();
+        }
+        return !crossedElist;
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -4034,6 +4034,65 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testSwitchExpressionAsInvocationTarget() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+
+        final String[] expected = {
+            "50:25: " + getCheckMessage(MSG_CHILD_ERROR, "lambda", 24, 16),
+            "52:25: " + getCheckMessage(MSG_CHILD_ERROR, "lambda", 24, 16),
+        };
+        verify(checkConfig,
+            getPath("InputIndentationSwitchExpressionAsInvocationTarget.java"),
+            expected);
+    }
+
+    @Test
+    public void testLambdaCastAsInvocationTarget() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+
+        final String[] expected = {
+            "16:25: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 24, "12, 20"),
+            "29:25: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 24, "12, 20"),
+        };
+        verify(checkConfig,
+            getPath("InputIndentationLambdaCastAsInvocationTarget.java"),
+            expected);
+    }
+
+    @Test
+    public void testIndentationChainedMethodCallWithLambda() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+
+        final String[] expected = {
+            "23:29: " + getCheckMessage(MSG_ERROR, "if", 28, "20"),
+            "24:33: " + getCheckMessage(MSG_CHILD_ERROR, "if", 32, "24"),
+            "25:29: " + getCheckMessage(MSG_ERROR, "if rcurly", 28, "20"),
+            "26:25: " + getCheckMessage(MSG_ERROR, "block rcurly", 24, "16"),
+        };
+        verify(checkConfig,
+            getPath("InputIndentationChainedMethodCallWithLambda.java"),
+            expected);
+    }
+
+    @Test
     public void testYieldNestedSwitchExpressionWithCaseIndentZero() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("tabWidth", "4");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodCallWithLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodCallWithLambda.java
@@ -1,0 +1,46 @@
+//                                                                              //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;         //indent:0 exp:0
+
+/* Config:                                                                      //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:     //indent:1 exp:1
+ * basicOffset = 4                                                              //indent:1 exp:1
+ * braceAdjustment = 0                                                          //indent:1 exp:1
+ * caseIndent = 4                                                               //indent:1 exp:1
+ * tabWidth = 4                                                                 //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                  //indent:1 exp:1
+ * forceStrictCondition = false                                                 //indent:1 exp:1
+ */                                                                             //indent:1 exp:1
+public class InputIndentationChainedMethodCallWithLambda {                      //indent:0 exp:0
+    interface Stage {                                                           //indent:4 exp:4
+        Stage thenCompose(java.util.function.Function<Object, Stage> fn);       //indent:8 exp:8
+        void thenAccept(java.util.function.Consumer<Object> fn);                //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+
+    void method1(String topicName, boolean authoritative) {                     //indent:4 exp:4
+        validateAsync(topicName, authoritative)                                 //indent:8 exp:8
+                .thenCompose(__ -> getTopicReferenceAsync(topicName))           //indent:16 exp:16
+                .thenAccept(topic -> {                                          //indent:16 exp:16
+                            if (topic == null) {                                //indent:28 exp:20 warn
+                                return;                                         //indent:32 exp:24 warn
+                            }                                                   //indent:28 exp:20 warn
+                        });                                                     //indent:24 exp:16 warn
+    }                                                                           //indent:4 exp:4
+
+    void method2(String topicName, boolean authoritative) {                     //indent:4 exp:4
+        validateAsync(topicName, authoritative)                                 //indent:8 exp:8
+                .thenCompose(__ -> getTopicReferenceAsync(topicName))           //indent:16 exp:16
+                .thenAccept(topic -> {                                          //indent:16 exp:16
+                    if (topic == null) {                                        //indent:20 exp:20
+                        return;                                                 //indent:24 exp:24
+                    }                                                           //indent:20 exp:20
+                });                                                             //indent:16 exp:16
+    }                                                                           //indent:4 exp:4
+
+    private Stage validateAsync(String topicName, boolean authoritative) {      //indent:4 exp:4
+        return null;                                                            //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+
+    private Stage getTopicReferenceAsync(String topicName) {                    //indent:4 exp:4
+        return null;                                                            //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+}                                                                               //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaCastAsInvocationTarget.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambdaCastAsInvocationTarget.java
@@ -1,0 +1,32 @@
+//                                                                              //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;         //indent:0 exp:0
+
+/* Config:                                                                      //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:     //indent:1 exp:1
+ * basicOffset = 4                                                              //indent:1 exp:1
+ * braceAdjustment = 0                                                          //indent:1 exp:1
+ * caseIndent = 4                                                               //indent:1 exp:1
+ * tabWidth = 4                                                                 //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                  //indent:1 exp:1
+ * forceStrictCondition = false                                                 //indent:1 exp:1
+ */                                                                             //indent:1 exp:1
+public class InputIndentationLambdaCastAsInvocationTarget {                     //indent:0 exp:0
+    void method1() {                                                            //indent:4 exp:4
+        ((Runnable) (() -> {                                                    //indent:8 exp:8
+                        int x = 1; }))                                          //indent:24 exp:12,20 warn
+                .run();                                                         //indent:16 exp:16
+    }                                                                           //indent:4 exp:4
+
+    void method2() {                                                            //indent:4 exp:4
+        ((Runnable) (() -> {                                                    //indent:8 exp:8
+            int x = 1;                                                          //indent:12 exp:12
+        }))                                                                     //indent:8 exp:8
+                .run();                                                         //indent:16 exp:16
+    }                                                                           //indent:4 exp:4
+
+    void method3() {                                                            //indent:4 exp:4
+        ((Runnable) (() -> {                                                    //indent:8 exp:8
+                        System.out.println(this); }))                           //indent:24 exp:12,20 warn
+                .run();                                                         //indent:16 exp:16
+    }                                                                           //indent:4 exp:4
+}                                                                               //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSwitchExpressionAsInvocationTarget.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationSwitchExpressionAsInvocationTarget.java
@@ -1,0 +1,56 @@
+//                                                                              //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;         //indent:0 exp:0
+
+/* Config:                                                                      //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration:     //indent:1 exp:1
+ * basicOffset = 4                                                              //indent:1 exp:1
+ * braceAdjustment = 0                                                          //indent:1 exp:1
+ * caseIndent = 4                                                               //indent:1 exp:1
+ * tabWidth = 4                                                                 //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                  //indent:1 exp:1
+ * forceStrictCondition = false                                                 //indent:1 exp:1
+ */                                                                             //indent:1 exp:1
+public class InputIndentationSwitchExpressionAsInvocationTarget {               //indent:0 exp:0
+    void method1(String[] args) {                                               //indent:4 exp:4
+        int len = (switch (args.length) {                                       //indent:8 exp:8
+            case 1 -> args[0];                                                  //indent:12 exp:12
+            case 2 -> args[1];                                                  //indent:12 exp:12
+            default -> throw new IllegalArgumentException();                    //indent:12 exp:12
+        }).length();                                                            //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+
+    void method2(String[] args) {                                               //indent:4 exp:4
+        String s = switch (args.length) {                                       //indent:8 exp:8
+            case 1 -> args[0];                                                  //indent:12 exp:12
+            case 2 -> args[1];                                                  //indent:12 exp:12
+            default -> throw new IllegalArgumentException();                    //indent:12 exp:12
+        };                                                                      //indent:8 exp:8
+        s.length();                                                             //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+
+    void method3(int x) {                                                       //indent:4 exp:4
+        System.out.println(                                                     //indent:8 exp:8
+            switch (x) {                                                        //indent:12 exp:12
+                case 1 -> "one";                                                //indent:16 exp:16
+                default -> "other";                                             //indent:16 exp:16
+            }                                                                   //indent:12 exp:12
+        );                                                                      //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+
+    void method4(String[] args) {                                               //indent:4 exp:4
+        boolean empty = (switch (args.length) {                                 //indent:8 exp:8
+            case 1 -> args[0];                                                  //indent:12 exp:12
+            default -> throw new IllegalArgumentException();                    //indent:12 exp:12
+        }).isEmpty();                                                           //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+
+    void method5(Object kind) {                                                 //indent:4 exp:4
+        String name = (switch (kind.toString()) {                               //indent:8 exp:8
+            case "PACKAGE", "MODULE" ->                                         //indent:12 exp:12
+                        kind.toString();                                        //indent:24 exp:16 warn
+            case "CONSTRUCTOR" ->                                               //indent:12 exp:12
+                        kind.getClass().getSimpleName();                        //indent:24 exp:16 warn
+            default -> kind.toString();                                         //indent:12 exp:12
+        }).toLowerCase();                                                       //indent:8 exp:8
+    }                                                                           //indent:4 exp:4
+}                                                                               //indent:0 exp:0


### PR DESCRIPTION
Fixes #11741
Fix `Indentation` when switch expression is invocation target.

Diff Regression config: https://gist.githubusercontent.com/ZaheerAhmadDev/ee401562fc60316f636d1e7f77bac085/raw/4713fb38e15968f9c5ec6e27bd69c06bae5daa84/check.xml
Diff Regression projects: https://gist.githubusercontent.com/ZaheerAhmadDev/4e03d0754dee28529e7d8e31ed621580/raw/fda44e0c006ba3dafbec8c6bba78441e7e7e8af6/latest-projects-to-test-on.properties 
