### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - equalsavoidnull

### DIFF
--- a/src/site/xdoc/checks/coding/equalsavoidnull.xml
+++ b/src/site/xdoc/checks/coding/equalsavoidnull.xml
@@ -51,9 +51,7 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-    &lt;module name="EqualsAvoidNull"&gt;
-      &lt;property name="ignoreEqualsIgnoreCase" value="false"/&gt;
-    &lt;/module&gt;
+    &lt;module name="EqualsAvoidNull"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -101,6 +99,7 @@ public class Example2 {
     nullString.equals("My_Sweet_String");
     "My_Sweet_String".equals(nullString);
 
+    // ok, ignoreEqualsIgnoreCase is true
     nullString.equalsIgnoreCase("My_Sweet_String");
     "My_Sweet_String".equalsIgnoreCase(nullString);
   }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -101,7 +101,6 @@ public class XdocsExamplesAstConsistencyTest {
      * <p>Until: <a href="https://github.com/checkstyle/checkstyle/issues/18435">...</a>
      */
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
-            "checks/coding/equalsavoidnull/Example2",
             "checks/coding/explicitinitialization/Example2",
             "checks/coding/illegalsymbol/Example4",
             "checks/coding/illegalthrows/Example2",
@@ -260,6 +259,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/indentation/commentsindentation/Example6",
             "checks/indentation/commentsindentation/Example7",
             "checks/indentation/commentsindentation/Example8",
+            "checks/coding/equalsavoidnull/Example2",
             "checks/blocks/needbraces/Example4",
             "checks/blocks/needbraces/Example6",
             "checks/metrics/classfanoutcomplexity/Example6",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckExamplesTest.java
@@ -35,8 +35,8 @@ public class EqualsAvoidNullCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "20:22: " + getCheckMessage(MSG_EQUALS_AVOID_NULL),
-            "24:32: " + getCheckMessage(MSG_EQUALS_IGNORE_CASE_AVOID_NULL),
+            "18:22: " + getCheckMessage(MSG_EQUALS_AVOID_NULL),
+            "22:32: " + getCheckMessage(MSG_EQUALS_IGNORE_CASE_AVOID_NULL),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example1.java
@@ -1,9 +1,7 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="EqualsAvoidNull">
-      <property name="ignoreEqualsIgnoreCase" value="false"/>
-    </module>
+    <module name="EqualsAvoidNull"/>
   </module>
 </module>
 */

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/Example2.java
@@ -20,6 +20,7 @@ public class Example2 {
     nullString.equals("My_Sweet_String");
     "My_Sweet_String".equals(nullString);
 
+    // ok, ignoreEqualsIgnoreCase is true
     nullString.equalsIgnoreCase("My_Sweet_String");
     "My_Sweet_String".equalsIgnoreCase(nullString);
   }


### PR DESCRIPTION
#18435 

Example1 ->"ignoreEqualsIgnoreCase" value="false"
Example2->"ignoreEqualsIgnoreCase" value="true"

Section1 -> Example1
UseCase -> Example2
