### PR TITLE
Issue #19764: Move violation comments out of Javadoc

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -469,11 +469,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckCommentsContent.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationCustomTags.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadocblocktaglocation[\\/]InputJavadocBlockTagLocationIncorrect.java"/>
-
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignIncorrect.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignTabs.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
@@ -74,13 +74,13 @@ public class JavadocBlockTagLocationCheckTest extends AbstractModuleTestSupport 
     @Test
     public void testIncorrect() throws Exception {
         final String[] expected = {
-            "15: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "author"),
-            "16: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "since"),
-            "17: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "param"),
-            "19: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "throws"),
-            "20: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "see"),
-            "21: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "return"),
-            "21: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "throws"),
+            "22: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "author"),
+            "23: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "since"),
+            "24: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "param"),
+            "26: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "throws"),
+            "27: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "see"),
+            "28: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "return"),
+            "28: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "throws"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocBlockTagLocationIncorrect.java"), expected);
@@ -89,12 +89,12 @@ public class JavadocBlockTagLocationCheckTest extends AbstractModuleTestSupport 
     @Test
     public void testCustomTags() throws Exception {
         final String[] expected = {
-            "14: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
-            "14: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
-            "14: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
-            "16: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
-            "17: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
-            "18: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
+            "20: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
+            "20: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
+            "20: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
+            "22: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
+            "23: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
+            "24: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocBlockTagLocationCustomTags.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCustomTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCustomTags.java
@@ -10,12 +10,18 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
 public class InputJavadocBlockTagLocationCustomTags {
 
+    // violation 7 lines below
+    // violation 6 lines below
+    // violation 5 lines below
+    // violation 6 lines below
+    // violation 6 lines below
+    // violation 6 lines below
     /**
-     * Text. @apiNote note @implNote note @implSpec spec // 3 violations
+     * Text. @apiNote note @implNote note @implSpec spec
      * {@code @apiNote}
-     * text @apiNote note1 // violation
-     * text text @implNote note2  // violation
-     * text @implSpec  // violation
+     * text @apiNote note1
+     * text text @implNote note2
+     * text @implSpec
      * text @since 1.0
      */
     public void method(int param) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationIncorrect.java
@@ -11,14 +11,21 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
 public class InputJavadocBlockTagLocationIncorrect {
 
+    // violation 8 lines below
+    // violation 8 lines below
+    // violation 8 lines below
+    // violation 9 lines below
+    // violation 9 lines below
+    // violation 9 lines below
+    // violation 8 lines below
     /**
-     * Summary. @author me // violation
-     * <p>Text</p> @since 1.0 // violation
-     * @param param1 a parameter @param, @custom // violation
+     * Summary. @author me
+     * <p>Text</p> @since 1.0
+     * @param param1 a parameter @param, @custom
      * @param param2 a parameter @custom
-     * * @throws Exception // violation
-    +    * @see PersistenceContext#setReadOnly(Object,boolean) // violation
-     * text @return one more @throws text again. // 2 violations
+     * * @throws Exception
+    +    * @see PersistenceContext#setReadOnly(Object,boolean)
+     * text @return one more @throws text again.
      */
     public void method(int param1, int param2) {
     }


### PR DESCRIPTION
Issue #19764

Moved violation comments in the `javadoc/javadocblocktaglocation` input files so they are no longer placed inside Javadoc blocks.

Changes:
- Moved the relevant `// violation` comments out of Javadoc blocks.
- Used `// violation N lines below` markers to preserve the exact expected violation targets.
- Removed the corresponding `noViolationCommentsInJavadoc` suppressions.
- Updated expected violation line numbers in `JavadocBlockTagLocationCheckTest`.

Scope:
- This PR covers only the `javadoc/javadocblocktaglocation` group.