### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - leftcurly

### DIFF
--- a/src/site/xdoc/checks/blocks/leftcurly.xml
+++ b/src/site/xdoc/checks/blocks/leftcurly.xml
@@ -215,38 +215,6 @@ class Example2
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example3-config">
-          To configure the check to apply the <code>nlow</code> policy to
-          type blocks:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="LeftCurly"&gt;
-      &lt;property name="option" value="nlow"/&gt;
-      &lt;property name="tokens" value="CLASS_DEF,INTERFACE_DEF"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example3-code">Example: </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example3
-{ // violation, ''{' at column 1 should be on the previous line.'
-  private interface TestInterface {
-  }
-
-  private
-    class
-    MyClass { // violation, ''{' at column 13 should be on a new line.'
-  }
-
-  enum Colors {RED,
-    BLUE,
-    GREEN;
-  }
-}
-</code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
           An example of how to configure the check to validate enum definitions:
         </p>
@@ -273,6 +241,39 @@ class Example4
   }
 
   enum Colors {RED, // violation, ''{' at column 15 should have line break after.'
+    BLUE,
+    GREEN;
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check to apply the <code>nlow</code> policy to
+          type blocks:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="LeftCurly"&gt;
+      &lt;property name="option" value="nlow"/&gt;
+      &lt;property name="tokens" value="CLASS_DEF,INTERFACE_DEF"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">Example: </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example3
+{ // violation, ''{' at column 1 should be on the previous line.'
+  private interface TestInterface
+  { // violation, ''{' at column 3 should be on the previous line.'
+  }
+
+  private
+    class
+    MyClass { // violation, ''{' at column 13 should be on a new line.'
+  }
+
+  enum Colors {RED,
     BLUE,
     GREEN;
   }

--- a/src/site/xdoc/checks/blocks/leftcurly.xml.template
+++ b/src/site/xdoc/checks/blocks/leftcurly.xml.template
@@ -52,6 +52,18 @@
             <param name="path" value="/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/Example2.java"/>
             <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
+        <p id="Example4-config">
+          An example of how to configure the check to validate enum definitions:
+        </p>
+        <macro name="example">
+            <param name="path" value="/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/Example4.java"/>
+            <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">Example: </p>
+        <macro name="example">
+            <param name="path" value="/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/Example4.java"/>
+            <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
         <p id="Example3-config">
           To configure the check to apply the <code>nlow</code> policy to
           type blocks:
@@ -63,18 +75,6 @@
         <p id="Example3-code">Example: </p>
         <macro name="example">
             <param name="path" value="/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/Example3.java"/>
-            <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-        <p id="Example4-config">
-          An example of how to configure the check to validate enum definitions:
-        </p>
-        <macro name="example">
-            <param name="path" value="/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/Example4.java"/>
-            <param name="type" value="config"/>
-        </macro>
-        <p id="Example4-code">Example: </p>
-        <macro name="example">
-            <param name="path" value="/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/Example4.java"/>
             <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -101,7 +101,6 @@ public class XdocsExamplesAstConsistencyTest {
      * <p>Until: <a href="https://github.com/checkstyle/checkstyle/issues/18435">...</a>
      */
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
-            "checks/blocks/leftcurly/Example3",
             "checks/coding/equalsavoidnull/Example2",
             "checks/coding/explicitinitialization/Example2",
             "checks/coding/illegalsymbol/Example4",
@@ -253,6 +252,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/imports/importorder/Example8",
             "checks/imports/importorder/Example9",
             // until https://github.com/checkstyle/checkstyle/issues/19891
+            "checks/blocks/leftcurly/Example3",
             "checks/whitespace/parenpad/Example3",
             "checks/indentation/commentsindentation/Example3",
             "checks/indentation/commentsindentation/Example4",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckExamplesTest.java
@@ -56,7 +56,8 @@ public class LeftCurlyCheckExamplesTest extends AbstractExamplesModuleTestSuppor
     public void testExample3() throws Exception {
         final String[] expected = {
             "16:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", "1"),
-            "22:13: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", "13"),
+            "18:3: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", "3"),
+            "23:13: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", "13"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/Example3.java
@@ -14,7 +14,8 @@ package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
 // xdoc section -- start
 class Example3
 { // violation, ''{' at column 1 should be on the previous line.'
-  private interface TestInterface {
+  private interface TestInterface
+  { // violation, ''{' at column 3 should be on the previous line.'
   }
 
   private


### PR DESCRIPTION
#18435

Example1 -> default
Example2 -> options,tokens
Example3 -> options,tokens
Example4 -> ignoreEnums

Example 1,2,4 ->Section1
Example 3 -> UseCase