### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - emptyblock

### DIFF
--- a/src/site/xdoc/checks/blocks/emptyblock.xml
+++ b/src/site/xdoc/checks/blocks/emptyblock.xml
@@ -134,9 +134,7 @@ public class Example1 {
   private void testBadSwitchStatement(int a) {
     switch (a) {
       case 1: { }
-
       case 2: {} {};
-
       case 3: {} { System.out.println(); }
 
       case 4: { System.out.println(); } {}
@@ -180,7 +178,7 @@ public class Example1 {
 public class Example2 {
   private void emptyLoop() {
     for (int i = 0; i &lt; 10; i++) {
-      // ignored
+
     }
 
     try {
@@ -193,9 +191,7 @@ public class Example2 {
   private void testBadSwitchStatement(int a) {
     switch (a) {
       case 1: { }
-
       case 2: {} {};
-
       case 3: {} { System.out.println(); }
 
       case 4: { System.out.println(); } {}
@@ -249,14 +245,12 @@ public class Example3 {
 
   private void testBadSwitchStatement(int a) {
     switch (a) {
-      case 1: { } // violation 'Must have at least one statement'
-      // the second empty block is 'sequential', skipped.
+      case 1: { }    // violation 'Must have at least one statement'
       case 2: {} {}; // violation 'Must have at least one statement'
-      // violation below, 'Must have at least one statement'
       case 3: {} { System.out.println(); }
-      // the second empty block is 'sequential', skipped.
+      // violation above 'Must have at least one statement'
       case 4: { System.out.println(); } {}
-      default: { } // violation 'Must have at least one statement'
+      default: { }   // violation 'Must have at least one statement'
     }
   }
 
@@ -269,7 +263,7 @@ public class Example3 {
 
   private void testBadSwitchRule(int a) {
     switch (a) {
-      case 1 -&gt; { } // violation 'Must have at least one statement'
+      case 1 -&gt; { }  // violation 'Must have at least one statement'
       default -&gt; { } // violation 'Must have at least one statement'
     }
   }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -109,8 +109,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/annotation/suppresswarningsholder/Example2",
             "checks/annotation/suppresswarningsholder/Example3",
             "checks/annotation/suppresswarningsholder/Example4",
-            "checks/blocks/emptyblock/Example2",
-            "checks/blocks/emptyblock/Example3",
             "checks/blocks/leftcurly/Example3",
             "checks/blocks/needbraces/Example2",
             "checks/blocks/needbraces/Example3",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckExamplesTest.java
@@ -55,11 +55,11 @@ public class EmptyBlockCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     public void testExample3() throws Exception {
         final String[] expected = {
             "30:15: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "31:15: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
             "32:15: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
-            "34:15: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
-            "37:16: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
-            "50:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
-            "51:18: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "35:16: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "48:17: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
+            "49:18: " + getCheckMessage(MSG_KEY_BLOCK_NO_STATEMENT, "case"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example1.java
@@ -26,9 +26,7 @@ public class Example1 {
   private void testBadSwitchStatement(int a) {
     switch (a) {
       case 1: { }
-
       case 2: {} {};
-
       case 3: {} { System.out.println(); }
 
       case 4: { System.out.println(); } {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example2.java
@@ -16,7 +16,7 @@ package com.puppycrawl.tools.checkstyle.checks.blocks.emptyblock;
 public class Example2 {
   private void emptyLoop() {
     for (int i = 0; i < 10; i++) {
-      // ignored
+
     }
 
     try {
@@ -29,9 +29,7 @@ public class Example2 {
   private void testBadSwitchStatement(int a) {
     switch (a) {
       case 1: { }
-
       case 2: {} {};
-
       case 3: {} { System.out.println(); }
 
       case 4: { System.out.println(); } {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock/Example3.java
@@ -27,14 +27,12 @@ public class Example3 {
 
   private void testBadSwitchStatement(int a) {
     switch (a) {
-      case 1: { } // violation 'Must have at least one statement'
-      // the second empty block is 'sequential', skipped.
+      case 1: { }    // violation 'Must have at least one statement'
       case 2: {} {}; // violation 'Must have at least one statement'
-      // violation below, 'Must have at least one statement'
       case 3: {} { System.out.println(); }
-      // the second empty block is 'sequential', skipped.
+      // violation above 'Must have at least one statement'
       case 4: { System.out.println(); } {}
-      default: { } // violation 'Must have at least one statement'
+      default: { }   // violation 'Must have at least one statement'
     }
   }
 
@@ -47,7 +45,7 @@ public class Example3 {
 
   private void testBadSwitchRule(int a) {
     switch (a) {
-      case 1 -> { } // violation 'Must have at least one statement'
+      case 1 -> { }  // violation 'Must have at least one statement'
       default -> { } // violation 'Must have at least one statement'
     }
   }


### PR DESCRIPTION
#18435 


Example1 -> default
Example2 ->  property options and token
Example3 -> property -> token

Section1 -> Example1,2,3