### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - regexpsingleline

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -257,13 +257,6 @@ public class XdocsExamplesAstConsistencyTest {
             "filters/suppresswithnearbytextfilter/Example7",
             "filters/suppresswithnearbytextfilter/Example8",
             "filters/suppresswithnearbytextfilter/Example9",
-            "filters/suppresswithplaintextcommentfilter/Example2",
-            "filters/suppresswithplaintextcommentfilter/Example3",
-            "filters/suppresswithplaintextcommentfilter/Example4",
-            "filters/suppresswithplaintextcommentfilter/Example5",
-            "filters/suppresswithplaintextcommentfilter/Example6",
-            "filters/suppresswithplaintextcommentfilter/Example7",
-            "filters/suppresswithplaintextcommentfilter/Example8",
             // Note: customImport/ImportOrder changes import group ORDER affecting AST structure
             "checks/imports/customimportorder/Example10",
             "checks/imports/customimportorder/Example11",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example1.java
@@ -10,7 +10,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
 
-public class Example1 { }
-
 // xdoc section -- start
+public class Example1 { }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example2.java
@@ -14,7 +14,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
 
-public class Example2 { }
-
 // xdoc section -- start
+public class Example2 { }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example3.java
@@ -16,7 +16,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
 
-public class Example3 { }
-
 // xdoc section -- start
+public class Example3 { }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example4.java
@@ -20,7 +20,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
 
-public class Example4 { }
-
 // xdoc section -- start
+public class Example4 { }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example5.java
@@ -20,7 +20,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
 
-public class Example5 { }
-
 // xdoc section -- start
+public class Example5 { }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example6.java
@@ -27,7 +27,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
 
-public class Example6 { }
-
 // xdoc section -- start
+public class Example6 { }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example7.java
@@ -28,7 +28,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
 
-public class Example7 { }
-
 // xdoc section -- start
+public class Example7 { }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/Example8.java
@@ -22,7 +22,6 @@
 
 package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
 
-public class Example8 { }
-
 // xdoc section -- start
+public class Example8 { }
 // xdoc section -- end


### PR DESCRIPTION
#18435 



**Example1**: No properties (default configuration)

**Example2**:
- offCommentFormat: "STOP CHECK"
- onCommentFormat: "RESUME CHECK"

**Example3**:
- offCommentFormat: "STOP UNIQUE CHECK"
- onCommentFormat: "RESUME UNIQUE CHECK"
- checkFormat: "UniquePropertiesCheck"

**Example4**:
- offCommentFormat: "CSOFF\: ([\w\|]+)"
- onCommentFormat: "CSON\: ([\w\|]+)"
- checkFormat: "$1"

**Example5**:
- offCommentFormat: "CSOFF\: ALMOST_ALL"
- onCommentFormat: "CSON\: ALMOST_ALL"
- checkFormat: "^((?!(RegexpSinglelineCheck)).)*$"

**Example6**:
- offCommentFormat: "CSOFF"
- onCommentFormat: "CSON"
- checkFormat: "RegexpSinglelineCheck"
- messageFormat: "^Type code is not allowed. Use type raw instead.$"

**Example7**:
- offCommentFormat: "CSOFF (\w+) \(([\w\s]+)\)"
- onCommentFormat: "CSON (\w+)"
- idFormat: "$1"

**Example8**:
- offCommentFormat: "CSOFF\: ([\w\|]+)"
- onCommentFormat: "CSON\: ([\w\|]+)"
- checkFormat: "$1"

**Example9**:
- offCommentFormat: '=\s+"""'
- onCommentFormat: '^\s+""";'

Only example 9 appears in the website