### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - annotationuse…

### DIFF
--- a/src/site/xdoc/checks/annotation/annotationusestyle.xml
+++ b/src/site/xdoc/checks/annotation/annotationusestyle.xml
@@ -139,19 +139,17 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 @SuppressWarnings("unchecked") // ok as it's in implied style
 @Deprecated // ok as it matches closingParens default property
+
 @SomeArrays({"unchecked","unused"}) // ok as it's in implied style
-public class Example1
-{
+public class Example1 {
 
 }
-
 // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
 @SuppressWarnings(value={"unchecked"})
 @Deprecated() // violation 'Annotation cannot have closing parenthesis'
 // violation below 'Annotation array values cannot contain trailing comma'
 @SomeArrays(value={"unchecked","unused",})
-class TestStyle1
-{
+class TestStyle1 {
 
 }
 </code></pre></div><hr class="example-separator"/>
@@ -176,8 +174,7 @@ class TestStyle1
 @Deprecated // ok as closingParens property set to never
 // violation below 'Annotation style must be 'EXPANDED''
 @SomeArrays({"unchecked","unused"})
-public class Example2
-{
+public class Example2 {
 
 }
 
@@ -208,12 +205,11 @@ class TestStyle2 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 @SuppressWarnings("unchecked") // ok as element style set to compact
 @Deprecated // violation 'Annotation must have closing parenthesis'
+
 @SomeArrays({"unchecked","unused"}) // ok as it's in compact style
-public class Example3
-{
+public class Example3 {
 
 }
-
 // violation below 'Annotation style must be 'COMPACT''
 @SuppressWarnings(value={"unchecked"})
 @Deprecated() // ok as closingParens set to always
@@ -241,17 +237,15 @@ class TestStyle3 {
         <p id="Example4-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 @SuppressWarnings("unchecked") // ok as element style set to 'ignore'
-@Deprecated // ok as 'closingParens' is set to 'ignore
+@Deprecated // ok as 'closingParens' is set to 'ignore'
 // violation below 'Annotation array values must contain trailing comma'
 @SomeArrays({"unchecked","unused"})
-public class Example4
-{
+public class Example4 {
 
 }
-
 // violation below 'Annotation array values must contain trailing comma'
 @SuppressWarnings(value={"unchecked"})
-@Deprecated() // ok as 'closingParens' is set to 'ignore
+@Deprecated() // ok as 'closingParens' is set to 'ignore'
 // ok below as it has a trailing array comma
 @SomeArrays(value={"unchecked","unused",})
 class TestStyle4 {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -101,9 +101,6 @@ public class XdocsExamplesAstConsistencyTest {
      * <p>Until: <a href="https://github.com/checkstyle/checkstyle/issues/18435">...</a>
      */
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
-            "checks/annotation/annotationusestyle/Example2",
-            "checks/annotation/annotationusestyle/Example3",
-            "checks/annotation/annotationusestyle/Example4",
             "checks/annotation/missingoverride/Example2",
             "checks/annotation/suppresswarnings/Example2",
             "checks/annotation/suppresswarningsholder/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckExamplesTest.java
@@ -38,9 +38,9 @@ public class AnnotationUseStyleCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "25:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "26:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "28:40: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
+            "24:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "25:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "27:40: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -51,8 +51,8 @@ public class AnnotationUseStyleCheckExamplesTest extends AbstractExamplesModuleT
         final String[] expected = {
             "16:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
             "19:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "26:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "28:40: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
+            "25:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "27:40: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
 
         };
 
@@ -63,8 +63,8 @@ public class AnnotationUseStyleCheckExamplesTest extends AbstractExamplesModuleT
     public void testExample3() throws Exception {
         final String[] expected = {
             "17:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
-            "25:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
-            "28:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
+            "24:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
+            "27:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
 
         };
 
@@ -75,7 +75,7 @@ public class AnnotationUseStyleCheckExamplesTest extends AbstractExamplesModuleT
     public void testExample4() throws Exception {
         final String[] expected = {
             "19:34: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "26:37: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "24:37: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
 
         };
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/Example1.java
@@ -15,19 +15,17 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 // xdoc section -- start
 @SuppressWarnings("unchecked") // ok as it's in implied style
 @Deprecated // ok as it matches closingParens default property
+
 @SomeArrays({"unchecked","unused"}) // ok as it's in implied style
-public class Example1
-{
+public class Example1 {
 
 }
-
 // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
 @SuppressWarnings(value={"unchecked"})
 @Deprecated() // violation 'Annotation cannot have closing parenthesis'
 // violation below 'Annotation array values cannot contain trailing comma'
 @SomeArrays(value={"unchecked","unused",})
-class TestStyle1
-{
+class TestStyle1 {
 
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/Example2.java
@@ -17,8 +17,7 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 @Deprecated // ok as closingParens property set to never
 // violation below 'Annotation style must be 'EXPANDED''
 @SomeArrays({"unchecked","unused"})
-public class Example2
-{
+public class Example2 {
 
 }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/Example3.java
@@ -15,12 +15,11 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 // xdoc section -- start
 @SuppressWarnings("unchecked") // ok as element style set to compact
 @Deprecated // violation 'Annotation must have closing parenthesis'
+
 @SomeArrays({"unchecked","unused"}) // ok as it's in compact style
-public class Example3
-{
+public class Example3 {
 
 }
-
 // violation below 'Annotation style must be 'COMPACT''
 @SuppressWarnings(value={"unchecked"})
 @Deprecated() // ok as closingParens set to always

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/Example4.java
@@ -14,17 +14,15 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
 // xdoc section -- start
 @SuppressWarnings("unchecked") // ok as element style set to 'ignore'
-@Deprecated // ok as 'closingParens' is set to 'ignore
+@Deprecated // ok as 'closingParens' is set to 'ignore'
 // violation below 'Annotation array values must contain trailing comma'
 @SomeArrays({"unchecked","unused"})
-public class Example4
-{
+public class Example4 {
 
 }
-
 // violation below 'Annotation array values must contain trailing comma'
 @SuppressWarnings(value={"unchecked"})
-@Deprecated() // ok as 'closingParens' is set to 'ignore
+@Deprecated() // ok as 'closingParens' is set to 'ignore'
 // ok below as it has a trailing array comma
 @SomeArrays(value={"unchecked","unused",})
 class TestStyle4 {


### PR DESCRIPTION
#18435 

**Example1** — default config

**Example2** — expanded style, never parens, never comma
- `elementStyle` = `EXPANDED`
- `closingParens` = `NEVER`
- `trailingArrayComma` = `NEVER`

**Example3** — compact style, always parens, ignore comma
- `elementStyle` = `COMPACT`
- `closingParens` = `ALWAYS`
- `trailingArrayComma` = `IGNORE`

**Example4** — ignore style, ignore parens, always comma
- `elementStyle` = `IGNORE`
- `closingParens` = `IGNORE`
- `trailingArrayComma` = `ALWAYS`

Section 1 -> Example1,2,3,4