### PR TITLE
Issue #20357: Add new property in UnusedLocalVariableCheck

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -3668,6 +3668,13 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference ident</message>
+    <lineContent>final VariableDesc desc = new VariableDesc(ident.getText(), ident, scope);</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference ident</message>
     <lineContent>return UNNAMED_VAR.equals(ident.getText());</lineContent>
   </checkerFrameworkError>
 
@@ -3676,13 +3683,6 @@
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference ident</message>
     <lineContent>return allowUnnamedVariables &amp;&amp; UNNAMED_VAR.equals(ident.getText());</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
-    <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference ident</message>
-    <lineContent>variablesStack.push(new VariableDesc(ident.getText(), ident, scope));</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -638,7 +638,9 @@
       -->
       <property name="severity" value="ignore"/>
     </module>
-    <module name="UnusedLocalVariable"/>
+    <module name="UnusedLocalVariable">
+      <property name="jdkVersion" value="${checkstyle.java.version}"/>
+    </module>
     <!-- until https://github.com/checkstyle/checkstyle/issues/19830 -->
     <module name="UnusedTryResourceShouldBeUnnamed">
       <property name="severity" value="ignore"/>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -409,7 +409,9 @@
       <property name="violationSuppressXPath"
                 value="//ClassDeclaration[@SimpleName='JavaAstVisitor'
                     or @SimpleName='SiteUtil' or @SimpleName='JavadocCommentsAstVisitor'
-                    or @SimpleName='RequireThisCheck']"/>
+                    or @SimpleName='RequireThisCheck'
+                    or @SimpleName='UnusedLocalVariableCheck']"/>
+
     </properties>
   </rule>
   <rule ref="category/java/design.xml/ExcessiveParameterList">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -147,6 +147,11 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
     private static final String UNNAMED_VAR = "_";
 
     /**
+     * Constant for JDK 22 version number.
+     */
+    private static final int JDK_22 = 22;
+
+    /**
      * Keeps tracks of the variables declared in file.
      */
     private final Deque<VariableDesc> variables = new ArrayDeque<>();
@@ -183,6 +188,19 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
     private boolean allowUnnamedVariables = true;
 
     /**
+     * Set the JDK version that you are using.
+     * Old JDK version numbering is supported (e.g. 1.8 for Java 8)
+     * as well as just the major JDK version alone (e.g. 8) is supported.
+     * This property only considers features from officially released
+     * Java versions as supported. Features introduced in preview releases
+     * are not considered supported until they are included in a non-preview release.
+     * Before JDK 22, named pattern variables in switch labels cannot be replaced
+     * with {@code _}, so violations on them are suppressed when jdkVersion is set
+     * below 22.
+     */
+    private int jdkVersion = JDK_22;
+
+    /**
      * Name of the package.
      */
     private String packageName;
@@ -202,6 +220,31 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
      */
     public void setAllowUnnamedVariables(boolean allowUnnamedVariables) {
         this.allowUnnamedVariables = allowUnnamedVariables;
+    }
+
+    /**
+     * Setter to set the JDK version that you are using.
+     * Old JDK version numbering is supported (e.g. 1.8 for Java 8)
+     * as well as just the major JDK version alone (e.g. 8) is supported.
+     * This property only considers features from officially released
+     * Java versions as supported. Features introduced in preview releases
+     * are not considered supported until they are included in a non-preview release.
+     * Before JDK 22, named pattern variables in switch labels cannot be replaced
+     * with {@code _}, so violations on them are suppressed when jdkVersion is set
+     * below 22.
+     *
+     * @param jdkVersion the Java version.
+     * @since 13.7.0
+     */
+    public void setJdkVersion(String jdkVersion) {
+        final String singleVersionNumber;
+        if (jdkVersion.startsWith("1.")) {
+            singleVersionNumber = jdkVersion.substring(2);
+        }
+        else {
+            singleVersionNumber = jdkVersion;
+        }
+        this.jdkVersion = Integer.parseInt(singleVersionNumber);
     }
 
     @Override
