### PR TITLE
Fix #19475: StringLiteralEqualityCheck false negative for new String(...) == literal

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -77,8 +77,12 @@ public class StringLiteralEqualityCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         final boolean hasStringLiteralChild = hasStringLiteralChild(ast);
+        final DetailAST left = ast.getFirstChild();
+        final DetailAST right = left.getNextSibling();
 
-        if (hasStringLiteralChild) {
+        if (hasStringLiteralChild
+                || isNewStringExpression(left)
+                || isNewStringExpression(right)) {
             log(ast, MSG_KEY, ast.getText());
         }
     }
@@ -103,6 +107,22 @@ public class StringLiteralEqualityCheck extends AbstractCheck {
             }
         }
         return result;
+    }
+
+    /**
+     * Returns true if the node represents a new String(...) expression.
+     *
+     * @param node the AST node to check
+     * @return true if node is a new String(...) construction
+     */
+    private static boolean isNewStringExpression(DetailAST node) {
+        if (node.getType() != TokenTypes.LITERAL_NEW) {
+            return false;
+        }
+        final DetailAST ident = node.getFirstChild();
+        return ident != null
+            && ident.getType() == TokenTypes.IDENT
+            && "String".equals(ident.getText());
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheckTest.java
@@ -119,4 +119,20 @@ public class StringLiteralEqualityCheckTest
             .isNotNull();
     }
 
+    @Test
+    public void testNewStringExpression() throws Exception {
+        final String[] expected = {
+            "15:39: " + getCheckMessage(MSG_KEY, "=="),
+            "17:27: " + getCheckMessage(MSG_KEY, "=="),
+            "19:39: " + getCheckMessage(MSG_KEY, "!="),
+            "21:31: " + getCheckMessage(MSG_KEY, "=="),
+            "23:39: " + getCheckMessage(MSG_KEY, "=="),
+        };
+
+        verifyWithInlineConfigParser(
+            getPath("InputStringLiteralEqualityNewString.java"),
+            expected
+        );
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityNewString.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityNewString.java
@@ -1,0 +1,29 @@
+/*
+StringLiteralEquality
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.stringliteralequality;
+
+public class InputStringLiteralEqualityNewString {
+
+    public void test() {
+        String literal = "hello";
+
+        // violation below 'Literal Strings should be compared using equals(), not '==''
+        boolean r1 = (new String("x") == "x");
+        // violation below 'Literal Strings should be compared using equals(), not '==''
+        boolean r2 = ("x" == new String("x"));
+        // violation below 'Literal Strings should be compared using equals(), not '!=''
+        boolean r3 = (new String("x") != "x");
+        // violation below 'Literal Strings should be compared using equals(), not '==''
+        boolean r4 = ("hello" == "world");
+        // violation below 'Literal Strings should be compared using equals(), not '==''
+        boolean r5 = (new String("a") == new String("b"));
+
+        // no violations expected below
+        boolean r6 = (literal.equals("test"));
+        boolean r7 = ("hello".equals(literal));
+    }
+}


### PR DESCRIPTION
Closes #19475

## Summary

`StringLiteralEqualityCheck` previously only detected `==`/`!=` comparisons where one side was a string literal or text block. It missed cases where `new String(...)` was used, e.g.:

```java
if (new String("x") == "x") { ... }  // was not flagged
```

## Changes

- **`StringLiteralEqualityCheck.java`**: Added `isNewStringExpression()` helper that detects `new String(...)` constructor expressions. The `visitToken` method now checks both operands for `new String(...)` in addition to the existing string literal check.
- **`InputStringLiteralEqualityNewString.java`**: New test input file covering `new String(...)` on left/right side of `==`/`!=`, as well as `new String(...) == new String(...)`.
- **`StringLiteralEqualityCheckTest.java`**: Added `testNewStringExpression()` test method verifying 5 expected violations.
