### PR TITLE
Issue #19724: adding accessModifier protected for JavadocMethod

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/WhereJavadocIsUsedTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/WhereJavadocIsUsedTest.java
@@ -55,4 +55,9 @@ public class WhereJavadocIsUsedTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputJavadocTypeOnRecord2.java"));
     }
 
+    @Test
+    public void testJavadocMethodProtected() throws Exception {
+        verifyWithWholeConfig(getPath("InputJavadocMethodProtected.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodProtected.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputJavadocMethodProtected.java
@@ -1,0 +1,38 @@
+package com.google.checkstyle.test.chapter7javadoc.rule73wherejavadocrequired;
+
+/** Some javadoc. */
+public class InputJavadocMethodProtected {
+
+  /**
+   * Some javadoc.
+   *
+   * @param b this parameter doesn't exist
+   */
+  protected void foo(int a) {}
+
+  // violation 4 lines above 'Unused @param tag for 'b''
+
+  /**
+   * Some javadoc.
+   *
+   * @param a this parameter do exist
+   */
+  protected void foo1(int a) {}
+
+  /**
+   * Some javadoc.
+   *
+   * @param b parameter exist
+   * @param c paramter doesn't exist
+   */
+  protected void foo2(int b) {}
+
+  // violation 4 lines above 'Unused @param tag for 'c''
+
+  /**
+   * Some javadoc.
+   *
+   * @param b parameter exist
+   */
+  protected void foo3(int b) {}
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -438,7 +438,7 @@
                                   VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="accessModifiers" value="public"/>
+      <property name="accessModifiers" value="public, protected"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>


### PR DESCRIPTION
Issue: #19724 

The Google Java Style Guide requires Javadoc for all visible members, including `protected` methods in visible classes ([§7.3 Where Javadoc is used](https://google.github.io/styleguide/javaguide.html#s7.3-javadoc-where-required)).

Currently, the Google configuration uses different visibility scopes for Javadoc presence and Javadoc validation:

| Check                  | Configuration              | Covered Methods       |
| ---------------------- | -------------------------- | --------------------- |
| `MissingJavadocMethod` | `scope="protected"`        | `public`, `protected` |
| `JavadocMethod`        | `accessModifiers="public"` | `public` only         |

This leads to a gap in enforcement. A `protected` method is required to have Javadoc, but the content of that Javadoc is not validated. As a result,  invalid `@param`, `@return`, and `@throws` tags on `protected` methods are not reported.

Diff Regression config: https://gist.githubusercontent.com/Atharv3221/bf0f9fb30db5de4b3693fdf075de6bf9/raw/3df02fb83951a4685791ecb3ebc497a3fb3151aa/javadocMethod.xml

Diff Regression patch config: https://gist.githubusercontent.com/Atharv3221/ec1faf92e68d82ecf2089d2da5abfd8a/raw/429d30df9aab93e1ab5e7e069af831935ffe322a/javadocMethod2.xml
