### PR TITLE
Issue #19915: Add Required Tags in Doc Comments Style

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1165,6 +1165,7 @@ releasenotes
 RELi
 remkop
 reportyml
+requiredtags
 requireemptylinebeforeblocktaggroup
 requirethis
 resourceleak

--- a/src/it/java/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/requiredtags/RequiredTagsTest.java
+++ b/src/it/java/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/requiredtags/RequiredTagsTest.java
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.doccomments.checkstyle.test.writingdoccomments.tagconventions.requiredtags;
+
+import org.junit.jupiter.api.Test;
+
+import com.doccomments.checkstyle.test.base.AbstractDocCommentsModuleTestSupport;
+
+public class RequiredTagsTest extends AbstractDocCommentsModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/doccomments/checkstyle/test/writingdoccomments/tagconventions/requiredtags";
+    }
+
+    @Test
+    public void testRequiredTags() throws Exception {
+        verifyWithWholeConfig(getPath("InputRequiredTags.java"));
+    }
+
+    @Test
+    public void testRequiredTagsOtherTokens() throws Exception {
+        verifyWithWholeConfig(getPath("InputRequiredTagsOtherTokens.java"));
+    }
+
+}

--- a/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/requiredtags/InputRequiredTags.java
+++ b/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/requiredtags/InputRequiredTags.java
@@ -1,0 +1,74 @@
+package com.doccomments.checkstyle.test.writingdoccomments.tagconventions.requiredtags;
+
+/**
+ * Input for JavadocMethodCheck required tags examples.
+ */
+public class InputRequiredTags {
+
+    private final String name;
+
+    /**
+     * Creates a sample instance.
+     *
+     * @param name name to store
+     */
+    public InputRequiredTags(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns the stored name.
+     *
+     * @return stored name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Calculates a sum from both values.
+     *
+     * @param first first value
+     * @param second second value
+     * @return sum of values
+     */
+    public int sum(int first, int second) {
+        return first + second;
+    }
+
+    /**
+     * Records the supplied text.
+     *
+     * @param text text to record
+     */
+    public void record(String text) {
+    }
+
+    /**
+     * Validates and returns the supplied value.
+     *
+     * @param value value to validate
+     * @return validated value
+     */
+    public int validate(int value) throws IllegalArgumentException {
+        if (value < 0) {
+            throw new IllegalArgumentException();
+        }
+        return value;
+    }
+
+    // violation 4 lines below '@return tag should be present and have description.'
+    /**
+     * Returns the current size.
+     */
+    public int missingReturnTag() {
+        return 1;
+    }
+
+    // violation 4 lines below 'Expected @param tag for 'value'.'
+    /**
+     * Updates the current value.
+     */
+    public void missingParamTag(String value) {
+    }
+}

--- a/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/requiredtags/InputRequiredTagsOtherTokens.java
+++ b/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/requiredtags/InputRequiredTagsOtherTokens.java
@@ -1,0 +1,60 @@
+package com.doccomments.checkstyle.test.writingdoccomments.tagconventions.requiredtags;
+
+/**
+ * Input for JavadocMethodCheck required tags examples for additional tokens.
+ */
+public class InputRequiredTagsOtherTokens {
+
+    public InputRequiredTagsOtherTokens() {
+    }
+
+    /**
+     * Valid compact constructor record.
+     *
+     * @param name name to store
+     */
+    record ValidCompactCtor(String name) {
+
+        /**
+         * Creates a record instance.
+         *
+         * @param name name to store
+         */
+        ValidCompactCtor {
+        }
+    }
+
+    /**
+     * Invalid compact constructor record.
+     *
+     * @param name name to store
+     */
+    record InvalidCompactCtor(String name) {
+
+        // violation 4 lines below 'Expected @param tag for 'name'.'
+        /**
+         * Creates a record instance.
+         */
+        InvalidCompactCtor {
+        }
+    }
+
+    /**
+     * Required tags annotation.
+     */
+    @interface RequiredTagsAnnotation {
+
+        /**
+         * Returns configured value.
+         *
+         * @return configured value
+         */
+        String value();
+
+        // violation 4 lines below '@return tag should be present and have description.'
+        /**
+         * Returns missing value.
+         */
+        String missing();
+    }
+}

--- a/src/main/resources/doc_comments_checks.xml
+++ b/src/main/resources/doc_comments_checks.xml
@@ -39,6 +39,11 @@
     <!-- Tag conventions -->
     <module name="AtclauseOrder"/>
 
+    <!-- Required Tags -->
+    <module name="JavadocMethod">
+      <property name="allowedAnnotations" value=""/>
+    </module>
+
     <!-- Documenting default constructors -->
     <module name="MissingCtor">
       <message key="missing.ctor" value="Class should define an explicit constructor.

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml
@@ -565,6 +565,10 @@ public class Example3 {
             Sun Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fdoc_comments_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
+            Documentation Comments Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
@@ -157,6 +157,10 @@
             Sun Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fdoc_comments_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
+            Documentation Comments Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/doc_comments_style.xml
+++ b/src/site/xdoc/doc_comments_style.xml
@@ -606,8 +606,20 @@
                     Required Tags
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/javadoc/javadocmethod.html#JavadocMethod">
+                    JavadocMethod</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fdoc_comments_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/tagconventions/requiredtags">
+                    samples
+                  </a>
+                </td>
               </tr>
 
               <tr>


### PR DESCRIPTION
closes #19915

Diff Regression config: https://gist.githubusercontent.com/gianmarcoschifone/7a7f5d5c6a112828202d97b3ed021c18/raw/801c9906ba3c2e1ba14644038ef2eb6e3cc4252b/base.xml

Diff Regression patch config: https://gist.githubusercontent.com/gianmarcoschifone/28bbcf191c9c895f0eee98991869aa9e/raw/08033dc99d2812263fef0229fd597c61b92623a9/patch.xml