### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - filelength

### DIFF
--- a/src/site/xdoc/checks/sizes/filelength.xml
+++ b/src/site/xdoc/checks/sizes/filelength.xml
@@ -61,7 +61,7 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
   public void myTest() {
-    // small class less than 2000 lines
+    // small class with more than 5 lines less than 2000 lines
     String test = "Some content";
   }
 }
@@ -80,8 +80,8 @@ public class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
   public void myTest() {
-    // small class with more than 5 lines
-    String test = "Some content"; // there is violation
+    // small class with more than 5 lines less than 2000 lines
+    String test = "Some content";
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -100,8 +100,8 @@ public class Example2 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example3 {
   public void myTest() {
-    // small class with more than 5 lines
-    String test = "Some content"; // no violation as only txt files are validated
+    // small class with more than 5 lines less than 2000 lines
+    String test = "Some content"; // ok, no violation as only txt file validated
   }
 }
 </code></pre></div>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -209,8 +209,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/regexp/regexpsinglelinejava/Example3",
             "checks/regexp/regexpsinglelinejava/Example4",
             "checks/regexp/regexpsinglelinejava/Example5",
-            "checks/sizes/filelength/Example2",
-            "checks/sizes/filelength/Example3",
             "checks/sizes/lambdabodylength/Example2",
             "checks/sizes/methodcount/Example2",
             "checks/sizes/methodcount/Example3",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example1.java
@@ -9,7 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.filelength;
 // xdoc section -- start
 public class Example1 {
   public void myTest() {
-    // small class less than 2000 lines
+    // small class with more than 5 lines less than 2000 lines
     String test = "Some content";
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example2.java
@@ -11,8 +11,8 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.filelength;
 // xdoc section -- start
 public class Example2 {
   public void myTest() {
-    // small class with more than 5 lines
-    String test = "Some content"; // there is violation
+    // small class with more than 5 lines less than 2000 lines
+    String test = "Some content";
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example3.java
@@ -12,8 +12,8 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.filelength;
 // xdoc section -- start
 public class Example3 {
   public void myTest() {
-    // small class with more than 5 lines
-    String test = "Some content"; // no violation as only txt files are validated
+    // small class with more than 5 lines less than 2000 lines
+    String test = "Some content"; // ok, no violation as only txt file validated
   }
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 


**Example1.java**: Default FileLength 
**Example2.java**: max=5
**Example3.java**: 
- max=5
- fileExtensions=txt

Section1 -> Example1,2,3