### PR TITLE
Issue #20269: Fix UnnecessarySemicolonAfterOuterTypeDeclaration false…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheck.java
@@ -75,9 +75,26 @@ public final class UnnecessarySemicolonAfterOuterTypeDeclarationCheck extends Ab
     public void visitToken(DetailAST ast) {
         final DetailAST nextSibling = ast.getNextSibling();
         if (nextSibling != null
+                && nextSibling.getType() == TokenTypes.SEMI
                 && ScopeUtil.isOuterMostType(ast)
-                && nextSibling.getType() == TokenTypes.SEMI) {
+                && !isInCompactSourceFile(ast)) {
             log(nextSibling, MSG_SEMI);
         }
+    }
+
+    /**
+     * Checks whether the given node belongs to a JEP 512 compact source file.
+     * In a compact source file every top-level type declaration is a member of
+     * the implicit class, so there is no outer type for this check to police.
+     *
+     * @param ast the node to check
+     * @return true if the tree root is a compact compilation unit
+     */
+    private static boolean isInCompactSourceFile(DetailAST ast) {
+        DetailAST root = ast;
+        while (root.getParent() != null) {
+            root = root.getParent();
+        }
+        return root.getType() == TokenTypes.COMPACT_COMPILATION_UNIT;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheckTest.java
@@ -66,6 +66,16 @@ public class UnnecessarySemicolonAfterOuterTypeDeclarationCheckTest
     }
 
     @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+            getNonCompilablePath(
+                "InputUnnecessarySemicolonAfterOuterTypeDeclarationCompactSourceFile.java"),
+            expected);
+    }
+
+    @Test
     public void testTokens() {
         final UnnecessarySemicolonAfterOuterTypeDeclarationCheck check =
             new UnnecessarySemicolonAfterOuterTypeDeclarationCheck();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/InputUnnecessarySemicolonAfterOuterTypeDeclarationCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/InputUnnecessarySemicolonAfterOuterTypeDeclarationCompactSourceFile.java
@@ -1,0 +1,57 @@
+/*
+UnnecessarySemicolonAfterOuterTypeDeclaration
+tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+class MemberClass {
+
+};
+
+interface MemberInterface {
+
+};
+
+enum MemberEnum {
+
+};
+
+@interface MemberAnnotation {
+
+};
+
+record MemberRecord() {
+
+};
+
+class OuterWithNested {
+
+    class Nested {
+
+    };
+
+    enum NestedEnum {
+
+    };
+
+};
+
+class CleanClass {}
+
+interface CleanInterface {}
+
+enum CleanEnum {}
+
+@interface CleanAnnotation {}
+
+record CleanRecord() {}
+
+void main() {
+    class LocalClass {
+
+    };
+    System.out.println("Hello!");
+}


### PR DESCRIPTION
Issue #20269

`UnnecessarySemicolonAfterOuterTypeDeclaration` reported a false positive on JEP 512 compact source files.

In a compact source file the whole file is the body of an implicit class, so every top-level type is a *member*, not an outer type. The check still flagged trailing semicolons after them because `ScopeUtil.isOuterMostType` finds no type ancestor
(the AST root is `COMPACT_COMPILATION_UNIT`, with no synthetic wrapping class) and treats the type as outermost.

### Fix
Skip the check when the node belongs to a compact source file, detected by walking to the tree root and checking for `COMPACT_COMPILATION_UNIT`. The check stays @StatelessCheck (the detection is a `static` helper, no per-file field).
