### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - suppresswarni…

### DIFF
--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
@@ -60,19 +60,37 @@
 </code></pre></div>
         <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example1 {
+public class Example1 {
+
   private int K; // violation, 'Name 'K' must match pattern'
+
   @SuppressWarnings({"membername"})
   private int J; // violation suppressed
 
   private static final int i = 0; // violation, 'Name 'i' must match pattern'
+
   @SuppressWarnings("checkstyle:constantname")
   private static final int m = 0; // violation suppressed
 
+  // violation below, 'More than 7 parameters (found 8)'
+  public void needsLotsOfParameters(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
+  }
+
   @SuppressWarnings("ParamNumberId")
-    public void needsLotsOfParameters1 (int a, // violation suppressed
-     int b, int c, int d, int e, int f, int g, int h) {
-     // ...
+  public void needsLotsOfParameters1(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) { // violation suppressed
+
+  }
+  // violation 2 lines below 'More than 7 parameters (found 8)'
+  @SuppressWarnings("paramnum")
+  public void needsLotsOfParameters2(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
   }
 
   private int [] ARR; // violation ''int' is followed by whitespace'
@@ -106,18 +124,42 @@ class Example1 {
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
+
+  private int K;
+
+  @SuppressWarnings({"membername"})
+  private int J;
+
+  private static final int i = 0;
+
+  @SuppressWarnings("checkstyle:constantname")
+  private static final int m = 0;
+
   // violation below, 'More than 7 parameters (found 8)'
-  public void needsLotsOfParameters (int a,
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
+  }
+  // violation 2 lines below 'More than 7 parameters (found 8)'
+  @SuppressWarnings("ParamNumberId")
+  public void needsLotsOfParameters1(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
   }
 
   @SuppressWarnings("paramnum")
-  public void needsLotsOfParameters1 (int a, // violation suppressed
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters2(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) { // violation suppressed
+
   }
 
+  private int [] ARR;
+
+  @SuppressWarnings("all")
+  private int [] ARRAY;
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -138,18 +180,42 @@ public class Example2 {
         <p id="Example3-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example3 {
+
+  private int K;
+
+  @SuppressWarnings({"membername"})
+  private int J;
+
+  private static final int i = 0;
+
+  @SuppressWarnings("checkstyle:constantname")
+  private static final int m = 0;
+
   // violation below, 'More than 7 parameters (found 8)'
-  public void needsLotsOfParameters (int a,
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
+  }
+  // violation 2 lines below 'More than 7 parameters (found 8)'
+  @SuppressWarnings("ParamNumberId")
+  public void needsLotsOfParameters1(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
   }
 
   @SuppressWarnings("paramnum")
-  public void needsLotsOfParameters1 (int a, // violation suppressed
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters2(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) { // violation suppressed
+
   }
 
+  private int [] ARR;
+
+  @SuppressWarnings("all")
+  private int [] ARRAY;
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -170,18 +236,42 @@ public class Example3 {
         <p id="Example4-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example4 {
+
+  private int K;
+
+  @SuppressWarnings({"membername"})
+  private int J;
+
+  private static final int i = 0;
+
+  @SuppressWarnings("checkstyle:constantname")
+  private static final int m = 0;
+
   // violation below, 'More than 7 parameters (found 8)'
-  public void needsLotsOfParameters (int a,
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
+  }
+  // violation 2 lines below 'More than 7 parameters (found 8)'
+  @SuppressWarnings("ParamNumberId")
+  public void needsLotsOfParameters1(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
   }
 
   @SuppressWarnings("paramnum")
-  public void needsLotsOfParameters1 (int a, // violation suppressed
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters2(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) { // violation suppressed
+
   }
 
+  private int [] ARR;
+
+  @SuppressWarnings("all")
+  private int [] ARRAY;
 }
 </code></pre></div>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -102,9 +102,6 @@ public class XdocsExamplesAstConsistencyTest {
      */
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
             "checks/annotation/suppresswarnings/Example2",
-            "checks/annotation/suppresswarningsholder/Example2",
-            "checks/annotation/suppresswarningsholder/Example3",
-            "checks/annotation/suppresswarningsholder/Example4",
             "checks/blocks/leftcurly/Example3",
             "checks/blocks/rightcurly/Example2",
             "checks/coding/equalsavoidnull/Example2",
@@ -333,6 +330,8 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/regexp/regexp/Example6",
             "checks/javadoc/writetag/Example5",
             "checks/coding/illegalinstantiation/Example3",
+            "checks/annotation/suppresswarningsholder/Example3",
+            "checks/annotation/suppresswarningsholder/Example4",
             "checks/coding/matchxpath/Example2",
             "checks/coding/matchxpath/Example3",
             "checks/coding/matchxpath/Example4",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsHolderExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsHolderExamplesTest.java
@@ -39,13 +39,17 @@ public class SuppressWarningsHolderExamplesTest extends AbstractExamplesModuleTe
         final String pattern1 = "^[a-z][a-zA-Z0-9]*$";
         final String pattern2 = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
         final String[] expected = {
-            "20:15: " + getCheckMessage(MemberNameCheck.class,
+            "21:15: " + getCheckMessage(MemberNameCheck.class,
                         AbstractNameCheck.MSG_INVALID_PATTERN, "K", pattern1),
-            "24:28: " + getCheckMessage(ConstantNameCheck.class,
+            "26:28: " + getCheckMessage(ConstantNameCheck.class,
                         AbstractNameCheck.MSG_INVALID_PATTERN, "i", pattern2),
-            "34:15: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+            "32:15: " + getCheckMessage(ParameterNumberCheck.class,
+                        ParameterNumberCheck.MSG_KEY, 7, 8),
+            "46:15: " + getCheckMessage(ParameterNumberCheck.class,
+                        ParameterNumberCheck.MSG_KEY, 7, 8),
+            "52:15: " + getCheckMessage(NoWhitespaceAfterCheck.class,
                         NoWhitespaceAfterCheck.MSG_KEY, "int"),
-            "34:18: " + getCheckMessage(MemberNameCheck.class,
+            "52:18: " + getCheckMessage(MemberNameCheck.class,
                         AbstractNameCheck.MSG_INVALID_PATTERN, "ARR", pattern1),
 
         };
@@ -56,7 +60,9 @@ public class SuppressWarningsHolderExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "19:15: " + getCheckMessage(ParameterNumberCheck.class,
+            "30:15: " + getCheckMessage(ParameterNumberCheck.class,
+                        ParameterNumberCheck.MSG_KEY, 7, 8),
+            "37:15: " + getCheckMessage(ParameterNumberCheck.class,
                         ParameterNumberCheck.MSG_KEY, 7, 8),
 
         };
@@ -67,7 +73,9 @@ public class SuppressWarningsHolderExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "18:15: " + getCheckMessage(ParameterNumberCheck.class,
+            "29:15: " + getCheckMessage(ParameterNumberCheck.class,
+                        ParameterNumberCheck.MSG_KEY, 7, 8),
+            "36:15: " + getCheckMessage(ParameterNumberCheck.class,
                         ParameterNumberCheck.MSG_KEY, 7, 8),
         };
 
@@ -77,7 +85,9 @@ public class SuppressWarningsHolderExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "18:15: " + getCheckMessage(ParameterNumberCheck.class,
+            "29:15: " + getCheckMessage(ParameterNumberCheck.class,
+                        ParameterNumberCheck.MSG_KEY, 7, 8),
+            "36:15: " + getCheckMessage(ParameterNumberCheck.class,
                         ParameterNumberCheck.MSG_KEY, 7, 8),
         };
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example1.java
@@ -16,19 +16,37 @@
 package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarningsholder;
 
 // xdoc section -- start
-class Example1 {
+public class Example1 {
+
   private int K; // violation, 'Name 'K' must match pattern'
+
   @SuppressWarnings({"membername"})
   private int J; // violation suppressed
 
   private static final int i = 0; // violation, 'Name 'i' must match pattern'
+
   @SuppressWarnings("checkstyle:constantname")
   private static final int m = 0; // violation suppressed
 
+  // violation below, 'More than 7 parameters (found 8)'
+  public void needsLotsOfParameters(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
+  }
+
   @SuppressWarnings("ParamNumberId")
-    public void needsLotsOfParameters1 (int a, // violation suppressed
-     int b, int c, int d, int e, int f, int g, int h) {
-     // ...
+  public void needsLotsOfParameters1(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) { // violation suppressed
+
+  }
+  // violation 2 lines below 'More than 7 parameters (found 8)'
+  @SuppressWarnings("paramnum")
+  public void needsLotsOfParameters2(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
   }
 
   private int [] ARR; // violation ''int' is followed by whitespace'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example2.java
@@ -15,17 +15,41 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarningsholder
 
 // xdoc section -- start
 public class Example2 {
+
+  private int K;
+
+  @SuppressWarnings({"membername"})
+  private int J;
+
+  private static final int i = 0;
+
+  @SuppressWarnings("checkstyle:constantname")
+  private static final int m = 0;
+
   // violation below, 'More than 7 parameters (found 8)'
-  public void needsLotsOfParameters (int a,
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
+  }
+  // violation 2 lines below 'More than 7 parameters (found 8)'
+  @SuppressWarnings("ParamNumberId")
+  public void needsLotsOfParameters1(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
   }
 
   @SuppressWarnings("paramnum")
-  public void needsLotsOfParameters1 (int a, // violation suppressed
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters2(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) { // violation suppressed
+
   }
 
+  private int [] ARR;
+
+  @SuppressWarnings("all")
+  private int [] ARRAY;
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example3.java
@@ -14,17 +14,42 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarningsholder
 
 // xdoc section -- start
 public class Example3 {
+
+  private int K;
+
+  @SuppressWarnings({"membername"})
+  private int J;
+
+  private static final int i = 0;
+
+  @SuppressWarnings("checkstyle:constantname")
+  private static final int m = 0;
+
   // violation below, 'More than 7 parameters (found 8)'
-  public void needsLotsOfParameters (int a,
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
+  }
+  // violation 2 lines below 'More than 7 parameters (found 8)'
+  @SuppressWarnings("ParamNumberId")
+  public void needsLotsOfParameters1(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
   }
 
   @SuppressWarnings("paramnum")
-  public void needsLotsOfParameters1 (int a, // violation suppressed
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters2(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) { // violation suppressed
+
   }
 
+  private int [] ARR;
+
+  @SuppressWarnings("all")
+  private int [] ARRAY;
 }
 // xdoc section -- end
+

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example4.java
@@ -14,17 +14,41 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarningsholder
 
 // xdoc section -- start
 public class Example4 {
+
+  private int K;
+
+  @SuppressWarnings({"membername"})
+  private int J;
+
+  private static final int i = 0;
+
+  @SuppressWarnings("checkstyle:constantname")
+  private static final int m = 0;
+
   // violation below, 'More than 7 parameters (found 8)'
-  public void needsLotsOfParameters (int a,
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
+  }
+  // violation 2 lines below 'More than 7 parameters (found 8)'
+  @SuppressWarnings("ParamNumberId")
+  public void needsLotsOfParameters1(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) {
+
   }
 
   @SuppressWarnings("paramnum")
-  public void needsLotsOfParameters1 (int a, // violation suppressed
-    int b, int c, int d, int e, int f, int g, int h) {
-    // ...
+  public void needsLotsOfParameters2(
+          int a, int b, int c, int d,
+          int e, int f, int g, int h) { // violation suppressed
+
   }
 
+  private int [] ARR;
+
+  @SuppressWarnings("all")
+  private int [] ARRAY;
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

**Example1.java**: ParameterNumber id=ParamNumberId
**Example2.java**: SuppressWarningsHolder aliasList=com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck=paramnum
**Example3.java**: SuppressWarningsHolder aliasList=ParameterNumberCheck=paramnum
**Example4.java**: SuppressWarningsHolder aliasList=ParameterNumber=paramnum

Section1 -> Example1,2
UseCase -> Example3,4