### PR TITLE
Fix #19475: StringLiteralEqualityCheck false negative for new String(...) == literal

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -76,12 +76,45 @@ public class StringLiteralEqualityCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        final boolean hasStringLiteralChild = hasStringLiteralChild(ast);
+       @Override
+public void visitToken(DetailAST ast) {
+    final DetailAST left  = ast.getFirstChild();
+    final DetailAST right = left.getNextSibling();
 
-        if (hasStringLiteralChild) {
-            log(ast, MSG_KEY, ast.getText());
-        }
+    if (isStringLiteralOrTextBlock(left)
+            || isStringLiteralOrTextBlock(right)
+            || isNewStringExpression(left)
+            || isNewStringExpression(right)) {
+        log(ast, MSG_KEY, ast.getText());
     }
+}
+
+/**
+ * Returns true if the node is a string literal or text block literal.
+ *
+ * @param node the AST node to check
+ * @return true if node is STRING_LITERAL or TEXT_BLOCK_LITERAL_BEGIN
+ */
+private static boolean isStringLiteralOrTextBlock(DetailAST node) {
+    return node.getType() == TokenTypes.STRING_LITERAL
+        || node.getType() == TokenTypes.TEXT_BLOCK_LITERAL_BEGIN;
+}
+
+/**
+ * Returns true if the node represents a new String(...) expression.
+ *
+ * @param node the AST node to check
+ * @return true if node is a new String(...) construction
+ */
+private static boolean isNewStringExpression(DetailAST node) {
+    if (node.getType() != TokenTypes.LITERAL_NEW) {
+        return false;
+    }
+    final DetailAST ident = node.getFirstChild();
+    return ident != null
+        && ident.getType() == TokenTypes.IDENT
+        && "String".equals(ident.getText());
+}    }
 
     /**
      * Checks whether string literal or text block literals are concatenated.
@@ -104,5 +137,20 @@ public class StringLiteralEqualityCheck extends AbstractCheck {
         }
         return result;
     }
+@Test
+public void testNewStringExpression() throws Exception {
+    final String[] expected = {
+        "14:22: " + getCheckMessage(MSG_KEY, "=="),
+        "15:22: " + getCheckMessage(MSG_KEY, "=="),
+        "16:22: " + getCheckMessage(MSG_KEY, "=="),
+        "17:22: " + getCheckMessage(MSG_KEY, "!="),
+        "18:22: " + getCheckMessage(MSG_KEY, "=="),
+    };
+
+    verifyWithInlineConfigParser(
+        getPath("InputStringLiteralEqualityNewString.java"),
+        expected
+    );
+}
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityNewString.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityNewString.java
@@ -1,0 +1,25 @@
+/*
+ * InputStringLiteralEqualityNewString - tests for false negative
+ * when new String(...) is compared with == or != against a string literal.
+ * Issue: https://github.com/checkstyle/checkstyle/issues/19475
+ */
+package com.puppycrawl.tools.checkstyle.checks.coding.stringliteralequality;
+
+public class InputStringLiteralEqualityNewString {
+
+    public void test() {
+        String literal = "hello";
+        String newStr  = new String("hello");
+
+        boolean r1 = (newStr == literal);            // violation
+        boolean r2 = (literal == newStr);            // violation
+        boolean r3 = (new String("x") == "x");      // violation
+        boolean r4 = (new String("x") != "x");      // violation
+        boolean r5 = ("hello" == "world");           // violation (pre-existing)
+
+        // OK - no violations expected:
+        boolean r6 = (newStr.equals(literal));
+        boolean r7 = ("hello".equals(newStr));
+    }
+}
+EOF


### PR DESCRIPTION
## Description

Fixes https://github.com/checkstyle/checkstyle/issues/19475

`StringLiteralEqualityCheck` previously did not detect `==` / `!=` comparisons when one operand was a `new String(...)` expression. This PR extends the check to also flag those cases.

## Changes

- **`StringLiteralEqualityCheck.java`**: Added `isNewStringExpression()` helper method that detects `new String(...)` AST patterns (`LITERAL_NEW` with child `IDENT` = `String`). Updated `visitToken()` to also trigger a violation when either operand is a `new String(...)` expression.
- **`InputStringLiteralEqualityNewString.java`** (new test input): Contains test cases for `new String(...) == literal`, `literal == new String(...)`, `new String(...) != literal`, and non-violation cases using `.equals()`.
- **`StringLiteralEqualityCheckTest.java`**: Added `testNewStringExpression()` test method to verify the new detection logic.

## How to test

```bash
mvn test -Dtest=StringLiteralEqualityCheckTest
```
