### PR TITLE
Issue #20340: Add 'first line' and 'last line' violation hint pattern…

### DIFF
--- a/docs/specifying-violations.md
+++ b/docs/specifying-violations.md
@@ -77,6 +77,35 @@ return obj != null && obj instanceof Integer ? (Integer) obj * 2
         // violation 2 lines above 'Unnecessary nullity check'
 ```
 
+### Violation on First or Last Line of File
+
+Some checks report violations on the first or last line of the entire file
+(e.g. `NewlineAtEndOfFile` always reports at line 1 regardless of where
+in the file the comment appears). Using `violation N lines above` with a
+large `N` would be confusing to readers who only see the xdoc snippet.
+Use `violation first line` or `violation last line` instead — they can be
+placed at any visible line within the snippet.
+
+**Example using `violation first line`:**
+
+```java
+// xdoc section -- start
+public class Example2 { // ⤶
+// ⤶
+} // violation first line 'File does not end with a newline.'
+// xdoc section -- end
+```
+
+**Example using `violation last line`:**
+
+```java
+// xdoc section -- start
+public class Example3 { // ⤶
+// ⤶
+} // violation last line 'File ends with extra blank lines.'
+// xdoc section -- end
+```
+
 ## Violation Message Content and Format
 
 ### Content

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -1081,9 +1081,8 @@ public final class InlineConfigParser {
      *      parser requires giant if/else
      * @throws CheckstyleException if violation message is not specified
      */
-    // -@cs[ExecutableStatementCount] splitting this method is not reasonable.
-    // -@cs[JavaNCSS] splitting this method is not reasonable.
-    // -@cs[CyclomaticComplexity] splitting this method is not reasonable.
+    // -@cs[JavaNCSS|CyclomaticComplexity] splitting this method is not reasonable.
+    // -@cs[MethodLength|ExecutableStatementCount] splitting this method is not reasonable.
     private static void setViolations(TestInputConfiguration.Builder inputConfigBuilder,
                                       List<String> lines, boolean useFilteredViolations,
                                       int lineNo, boolean specifyViolationMessage)
@@ -1096,39 +1095,26 @@ public final class InlineConfigParser {
         }
 
         final Matcher violationMatcher =
-                VIOLATION_PATTERN.matcher(lines.get(lineNo));
+                VIOLATION_PATTERN.matcher(line);
         final Matcher violationAboveMatcher =
-                VIOLATION_ABOVE_PATTERN.matcher(lines.get(lineNo));
+                VIOLATION_ABOVE_PATTERN.matcher(line);
         final Matcher violationBelowMatcher =
-                VIOLATION_BELOW_PATTERN.matcher(lines.get(lineNo));
+                VIOLATION_BELOW_PATTERN.matcher(line);
         final Matcher violationAboveWithExplanationMatcher =
-                VIOLATION_ABOVE_WITH_EXPLANATION_PATTERN.matcher(lines.get(lineNo));
+                VIOLATION_ABOVE_WITH_EXPLANATION_PATTERN.matcher(line);
         final Matcher violationBelowWithExplanationMatcher =
-                VIOLATION_BELOW_WITH_EXPLANATION_PATTERN.matcher(lines.get(lineNo));
+                VIOLATION_BELOW_WITH_EXPLANATION_PATTERN.matcher(line);
         final Matcher violationWithExplanationMatcher =
-                VIOLATION_WITH_EXPLANATION_PATTERN.matcher(lines.get(lineNo));
-        final Matcher multipleViolationsMatcher =
-                MULTIPLE_VIOLATIONS_PATTERN.matcher(lines.get(lineNo));
-        final Matcher multipleViolationsAboveMatcher =
-                MULTIPLE_VIOLATIONS_ABOVE_PATTERN.matcher(lines.get(lineNo));
-        final Matcher multipleViolationsBelowMatcher =
-                MULTIPLE_VIOLATIONS_BELOW_PATTERN.matcher(lines.get(lineNo));
+                VIOLATION_WITH_EXPLANATION_PATTERN.matcher(line);
         final Matcher violationSomeLinesAboveMatcher =
-                VIOLATION_SOME_LINES_ABOVE_PATTERN.matcher(lines.get(lineNo));
+                VIOLATION_SOME_LINES_ABOVE_PATTERN.matcher(line);
         final Matcher violationSomeLinesBelowMatcher =
-                VIOLATION_SOME_LINES_BELOW_PATTERN.matcher(lines.get(lineNo));
+                VIOLATION_SOME_LINES_BELOW_PATTERN.matcher(line);
         final Matcher violationFirstLineMatcher =
-                VIOLATION_FIRST_LINE_PATTERN.matcher(lines.get(lineNo));
+                VIOLATION_FIRST_LINE_PATTERN.matcher(line);
         final Matcher violationLastLineMatcher =
-                VIOLATION_LAST_LINE_PATTERN.matcher(lines.get(lineNo));
-        final Matcher violationsAboveMatcherWithMessages =
-                VIOLATIONS_ABOVE_PATTERN_WITH_MESSAGES.matcher(lines.get(lineNo));
-        final Matcher violationsSomeLinesAboveMatcher =
-                VIOLATIONS_SOME_LINES_ABOVE_PATTERN.matcher(lines.get(lineNo));
-        final Matcher violationsSomeLinesBelowMatcher =
-                VIOLATIONS_SOME_LINES_BELOW_PATTERN.matcher(lines.get(lineNo));
-        final Matcher violationsDefault =
-                VIOLATION_DEFAULT.matcher(lines.get(lineNo));
+                VIOLATION_LAST_LINE_PATTERN.matcher(line);
+
         if (violationMatcher.matches()) {
             final String violationMessage =
                     extractMessage(violationMatcher.group(1), lines, lineNo);
@@ -1201,15 +1187,52 @@ public final class InlineConfigParser {
                     lastLineNum);
             inputConfigBuilder.addViolation(lastLineNum, violationMessage);
         }
-        else if (violationsAboveMatcherWithMessages.matches()) {
+        else {
+            setViolationsForMultipleAndFiltered(inputConfigBuilder, lines,
+                    useFilteredViolations, lineNo, specifyViolationMessage);
+        }
+    }
+
+    /**
+     * Sets violations for multiple-violation patterns, grouped patterns, and filtered violations.
+     *
+     * @param inputConfigBuilder the builder to add violations to.
+     * @param lines all the lines in the file.
+     * @param useFilteredViolations flag to set filtered violations.
+     * @param lineNo current line number.
+     * @param specifyViolationMessage whether violation message must be specified.
+     * @throws CheckstyleException if violation message is not specified.
+     */
+    private static void setViolationsForMultipleAndFiltered(
+            TestInputConfiguration.Builder inputConfigBuilder,
+            List<String> lines, boolean useFilteredViolations,
+            int lineNo, boolean specifyViolationMessage)
+            throws CheckstyleException {
+        final String line = lines.get(lineNo);
+        final Matcher multipleViolationsMatcher =
+                MULTIPLE_VIOLATIONS_PATTERN.matcher(line);
+        final Matcher multipleViolationsAboveMatcher =
+                MULTIPLE_VIOLATIONS_ABOVE_PATTERN.matcher(line);
+        final Matcher multipleViolationsBelowMatcher =
+                MULTIPLE_VIOLATIONS_BELOW_PATTERN.matcher(line);
+        final Matcher violationsAboveMatcherWithMessages =
+                VIOLATIONS_ABOVE_PATTERN_WITH_MESSAGES.matcher(line);
+        final Matcher violationsSomeLinesAboveMatcher =
+                VIOLATIONS_SOME_LINES_ABOVE_PATTERN.matcher(line);
+        final Matcher violationsSomeLinesBelowMatcher =
+                VIOLATIONS_SOME_LINES_BELOW_PATTERN.matcher(line);
+        final Matcher violationsDefault =
+                VIOLATION_DEFAULT.matcher(line);
+
+        if (violationsAboveMatcherWithMessages.matches()) {
             inputConfigBuilder.addViolations(
-                    getExpectedViolationsForSpecificLine(
-                            lines, lineNo, lineNo, violationsAboveMatcherWithMessages));
+                getExpectedViolationsForSpecificLine(
+                    lines, lineNo, lineNo, violationsAboveMatcherWithMessages));
         }
         else if (violationsSomeLinesAboveMatcher.matches()) {
             inputConfigBuilder.addViolations(
-                    getExpectedViolations(
-                            lines, lineNo, violationsSomeLinesAboveMatcher, true));
+                getExpectedViolations(
+                    lines, lineNo, violationsSomeLinesAboveMatcher, true));
         }
         else if (violationsSomeLinesBelowMatcher.matches()) {
             inputConfigBuilder.addViolations(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -167,6 +167,14 @@ public final class InlineConfigParser {
     private static final Pattern VIOLATION_SOME_LINES_BELOW_PATTERN = Pattern
             .compile(".*//\\s*violation (\\d+) lines below\\s*(?:['\"](.*))?$");
 
+    /** A pattern to find the string: "// violation first line". */
+    private static final Pattern VIOLATION_FIRST_LINE_PATTERN = Pattern
+            .compile(".*//\\s*violation first line\\s*(?:['\"](.*))?$");
+
+    /** A pattern to find the string: "// violation last line". */
+    private static final Pattern VIOLATION_LAST_LINE_PATTERN = Pattern
+            .compile(".*//\\s*violation last line\\s*(?:['\"](.*))?$");
+
     /**
      * <div>
      * Multiple violations for above line. Messages are X lines below.
@@ -1109,6 +1117,10 @@ public final class InlineConfigParser {
                 VIOLATION_SOME_LINES_ABOVE_PATTERN.matcher(lines.get(lineNo));
         final Matcher violationSomeLinesBelowMatcher =
                 VIOLATION_SOME_LINES_BELOW_PATTERN.matcher(lines.get(lineNo));
+        final Matcher violationFirstLineMatcher =
+                VIOLATION_FIRST_LINE_PATTERN.matcher(lines.get(lineNo));
+        final Matcher violationLastLineMatcher =
+                VIOLATION_LAST_LINE_PATTERN.matcher(lines.get(lineNo));
         final Matcher violationsAboveMatcherWithMessages =
                 VIOLATIONS_ABOVE_PATTERN_WITH_MESSAGES.matcher(lines.get(lineNo));
         final Matcher violationsSomeLinesAboveMatcher =
@@ -1175,15 +1187,29 @@ public final class InlineConfigParser {
                     violationLineNum);
             inputConfigBuilder.addViolation(violationLineNum, violationMessage);
         }
+        else if (violationFirstLineMatcher.matches()) {
+            final String violationMessage =
+                    extractMessage(violationFirstLineMatcher.group(1), lines, lineNo);
+            checkWhetherViolationSpecified(specifyViolationMessage, violationMessage, 1);
+            inputConfigBuilder.addViolation(1, violationMessage);
+        }
+        else if (violationLastLineMatcher.matches()) {
+            final String violationMessage =
+                    extractMessage(violationLastLineMatcher.group(1), lines, lineNo);
+            final int lastLineNum = lines.size();
+            checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
+                    lastLineNum);
+            inputConfigBuilder.addViolation(lastLineNum, violationMessage);
+        }
         else if (violationsAboveMatcherWithMessages.matches()) {
             inputConfigBuilder.addViolations(
-                getExpectedViolationsForSpecificLine(
-                    lines, lineNo, lineNo, violationsAboveMatcherWithMessages));
+                    getExpectedViolationsForSpecificLine(
+                            lines, lineNo, lineNo, violationsAboveMatcherWithMessages));
         }
         else if (violationsSomeLinesAboveMatcher.matches()) {
             inputConfigBuilder.addViolations(
-                getExpectedViolations(
-                    lines, lineNo, violationsSomeLinesAboveMatcher, true));
+                    getExpectedViolations(
+                            lines, lineNo, violationsSomeLinesAboveMatcher, true));
         }
         else if (violationsSomeLinesBelowMatcher.matches()) {
             inputConfigBuilder.addViolations(
@@ -1326,6 +1352,8 @@ public final class InlineConfigParser {
                 || VIOLATION_BELOW_PATTERN.matcher(line).matches()
                 || VIOLATION_SOME_LINES_ABOVE_PATTERN.matcher(line).matches()
                 || VIOLATION_SOME_LINES_BELOW_PATTERN.matcher(line).matches()
+                || VIOLATION_FIRST_LINE_PATTERN.matcher(line).matches()
+                || VIOLATION_LAST_LINE_PATTERN.matcher(line).matches()
                 || FILTERED_VIOLATION_PATTERN.matcher(line).matches();
     }
 


### PR DESCRIPTION
#20340 

New Violation Patterns:
Added `VIOLATION_FIRST_LINE_PATTERN `to match // violation first line.
Added `VIOLATION_LAST_LINE_PATTERN `to match // violation last line.
Integrated these into the `handleRelativeOrAbsoluteViolation `logic.