### PR TITLE
Issue #19803: move violation comments above annotated types

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -817,12 +817,6 @@
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]missingjavadocmethod[\\/]InputMissingJavadocMethodExtendAnnotation\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]missingjavadocmethod[\\/]InputMissingJavadocMethodJavadocInMethod\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]missingjavadoctype[\\/]InputMissingJavadocTypeQualifiedAnnotation1\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]missingjavadoctype[\\/]InputMissingJavadocTypeQualifiedAnnotation3\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]missingjavadoctype[\\/]InputMissingJavadocTypeQualifiedAnnotation4\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]nonemptyatclausedescription[\\/]InputNonEmptyAtclauseDescriptionOne\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
@@ -373,9 +373,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testQualifiedAnnotation1() throws Exception {
         final String[] expected = {
-            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "26:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeQualifiedAnnotation1.java"), expected);
@@ -394,8 +394,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testQualifiedAnnotation3() throws Exception {
         final String[] expected = {
-            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeQualifiedAnnotation3.java"), expected);
@@ -404,8 +404,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testQualifiedAnnotation4() throws Exception {
         final String[] expected = {
-            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "19:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeQualifiedAnnotation4.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation1.java
@@ -14,14 +14,16 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 public class InputMissingJavadocTypeQualifiedAnnotation1 {
     public @interface SomeAnnotation { }
 
-    @SomeAnnotation // violation 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    @SomeAnnotation
     public interface A { }
 
     // violation below 'Missing a Javadoc comment.'
     @InputMissingJavadocTypeQualifiedAnnotation1.SomeAnnotation
     public interface B { }
 
-    @com.puppycrawl.tools.checkstyle.checks.javadoc // violation 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    @com.puppycrawl.tools.checkstyle.checks.javadoc
         .missingjavadoctype.InputMissingJavadocTypeQualifiedAnnotation1.SomeAnnotation
     public interface C { }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation3.java
@@ -14,13 +14,15 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 public class InputMissingJavadocTypeQualifiedAnnotation3 {
     public @interface SomeAnnotation { }
 
-    @SomeAnnotation // violation 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    @SomeAnnotation
     public interface A { }
 
     @InputMissingJavadocTypeQualifiedAnnotation3.SomeAnnotation
     public interface B { }
 
-    @com.puppycrawl.tools.checkstyle.checks.javadoc // violation 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    @com.puppycrawl.tools.checkstyle.checks.javadoc
         .missingjavadoctype.InputMissingJavadocTypeQualifiedAnnotation3.SomeAnnotation
     public interface C { }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation4.java
@@ -15,7 +15,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 public class InputMissingJavadocTypeQualifiedAnnotation4 {
     public @interface SomeAnnotation { }
 
-    @SomeAnnotation // violation 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    @SomeAnnotation
     public interface A { }
 
     // violation below 'Missing a Javadoc comment.'


### PR DESCRIPTION
Issue #19803

Moved violation comments in the `javadoc/missingjavadoctype` input files so they are no longer placed between annotations and the annotated type declarations.

Changes:

* Moved the relevant `// violation` comments above the annotation blocks.
* Removed the corresponding `violationBetweenAnnotationAndMethod` suppressions.
* Updated expected violation line numbers in `MissingJavadocTypeCheckTest`.

Scope:

* This PR covers only the `javadoc/missingjavadoctype` group.