### PR TITLE
Issue #19806: quote record component name in JavadocType missing tag …

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionJavadocTypeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionJavadocTypeTest.java
@@ -20,6 +20,7 @@
 package org.checkstyle.suppressionxpathfilter.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_MISSING_TAG;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_MISSING_TAG_WITH_QUOTES;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_TAG_FORMAT;
 
 import java.io.File;
@@ -114,7 +115,7 @@ public class XpathRegressionJavadocTypeTest extends AbstractXpathTestSupport {
 
         final String[] expectedViolation = {
             "8:1: " + getCheckMessage(JavadocTypeCheck.class,
-                MSG_MISSING_TAG, JavadocTagInfo.PARAM.getText() + " <C>"),
+                MSG_MISSING_TAG_WITH_QUOTES, JavadocTagInfo.PARAM.getText(), "<C>"),
         };
 
         final List<String> expectedXpathQueries = Arrays.asList(

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -94,6 +94,13 @@ public class JavadocTypeCheck
      * A key is pointing to the warning message text in "messages.properties"
      * file.
      */
+    public static final String MSG_MISSING_TAG_WITH_QUOTES =
+            "type.missingTagWithQuotes";
+
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
     public static final String MSG_UNUSED_TAG = "javadoc.unusedTag";
 
     /**
@@ -414,8 +421,8 @@ public class JavadocTypeCheck
                 });
 
         if (!found) {
-            log(ast, MSG_MISSING_TAG, JavadocTagInfo.PARAM.getText()
-                + SPACE + recordComponentName);
+            log(ast, MSG_MISSING_TAG_WITH_QUOTES,
+                JavadocTagInfo.PARAM.getText(), recordComponentName);
         }
     }
 
@@ -438,8 +445,8 @@ public class JavadocTypeCheck
             .anyMatch(tag -> tag.getFirstArg().indexOf(typeParamNameWithBrackets) == 0);
 
         if (!found) {
-            log(ast, MSG_MISSING_TAG, JavadocTagInfo.PARAM.getText()
-                + SPACE + typeParamNameWithBrackets);
+            log(ast, MSG_MISSING_TAG_WITH_QUOTES, JavadocTagInfo.PARAM.getText(),
+                typeParamNameWithBrackets);
         }
     }
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -35,4 +35,5 @@ summary.javaDoc.missing=Summary javadoc is missing.
 summary.javaDoc.missing.period=Summary of Javadoc is missing an ending period.
 tag.continuation.indent=Line continuation have incorrect indentation level, expected level should be {0}.
 type.missingTag=Type Javadoc comment is missing {0} tag.
+type.missingTagWithQuotes=Type Javadoc comment is missing {0} ''{1}'' tag.
 type.tagFormat=Type Javadoc tag {0} must match pattern ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -35,4 +35,5 @@ summary.javaDoc.missing=Javadoc-Zusammenfassung fehlt.
 summary.javaDoc.missing.period=Zusammenfassung von Javadoc fehlt eine Endperiode.
 tag.continuation.indent=Fortsetzung der Zeile hat falsche Einrückungstiefe (erwartet: {0}).
 type.missingTag=Im Javadoc des Typs fehlt das Tag {0}.
+type.missingTagWithQuotes=Im Javadoc des Typs fehlt das Tag {0} ''{1}''.
 type.tagFormat=Das Tag {0} im Javadoc des Typs muss dem Muster ''{1}'' entsprechen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -35,4 +35,5 @@ summary.javaDoc.missing=El resumen del Javadoc falta.
 summary.javaDoc.missing.period=El resumen de Javadoc falta un punto final.
 tag.continuation.indent=La continuación de la línea tiene un nivel de sangría incorrecto. El nivel esperado era {0}.
 type.missingTag=El comentario Javadoc del tipo falta una etiqueta ''{0}''.
+type.missingTagWithQuotes=El comentario Javadoc del tipo falta una etiqueta ''{0}'' ''{1}''.
 type.tagFormat=El formato de la etiqueta Javadoc ''{0}'' debería coincidir con el patrón ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -35,4 +35,5 @@ summary.javaDoc.missing=Yhteenveto javadoc puuttuu.
 summary.javaDoc.missing.period=Javadoc-yhteenvedosta puuttuu loppuvaihe.
 tag.continuation.indent=Jatkorivin on väärä sisennystason, odotettu taso olisi {0} .
 type.missingTag=Javadoc-kommentista puuttuu {0}-tagi.
+type.missingTagWithQuotes=Javadoc-kommentista puuttuu {0} ''{1}'' -tagi.
 type.tagFormat=Javadoc-tagin {0} pitää olla mallin ''{1}'' mukainen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -35,4 +35,5 @@ summary.javaDoc.missing=Le résumé Javadoc est manquant.
 summary.javaDoc.missing.period=Le résumé de Javadoc n''a pas de période de fin.
 tag.continuation.indent=La continuation de la ligne a un niveau d''indentation incorrect, le niveau attendu doit être {0}.
 type.missingTag=Dans le commentaire Javadoc de la classe, il manque une balise {0}.
+type.missingTagWithQuotes=Dans le commentaire Javadoc de la classe, il manque une balise {0} ''{1}''.
 type.tagFormat=La balise Javadoc {0} doit correspondre au motif ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -35,4 +35,5 @@ summary.javaDoc.missing=要約javadocがありません。
 summary.javaDoc.missing.period=Javadocの要約の末尾にピリオドがありません。
 tag.continuation.indent=行継続のインデントのレベルが間違っています。期待されるレベルは {0} です。
 type.missingTag=クラスの Javadoc コメントに {0} タグがありません。
+type.missingTagWithQuotes=クラスの Javadoc コメントに {0} ''{1}'' タグがありません。
 type.tagFormat=クラスの Javadoc タグ {0} はパターン ''{1}'' に合致しなければなりません。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -35,4 +35,5 @@ summary.javaDoc.missing=O resumo do Javadoc está ausente.
 summary.javaDoc.missing.period=O resumo do Javadoc está sem um ponto final.
 tag.continuation.indent=Continuação de linha têm um nível de indentação incorreto. O nível esperado era {0}.
 type.missingTag=O comentário Javadoc do tipo está com uma tag {0} faltando.
+type.missingTagWithQuotes=O comentário Javadoc do tipo está com uma tag {0} ''{1}'' faltando.
 type.tagFormat=O formato da tag Javadoc {0} deveria condizer com o padrão ''{1}''

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ru.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ru.properties
@@ -35,4 +35,5 @@ summary.javaDoc.missing=Отсутствует обобщающего предл
 summary.javaDoc.missing.period=Summary блок должен заканчиваться точкой.
 tag.continuation.indent=Неправильный уровень отступа для продолжения строки. Ожидаемый уровень: {0}.
 type.missingTag=Отсутствует тег {0}.
+type.missingTagWithQuotes=Отсутствует тег {0} ''{1}''.
 type.tagFormat=Тег {0} должен соответствовать ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -35,4 +35,5 @@ summary.javaDoc.missing=Özet javadoc eksik.
 summary.javaDoc.missing.period=Javadoc''un özetinde bir bitiş dönemi eksik.
 tag.continuation.indent=Çizgi devamı yanlış girinti düzeyine sahip, beklenen seviyede olmalıdır {0}
 type.missingTag=Tür için yazılan Javadoc açıklamasında {0} etiketi eksik.
+type.missingTagWithQuotes=Tür için yazılan Javadoc açıklamasında {0} ''{1}'' etiketi eksik.
 type.tagFormat=Tür için yazılan {0} Javadoc etiketi şu kalıpta olmalı: ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -35,4 +35,5 @@ summary.javaDoc.missing=缺少摘要javadoc。
 summary.javaDoc.missing.period=Javadoc的摘要缺少结束时间。
 tag.continuation.indent=Javadoc 缩进级别错误，应为 {0} 个缩进符。
 type.missingTag=缺少 {0} 标签。
+type.missingTagWithQuotes=缺少 {0} ''{1}'' 标签。
 type.tagFormat=标签 {0} 必须匹配： ''{1}'' 。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocTypeCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocTypeCheck.xml
@@ -65,6 +65,7 @@
             <message-key key="javadoc.unusedTag"/>
             <message-key key="javadoc.unusedTagGeneral"/>
             <message-key key="type.missingTag"/>
+            <message-key key="type.missingTagWithQuotes"/>
             <message-key key="type.tagFormat"/>
          </message-keys>
       </check>

--- a/src/site/xdoc/checks/javadoc/javadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctype.xml
@@ -519,7 +519,7 @@ public class Example8 {
   private class ClassF&lt;T&gt; {} // violation, as param tag for &lt;T&gt; is missing
 
   /** */
-  @Generated("tool") // violation, 'Type Javadoc comment is missing @param &lt;T&gt; tag'
+  @Generated("tool") // violation, 'Type Javadoc comment is missing @param '&lt;T&gt;' tag'
   public class ClassG&lt;T&gt; {}
 }
 </code></pre></div><hr class="example-separator"/>
