### PR TITLE
Pull #20346: fill SarifLogger result templates in a single pass

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.Objects;
 import java.util.ResourceBundle;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -110,6 +111,9 @@ public final class SarifLogger extends AbstractAutomaticBean implements AuditLis
     /** A pattern to match a file with a Windows drive letter. */
     private static final Pattern WINDOWS_DRIVE_LETTER_PATTERN =
             Pattern.compile("\\A[A-Z]:", Pattern.CASE_INSENSITIVE);
+
+    /** A pattern matching a template placeholder such as {@code ${uri}}. */
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{\\w+}");
 
     /** Comma and line separator. */
     private static final String COMMA_LINE_SEPARATOR = ",\n";
@@ -343,23 +347,21 @@ public final class SarifLogger extends AbstractAutomaticBean implements AuditLis
         final RuleKey ruleKey = cacheRuleMetadata(event);
         final String message = generateMessage(ruleKey, event);
         if (event.getColumn() > 0) {
-            results.add(resultLineColumn
-                .replace(SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()))
-                .replace(URI_PLACEHOLDER, renderFileNameUri(event.getFileName()))
-                .replace(COLUMN_PLACEHOLDER, Integer.toString(event.getColumn()))
-                .replace(LINE_PLACEHOLDER, Integer.toString(event.getLine()))
-                .replace(MESSAGE_PLACEHOLDER, message)
-                .replace(RULE_ID_PLACEHOLDER, ruleKey.toRuleId())
-            );
+            results.add(fillTemplate(resultLineColumn, Map.of(
+                SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()),
+                URI_PLACEHOLDER, renderFileNameUri(event.getFileName()),
+                COLUMN_PLACEHOLDER, Integer.toString(event.getColumn()),
+                LINE_PLACEHOLDER, Integer.toString(event.getLine()),
+                MESSAGE_PLACEHOLDER, message,
+                RULE_ID_PLACEHOLDER, ruleKey.toRuleId())));
         }
         else {
-            results.add(resultLineOnly
-                .replace(SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()))
-                .replace(URI_PLACEHOLDER, renderFileNameUri(event.getFileName()))
-                .replace(LINE_PLACEHOLDER, Integer.toString(event.getLine()))
-                .replace(MESSAGE_PLACEHOLDER, message)
-                .replace(RULE_ID_PLACEHOLDER, ruleKey.toRuleId())
-            );
+            results.add(fillTemplate(resultLineOnly, Map.of(
+                SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()),
+                URI_PLACEHOLDER, renderFileNameUri(event.getFileName()),
+                LINE_PLACEHOLDER, Integer.toString(event.getLine()),
+                MESSAGE_PLACEHOLDER, message,
+                RULE_ID_PLACEHOLDER, ruleKey.toRuleId())));
         }
     }
 
@@ -408,17 +410,15 @@ public final class SarifLogger extends AbstractAutomaticBean implements AuditLis
         final String message = messageTextOnly
                 .replace(MESSAGE_TEXT_PLACEHOLDER, escape(stringWriter.toString()));
         if (event.getFileName() == null) {
-            results.add(resultErrorOnly
-                .replace(SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()))
-                .replace(MESSAGE_PLACEHOLDER, message)
-            );
+            results.add(fillTemplate(resultErrorOnly, Map.of(
+                SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()),
+                MESSAGE_PLACEHOLDER, message)));
         }
         else {
-            results.add(resultFileOnly
-                .replace(SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()))
-                .replace(URI_PLACEHOLDER, renderFileNameUri(event.getFileName()))
-                .replace(MESSAGE_PLACEHOLDER, message)
-            );
+            results.add(fillTemplate(resultFileOnly, Map.of(
+                SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()),
+                URI_PLACEHOLDER, renderFileNameUri(event.getFileName()),
+                MESSAGE_PLACEHOLDER, message)));
         }
     }
 
