### PR TITLE
Issue #20271: Fix UnnecessarySemicolonAfterTypeMemberDeclaration fals…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheck.java
@@ -76,25 +76,8 @@ public final class UnnecessarySemicolonAfterOuterTypeDeclarationCheck extends Ab
         final DetailAST nextSibling = ast.getNextSibling();
         if (nextSibling != null
                 && nextSibling.getType() == TokenTypes.SEMI
-                && ScopeUtil.isOuterMostType(ast)
-                && !isInCompactSourceFile(ast)) {
+                && ScopeUtil.isOuterMostType(ast)) {
             log(nextSibling, MSG_SEMI);
         }
-    }
-
-    /**
-     * Checks whether the given node belongs to a JEP 512 compact source file.
-     * In a compact source file every top-level type declaration is a member of
-     * the implicit class, so there is no outer type for this check to police.
-     *
-     * @param ast the node to check
-     * @return true if the tree root is a compact compilation unit
-     */
-    private static boolean isInCompactSourceFile(DetailAST ast) {
-        DetailAST root = ast;
-        while (root.getParent() != null) {
-            root = root.getParent();
-        }
-        return root.getType() == TokenTypes.COMPACT_COMPILATION_UNIT;
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -291,7 +291,8 @@ public final class ScopeUtil {
         for (DetailAST parent = node.getParent();
              parent != null;
              parent = parent.getParent()) {
-            if (TokenUtil.isTypeDeclaration(parent.getType())) {
+            if (TokenUtil.isTypeDeclaration(parent.getType())
+                    || parent.getType() == TokenTypes.COMPACT_COMPILATION_UNIT) {
                 returnValue = false;
                 break;
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterTypeMemberDeclarationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterTypeMemberDeclarationCheckTest.java
@@ -82,6 +82,28 @@ public class UnnecessarySemicolonAfterTypeMemberDeclarationCheckTest
     }
 
     @Test
+    public void testCompactSourceFile() throws Exception {
+
+        final String[] expected = {
+            "14:2: " + getCheckMessage(MSG_SEMI),
+            "18:2: " + getCheckMessage(MSG_SEMI),
+            "22:2: " + getCheckMessage(MSG_SEMI),
+            "26:2: " + getCheckMessage(MSG_SEMI),
+            "30:2: " + getCheckMessage(MSG_SEMI),
+            "36:6: " + getCheckMessage(MSG_SEMI),
+            "38:2: " + getCheckMessage(MSG_SEMI),
+            "41:5: " + getCheckMessage(MSG_SEMI),
+            "48:11: " + getCheckMessage(MSG_SEMI),
+            "52:2: " + getCheckMessage(MSG_SEMI),
+        };
+
+        verifyWithInlineConfigParser(
+            getNonCompilablePath(
+                "InputUnnecessarySemicolonAfterTypeMemberDeclarationCompactSourceFile.java"),
+            expected);
+    }
+
+    @Test
     public void testTokens() {
         final UnnecessarySemicolonAfterTypeMemberDeclarationCheck check =
             new UnnecessarySemicolonAfterTypeMemberDeclarationCheck();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonaftertypememberdeclaration/InputUnnecessarySemicolonAfterTypeMemberDeclarationCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonaftertypememberdeclaration/InputUnnecessarySemicolonAfterTypeMemberDeclarationCompactSourceFile.java
@@ -1,0 +1,59 @@
+/*
+UnnecessarySemicolonAfterTypeMemberDeclaration
+tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, VARIABLE_DEF, \
+         ANNOTATION_FIELD_DEF, STATIC_INIT, INSTANCE_INIT, CTOR_DEF, METHOD_DEF, \
+         ENUM_CONSTANT_DEF, COMPACT_CTOR_DEF, RECORD_DEF
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+class MemberClass {
+
+}; // violation, 'Unnecessary semicolon.'
+
+interface MemberInterface {
+
+}; // violation, 'Unnecessary semicolon.'
+
+enum MemberEnum {
+
+}; // violation, 'Unnecessary semicolon.'
+
+@interface MemberAnnotation {
+
+}; // violation, 'Unnecessary semicolon.'
+
+record MemberRecord() {
+
+}; // violation, 'Unnecessary semicolon.'
+
+class OuterWithNested {
+
+    class Nested {
+
+    }; // violation, 'Unnecessary semicolon.'
+
+}; // violation, 'Unnecessary semicolon.'
+
+class LeadingSemicolon {
+    ; // violation, 'Unnecessary semicolon.'
+}
+
+enum EnumLeadingSemicolon {
+    ;
+}
+
+int field;; // violation, 'Unnecessary semicolon.'
+
+void method() {
+
+}; // violation, 'Unnecessary semicolon.'
+
+class CleanClass {
+
+}
+
+void main() {
+}


### PR DESCRIPTION
Issue #20271

`UnnecessarySemicolonAfterTypeMemberDeclaration` did not flag the trailing semicolon after a type declared in a JEP 512 compact source file (`class Inner { };`).

### Fix
`ScopeUtil.isOuterMostType` now treats the implicit class (`COMPACT_COMPILATION_UNIT`) as an enclosing type, so a type declared in a compact file is recognized as a member of the implicit class rather than as the outermost type.

### Checks affected (all callers of `isOuterMostType`)
- **UnnecessarySemicolonAfterTypeMemberDeclaration**  now flags the member's trailing `;` (the fix).
- **UnnecessarySemicolonAfterOuterTypeDeclaration**  behavior unchanged; the now-redundant `isInCompactSourceFile` guard from #20269 is removed.
- **JavadocType**  no longer requires `@author`/`@version` on the implicit class's member types (they are members, not the outermost type).