@@ -609,6 +609,11 @@ public class Example9 {
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22type.missingTag%22">
               type.missingTag
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22type.missingTagWithQuotes%22">
+              type.missingTagWithQuotes
             </a>
           </li>
           <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_MISSING_TAG;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_MISSING_TAG_WITH_QUOTES;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_TAG_FORMAT;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_UNKNOWN_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_UNUSED_TAG;
@@ -119,7 +120,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPkg() throws Exception {
         final String[] expected = {
-            "53:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "53:5: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeScopeInnerClasses.java"), expected);
@@ -217,8 +218,8 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testScopes() throws Exception {
         final String[] expected = {
-            "18:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
-            "137:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "18:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
+            "137:5: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeNoJavadoc.java"),
@@ -236,7 +237,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testScopes2() throws Exception {
         final String[] expected = {
-            "18:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "18:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeNoJavadoc_2.java"),
@@ -246,7 +247,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testExcludeScope() throws Exception {
         final String[] expected = {
-            "137:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "137:5: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeNoJavadoc_1.java"),
@@ -257,9 +258,9 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testTypeParameters() throws Exception {
         final String[] expected = {
             "22:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<D123>"),
-            "26:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <C456>"),
+            "26:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<C456>"),
             "61:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
-            "64:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <B>"),
+            "64:5: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<B>"),
             "77:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
             "81:5: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL, "@param"),
         };
@@ -340,7 +341,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testAllowedAnnotationsNotAllowed() throws Exception {
 
         final String[] expected = {
-            "38:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "38:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeAllowedAnnotations_3.java"),
@@ -373,13 +374,13 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testJavadocTypeRecordComponentNameMismatch() throws Exception {
         final String[] expected1 = {
             "21:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "valueExtra"),
-            "23:1: " + getCheckMessage(MSG_MISSING_TAG, "@param value"),
+            "23:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "value"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeRecordComponentNameMismatch.java"), expected1);
 
         final String[] expected2 = {
-            "23:1: " + getCheckMessage(MSG_MISSING_TAG, "@param value"),
+            "23:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "value"),
             "21:4: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
         };
         verifyWithInlineConfigParser(
@@ -390,7 +391,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testJavadocTypeParamDescriptionWithAngularTags() throws Exception {
         final String[] expected = {
             "50:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
-            "52:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
+            "52:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<U>"),
             "57:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
         };
 
@@ -402,11 +403,11 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testJavadocTypeRecordParamDescriptionWithAngularTags() throws Exception {
         final String[] expected = {
             "57:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<P>"),
-            "59:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <U>"),
+            "59:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<U>"),
             "64:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "region"),
-            "66:1: " + getCheckMessage(MSG_MISSING_TAG, "@param a"),
+            "66:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "a"),
             "80:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "e"),
-            "82:1: " + getCheckMessage(MSG_MISSING_TAG, "@param c"),
+            "82:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "c"),
         };
 
         verifyWithInlineConfigParser(
@@ -419,18 +420,18 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testJavadocTypeRecordComponents2() throws Exception {
 
         final String[] expected = {
-            "44:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <X>"),
+            "44:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<X>"),
             "49:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
             "61:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "notMyString"),
-            "64:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myString"),
-            "64:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myInt"),
+            "64:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "myString"),
+            "64:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "myInt"),
             "69:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
-            "71:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myList"),
-            "78:1: " + getCheckMessage(MSG_MISSING_TAG, "@param X"),
+            "71:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "myList"),
+            "78:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "X"),
             "82:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "notMyString"),
-            "85:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
-            "85:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myInt"),
-            "85:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myString"),
+            "85:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
+            "85:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "myInt"),
+            "85:1: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "myString"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeRecordComponents2.java"), expected);
@@ -475,7 +476,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testJavadocType() throws Exception {
         final String[] expected = {
-            "28:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "28:5: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocType3.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocType3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocType3.java
@@ -25,7 +25,7 @@ public class InputJavadocType3 {
     *
     * @link <T>
     */
-    protected class InnerPublic2<T> // violation 'missing @param <T> tag.'
+    protected class InnerPublic2<T> // violation 'missing @param '<T>' tag.'
     {
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAllowedAnnotations_3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAllowedAnnotations_3.java
@@ -35,7 +35,7 @@ class InputJavadocTypeAllowedAnnotationByDefault_3 {
 @interface ThisIsOk_3 {}
 
 /** */
-@Generated // violation 'Type Javadoc comment is missing @param <T> tag'
+@Generated // violation 'Type Javadoc comment is missing @param '<T>' tag'
 class Application<T> {}
 
 @interface Generated {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc.java
@@ -15,7 +15,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
 /** */
-public class InputJavadocTypeNoJavadoc<T> // violation 'missing @param <T>.'
+public class InputJavadocTypeNoJavadoc<T> // violation 'missing @param '<T>'.'
 {
     public int i1;
     protected int i2;
@@ -134,6 +134,6 @@ class PackageClass {
     void methodWithTwoStarComment() {}
 
     /** */
-    protected class ProtectedInner2<T> { // violation 'missing @param <T>.'
+    protected class ProtectedInner2<T> { // violation 'missing @param '<T>'.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc_1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc_1.java
@@ -134,6 +134,6 @@ class PackageClass_1 {
     void methodWithTwoStarComment() {}
 
     /** */
-    protected class ProtectedInner2<T> { // violation 'missing @param <T>.'
+    protected class ProtectedInner2<T> { // violation 'missing @param '<T>'.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc_2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc_2.java
@@ -15,7 +15,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
 /** */
-public class InputJavadocTypeNoJavadoc_2<T> // violation 'missing @param <T>.'
+public class InputJavadocTypeNoJavadoc_2<T> // violation 'missing @param '<T>'.'
 {
     public int i1;
     protected int i2;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeParamDescriptionWithAngularTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeParamDescriptionWithAngularTags.java
@@ -49,7 +49,7 @@ class Shogun<T, U> {
  * @param    <T>
  * @param <P> stuff <><><<stuff></></></> stuff
  */
-interface Regent<T, U> {} // violation, 'Type Javadoc comment is missing @param <U> tag.'
+interface Regent<T, U> {} // violation, 'Type Javadoc comment is missing @param '<U>' tag.'
 
 // violation 3 lines below 'Unused @param tag for 'region'.'
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponentNameMismatch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponentNameMismatch.java
@@ -21,5 +21,5 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  * @param valueExtra wrong tag for a different component
  */
 public record InputJavadocTypeRecordComponentNameMismatch(String value) {
-    // violation above 'Type Javadoc comment is missing @param value tag.'
+    // violation above 'Type Javadoc comment is missing @param 'value' tag.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponentNameMismatch2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponentNameMismatch2.java
@@ -21,5 +21,5 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  * @param
  */
 public record InputJavadocTypeRecordComponentNameMismatch2(String value) {
-    // violation above 'Type Javadoc comment is missing @param value tag.'
+    // violation above 'Type Javadoc comment is missing @param 'value' tag.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents2.java
@@ -41,7 +41,7 @@ record MyRecord2(HashMap<String, String> myHashMap){}
 /**
  *
  */
-record MyRecord3<X>(){} // violation 'missing @param <X> tag.'
+record MyRecord3<X>(){} // violation 'missing @param '<X>' tag.'
 
 // violation 3 lines below 'Unused @param tag for 'x'.'
 /**
@@ -68,14 +68,14 @@ record MyRecord6<X>(String myString, int myInt){} // 2 violations
  *
  * @param x
  */
-record MyRecord7(List<String>myList){} // violation 'missing @param myList tag.'
+record MyRecord7(List<String>myList){} // violation 'missing @param 'myList' tag.'
 
 /**
  * @author X
  * @param <X>
  * @param <T>
  */
-record MyRecord8<X, T>(String X){} // violation 'missing @param X tag.'
+record MyRecord8<X, T>(String X){} // violation 'missing @param 'X' tag.'
 
 // violation 2 lines below 'Unused @param tag for 'notMyString'.'
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordParamDescriptionWithAngularTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordParamDescriptionWithAngularTags.java
@@ -56,14 +56,14 @@ record Record2<T>(int a, int b) {
  * @param <T>
  * @param    <P>     stuff <><><<stuff></></></> stuff
  */
-record Record5<T, U>() {} // violation, 'Type Javadoc comment is missing @param <U> tag.'
+record Record5<T, U>() {} // violation, 'Type Javadoc comment is missing @param '<U>' tag.'
 
 // violation 3 lines below 'Unused @param tag for \'region\'.'
 /**
  *
  * @param region [(<>{@code stuff<stuff🐦‍🔥>🐦‍🔥&lt;stuff&gt;}</>)]{@code {&lt;stuff&gt;}}
  */
-record Record6(int a) {} // violation, 'Type Javadoc comment is missing @param a tag.'
+record Record6(int a) {} // violation, 'Type Javadoc comment is missing @param 'a' tag.'
 
 /**
  *
@@ -79,7 +79,7 @@ record Record7<T>(int a, int b) {}
  * @param b stuff<stuff>:<>:<>:<🐦‍🔥<<🐦‍🔥>>🐦‍🔥>
  * @param e [(<>{@code stuff<stuff🐦[(‍{🔥}])>🐦‍🔥&lt;stuff&gt;}</>)]{@code {&lt;stuff&gt;}}
  */
-record Record8(int a, int b, int c) { // violation, 'Type Javadoc comment is missing @param c tag.'
+record Record8(int a, int b, int c) { // violation, 'missing @param 'c' tag.'
 }
 
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeScopeInnerClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeScopeInnerClasses.java
@@ -50,7 +50,7 @@ public class InputJavadocTypeScopeInnerClasses
         }
     }
     /** */
-    protected class InnerPublic2<T> // violation 'missing @param <T> tag.'
+    protected class InnerPublic2<T> // violation 'missing @param '<T>' tag.'
     {
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags_1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags_1.java
@@ -24,7 +24,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  * @version 1.0
  */
 public class InputJavadocTypeTypeParamsTags_1<A,B1,C456 extends Comparable>
-// violation above 'missing @param <C456> tag.'
+// violation above 'missing @param '<C456>' tag.'
 {
     /**
      * Some explanation.
@@ -61,7 +61,7 @@ public class InputJavadocTypeTypeParamsTags_1<A,B1,C456 extends Comparable>
      * @param <C> extra parameter
      */
 
-    public static class InnerClass_1<A,B> // violation 'missing @param <B> tag.'
+    public static class InnerClass_1<A,B> // violation 'missing @param '<B>' tag.'
     {
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckExamplesTest.java
@@ -19,7 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_MISSING_TAG;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_MISSING_TAG_WITH_QUOTES;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_UNKNOWN_TAG;
 
 import org.junit.jupiter.api.Test;
@@ -36,8 +36,8 @@ public class JavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     public void testExample1() throws Exception {
         final String[] expected = {
             "28:6: " + getCheckMessage(MSG_UNKNOWN_TAG, "unknownTag"),
-            "36:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
-            "39:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "36:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
+            "39:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -47,7 +47,7 @@ public class JavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     public void testExample2() throws Exception {
         final String[] expected = {
             "30:6: " + getCheckMessage(MSG_UNKNOWN_TAG, "unknownTag"),
-            "38:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "38:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -57,8 +57,8 @@ public class JavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     public void testExample3() throws Exception {
         final String[] expected = {
             "30:6: " + getCheckMessage(MSG_UNKNOWN_TAG, "unknownTag"),
-            "38:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
-            "41:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "38:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
+            "41:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -68,8 +68,8 @@ public class JavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     public void testExample4() throws Exception {
         final String[] expected = {
             "30:6: " + getCheckMessage(MSG_UNKNOWN_TAG, "unknownTag"),
-            "38:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
-            "41:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "38:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
+            "41:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
 
         };
 
@@ -79,7 +79,7 @@ public class JavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "42:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "42:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
@@ -97,8 +97,8 @@ public class JavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample7() throws Exception {
         final String[] expected = {
-            "38:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
-            "41:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "38:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
+            "41:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
@@ -108,9 +108,9 @@ public class JavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     public void testExample8() throws Exception {
         final String[] expected = {
             "30:6: " + getCheckMessage(MSG_UNKNOWN_TAG, "unknownTag"),
-            "38:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
-            "41:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
-            "44:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "38:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
+            "41:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
+            "44:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
 
         verifyWithInlineConfigParser(getPath("Example8.java"), expected);
@@ -120,8 +120,8 @@ public class JavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     public void testExample9() throws Exception {
         final String[] expected = {
             "31:6: " + getCheckMessage(MSG_UNKNOWN_TAG, "unknownTag"),
-            "39:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
-            "42:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "39:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
+            "42:3: " + getCheckMessage(MSG_MISSING_TAG_WITH_QUOTES, "@param", "<T>"),
         };
 
         verifyWithInlineConfigParser(getPath("Example9.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example8.java
@@ -41,7 +41,7 @@ public class Example8 {
   private class ClassF<T> {} // violation, as param tag for <T> is missing
 
   /** */
-  @Generated("tool") // violation, 'Type Javadoc comment is missing @param <T> tag'
+  @Generated("tool") // violation, 'Type Javadoc comment is missing @param '<T>' tag'
   public class ClassG<T> {}
 }
 // xdoc section -- end


### PR DESCRIPTION
Fixes #19806

`JavadocType` produced confusing missing-tag violations when values taken from
Java source were not clearly delimited, for example:

`Type Javadoc comment is missing @param value tag.`

This updates the message handling so source-derived values are wrapped in
single quotes:

`Type Javadoc comment is missing @param 'value' tag.`

Changes:

- kept `type.missingTag` for missing tags without a source-derived value;
- added `type.missingTagWithQuotes` for messages containing values taken from
  Java source;
- updated `JavadocTypeCheck` to use the quoted message for record components
  and type parameters;
- kept `WriteTagCheck` on the existing general missing-tag message;
- updated locale bundles, metadata, tests, violation comments, and generated
  JavadocType documentation.