### PR TITLE
Issue #20222: HiddenFieldCheck: fix parameter shadowing detection in compact source files

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -135,6 +137,7 @@ public class HiddenFieldCheck
             TokenTypes.LAMBDA,
             TokenTypes.RECORD_DEF,
             TokenTypes.RECORD_COMPONENT_DEF,
+            TokenTypes.COMPACT_COMPILATION_UNIT,
         };
     }
 
@@ -145,6 +148,7 @@ public class HiddenFieldCheck
             TokenTypes.ENUM_DEF,
             TokenTypes.ENUM_CONSTANT_DEF,
             TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_COMPILATION_UNIT,
         };
     }
 
@@ -216,7 +220,7 @@ public class HiddenFieldCheck
         final FieldFrame newFrame = new FieldFrame(frame, isStaticInnerType, frameName);
 
         // add fields to container
-        final DetailAST objBlock = ast.findFirstToken(TokenTypes.OBJBLOCK);
+        final DetailAST objBlock = getFieldContainer(ast);
         // enum constants may not have bodies
         if (objBlock != null) {
             DetailAST child = objBlock.getFirstChild();
@@ -249,6 +253,25 @@ public class HiddenFieldCheck
         }
         // push container
         frame = newFrame;
+    }
+
+    /**
+     * Gets the member container for field declaration harvesting.
+     *
+     * @param ast the type definition node.
+     * @return the member container, either the compact compilation unit
+     *     itself or the OBJBLOCK child of a standard type definition.
+     */
+    @Nullable
+    private static DetailAST getFieldContainer(DetailAST ast) {
+        final DetailAST result;
+        if (ast.getType() == TokenTypes.COMPACT_COMPILATION_UNIT) {
+            result = ast;
+        }
+        else {
+            result = ast.findFirstToken(TokenTypes.OBJBLOCK);
+        }
+        return result;
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -684,6 +684,53 @@ public class HiddenFieldCheckTest
     }
 
     @Test
+    public void testHiddenFieldCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "18:21: " + getCheckMessage(MSG_KEY, "name"),
+            "18:31: " + getCheckMessage(MSG_KEY, "count"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputHiddenFieldCompactSourceFile.java"), expected);
+    }
+
+    @Test
+    public void testHiddenFieldCompactSourceFileStatic() throws Exception {
+        final String[] expected = {
+            "17:21: " + getCheckMessage(MSG_KEY, "name"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputHiddenFieldCompactSourceFileStatic.java"), expected);
+    }
+
+    @Test
+    public void testHiddenFieldCompactSourceFileStaticFieldAndMethod() throws Exception {
+        final String[] expected = {
+            "17:28: " + getCheckMessage(MSG_KEY, "name"),
+        };
+        final String file = "InputHiddenFieldCompactSourceFileStaticFieldAndMethod.java";
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(file), expected);
+    }
+
+    @Test
+    public void testHiddenFieldCompactSourceFileInstanceFieldStaticMethod() throws Exception {
+        final String[] expected = {};
+        final String file = "InputHiddenFieldCompactSourceFileInstanceFieldStaticMethod.java";
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(file), expected);
+    }
+
+    @Test
+    public void testHiddenFieldCompactSourceFileNested() throws Exception {
+        final String[] expected = {
+            "24:25: " + getCheckMessage(MSG_KEY, "name"),
+        };
+        final String file = "InputHiddenFieldCompactSourceFileNested.java";
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(file), expected);
+    }
+
+    @Test
     public void testHiddenFieldRecordPattern() throws Exception {
 
         final String[] expected = {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldCompactSourceFile.java
@@ -1,0 +1,25 @@
+/*
+HiddenField
+ignoreFormat = (default)null
+ignoreConstructorParameter = (default)false
+ignoreSetter = (default)false
+setterCanReturnItsClass = (default)false
+ignoreAbstractMethods = (default)false
+tokens = VARIABLE_DEF, PARAMETER_DEF
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+String name = "default";
+int count = 0;
+
+void process(String name, int count) {
+    // 2 violations above:
+    //                   ''name' hides a field.'
+    //                   ''count' hides a field.'
+    System.out.println(name + ": " + count);
+}
+
+void main() { process("test", 42); }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldCompactSourceFileInstanceFieldStaticMethod.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldCompactSourceFileInstanceFieldStaticMethod.java
@@ -1,0 +1,21 @@
+/*
+HiddenField
+ignoreFormat = (default)null
+ignoreConstructorParameter = (default)false
+ignoreSetter = (default)false
+setterCanReturnItsClass = (default)false
+ignoreAbstractMethods = (default)false
+tokens = VARIABLE_DEF, PARAMETER_DEF
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+String name = "default";
+
+static void process(String name) {
+    System.out.println(name);
+}
+
+void main() { process("test"); }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldCompactSourceFileNested.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldCompactSourceFileNested.java
@@ -1,0 +1,25 @@
+/*
+HiddenField
+ignoreFormat = (default)null
+ignoreConstructorParameter = (default)false
+ignoreSetter = (default)false
+setterCanReturnItsClass = (default)false
+ignoreAbstractMethods = (default)false
+tokens = VARIABLE_DEF, PARAMETER_DEF
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+String name = "default";
+
+void main() { }
+
+static class StaticNested {
+    void process(String name) { }
+}
+
+class Inner {
+    void process(String name) { } // violation ''name' hides a field'
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldCompactSourceFileStatic.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldCompactSourceFileStatic.java
@@ -1,0 +1,21 @@
+/*
+HiddenField
+ignoreFormat = (default)null
+ignoreConstructorParameter = (default)false
+ignoreSetter = (default)false
+setterCanReturnItsClass = (default)false
+ignoreAbstractMethods = (default)false
+tokens = VARIABLE_DEF, PARAMETER_DEF
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+static String name = "default";
+
+void process(String name) { // violation, ''name' hides a field'
+    System.out.println(name);
+}
+
+void main() { process("test"); }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldCompactSourceFileStaticFieldAndMethod.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldCompactSourceFileStaticFieldAndMethod.java
@@ -1,0 +1,21 @@
+/*
+HiddenField
+ignoreFormat = (default)null
+ignoreConstructorParameter = (default)false
+ignoreSetter = (default)false
+setterCanReturnItsClass = (default)false
+ignoreAbstractMethods = (default)false
+tokens = VARIABLE_DEF, PARAMETER_DEF
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+static String name = "default";
+
+static void process(String name) { // violation ''name' hides a field'
+    System.out.println(name);
+}
+
+void main() { process("test"); }


### PR DESCRIPTION
closes #20222

HiddenFieldCheck was not detecting method parameters that shadow top-level
fields in JEP 512 compact source files.

## Fix
Modified `beginTree()` to scan the compilation unit's direct children for`VARIABLE_DEF` and register them in the root frame as instance or static fields (based on modifiers). Guarded with `rootAST != null` for the `testClearState` test path.