@@ -398,7 +441,26 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
             Deque<VariableDesc> variablesStack) {
         final DetailAST ident = patternVarDefAst.findFirstToken(TokenTypes.IDENT);
         final DetailAST scope = findScopeOfPatternVariable(patternVarDefAst);
-        variablesStack.push(new VariableDesc(ident.getText(), ident, scope));
+        final VariableDesc desc = new VariableDesc(ident.getText(), ident, scope);
+        if (isSwitchCasePatternVariable(patternVarDefAst)) {
+            desc.registerAsNamedPatternVar();
+        }
+        variablesStack.push(desc);
+    }
+
+    /**
+     * Checks whether the pattern variable is declared in a switch labels.
+     *
+     * @param patternVarDefAst ast of type {@link TokenTypes#PATTERN_VARIABLE_DEF}
+     * @return true if the pattern variable is declared in a switch label
+     */
+    private static boolean isSwitchCasePatternVariable(DetailAST patternVarDefAst) {
+        DetailAST current = patternVarDefAst;
+        while (current != null
+                && current.getType() != TokenTypes.LITERAL_CASE) {
+            current = current.getParent();
+        }
+        return current != null;
     }
 
     /**
@@ -455,7 +517,9 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
             if (variableDesc.getScope() == scopeAst) {
                 iterator.remove();
                 if (!variableDesc.isUsed()
-                        && !variableDesc.isInstVarOrClassVar()) {
+                        && !variableDesc.isInstVarOrClassVar()
+                        && !(jdkVersion < JDK_22
+                                && variableDesc.isNamedPatternVar())) {
                     final DetailAST typeAst = variableDesc.getTypeAst();
                     if (allowUnnamedVariables) {
                         log(typeAst, MSG_UNUSED_NAMED_LOCAL_VARIABLE, variableDesc.getName());
@@ -950,6 +1014,11 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
         private boolean instVarOrClassVar;
 
         /**
+         * Is a named pattern variable declared in a switch label.
+         */
+        private boolean namedPatternVar;
+
+        /**
          * Is the variable used.
          */
         private boolean used;
@@ -1035,6 +1104,14 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
         }
 
         /**
+         * Register the variable as a named pattern variable
+         * declared in a switch label.
+         */
+        /* package */ void registerAsNamedPatternVar() {
+            namedPatternVar = true;
+        }
+
+        /**
          * Is the variable used or not.
          *
          * @return true if variable is used
@@ -1050,6 +1127,17 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
          */
         /* package */ boolean isInstVarOrClassVar() {
             return instVarOrClassVar;
+        }
+
+        /**
+         * Is a named pattern variable from a switch label.
+         *
+         * @return true if this variable was declared via a
+         *         {@link TokenTypes#PATTERN_VARIABLE_DEF} with a non-underscore name
+         *         in a switch label
+         */
+        /* package */ boolean isNamedPatternVar() {
+            return namedPatternVar;
         }
     }
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UnusedLocalVariableCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UnusedLocalVariableCheck.xml
@@ -20,6 +20,9 @@
                <description>Allow variables named with a single underscore (known as &lt;a href="https://docs.oracle.com/en/java/javase/21/docs/specs/unnamed-jls.html"&gt;
  unnamed variables&lt;/a&gt; in Java 21+).</description>
             </property>
+            <property default-value="22" name="jdkVersion" type="int">
+               <description>Set the JDK version that you are using. Old JDK version numbering is supported (e.g. 1.8 for Java 8) as well as just the major JDK version alone (e.g. 8) is supported. This property only considers features from officially released Java versions as supported. Features introduced in preview releases are not considered supported until they are included in a non-preview release. Before JDK 22, named pattern variables in switch labels cannot be replaced with &lt;code&gt;_&lt;/code&gt;, so violations on them are suppressed when jdkVersion is set below 22.</description>
+            </property>
          </properties>
          <message-keys>
             <message-key key="unused.local.var"/>

--- a/src/site/xdoc/checks/coding/unusedlocalvariable.xml
+++ b/src/site/xdoc/checks/coding/unusedlocalvariable.xml
@@ -40,6 +40,13 @@
               <td><code>true</code></td>
               <td>10.18.0</td>
             </tr>
+            <tr>
+              <td><a id="jdkVersion"/><a href="#jdkVersion">jdkVersion</a></td>
+              <td>Set the JDK version that you are using. Old JDK version numbering is supported (e.g. 1.8 for Java 8) as well as just the major JDK version alone (e.g. 8) is supported. This property only considers features from officially released Java versions as supported. Features introduced in preview releases are not considered supported until they are included in a non-preview release. Before JDK 22, named pattern variables in switch labels cannot be replaced with <code>_</code>, so violations on them are suppressed when jdkVersion is set below 22.</td>
+              <td><a href="../../property_types.html#int">int</a></td>
+              <td><code>22</code></td>
+              <td>13.7.0</td>
+            </tr>
           </table>
         </div>
       </subsection>
