### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - suppresswarning

### DIFF
--- a/src/site/xdoc/checks/annotation/suppresswarnings.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarnings.xml
@@ -165,8 +165,10 @@ class Example1 {
 
   @SuppressWarnings("all")
   void foo2(int param) {}
+
   @SuppressWarnings("unused")
   void foo3(int param) {}
+
   @SuppressWarnings(true?"all":"unused")
   void foo4(int param) {}
 }
@@ -203,27 +205,24 @@ class Example2 {
   // ok below as VARIABLE_DEF is not configured in tokens to check
   @SuppressWarnings("")
   final int num1 = 1;
+
   @SuppressWarnings("all")
   final int num2 = 2;
+
   @SuppressWarnings("unused")
   final int num3 = 3;
-
   // ok below as PARAMETER_DEF is not configured in tokens to check
   void foo1(@SuppressWarnings("unused") int param) {}
-
   // ok below, since we are only checking for '^unchecked$|^unused$'
   @SuppressWarnings("all")
   void foo2(int param) {}
-
   // violation below, 'The warning 'unused' cannot be suppressed at this location'
   @SuppressWarnings("unused")
   void foo3(int param) {}
-
   // violation below, 'The warning 'unused' cannot be suppressed at this location'
   @SuppressWarnings(true?"all":"unused")
   void foo4(int param) {}
 }
-
 // violation below, 'The warning 'unchecked' cannot be suppressed at this location'
 @SuppressWarnings("unchecked")
 class Test2 {}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -101,7 +101,6 @@ public class XdocsExamplesAstConsistencyTest {
      * <p>Until: <a href="https://github.com/checkstyle/checkstyle/issues/18435">...</a>
      */
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
-            "checks/annotation/suppresswarnings/Example2",
             "checks/blocks/leftcurly/Example3",
             "checks/coding/equalsavoidnull/Example2",
             "checks/coding/explicitinitialization/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckExamplesTest.java
@@ -45,9 +45,9 @@ public class SuppressWarningsCheckExamplesTest extends AbstractExamplesModuleTes
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "40:21: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unused"),
-            "44:32: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unused"),
-            "49:19: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unchecked"),
+            "39:21: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unused"),
+            "42:32: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unused"),
+            "46:19: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unchecked"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/Example1.java
@@ -26,8 +26,10 @@ class Example1 {
 
   @SuppressWarnings("all")
   void foo2(int param) {}
+
   @SuppressWarnings("unused")
   void foo3(int param) {}
+
   @SuppressWarnings(true?"all":"unused")
   void foo4(int param) {}
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/Example2.java
@@ -24,27 +24,24 @@ class Example2 {
   // ok below as VARIABLE_DEF is not configured in tokens to check
   @SuppressWarnings("")
   final int num1 = 1;
+
   @SuppressWarnings("all")
   final int num2 = 2;
+
   @SuppressWarnings("unused")
   final int num3 = 3;
-
   // ok below as PARAMETER_DEF is not configured in tokens to check
   void foo1(@SuppressWarnings("unused") int param) {}
-
   // ok below, since we are only checking for '^unchecked$|^unused$'
   @SuppressWarnings("all")
   void foo2(int param) {}
-
   // violation below, 'The warning 'unused' cannot be suppressed at this location'
   @SuppressWarnings("unused")
   void foo3(int param) {}
-
   // violation below, 'The warning 'unused' cannot be suppressed at this location'
   @SuppressWarnings(true?"all":"unused")
   void foo4(int param) {}
 }
-
 // violation below, 'The warning 'unchecked' cannot be suppressed at this location'
 @SuppressWarnings("unchecked")
 class Test2 {}


### PR DESCRIPTION
#18435

Example1 -> default config
Example2 -> property tokens

Section1 -> Example1,2