### PR TITLE
Issue #20385: Added checks for section 4.2 openjdk

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1195,6 +1195,7 @@ Rsa
 RSPEC
 Rtl
 ru
+ruleclassinterfaceandenumnames
 ruleimportstatements
 ruleindentation
 rulejavasourcefiles

--- a/src/it/java/com/openjdk/checkstyle/test/chapternaming/ruleclassinterfaceandenumnames/ClassInterfaceAndEnumNamesTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapternaming/ruleclassinterfaceandenumnames/ClassInterfaceAndEnumNamesTest.java
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapternaming.ruleclassinterfaceandenumnames;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class ClassInterfaceAndEnumNamesTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapternaming/ruleclassinterfaceandenumnames";
+    }
+
+    @Test
+    public void testClassInterfaceAndEnumNamesInvalid() throws Exception {
+        verifyWithWholeConfig(getPath("InputClassInterfaceAndEnumNamesInvalid.java"));
+    }
+
+    @Test
+    public void testClassInterfaceAndEnumNamesValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputClassInterfaceAndEnumNamesValid.java"));
+    }
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapternaming/ruleclassinterfaceandenumnames/InputClassInterfaceAndEnumNamesInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapternaming/ruleclassinterfaceandenumnames/InputClassInterfaceAndEnumNamesInvalid.java
@@ -1,0 +1,43 @@
+package com.openjdk.checkstyle.test.chapternaming.ruleclassinterfaceandenumnames;
+
+/** Invalid class, interface and enum names for OpenJDK style section 4.2. */
+public class InputClassInterfaceAndEnumNamesInvalid {
+    class invalidClassName { // violation 'Name 'invalidClassName' must match pattern'
+    }
+
+    interface invalidInterfaceName { // violation 'Name 'invalidInterfaceName' must match pattern'
+    }
+
+    enum invalidEnumName { // violation 'Name 'invalidEnumName' must match pattern'
+    }
+
+    interface ReportHTTP {}
+    // violation above 'Abbreviation in name 'ReportHTTP'
+    // must contain no more than '1' consecutive capital letters.'
+
+    class _invalidClassName {} // violation 'Name '_invalidClassName' must match pattern'
+
+    class invalid_class_name {}  // violation 'Name 'invalid_class_name' must match pattern'
+
+    class XMLParser {}
+    // violation above 'Abbreviation in name 'XMLParser'
+    // must contain no more than '1' consecutive capital letters.'
+
+    interface XML_Parser {}
+    // violation above 'Abbreviation in name 'XML_Parser'
+    // must contain no more than '1' consecutive capital letters.'
+    // violation 3 lines above 'Name 'XML_Parser' must match pattern'
+
+    enum XMLParsers {}
+    // violation above 'Abbreviation in name 'XMLParsers'
+    // must contain no more than '1' consecutive capital letters.'
+
+    class ab {} // violation  'Name 'ab' must match pattern'
+
+    enum b {} // violation  'Name 'b' must match pattern'
+
+    interface a {} // violation  'Name 'a' must match pattern'
+
+    class abc {} // violation 'Name 'abc' must match pattern'
+
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapternaming/ruleclassinterfaceandenumnames/InputClassInterfaceAndEnumNamesValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapternaming/ruleclassinterfaceandenumnames/InputClassInterfaceAndEnumNamesValid.java
@@ -1,0 +1,14 @@
+package com.openjdk.checkstyle.test.chapternaming.ruleclassinterfaceandenumnames;
+
+/** Valid class, interface and enum names for OpenJDK style section 4.2. */
+public class InputClassInterfaceAndEnumNamesValid {
+    class ValidClassName {
+    }
+
+    interface ValidInterfaceName {
+    }
+
+    enum ValidEnumName {
+    }
+
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -90,6 +90,17 @@
     <module name="MethodName">
       <property name="format" value="^[a-z]{2,}[a-zA-Z0-9]*$"/>
     </module>
+    <module name="TypeName">
+      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF"/>
+      <property name="format" value="^[A-Z][a-zA-Z0-9]*$"/>
+    </module>
+    <module name="AbbreviationAsWordInName">
+      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF"/>
+      <property name="allowedAbbreviationLength" value="0"/>
+      <property name="ignoreFinal" value="false"/>
+      <property name="ignoreStatic" value="false"/>
+      <property name="ignoreStaticFinal" value="false"/>
+    </module>
 
     <!-- §3.3: Import statements should be sorted -->
     <module name="AvoidStarImport">

--- a/src/site/xdoc/checks/naming/abbreviationaswordinname.xml
+++ b/src/site/xdoc/checks/naming/abbreviationaswordinname.xml
@@ -453,6 +453,10 @@ class Example7 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AbbreviationAsWordInName">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AbbreviationAsWordInName">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/naming/abbreviationaswordinname.xml.template
+++ b/src/site/xdoc/checks/naming/abbreviationaswordinname.xml.template
@@ -158,6 +158,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AbbreviationAsWordInName">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AbbreviationAsWordInName">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/naming/typename.xml
+++ b/src/site/xdoc/checks/naming/typename.xml
@@ -205,6 +205,10 @@ class Example4 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+TypeName">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TypeName">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/naming/typename.xml.template
+++ b/src/site/xdoc/checks/naming/typename.xml.template
@@ -107,6 +107,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+TypeName">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TypeName">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -851,8 +851,36 @@
                     Class, Interface and Enum Names
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_blue.png" alt="" />
+                  </span>
+                  <a href="checks/naming/typename.html#TypeName">TypeName</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TypeName">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/naming/abbreviationaswordinname.html#AbbreviationAsWordInName">
+                    AbbreviationAsWordInName</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AbbreviationAsWordInName">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ban_red.png" alt="" />
+                  </span>
+                  Checkstyle is a Static analysis tool. It lacks the linguistic dictionary and
+                  contextual awareness required to identify grammatical parts of speech like nouns
+                  or adjectives. Consequently, it cannot evaluate word meanings to judge whether an
+                  abbreviation is widely understood or if a term is being used correctly.
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapternaming/ruleclassinterfaceandenumnames">
+                    samples</a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
Issue:  #20385


Added checks for Section 4.2 of openjdk style guide . Some of the grammer rules can not be covered so i have provided reason for them.