### PR TITLE
Issue #20330: EmptyLineSeparator false positive on multi-variable field

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -487,8 +487,9 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      */
     private boolean isViolatingEmptyLineBetweenFieldsPolicy(DetailAST detailAST) {
         return detailAST.getType() != TokenTypes.RCURLY
+                && detailAST.getType() != TokenTypes.COMMA
                 && (!allowNoEmptyLineBetweenFields
-                    || !TokenUtil.isOfType(detailAST, TokenTypes.COMMA, TokenTypes.VARIABLE_DEF));
+                    || detailAST.getType() != TokenTypes.VARIABLE_DEF);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -254,6 +254,23 @@ public class EmptyLineSeparatorCheckTest
     }
 
     @Test
+    public void testMultiVariableDeclaration() throws Exception {
+        final String[] expected = {
+            "22:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputEmptyLineSeparatorMultiVariableDeclaration.java"), expected);
+    }
+
+    @Test
+    public void testMultiVariableDeclarationAllowNoEmptyLine() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputEmptyLineSeparatorMultiVariableDeclarationAllowNoEmptyLine.java"),
+                expected);
+    }
+
+    @Test
     public void testAllowMultipleImportSeparatedFromPackage() throws Exception {
         final String[] expected = {
             "13:78: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "import"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorMultiVariableDeclaration.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorMultiVariableDeclaration.java
@@ -1,0 +1,23 @@
+/*
+EmptyLineSeparator
+allowNoEmptyLineBetweenFields = (default)false
+allowMultipleEmptyLines = (default)true
+allowMultipleEmptyLinesInsideClassMembers = (default)true
+tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, \
+         STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF, \
+         COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorMultiVariableDeclaration {
+    int a = 1, b = 2;
+
+    int c = 3,
+        d = 4;
+
+    int e = 5;
+    int f = 6; // violation ''VARIABLE_DEF' should be separated from previous line.'
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorMultiVariableDeclarationAllowNoEmptyLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorMultiVariableDeclarationAllowNoEmptyLine.java
@@ -1,0 +1,23 @@
+/*
+EmptyLineSeparator
+allowNoEmptyLineBetweenFields = true
+allowMultipleEmptyLines = (default)true
+allowMultipleEmptyLinesInsideClassMembers = (default)true
+tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, \
+         STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF, \
+         COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorMultiVariableDeclarationAllowNoEmptyLine {
+    int a = 1, b = 2;
+
+    int c = 3,
+        d = 4;
+
+    int e = 5;
+    int f = 6;
+}


### PR DESCRIPTION
Fixes #20330

`EmptyLineSeparator` reported a false positive `',' should be separated from
previous line.` on a single multi-variable field declaration such as
`int a = 1, b = 2;`.

Cause: In a multi-variable declaration the first `VARIABLE_DEF`'s next sibling
is the `COMMA`, so `processVariableDef` evaluated
`isViolatingEmptyLineBetweenFieldsPolicy(COMMA)`. That method only treated a
`COMMA` as non-violating when `allowNoEmptyLineBetweenFields=true`, so under the
default (`false`) the comma was flagged — an impossible requirement, since you
cannot put a blank line inside one declaration.

Fix: Treat a `COMMA` next-sibling as never violating the policy (regardless of
`allowNoEmptyLineBetweenFields`). The genuine case of two separate adjacent
field declarations (next-sibling is a `VARIABLE_DEF`) is unchanged and still
governed by `allowNoEmptyLineBetweenFields`.

Added regression inputs/tests for both the default config (no violation on the
comma, while genuinely unseparated separate fields are still flagged) and
`allowNoEmptyLineBetweenFields=true`.

`./mvnw clean verify` passes locally.