### PR TITLE
Issue #20225: Fix MethodCount false negative on compact source files

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -7032,14 +7032,14 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
-    <lineContent>result = latestDefinition == methodDef.getParent().getParent();</lineContent>
+    <lineContent>result = latestDefinition == scopeDefinition;</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
-    <lineContent>result = latestDefinition == methodDef.getParent().getParent();</lineContent>
+    <lineContent>result = latestDefinition == scopeDefinition;</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -142,6 +142,7 @@ public final class MethodCountCheck extends AbstractCheck {
             TokenTypes.ANNOTATION_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_COMPILATION_UNIT,
         };
     }
 
@@ -185,8 +186,16 @@ public final class MethodCountCheck extends AbstractCheck {
 
         if (!counters.isEmpty()) {
             final DetailAST latestDefinition = counters.peek().getScopeDefinition();
+            final DetailAST methodParent = methodDef.getParent();
+            final DetailAST scopeDefinition;
+            if (methodParent.getType() == TokenTypes.COMPACT_COMPILATION_UNIT) {
+                scopeDefinition = methodParent;
+            }
+            else {
+                scopeDefinition = methodParent.getParent();
+            }
 
-            result = latestDefinition == methodDef.getParent().getParent();
+            result = latestDefinition == scopeDefinition;
         }
 
         return result;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/MethodCountCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/MethodCountCheck.xml
@@ -62,7 +62,7 @@
             <property default-value="100" name="maxTotal" type="int">
                <description>Specify the maximum number of methods allowed at all scope levels.</description>
             </property>
-            <property default-value="CLASS_DEF,ENUM_CONSTANT_DEF,ENUM_DEF,INTERFACE_DEF,ANNOTATION_DEF,RECORD_DEF"
+            <property default-value="CLASS_DEF,ENUM_CONSTANT_DEF,ENUM_DEF,INTERFACE_DEF,ANNOTATION_DEF,RECORD_DEF,COMPACT_COMPILATION_UNIT"
                       name="tokens"
                       type="java.lang.String[]"
                       validation-type="tokenSet">

--- a/src/site/xdoc/checks/sizes/methodcount.xml
+++ b/src/site/xdoc/checks/sizes/methodcount.xml
@@ -114,6 +114,8 @@ public class ExampleClass {
                     ANNOTATION_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
                     RECORD_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_COMPILATION_UNIT">
+                    COMPACT_COMPILATION_UNIT</a>
                   .
               </td>
               <td>
@@ -129,6 +131,8 @@ public class ExampleClass {
                     ANNOTATION_DEF</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
                     RECORD_DEF</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_COMPILATION_UNIT">
+                    COMPACT_COMPILATION_UNIT</a>
                   .
               </td>
               <td>5.3</td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -60,6 +60,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
                  "InputNoCodeInFile3.java",
                  "InputNoCodeInFile5.java",
                  "InputOuterTypeFilenameEmpty.java",
+                 "InputMethodCountEmpty.java",
                  "InputDeclarationOrderEmpty.java"
         );
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckTest.java
@@ -61,6 +61,7 @@ public class MethodCountCheckTest extends AbstractModuleTestSupport {
             TokenTypes.ANNOTATION_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_COMPILATION_UNIT,
         };
 
         assertWithMessage("Default acceptable tokens are invalid")
@@ -218,6 +219,89 @@ public class MethodCountCheckTest extends AbstractModuleTestSupport {
 
         verifyWithInlineConfigParser(
                 getPath("InputMethodCountRecords.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "15:1: " + getCheckMessage(MSG_MANY_METHODS, 5, 3),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputMethodCountCompactSourceFile.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFileModifiers() throws Exception {
+        final String[] expected = {
+            "19:1: " + getCheckMessage(MSG_PACKAGE_METHODS, 2, 1),
+            "19:1: " + getCheckMessage(MSG_PRIVATE_METHODS, 1, 0),
+            "19:1: " + getCheckMessage(MSG_PROTECTED_METHODS, 1, 0),
+            "19:1: " + getCheckMessage(MSG_PUBLIC_METHODS, 1, 0),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputMethodCountCompactSourceFileModifiers.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFileWithType() throws Exception {
+        final String[] expected = {
+            "15:1: " + getCheckMessage(MSG_MANY_METHODS, 3, 2),
+            "19:1: " + getCheckMessage(MSG_MANY_METHODS, 3, 2),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputMethodCountCompactSourceFileWithType.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFileInnerClasses() throws Exception {
+        final String[] expected = {
+            "15:1: " + getCheckMessage(MSG_MANY_METHODS, 2, 1),
+            "19:5: " + getCheckMessage(MSG_MANY_METHODS, 2, 1),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                        "InputMethodCountCompactSourceFileInnerClasses.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFileValid() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputMethodCountCompactSourceFileValid.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFileFieldInitializer() throws Exception {
+        final String[] expected = {
+            "16:1: " + getCheckMessage(MSG_MANY_METHODS, 2, 1),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                        "InputMethodCountCompactSourceFileFieldInitializer.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFileStatic() throws Exception {
+        final String[] expected = {
+            "15:1: " + getCheckMessage(MSG_PACKAGE_METHODS, 3, 1),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputMethodCountCompactSourceFileStatic.java"), expected);
+    }
+
+    @Test
+    public void testEmptyFile() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputMethodCountEmpty.java"), expected);
     }
 
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFile.java
@@ -1,0 +1,23 @@
+/*
+MethodCount
+maxTotal = 3
+maxPrivate = (default)100
+maxPackage = (default)100
+maxProtected = (default)100
+maxPublic = (default)100
+tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTATION_DEF, \
+         METHOD_DEF, RECORD_DEF, COMPACT_COMPILATION_UNIT
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void a() {} // violation 'Total number of methods is 5 (max allowed is 3).'
+
+void b() {}
+
+void c() {}
+
+void d() {}
+
+void main() {}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileFieldInitializer.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileFieldInitializer.java
@@ -1,0 +1,22 @@
+/*
+MethodCount
+maxTotal = 1
+maxPrivate = (default)100
+maxPackage = (default)100
+maxProtected = (default)100
+maxPublic = (default)100
+tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTATION_DEF, \
+         METHOD_DEF, RECORD_DEF, COMPACT_COMPILATION_UNIT
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+// violation below 'Total number of methods is 2 (max allowed is 1).'
+Runnable r = new Runnable() {
+    public void run() {} // NOT counted towards the compact source file
+};
+
+void helper() {}
+
+void main() {}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileInnerClasses.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileInnerClasses.java
@@ -1,0 +1,26 @@
+/*
+MethodCount
+maxTotal = 1
+maxPrivate = (default)100
+maxPackage = (default)100
+maxProtected = (default)100
+maxPublic = (default)100
+tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTATION_DEF, \
+         METHOD_DEF, RECORD_DEF, COMPACT_COMPILATION_UNIT
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void run1() { // violation 'Total number of methods is 2 (max allowed is 1).'
+    Runnable r = new Runnable() {
+        public void run() {}
+    };
+    class Local { // violation 'Total number of methods is 2 (max allowed is 1).'
+        void h1() {}
+
+        void h2() {}
+    }
+}
+
+void main() {}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileModifiers.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileModifiers.java
@@ -1,0 +1,27 @@
+/*
+MethodCount
+maxTotal = (default)100
+maxPrivate = 0
+maxPackage = 1
+maxProtected = 0
+maxPublic = 0
+tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTATION_DEF, \
+         METHOD_DEF, RECORD_DEF, COMPACT_COMPILATION_UNIT
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+// violation 4 lines below 'Number of package methods is 2 (max allowed is 1).'
+// violation 3 lines below 'Number of private methods is 1 (max allowed is 0).'
+// violation 2 lines below 'Number of protected methods is 1 (max allowed is 0).'
+// violation below 'Number of public methods is 1 (max allowed is 0).'
+public void pub1() {}
+
+private void prv1() {}
+
+protected void pro1() {}
+
+void pkg1() {}
+
+void main() {}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileStatic.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileStatic.java
@@ -1,0 +1,19 @@
+/*
+MethodCount
+maxTotal = (default)100
+maxPrivate = (default)100
+maxPackage = 1
+maxProtected = (default)100
+maxPublic = (default)100
+tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTATION_DEF, \
+         METHOD_DEF, RECORD_DEF, COMPACT_COMPILATION_UNIT
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+static void s1() {} // violation 'Number of package methods is 3 (max allowed is 1).'
+
+static void s2() {}
+
+void main() {}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileValid.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileValid.java
@@ -1,0 +1,21 @@
+/*
+MethodCount
+maxTotal = 5
+maxPrivate = (default)100
+maxPackage = (default)100
+maxProtected = (default)100
+maxPublic = (default)100
+tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTATION_DEF, \
+         METHOD_DEF, RECORD_DEF, COMPACT_COMPILATION_UNIT
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+int counter = 3;
+
+void a() {}
+
+void b() {}
+
+void main() {}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileWithType.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountCompactSourceFileWithType.java
@@ -1,0 +1,27 @@
+/*
+MethodCount
+maxTotal = 2
+maxPrivate = (default)100
+maxPackage = (default)100
+maxProtected = (default)100
+maxPublic = (default)100
+tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTATION_DEF, \
+         METHOD_DEF, RECORD_DEF, COMPACT_COMPILATION_UNIT
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void m1() {} // violation 'Total number of methods is 3 (max allowed is 2).'
+
+void m2() {}
+
+class Inner { // violation 'Total number of methods is 3 (max allowed is 2).'
+    void x() {}
+
+    void y() {}
+
+    void z() {}
+}
+
+void main() {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountEmpty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountEmpty.java
@@ -1,0 +1,13 @@
+/*
+MethodCount
+maxTotal = (default)100
+maxPrivate = (default)100
+maxPackage = (default)100
+maxProtected = (default)100
+maxPublic = (default)100
+tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTATION_DEF, \
+         METHOD_DEF, RECORD_DEF, COMPACT_COMPILATION_UNIT
+
+*/
+
+/* Comment only, so the parsed tree root is null. */


### PR DESCRIPTION
Fixes #20225

`MethodCount` did not count the top-level methods of a JEP 512 compact source file. It pushes a counter per type token (`CLASS_DEF`, `ENUM_DEF`, `RECORD_DEF`, ...), but a compact file has no such token  its implicit class is the `COMPACT_COMPILATION_UNIT` root  so no counter was pushed and top-level methods were never counted.

Fix: register `COMPACT_COMPILATION_UNIT` as a token so the implicit class is treated as a counted scope (reusing the existing push/pop machinery), and match a top-level method as a direct child of that scope (it has no `OBJBLOCK`), in addition to the existing grandchild case for ordinary types.
