### PR TITLE
Issue #20219: Fix AnnotationLocation false negative on JEP 512 compac…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -187,7 +187,8 @@ public class AnnotationLocationCheck extends AbstractCheck {
     public void visitToken(DetailAST ast) {
         // ignore variable def tokens that are not field definitions
         if (ast.getType() != TokenTypes.VARIABLE_DEF
-                || ast.getParent().getType() == TokenTypes.OBJBLOCK) {
+                || ast.getParent().getType() == TokenTypes.OBJBLOCK
+                || ast.getParent().getType() == TokenTypes.COMPACT_COMPILATION_UNIT) {
             DetailAST node = ast.findFirstToken(TokenTypes.MODIFIERS);
             if (node == null) {
                 node = ast.findFirstToken(TokenTypes.ANNOTATIONS);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -339,4 +339,18 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
             expected);
     }
 
+    @Test
+    public void testAnnotationLocationCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "15:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "28:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "28:29: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Deprecated"),
+            "31:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "Deprecated", 4, 0),
+            "42:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputAnnotationLocationCompactSourceFile.java"),
+            expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationCompactSourceFile.java
@@ -1,0 +1,53 @@
+/*
+AnnotationLocation
+allowSamelineMultipleAnnotations = (default)false
+allowSamelineSingleParameterlessAnnotation = (default)true
+allowSamelineParameterizedAnnotation = (default)false
+tokens = (default)CLASS_DEF, INTERFACE_DEF, PACKAGE_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+// violation below, 'Annotation 'SuppressWarnings' should be alone on line.'
+@SuppressWarnings("unused") int field1 = 0;
+
+@Deprecated String field2 = "ok";
+
+@SuppressWarnings("unused")
+int field3 = 0;
+
+@Deprecated
+String field4 = "ok";
+
+// 2 violations 3 lines below:
+//    "Annotation 'SuppressWarnings' should be alone on line."
+//    "Annotation 'Deprecated' should be alone on line."
+@SuppressWarnings("unused") @Deprecated int field5 = 0;
+
+@SuppressWarnings("unused")
+    @Deprecated // violation '.* incorrect indentation level 4, .* should be 0.'
+int field6 = 0;
+
+void main() {
+    @SuppressWarnings("unused") int local1 = 0;
+    @Deprecated int local2 = 0;
+    System.out.println(local1 + local2 + field1);
+}
+
+class Nested {
+    // violation below, 'Annotation 'SuppressWarnings' should be alone on line.'
+    @SuppressWarnings("unused") int nestedField1 = 0;
+
+    @Deprecated String nestedField2 = "ok";
+
+    @SuppressWarnings("unused")
+    int nestedField3 = 0;
+
+    void nestedMethod() {
+        @SuppressWarnings("unused") int nestedLocal = 0;
+        System.out.println(nestedLocal);
+    }
+}


### PR DESCRIPTION
Issue #20219: 

AnnotationLocationCheck skipped annotations on top-level variables in compact source files. Its visitToken only treats a VARIABLE_DEF as a field when its parent is OBJBLOCK, but in a compact source file top-level fields are children of COMPACT_COMPILATION_UNIT, so they were ignored

Fix: treat COMPACT_COMPILATION_UNIT as a field container alongside OBJBLOCK, so top-level fields are validated like ordinary class fields while local/pattern variables stay out of scope