### PR TITLE
Issue #20268: Fix OuterTypeNumber false positive on JEP 512 compact s…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheck.java
@@ -51,6 +51,13 @@ public class OuterTypeNumberCheck extends AbstractCheck {
     /** Tracks the number of outer types found. */
     private int outerNum;
 
+    /**
+     * Whether the file is a JEP 512 compact source file. All its type
+     * declarations are members of the implicit class, so it always has exactly
+     * one outer type and the limit can never be exceeded.
+     */
+    private boolean isCompactSourceFile;
+
     @Override
     public int[] getDefaultTokens() {
         return getRequiredTokens();
@@ -76,11 +83,13 @@ public class OuterTypeNumberCheck extends AbstractCheck {
     public void beginTree(DetailAST ast) {
         currentDepth = 0;
         outerNum = 0;
+        isCompactSourceFile = ast != null
+                && ast.getType() == TokenTypes.COMPACT_COMPILATION_UNIT;
     }
 
     @Override
     public void finishTree(DetailAST ast) {
-        if (max < outerNum) {
+        if (!isCompactSourceFile && max < outerNum) {
             log(ast, MSG_KEY, outerNum, max);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
@@ -110,6 +110,13 @@ public class OuterTypeNumberCheckTest extends AbstractModuleTestSupport {
                 getPath("InputOuterTypeNumberRecords.java"), expected);
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputOuterTypeNumberCompactSourceFile.java"), expected);
+    }
+
     /**
      * Checks if the private field {@code currentDepth} and {@code outerNum} is
      * properly cleared during the start of processing the next file in the

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberCompactSourceFile.java
@@ -1,0 +1,36 @@
+/*
+OuterTypeNumber
+max = (default)1
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+// Every type declared below is a member of the implicit class synthesized for
+// this compact source file, not an outer type. The only outer type is the
+// implicit class itself, so the check must stay silent even though several
+// types of every kind, plus nested types, are declared.
+
+void main() {
+    System.out.println("Hello!");
+}
+
+class A {
+    class Inner {
+    }
+}
+
+interface B {
+}
+
+enum C {
+    ONE,
+    TWO
+}
+
+record D(int x) {
+}
+
+@interface E {
+}


### PR DESCRIPTION
Fixes #20268

`OuterTypeNumber` flagged a false positive on JEP 512 compact source files. The type declarations in a compact file are members of the implicit class, not top-level types, so the file has exactly one outer type and the check should never fire.

The check counts type-defs at root depth, but under the new grammar the root is `COMPACT_COMPILATION_UNIT` and its `CLASS_DEF`/etc. children are member declarations, they were wrongly counted as outer types.