### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - fallthrough

### DIFF
--- a/src/site/xdoc/checks/coding/fallthrough.xml
+++ b/src/site/xdoc/checks/coding/fallthrough.xml
@@ -82,7 +82,7 @@ class Example1 {
       switch (i) {
         case 1:
           i++;
-          /* block */ /* fallthru */ // comment
+          //ok, /* block */ /* fallthru */ // comment
         case 2: // ok, ReliefPattern is present in above line.
           i++;
           break;
@@ -128,7 +128,8 @@ class Example2 {
       switch (i) {
         case 1:
           i++;
-        case 2: // violation 'Fall\ through from previous branch of the switch'
+          //ok, /* block */ /* fallthru */ // comment
+        case 2: // ok, ReliefPattern is present in above line.
           i++;
           break;
         case 3:
@@ -171,6 +172,7 @@ class Example3 {
       switch (i) {
         case 1:
           i++;
+
         case 2: // violation 'Fall\ through from previous branch of the switch'
           i++;
           break;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -109,8 +109,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/blocks/rightcurly/Example2",
             "checks/coding/equalsavoidnull/Example2",
             "checks/coding/explicitinitialization/Example2",
-            "checks/coding/fallthrough/Example2",
-            "checks/coding/fallthrough/Example3",
             "checks/coding/illegalsymbol/Example4",
             "checks/coding/illegalthrows/Example2",
             "checks/coding/illegalthrows/Example3",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckExamplesTest.java
@@ -45,9 +45,8 @@ public class FallThroughCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "23:9: " + getCheckMessage(MSG_FALL_THROUGH),
-            "34:9: " + getCheckMessage(MSG_FALL_THROUGH),
-            "38:9: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
+            "35:9: " + getCheckMessage(MSG_FALL_THROUGH),
+            "39:9: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -56,7 +55,7 @@ public class FallThroughCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "23:9: " + getCheckMessage(MSG_FALL_THROUGH),
+            "24:9: " + getCheckMessage(MSG_FALL_THROUGH),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/Example1.java
@@ -18,7 +18,7 @@ class Example1 {
       switch (i) {
         case 1:
           i++;
-          /* block */ /* fallthru */ // comment
+          //ok, /* block */ /* fallthru */ // comment
         case 2: // ok, ReliefPattern is present in above line.
           i++;
           break;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/Example2.java
@@ -20,7 +20,8 @@ class Example2 {
       switch (i) {
         case 1:
           i++;
-        case 2: // violation 'Fall\ through from previous branch of the switch'
+          //ok, /* block */ /* fallthru */ // comment
+        case 2: // ok, ReliefPattern is present in above line.
           i++;
           break;
         case 3:

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/Example3.java
@@ -20,6 +20,7 @@ class Example3 {
       switch (i) {
         case 1:
           i++;
+
         case 2: // violation 'Fall\ through from previous branch of the switch'
           i++;
           break;


### PR DESCRIPTION
#18435 

**Example1.java**: Default FallThrough (no properties)
**Example2.java**: checkLastCaseGroup=true
**Example3.java**: reliefPattern=no break by design

Section1-> Example1,2,3