### PR TITLE
Issue #20223: Fix DeclarationOrder false negative on JEP 512 compact …

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -156,6 +156,7 @@ public class DeclarationOrderCheck extends AbstractCheck {
     public void beginTree(DetailAST rootAST) {
         scopeStates = new ArrayDeque<>();
         classFieldNames = new HashSet<>();
+        scopeStates.push(new ScopeState());
     }
 
     @Override
@@ -167,7 +168,7 @@ public class DeclarationOrderCheck extends AbstractCheck {
 
             case TokenTypes.MODIFIERS -> {
                 if (parentType == TokenTypes.VARIABLE_DEF
-                    && ast.getParent().getParent().getType() == TokenTypes.OBJBLOCK) {
+                    && isTypeMemberContainer(ast.getParent().getParent().getType())) {
                     processModifiers(ast);
                 }
             }
@@ -179,7 +180,7 @@ public class DeclarationOrderCheck extends AbstractCheck {
             }
 
             case TokenTypes.METHOD_DEF -> {
-                if (parentType == TokenTypes.OBJBLOCK) {
+                if (isTypeMemberContainer(parentType)) {
                     final ScopeState state = scopeStates.peek();
                     // nothing can be bigger than method's state
                     state.currentScopeState = STATE_METHOD_DEF;
@@ -197,6 +198,19 @@ public class DeclarationOrderCheck extends AbstractCheck {
                 // do nothing
             }
         }
+    }
+
+    /**
+     * Checks whether the given token type is a container of class-level
+     * members: an object block, or the implicit class of a JEP 512 compact
+     * source file.
+     *
+     * @param type the token type to check
+     * @return true if the type holds class-level members
+     */
+    private static boolean isTypeMemberContainer(int type) {
+        return type == TokenTypes.OBJBLOCK
+                || type == TokenTypes.COMPACT_COMPILATION_UNIT;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -59,7 +59,8 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
                  "InputNoCodeInFile2.java",
                  "InputNoCodeInFile3.java",
                  "InputNoCodeInFile5.java",
-                 "InputOuterTypeFilenameEmpty.java"
+                 "InputOuterTypeFilenameEmpty.java",
+                 "InputDeclarationOrderEmpty.java"
         );
 
     @TempDir

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
@@ -272,4 +272,30 @@ public class DeclarationOrderCheckTest
                 expected);
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "21:1: " + getCheckMessage(MSG_ACCESS),
+            "26:1: " + getCheckMessage(MSG_INSTANCE),
+            "28:1: " + getCheckMessage(MSG_STATIC),
+            "35:5: " + getCheckMessage(MSG_INSTANCE),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputDeclarationOrderCompactSourceFile.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFileValid() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputDeclarationOrderCompactSourceFileValid.java"), expected);
+    }
+
+    @Test
+    public void testEmptyFile() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputDeclarationOrderEmpty.java"), expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderCompactSourceFile.java
@@ -1,0 +1,39 @@
+/*
+DeclarationOrder
+ignoreConstructors = (default)false
+ignoreModifiers = (default)false
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+// Every member below belongs to the implicit class synthesized for this JEP 512
+// compact source file. The check must enforce the same declaration order it
+// applies inside an ordinary class body.
+
+static int staticVar = 1;
+
+public int pubInstance = 2;
+
+private int privInstance = 3;
+
+public int pubInstance2 = 4; // violation 'Variable access definition in wrong order'
+
+void method1() {
+}
+
+int afterMethod = 5; // violation 'Instance variable definition in wrong order'
+
+static int afterMethodStatic = 6; // violation 'Static variable definition in wrong order'
+
+class Inner {
+
+    void innerMethod() {
+    }
+
+    int innerField = 7; // violation 'Instance variable definition in wrong order'
+}
+
+void main() {
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderCompactSourceFileValid.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderCompactSourceFileValid.java
@@ -1,0 +1,26 @@
+/*
+DeclarationOrder
+ignoreConstructors = (default)false
+ignoreModifiers = (default)false
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+public static int PUB_STATIC = 1;
+
+private static int privStatic = 2;
+
+public int pubInstance = 3;
+
+protected int protInstance = 4;
+
+private int privInstance = 5;
+
+void helper() {
+}
+
+void main() {
+    System.out.println(pubInstance);
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderEmpty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderEmpty.java
@@ -1,0 +1,9 @@
+/*
+DeclarationOrder
+ignoreConstructors = (default)false
+ignoreModifiers = (default)false
+
+
+*/
+
+/* Comment only */


### PR DESCRIPTION
Issue #20223: 

DeclarationOrder skipped all top-level members of a compact source file. Its ordering logic is gated on the parent being OBJBLOCK, but in a compact file the members belong to the implicit class and hang off COMPACT_COMPILATION_UNIT, so no scope state was pushed and every check was bypassed

Fix: seed a ScopeState in beginTree when the root is COMPACT_COMPILATION_UNIT, and accept that token alongside OBJBLOCK in the member guards (via a small isTypeMemberContainer helper). Compact files now report the same violations as the equivalent ordinary class; ordinary files are unchanged