@@ -430,6 +430,28 @@ public final class SarifLogger extends AbstractAutomaticBean implements AuditLis
     @Override
     public void fileFinished(AuditEvent event) {
         // No need to implement this method in this class
+    }
+
+    /**
+     * Fill a template with its values in a single pass, so a value substituted for one
+     * placeholder is never scanned again and taken for another. A file name or message that
+     * happens to carry placeholder text is therefore kept verbatim instead of pulling
+     * another value into it.
+     *
+     * @param template the template to fill
+     * @param values the value to substitute for each placeholder
+     * @return the filled template
+     */
+    private static String fillTemplate(String template, Map<String, String> values) {
+        final Matcher matcher = PLACEHOLDER_PATTERN.matcher(template);
+        final StringBuilder result = new StringBuilder(256);
+        while (matcher.find()) {
+            final String placeholder = matcher.group();
+            final String value = values.getOrDefault(placeholder, placeholder);
+            matcher.appendReplacement(result, Matcher.quoteReplacement(value));
+        }
+        matcher.appendTail(result);
+        return result.toString();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -270,6 +270,51 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
     }
 
     /**
+     * The file name is taken verbatim from the analysed tree, so it may contain the literal
+     * text of a report placeholder such as {@code ${message}}. Every placeholder is filled
+     * in a single pass, so that text is kept verbatim and cannot splice the message object
+     * into the uri string.
+     */
+    @Test
+    public void testAddErrorWithPlaceholderInPath() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, "report${message}.java", violation);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerPlaceholderInPath.sarif"), outStream);
+    }
+
+    /**
+     * A violation message can carry the literal text of a placeholder such as {@code ${uri}},
+     * for instance when a check reports the text it matched. Every placeholder is filled in a
+     * single pass, so the file name is not pulled into the message text.
+     */
+    @Test
+    public void testAddErrorWithPlaceholderInMessage() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", new Object[] {"found ${uri} here"},
+                        SeverityLevel.ERROR, null, getClass(), "{0}");
+        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerPlaceholderInMessage.sarif"), outStream);
+    }
+
+    /**
      * Checker.process(...) obtains file paths from the current runtime File API, and
      * Checker.fireErrors(...) passes those paths through relativizePathWithCatch(...)
      * / CommonUtil.relativizePath(...). On Linux CI, File.getAbsolutePath() cannot produce

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerPlaceholderInMessage.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerPlaceholderInMessage.sarif
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+            {
+              "id": "com.puppycrawl.tools.checkstyle.SarifLoggerTest",
+              "messageStrings": {
+
+              },
+              "shortDescription": {
+                "text": "SarifLoggerTest"
+              },
+              "fullDescription": {
+                "text": "No description available"
+              }
+            }
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:Test.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found ${uri} here"
+          },
+          "ruleId": "com.puppycrawl.tools.checkstyle.SarifLoggerTest"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerPlaceholderInPath.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerPlaceholderInPath.sarif
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+            {
+              "id": "com.puppycrawl.tools.checkstyle.SarifLoggerTest",
+              "messageStrings": {
+
+              },
+              "shortDescription": {
+                "text": "SarifLoggerTest"
+              },
+              "fullDescription": {
+                "text": "No description available"
+              }
+            }
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:report${message}.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found an error"
+          },
+          "ruleId": "com.puppycrawl.tools.checkstyle.SarifLoggerTest"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
A file whose name contains the literal text `${message}` makes the SARIF logger emit malformed JSON. The name is not meant to be a variable; the substitution order lets it act as one. The same hazard exists on the message side: a violation message can carry placeholder text too.

#### Cause

The result template is filled by a chain of `String.replace`. On master the uri is substituted before the message:

```java
.replace(URI_PLACEHOLDER, renderFileNameUri(event.getFileName()))
...
.replace(MESSAGE_PLACEHOLDER, message)
```

`renderFileNameUri` returns the file name verbatim. When that name contains `${message}`, the text lands in the uri value, and the following `.replace(MESSAGE_PLACEHOLDER, message)` rescans the whole accumulated string and splices the message object into the middle of the uri. The injected quotes close the string early, so the JSON is broken. That output is what CI uploads to code scanning.

Reordering alone is not enough: a message can also carry placeholder text, e.g. `${uri}`, when a check echoes matched source text through a `MessageFormat` argument (arguments are not re-parsed, and `escape` leaves `${...}` untouched). Whichever of uri/message is substituted last would then pull the other value into it.

#### Fix

Fill every placeholder in a single pass, so a value substituted for one placeholder is never rescanned and taken for another. A file name or message that happens to carry placeholder text is kept verbatim. `addError` (both branches) and `addException` use the single-pass fill. Regression tests cover a name containing `${message}` and a message containing `${uri}`.

#### Reproduction (CLI)

Config (`config.xml`):

```xml
<module name="Checker">
  <module name="TreeWalker">
    <module name="EmptyStatement"/>
  </module>
</module>
```

A file named `report${message}.java` with one empty statement:

```java
class Foo {
    void m() {
        ;
    }
}
```

Command:

```
java -jar checkstyle.jar -c config.xml -f sarif 'report${message}.java'
```

On master the uri value is broken (message object spliced in, JSON no longer parses):

```
"uri": "file:.../report            "id": "empty.statement",
        "text": "Empty statement.".java"
```

On this branch the file name is preserved literally and the JSON is valid:

```
"uri": "file:.../report${message}.java"
```

Piping each output through `python3 -m json.tool`: master fails to parse, this branch parses.