@@ -197,7 +204,7 @@ public class Example3 {
     if (obj instanceof String _) { // ok, '_' is unnamed variable
       System.out.println("string");
     }
-    switch (s) { // violation below, unused named local variable 'c'
+    switch (s) { // violation below, unused local variable 'c'
       case Circle c -&gt; System.out.println("circle");
       case Rect r   -&gt; System.out.println(r); // ok, 'r' is used
       default       -&gt; { }
@@ -213,6 +220,7 @@ public class Example3 {
   &lt;module name="TreeWalker"&gt;
     &lt;module name="UnusedLocalVariable"&gt;
         &lt;property name="allowUnnamedVariables" value="false"/&gt;
+        &lt;property name="jdkVersion" value="21"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -235,7 +243,7 @@ public class Example4 {
     if (obj instanceof String _) { // ok, pattern variable '_' is always skipped
       System.out.println("string");
     }
-    switch (s) { // violation below, unused local variable 'c'
+    switch (s) {
       case Circle c -&gt; System.out.println("circle");
       case Rect r   -&gt; System.out.println(r); // ok, 'r' is used
       default       -&gt; { }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
@@ -262,7 +262,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
     @Test
     public void testLiteralNewCondition() throws Exception {
         final String[] expected = {
-            "11:9: " + getCheckMessage(UnusedLocalVariableCheck.class,
+            "12:9: " + getCheckMessage(UnusedLocalVariableCheck.class,
                     UnusedLocalVariableCheck.MSG_UNUSED_LOCAL_VARIABLE, "j"),
         };
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -581,9 +581,9 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
     @Test
     public void testIdent2() throws Exception {
         final String[] expected = {
-            "40:9: " + getCheckMessage(UnusedLocalVariableCheck.class,
+            "41:9: " + getCheckMessage(UnusedLocalVariableCheck.class,
                     MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "45:9: " + getCheckMessage(UnusedLocalVariableCheck.class,
+            "46:9: " + getCheckMessage(UnusedLocalVariableCheck.class,
                     MSG_UNUSED_LOCAL_VARIABLE, "a"),
         };
         verifyWithInlineConfigParser(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
@@ -115,20 +115,20 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariable() throws Exception {
         final String[] expected = {
-            "27:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "sameName"),
-            "28:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
-            "31:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "testInLambdas"),
-            "33:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "coding"),
-            "34:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE,
+            "28:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "sameName"),
+            "29:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
+            "32:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "testInLambdas"),
+            "34:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "coding"),
+            "35:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE,
                     "InputUnusedLocalVariable"),
-            "50:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
-            "54:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "c"),
-            "65:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
-            "67:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "c"),
-            "71:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "p"),
-            "81:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "f"),
-            "84:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "foo"),
-            "91:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "51:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
+            "55:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "c"),
+            "66:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
+            "68:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "c"),
+            "72:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "p"),
+            "82:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "f"),
+            "85:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "foo"),
+            "92:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariable.java"), expected);
@@ -137,15 +137,15 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVar2() throws Exception {
         final String[] expected = {
-            "17:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "i"),
-            "19:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
-            "30:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "31:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
-            "39:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
-            "40:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "Test"),
-            "41:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
-            "61:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "76:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
+            "18:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "i"),
+            "20:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
+            "31:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "32:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
+            "40:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
+            "41:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "Test"),
+            "42:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
+            "62:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "77:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariable2.java"),
@@ -155,7 +155,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVar3() throws Exception {
         final String[] expected = {
-            "21:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "22:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariable3.java"),
@@ -165,15 +165,15 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarInAnonInnerClasses() throws Exception {
         final String[] expected = {
-            "14:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "15:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
-            "17:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
-            "22:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
-            "32:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj2"),
-            "46:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "m"),
-            "47:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "l"),
-            "59:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "h"),
-            "62:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "v"),
+            "15:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "16:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
+            "18:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
+            "23:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
+            "33:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj2"),
+            "47:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "m"),
+            "48:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "l"),
+            "60:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "h"),
+            "63:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "v"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableAnonInnerClasses.java"),
@@ -183,14 +183,14 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarGenericAnonInnerClasses() throws Exception {
         final String[] expected = {
-            "13:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "l"),
-            "14:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
-            "33:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "l"),
-            "34:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj2"),
-            "47:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
-            "67:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "variable"),
-            "69:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "anotherVar"),
-            "78:47: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj2"),
+            "15:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "l"),
+            "16:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
+            "35:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "l"),
+            "36:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj2"),
+            "49:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
+            "69:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "variable"),
+            "71:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "anotherVar"),
+            "80:47: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj2"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableGenericAnonInnerClasses.java"),
@@ -200,10 +200,10 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarDepthOfClasses() throws Exception {
         final String[] expected = {
-            "28:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "r"),
-            "49:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "64:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "94:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "variable"),
+            "29:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "r"),
+            "50:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "65:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "95:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "variable"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableDepthOfClasses.java"),
@@ -213,13 +213,13 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarNestedClasses() throws Exception {
         final String[] expected = {
-            "21:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "V"),
-            "23:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "S"),
-            "24:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "Q"),
-            "36:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "variable"),
-            "44:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "anotherVariable"),
-            "67:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
-            "68:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "n"),
+            "22:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "V"),
+            "24:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "S"),
+            "25:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "Q"),
+            "37:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "variable"),
+            "45:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "anotherVariable"),
+            "68:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
+            "69:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "n"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableNestedClasses.java"),
@@ -229,11 +229,11 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarNestedClasses2() throws Exception {
         final String[] expected = {
-            "29:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "q"),
-            "30:51: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
-            "46:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
-            "57:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
-            "108:33: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
+            "30:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "q"),
+            "31:51: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
+            "47:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
+            "58:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
+            "109:33: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableNestedClasses2.java"),
@@ -243,10 +243,10 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarNestedClasses3() throws Exception {
         final String[] expected = {
-            "36:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "p2"),
-            "54:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "o"),
-            "93:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
-            "95:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "37:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "p2"),
+            "55:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "o"),
+            "94:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "b"),
+            "96:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
         };
 
         verifyWithInlineConfigParser(
@@ -257,8 +257,8 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarNestedClasses4() throws Exception {
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "13:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+            "13:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "14:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
         };
 
         verifyWithInlineConfigParser(
@@ -269,9 +269,9 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarNestedClasses5() throws Exception {
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "13:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
-            "19:11: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "abc"),
+            "13:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "14:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+            "20:11: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "abc"),
         };
 
         verifyWithInlineConfigParser(
@@ -282,8 +282,8 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarNestedClasses6() throws Exception {
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "13:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+            "13:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "14:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
         };
 
         verifyWithInlineConfigParser(
@@ -294,12 +294,12 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarNestedClasses7() throws Exception {
         final String[] expected = {
-            "10:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "11:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
-            "16:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
-            "23:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "24:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
-            "28:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "11:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "12:5: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+            "17:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+            "24:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "25:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+            "29:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
         };
 
         verifyWithInlineConfigParser(
@@ -310,7 +310,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarTestWarningSeverity() throws Exception {
         final String[] expected = {
-            "14:19: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "p2"),
+            "15:19: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "p2"),
         };
 
         verifyWithInlineConfigParser(
@@ -321,11 +321,11 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarEnum() throws Exception {
         final String[] expected = {
-            "22:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "50:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "77:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "80:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
-            "92:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "d"),
+            "23:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "51:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "78:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "81:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
+            "93:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "d"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableEnum.java"),
@@ -335,16 +335,16 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarLambdas() throws Exception {
         final String[] expected = {
-            "14:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "hoo"),
-            "19:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
-            "29:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "hoo2"),
-            "30:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "hoo3"),
-            "32:15: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "myComponent"),
-            "34:19: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "myComponent3"),
-            "40:25: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
-            "52:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
-            "65:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ja"),
-            "73:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "k"),
+            "15:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "hoo"),
+            "20:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
+            "30:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "hoo2"),
+            "31:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "hoo3"),
+            "33:15: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "myComponent"),
+            "35:19: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "myComponent3"),
+            "41:25: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
+            "53:21: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
+            "66:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ja"),
+            "74:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "k"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableLambdaExpression.java"),
@@ -354,8 +354,8 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariableLocalClasses() throws Exception {
         final String[] expected = {
-            "14:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "15:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
+            "15:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "16:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ab"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableLocalClasses.java"),
@@ -365,10 +365,10 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarRecords() throws Exception {
         final String[] expected = {
-            "16:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "var1"),
-            "25:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "var1"),
-            "26:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
-            "36:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "var2"),
+            "17:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "var1"),
+            "26:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "var1"),
+            "27:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
+            "37:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "var2"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableRecords.java"),
@@ -378,9 +378,9 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarWithoutPackageStatement() throws Exception {
         final String[] expected = {
-            "12:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "24:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "var2"),
-            "45:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "var3"),
+            "13:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "25:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "var2"),
+            "46:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "var3"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputUnusedLocalVariableWithoutPackageStatement.java"),
@@ -390,7 +390,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testCompactSourceFile() throws Exception {
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "unused"),
+            "13:5: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "unused"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputUnusedLocalVariableCompactSourceFile.java"),
@@ -416,7 +416,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariableSwitchStatement2() throws Exception {
         final String[] expected = {
-            "59:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
+            "61:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "j"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableSwitchStatement2.java"),
@@ -426,7 +426,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariableSwitchExpression() throws Exception {
         final String[] expected = {
-            "16:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "line2"),
+            "17:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "line2"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableSwitchExpression.java"),
@@ -436,10 +436,10 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariableWithAllowUnnamed() throws Exception {
         final String[] expected = {
-            "20:13: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "_x"),
-            "21:13: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "__"),
-            "35:14: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "__"),
-            "45:14: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "__"),
+            "22:13: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "_x"),
+            "23:13: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "__"),
+            "37:14: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "__"),
+            "47:14: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "__"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputUnusedLocalVariableWithAllowUnnamed.java"),
@@ -449,13 +449,13 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariableWithAllowUnnamedFalse() throws Exception {
         final String[] expected = {
-            "20:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "_x"),
-            "21:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "__"),
-            "22:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "_"),
-            "32:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "_"),
-            "35:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "__"),
-            "43:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "_"),
-            "46:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "__"),
+            "21:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "_x"),
+            "22:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "__"),
+            "23:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "_"),
+            "33:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "_"),
+            "36:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "__"),
+            "44:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "_"),
+            "47:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "__"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputUnusedLocalVariableWithAllowUnnamedFalse.java"),
@@ -465,13 +465,13 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariablePatternVariablesCondition() throws Exception {
         final String[] expected = {
-            "19:37: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "redBall"),
-            "21:46: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "greenBall"),
-            "40:39: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "redBall"),
-            "54:42: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "redBall"),
-            "60:40: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "redBall"),
-            "62:49: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "greenBall"),
-            "80:30: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "lr"),
+            "20:37: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "redBall"),
+            "22:46: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "greenBall"),
+            "41:39: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "redBall"),
+            "55:42: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "redBall"),
+            "61:40: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "redBall"),
+            "63:49: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "greenBall"),
+            "81:30: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "lr"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariablePatternVariablesCondition.java"),
@@ -481,12 +481,47 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariablePatternVariablesCondition2() throws Exception {
         final String[] expected = {
-            "23:68: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "lr"),
-            "43:33: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
-            "58:34: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s1"),
+            "24:68: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "lr"),
+            "44:33: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
+            "59:34: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s1"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariablePatternVariablesCondition2.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnusedLocalVariableNamedPatternVariable() throws Exception {
+        final String[] expected = {
+            "14:25: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ignored"),
+            "15:26: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ignored2"),
+            "21:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "x"),
+            "22:38: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ignored"),
+            "29:30: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "y"),
+            "29:37: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "z"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedLocalVariableAllowNamedPatternVariables.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnusedLocalVariableNamedPatternVariableTrue() throws Exception {
+        final String[] expected = {
+            "21:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "x"),
+            "22:38: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ignored"),
+            "30:46: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedLocalVariableAllowNamedPatternVariablesTrue.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnusedLocalVariableNamedPatternVariableLegacyJdkFormat() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedLocalVariableJdkVersionLegacyFormat.java"),
                 expected);
     }
 
@@ -603,7 +638,7 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarInAnonInnerClasses2() throws Exception {
         final String[] expected = {
-            "20:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
+            "21:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableAnonInnerClasses2.java"),
@@ -613,9 +648,9 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVarInAnonInnerClasses3() throws Exception {
         final String[] expected = {
-            "13:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
-            "20:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
-            "32:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
+            "14:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "21:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "obj"),
+            "33:13: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableAnonInnerClasses3.java"),
@@ -625,10 +660,10 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariablePatternVariables() throws Exception {
         final String[] expected = {
-            "18:25: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "c"),
-            "19:28: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "r"),
-            "42:29: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "c"),
-            "43:32: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "r"),
+            "19:25: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "c"),
+            "20:28: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "r"),
+            "43:29: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "c"),
+            "44:32: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "r"),
         };
         verifyWithInlineConfigParser(
                 getPath(
@@ -639,9 +674,9 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariablePatternVariables2() throws Exception {
         final String[] expected = {
-            "13:26: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "i"),
-            "27:25: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
-            "46:35: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
+            "14:26: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "i"),
+            "28:25: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
+            "47:35: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
         };
         verifyWithInlineConfigParser(
                 getPath(
@@ -652,11 +687,11 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariablePatternVariablesAllowUnnamed() throws Exception {
         final String[] expected = {
-            "18:28: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "c"),
-            "19:28: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "r"),
-            "29:32: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "c"),
-            "30:32: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "r"),
-            "45:35: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "s"),
+            "19:28: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "c"),
+            "20:28: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "r"),
+            "30:32: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "c"),
+            "31:32: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "r"),
+            "46:35: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "s"),
         };
         verifyWithInlineConfigParser(
                 getPath(

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableCompactSourceFile.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = (default)true
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithAllowUnnamed.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithAllowUnnamed.java
@@ -1,6 +1,8 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = (default)true
+jdkVersion = (default)22
+
 
 */
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithAllowUnnamedFalse.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithAllowUnnamedFalse.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithoutPackageStatement.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableWithoutPackageStatement.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder1.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder1.java
@@ -6,6 +6,7 @@ com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
 
 com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck
 allowUnnamedVariables = (default)true
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder2.java
@@ -6,6 +6,7 @@ com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
 
 com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck
 format = ^[a-z][_a-zA-Z0-9]{2,}$

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/api/fullident/InputFullIdentLiteralNewCondition.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/api/fullident/InputFullIdentLiteralNewCondition.java
@@ -1,6 +1,7 @@
 /*
 com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariable.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariable.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariable2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariable2.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariable3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariable3.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowNamedPatternVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowNamedPatternVariables.java
@@ -1,0 +1,33 @@
+/*
+UnusedLocalVariable
+allowUnnamedVariables = false
+jdkVersion = 23
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+public class InputUnusedLocalVariableAllowNamedPatternVariables {
+    record Ignored(int x, int y) {}
+
+    String whatClass(Object object) {
+        return switch (object) {
+            case String ignored -> "A String"; // violation, 'Unused local variable'
+            case Integer ignored2 -> "An Integer"; // violation, 'Unused local variable'
+            default -> "Something Else";
+        };
+    }
+
+    void method(Object object) {
+        int x = 10; // violation, 'Unused local variable'
+        if (object instanceof String ignored) { // violation, 'Unused local variable'
+            System.out.println("string");
+        }
+    }
+
+    String withrecord(Object object) {
+        return switch (object) { // violation below, unused local variable 'y'
+            case Ignored(int y, int z) -> "record switch"; // violation, unused local variable 'z'
+            default -> "other";
+        };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowNamedPatternVariablesTrue.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowNamedPatternVariablesTrue.java
@@ -1,0 +1,48 @@
+/*
+UnusedLocalVariable
+allowUnnamedVariables = false
+jdkVersion = 21
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+public class InputUnusedLocalVariableAllowNamedPatternVariablesTrue {
+    record Ignored(int x, int y) {}
+
+    String whatClass(Object object) {
+        return switch (object) {
+            case String ignored -> "A String";
+            case Integer ignored2 -> "An Integer";
+            default -> "Something Else";
+        };
+    }
+
+    void method(Object object) {
+        int x = 10; // violation, 'Unused local variable'
+        if (object instanceof String ignored) { // violation, 'Unused local variable'
+            System.out.println("string");
+        }
+    }
+
+    void whatClassTraditional(Object object) {
+        switch (object) {
+            case String ignored:
+                if (object instanceof String s){ // violation, 'Unused local variable'
+                    System.out.println("S");
+                }
+                System.out.println("String");
+                break;
+            case Integer ignored2:
+                System.out.println("Integer");
+                break;
+            default:
+            break;
+        }
+    }
+    String withrecord(Object object) {
+        return switch (object) {
+            case Ignored(int y, int z) -> "record switch";
+            default -> "other";
+        };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAnonInnerClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAnonInnerClasses.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAnonInnerClasses2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAnonInnerClasses2.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAnonInnerClasses3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAnonInnerClasses3.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableDepthOfClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableDepthOfClasses.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableEnum.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableGenericAnonInnerClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableGenericAnonInnerClasses.java
@@ -1,6 +1,8 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
+
 
 */
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableJdkVersionLegacyFormat.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableJdkVersionLegacyFormat.java
@@ -1,0 +1,17 @@
+/*
+UnusedLocalVariable
+allowUnnamedVariables = false
+jdkVersion = 1.21
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+public class InputUnusedLocalVariableJdkVersionLegacyFormat {
+    String whatClass(Object object) {
+        return switch (object) {
+            case String ignored -> "A String";
+            case Integer ignored2 -> "An Integer";
+            default -> "Something Else";
+        };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableLambdaAnonInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableLambdaAnonInner.java
@@ -1,6 +1,8 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
+
 */
 
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableLambdaExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableLambdaExpression.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableLocalClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableLocalClasses.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses2.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses3.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses4.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses5.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses6.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses7.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariables.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariables2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariables2.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesAllowUnnamed.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesAllowUnnamed.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = (default)true
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesCondition.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesCondition.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesCondition2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesCondition2.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableRecords.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableSwitchExpression.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableSwitchStatement.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableSwitchStatement.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableSwitchStatement2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableSwitchStatement2.java
@@ -1,6 +1,8 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
+
 
 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableTernaryAndExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableTernaryAndExpressions.java
@@ -1,6 +1,7 @@
 /*
 UnusedLocalVariable
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableTestWarningSeverity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableTestWarningSeverity.java
@@ -2,6 +2,7 @@
 UnusedLocalVariable
 severity = warning
 allowUnnamedVariables = false
+jdkVersion = (default)22
 
 */
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckExamplesTest.java
@@ -75,10 +75,10 @@ public class UnusedLocalVariableCheckExamplesTest extends AbstractExamplesModule
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "18:31: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "str"),
-            "28:19: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "c"),
+            "19:31: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "str"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example3.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example3.java
@@ -22,7 +22,7 @@ public class Example3 {
     if (obj instanceof String _) { // ok, '_' is unnamed variable
       System.out.println("string");
     }
-    switch (s) { // violation below, unused named local variable 'c'
+    switch (s) { // violation below, unused local variable 'c'
       case Circle c -> System.out.println("circle");
       case Rect r   -> System.out.println(r); // ok, 'r' is used
       default       -> { }

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example4.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example4.java
@@ -3,6 +3,7 @@
   <module name="TreeWalker">
     <module name="UnusedLocalVariable">
         <property name="allowUnnamedVariables" value="false"/>
+        <property name="jdkVersion" value="21"/>
     </module>
   </module>
 </module>
@@ -24,7 +25,7 @@ public class Example4 {
     if (obj instanceof String _) { // ok, pattern variable '_' is always skipped
       System.out.println("string");
     }
-    switch (s) { // violation below, unused local variable 'c'
+    switch (s) {
       case Circle c -> System.out.println("circle");
       case Rect r   -> System.out.println(r); // ok, 'r' is used
       default       -> { }


### PR DESCRIPTION
Fixes #20357
Added new property `allowNamedPatternVariables` to allow switch pattern variable.

Diff Regression config: https://gist.githubusercontent.com/ZaheerAhmadDev/ee401562fc60316f636d1e7f77bac085/raw/b63be3029b631a368bc7aa10901c914b653d3eff/check.xml

Diff Regression patch config: https://gist.githubusercontent.com/ZaheerAhmadDev/13a98af5f27abdcd1942860faf3dee0d/raw/b91619d52448b0ca22987c1301ecbede662c2879/checkpatch.xml