### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - annotationloc…

### DIFF
--- a/src/site/xdoc/checks/annotation/annotationlocation.xml
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml
@@ -169,11 +169,13 @@ class Example1 {
   @Nonnull
   private boolean field1;
   @Override public int hashCode() { return 1; }
+
   @Nonnull
   private boolean field2;
   @Override
   public boolean equals(Object obj) { return true; }
-  @Mock DataLoader loader1;
+  @Mock
+  DataLoader loader1;
   @SuppressWarnings("deprecation") DataLoader loader2;
   // violation above, 'Annotation 'SuppressWarnings' should be alone on line'
   @SuppressWarnings("deprecation") public int foo() { return 1; }
@@ -203,15 +205,18 @@ class Example2 {
   @Nonnull
   private boolean field1;
   @Override public int hashCode() { return 1; }
+
   @Nonnull
   private boolean field2;
   @Override
   public boolean equals(Object obj) { return true; }
   @Mock
   DataLoader loader1;
-  @SuppressWarnings("deprecation") DataLoader loader;
+  @SuppressWarnings("deprecation") DataLoader loader2;
+
   @SuppressWarnings("deprecation") public int foo() { return 1; }
-  @Nonnull @Mock DataLoader loader2;
+
+  @Nonnull @Mock DataLoader loader3;
   // ok above as 'allowSamelineMultipleAnnotations' set to true
 }
 </code></pre></div><hr class="example-separator"/>
@@ -234,21 +239,22 @@ class Example2 {
         <p id="Example3-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 {
-  // violation below, 'Annotation 'Nonnull' should be alone on line.'
-  @Nonnull private boolean field1;
-  // violation below, 'Annotation 'Override' should be alone on line.'
+  @Nonnull
+  private boolean field1;
   @Override public int hashCode() { return 1; }
+  // violation above, 'Annotation 'Override' should be alone on line'
   @Nonnull
   private boolean field2;
   @Override
   public boolean equals(Object obj) { return true; }
   @Mock
-  DataLoader loader;
-  @SuppressWarnings("deprecation") DataLoader loader1;
+  DataLoader loader1;
+  @SuppressWarnings("deprecation") DataLoader loader2;
+
   @SuppressWarnings("deprecation") public int foo() { return 1; }
-  // violation below, 'Annotation 'Nonnull' should be alone on line.'
-  @Nonnull @Mock DataLoader loader2;
-  // violation above, 'Annotation 'Mock' should be alone on line.'
+  // violation below, 'Annotation 'Nonnull' should be alone on line'
+  @Nonnull @Mock DataLoader loader3;
+  // violation above, 'Annotation 'Mock' should be alone on line'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -271,18 +277,22 @@ class Example3 {
         <p id="Example4-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example4 {
-  @NotNull private boolean field1; // ok, as 'tokens' property set to METHOD_DEF only
+  @Nonnull
+  private boolean field1;
   @Override public int hashCode() { return 1; }
-  @NotNull
+  // ok above, as 'tokens' property set to METHOD_DEF only
+  @Nonnull
   private boolean field2;
   @Override
   public boolean equals(Object obj) { return true; }
   @Mock
   DataLoader loader1;
-  @SuppressWarnings("deprecation") DataLoader loader;
+  @SuppressWarnings("deprecation") DataLoader loader2;
+  // ok above, as 'tokens' property set to METHOD_DEF only
   @SuppressWarnings("deprecation") public int foo() { return 1; }
-  // violation above, 'Annotation 'SuppressWarnings' should be alone on line.'
-  @NotNull @Mock DataLoader loader2;
+  // violation above, 'Annotation 'SuppressWarnings' should be alone on line'
+  @Nonnull @Mock DataLoader loader3;
+  // ok above, as 'tokens' property set to METHOD_DEF only
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -101,9 +101,6 @@ public class XdocsExamplesAstConsistencyTest {
      * <p>Until: <a href="https://github.com/checkstyle/checkstyle/issues/18435">...</a>
      */
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
-            "checks/annotation/annotationlocation/Example2",
-            "checks/annotation/annotationlocation/Example3",
-            "checks/annotation/annotationlocation/Example4",
             "checks/annotation/annotationonsameline/Example2",
             "checks/annotation/annotationusestyle/Example2",
             "checks/annotation/annotationusestyle/Example3",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationExamplesTest.java
@@ -34,9 +34,9 @@ public class AnnotationLocationExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "31:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
             "33:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
-            "35:12: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Mock"),
+            "35:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "37:12: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Mock"),
 
         };
 
@@ -55,10 +55,9 @@ public class AnnotationLocationExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "24:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Nonnull"),
-            "26:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Override"),
-            "36:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Nonnull"),
-            "36:12: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Mock"),
+            "25:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Override"),
+            "37:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Nonnull"),
+            "37:12: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Mock"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -67,7 +66,7 @@ public class AnnotationLocationExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "33:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "36:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example1.java
@@ -23,11 +23,13 @@ class Example1 {
   @Nonnull
   private boolean field1;
   @Override public int hashCode() { return 1; }
+
   @Nonnull
   private boolean field2;
   @Override
   public boolean equals(Object obj) { return true; }
-  @Mock DataLoader loader1;
+  @Mock
+  DataLoader loader1;
   @SuppressWarnings("deprecation") DataLoader loader2;
   // violation above, 'Annotation 'SuppressWarnings' should be alone on line'
   @SuppressWarnings("deprecation") public int foo() { return 1; }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example2.java
@@ -23,15 +23,18 @@ class Example2 {
   @Nonnull
   private boolean field1;
   @Override public int hashCode() { return 1; }
+
   @Nonnull
   private boolean field2;
   @Override
   public boolean equals(Object obj) { return true; }
   @Mock
   DataLoader loader1;
-  @SuppressWarnings("deprecation") DataLoader loader;
+  @SuppressWarnings("deprecation") DataLoader loader2;
+
   @SuppressWarnings("deprecation") public int foo() { return 1; }
-  @Nonnull @Mock DataLoader loader2;
+
+  @Nonnull @Mock DataLoader loader3;
   // ok above as 'allowSamelineMultipleAnnotations' set to true
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example3.java
@@ -20,20 +20,21 @@ import org.mockito.Mock;
 
 // xdoc section -- start
 class Example3 {
-  // violation below, 'Annotation 'Nonnull' should be alone on line.'
-  @Nonnull private boolean field1;
-  // violation below, 'Annotation 'Override' should be alone on line.'
+  @Nonnull
+  private boolean field1;
   @Override public int hashCode() { return 1; }
+  // violation above, 'Annotation 'Override' should be alone on line'
   @Nonnull
   private boolean field2;
   @Override
   public boolean equals(Object obj) { return true; }
   @Mock
-  DataLoader loader;
-  @SuppressWarnings("deprecation") DataLoader loader1;
+  DataLoader loader1;
+  @SuppressWarnings("deprecation") DataLoader loader2;
+
   @SuppressWarnings("deprecation") public int foo() { return 1; }
-  // violation below, 'Annotation 'Nonnull' should be alone on line.'
-  @Nonnull @Mock DataLoader loader2;
-  // violation above, 'Annotation 'Mock' should be alone on line.'
+  // violation below, 'Annotation 'Nonnull' should be alone on line'
+  @Nonnull @Mock DataLoader loader3;
+  // violation above, 'Annotation 'Mock' should be alone on line'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example4.java
@@ -16,22 +16,26 @@
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
 
-import org.antlr.v4.runtime.misc.NotNull;
+import javax.annotation.Nonnull;
 import org.mockito.Mock;
 
 // xdoc section -- start
 class Example4 {
-  @NotNull private boolean field1; // ok, as 'tokens' property set to METHOD_DEF only
+  @Nonnull
+  private boolean field1;
   @Override public int hashCode() { return 1; }
-  @NotNull
+  // ok above, as 'tokens' property set to METHOD_DEF only
+  @Nonnull
   private boolean field2;
   @Override
   public boolean equals(Object obj) { return true; }
   @Mock
   DataLoader loader1;
-  @SuppressWarnings("deprecation") DataLoader loader;
+  @SuppressWarnings("deprecation") DataLoader loader2;
+  // ok above, as 'tokens' property set to METHOD_DEF only
   @SuppressWarnings("deprecation") public int foo() { return 1; }
-  // violation above, 'Annotation 'SuppressWarnings' should be alone on line.'
-  @NotNull @Mock DataLoader loader2;
+  // violation above, 'Annotation 'SuppressWarnings' should be alone on line'
+  @Nonnull @Mock DataLoader loader3;
+  // ok above, as 'tokens' property set to METHOD_DEF only
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

Properties:

Example1 — default config
Example2 — allowSamelineSingleParameterlessAnnotation=false, allowSamelineParameterizedAnnotation=false, allowSamelineMultipleAnnotations=true
Example3 — allowSamelineMultipleAnnotations=false, allowSamelineSingleParameterlessAnnotation=false, allowSamelineParameterizedAnnotation=true
Example4 — tokens=METHOD_DEF, allowSamelineMultipleAnnotations=false, allowSamelineSingleParameterlessAnnotation=true, allowSamelineParameterizedAnnotation=false

All show different combinations of the same allowSameline* properties → all are Section 1.