### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - trailingcomment

### DIFF
--- a/src/site/xdoc/checks/misc/trailingcomment.xml
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml
@@ -114,7 +114,7 @@ public class Example1 {
   int a;
   int b;
   int c;
-  int d; // violation
+  int d; // violation, not suppressed
 
   public static void main(String[] args) {
     int x = 10;
@@ -191,9 +191,9 @@ public class Example2 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example3 {
-  int a; // SUPPRESS CHECKSTYLE
-  int b; // NOPMD
-  int c; // NOSONAR
+  int a;
+  int b;
+  int c;
   int d; // violation, not suppressed
 
   public static void main(String[] args) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -250,7 +250,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/whitespace/whitespaceafter/Example2",
             "checks/todocomment/Example2",
             "checks/todocomment/Example3",
-            "checks/trailingcomment/Example3",
             "checks/uncommentedmain/Example2",
             "checks/uniqueproperties/Example2",
             "checks/whitespace/emptyforiteratorpad/Example2",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example1.java
@@ -13,7 +13,7 @@ public class Example1 {
   int a;
   int b;
   int c;
-  int d; // violation
+  int d; // violation, not suppressed
 
   public static void main(String[] args) {
     int x = 10;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
@@ -12,9 +12,9 @@ package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
 
 // xdoc section -- start
 public class Example3 {
-  int a; // SUPPRESS CHECKSTYLE
-  int b; // NOPMD
-  int c; // NOSONAR
+  int a;
+  int b;
+  int c;
   int d; // violation, not suppressed
 
   public static void main(String[] args) {


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/18435

trailingcomment:

Example1 — default config
Example2 — format property (different from default)
Example3 — legalComment property with exact match pattern $
Example4 — legalComment property with prefix match .*
Example5 — legalComment property with TODO/FIXME pattern
Example6 — legalComment + SuppressionXpathSingleFilter (completely different structure with block comments)

Examples 3, 4, 5 — all demonstrate legalComment property with different patterns:

Example3: exact match ($)
Example4: prefix match (.*) — same property as Example3, different regex value → Use Case
Example5: TODO/FIXME pattern — same property as Example3, different regex value → Use Case

Example6 — legalComment + SuppressionXpathSingleFilter + uses block comments (/* */) instead of line comments (//) → completely different structure ( Use Case )
Example2 — format property ( unique property, Section 1 )
So:

Section 1: Examples 1, 2, 3
Use Cases: Examples 4, 5, 6