### PR TITLE
Issue #20382: Xdocs examples should reject violation comments between…

### DIFF
--- a/config/checkstyle-examples-checks.xml
+++ b/config/checkstyle-examples-checks.xml
@@ -98,6 +98,26 @@
     <property name="maximum" value="0"/>
   </module>
 
+  <module name="RegexpMultiline">
+    <property name="id" value="markerCommentBetweenAnnotationAndTarget"/>
+    <property name="format"
+              value="(?:\r?\n|\A)[ \t]*@[A-Za-z_][\w.]*(?:\([^\r\n]*\))?[ \t]*\r?\n[ \t]*//[ \t]*(?:ok|[^\r\n]*violation)"/>
+    <property name="message"
+              value="Marker comments must not be placed alone on a line between an
+annotation and its target. Place it before the annotation,
+or inline on the same line as the annotation."/>
+  </module>
+
+  <module name="RegexpMultiline">
+    <property name="id" value="markerCommentBetweenJavadocAndTarget"/>
+    <property name="format"
+              value="(?:\r?\n|\A)[ \t]*\*/[ \t]*\r?\n[ \t]*//[ \t]*(?:ok|[^\r\n]*violation)"/>
+    <property name="message"
+              value="Marker comments must not be placed alone on a line between a
+Javadoc block and its target. Place it before the Javadoc
+block, or inline on the same line as the closing '*/'."/>
+  </module>
+
   <!-- Miscellaneous -->
   <module name="NewlineAtEndOfFile"/>
 

--- a/src/site/xdoc/checks/design/visibilitymodifier.xml
+++ b/src/site/xdoc/checks/design/visibilitymodifier.xml
@@ -728,9 +728,8 @@ class Example7 {
   String annotatedString; // violation, annotation not configured 'must be private'
 
   @Deprecated
-  // violation below, annotation not configured 'must be private'
   String shortCustomAnnotated;
-
+  // violation above, annotation not configured 'must be private'
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
 }
@@ -781,9 +780,8 @@ class Example9 {
   String annotatedString; // violation, annotation not configured 'must be private'
 
   @Deprecated
-  // violation below, annotation not configured 'must be private'
   String shortCustomAnnotated;
-
+  // violation above, annotation not configured 'must be private'
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
 }
@@ -836,9 +834,8 @@ class Example10 {
 
   @Deprecated
   String shortCustomAnnotated;
-
+  // violation 2 lines below 'must be private'
   @com.google.common.annotations.VisibleForTesting
-  // violation below, annotation not configured 'must be private'
   public String testString = "";
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml
+++ b/src/site/xdoc/checks/javadoc/invalidjavadocposition.xml
@@ -36,8 +36,9 @@
           annotations of the Javadoc's target:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation 3 lines below 'Javadoc comment is placed in the wrong location'
 @SuppressWarnings("serial")
-// violation below, 'Javadoc comment is placed in the wrong location'
+
 /**
  * This comment looks like Javadoc but it is at an invalid location.
  * Therefore, the text will not get into TestClass.html.

--- a/src/site/xdoc/checks/javadoc/javadocparagraph.xml
+++ b/src/site/xdoc/checks/javadoc/javadocparagraph.xml
@@ -83,7 +83,8 @@
         <p id="Example1-code">By default, the check will report a violation if there is
           no empty line before or whitespace after the &lt;p&gt; tag: </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-// violation 5 lines below '&lt;p&gt; tag should be preceded with an empty line'
+// violation 6 lines below '&lt;p&gt; tag should be preceded with an empty line'
+
 /**
  * No tag
  *
@@ -97,10 +98,10 @@
  *
  * &lt;p&gt;&lt;b&gt;p tag before inline tag B, this is ok&lt;/b&gt;&lt;/p&gt;
  */
-// violation 4 lines above 'tag should be placed immediately before the first word'
 
 public class Example1 {
 
+  // violation 7 lines above 'tag should be placed immediately before the first word'
 
   // violation 4 lines below '&lt;p&gt; tag should not precede HTML block-tag '&lt;pre&gt;''
   /**
@@ -157,7 +158,8 @@ public class Example1 {
           the following example will have violations:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-// violation 5 lines below '&lt;p&gt; tag should be preceded with an empty line'
+// violation 6 lines below '&lt;p&gt; tag should be preceded with an empty line'
+// violation 7 lines below 'tag should be placed immediately before the first word'
 /**
  * No tag
  *
@@ -171,9 +173,9 @@ public class Example1 {
  *
  * &lt;p&gt;&lt;b&gt;p tag before inline tag B, this is ok&lt;/b&gt;&lt;/p&gt;
  */
-// violation 7 lines above 'tag should be placed immediately before the first word'
-// violation 5 lines above 'tag should be placed immediately before the first word'
+
 public class Example2 {
+  // violation 6 lines above 'tag should be placed immediately before the first word'
   // 2 violations 6 lines below:
   //  'tag should be placed immediately before the first word'
   //  '&lt;p&gt; tag should not precede HTML block-tag '&lt;pre&gt;''

--- a/src/site/xdoc/checks/sizes/filelength.xml
+++ b/src/site/xdoc/checks/sizes/filelength.xml
@@ -78,6 +78,7 @@ public class Example1 {
 </code></pre></div>
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation first line 'File length is 19 lines (max allowed is 5)'
 public class Example2 {
   public void myTest() {
     // small class with more than 5 lines less than 2000 lines

--- a/src/site/xdoc/checks/sizes/parameternumber.xml
+++ b/src/site/xdoc/checks/sizes/parameternumber.xml
@@ -84,19 +84,17 @@
 class Example1 extends ExternalService1 {
 
   @JsonCreator
-  // violation below, 'More than 7 parameters (found 8)'
   Example1(int a, int b, int c, int d,
            int e, int f, int g, int h) {}
-
+  // violation 2 lines above 'More than 7 parameters (found 8)'
   // violation below, 'More than 7 parameters (found 8)'
   Example1(String a, String b, String c, String d,
            String e, String f, String g, String h) {}
 
   @Override
-  // violation below, 'More than 7 parameters (found 8)'
   public void processData(String a, String b, String c, String d,
                           String e, String f, String g, String h) {}
-
+  // violation 2 lines above 'More than 7 parameters (found 8)'
 }
 
 class ExternalService1 {
@@ -125,8 +123,7 @@ class ExternalService1 {
 class Example2 extends ExternalService2 {
 
   @JsonCreator
-  // ok below, constructor is not in tokens to check
-  Example2(int a, int b, int c, int d,
+  Example2(int a, int b, int c, int d, // ok, constructor is not in tokens to check
            int e, int f, int g, int h) {}
 
   // ok below, constructor is not in tokens to check
@@ -134,10 +131,9 @@ class Example2 extends ExternalService2 {
            String e, String f, String g, String h) {}
 
   @Override
-  // ok below, less than 10 parameters (found 8)
   public void processData(String a, String b, String c, String d,
                           String e, String f, String g, String h) {}
-
+  // ok above, less than 10 parameters (found 8)
 }
 
 class ExternalService2 {
@@ -170,9 +166,8 @@ class ExternalService2 {
         <p id="Example3-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 extends ExternalService3 {
-
+  // violation 2 lines below 'More than 7 parameters (found 8)'
   @JsonCreator
-  // violation below, 'More than 7 parameters (found 8)'
   Example3(int a, int b, int c, int d,
            int e, int f, int g, int h) {}
 
@@ -181,10 +176,9 @@ class Example3 extends ExternalService3 {
            String e, String f, String g, String h) {}
 
   @Override
-  // ok below, overridden method is ignored
   public void processData(String a, String b, String c, String d,
                           String e, String f, String g, String h) {}
-
+  // ok above, overridden method is ignored
 }
 
 class ExternalService3 {
@@ -213,19 +207,17 @@ class ExternalService3 {
 class Example4 extends ExternalService4 {
 
   @JsonCreator
-  // ok below, constructor annotated with JsonCreator annotation is ignored
   Example4(int a, int b, int c, int d,
            int e, int f, int g, int h) {}
-
+  // ok above, constructor annotated with JsonCreator annotation is ignored
   // violation below, 'More than 7 parameters (found 8)'
   Example4(String a, String b, String c, String d,
            String e, String f, String g, String h) {}
 
   @Override
-  // violation below, 'More than 7 parameters (found 8)'
   public void processData(String a, String b, String c, String d,
                           String e, String f, String g, String h) {}
-
+  // violation 2 lines above 'More than 7 parameters (found 8)'
 }
 
 class ExternalService4 {

--- a/src/site/xdoc/filters/suppresswarningsfilter.xml
+++ b/src/site/xdoc/filters/suppresswarningsfilter.xml
@@ -91,7 +91,7 @@ public class Example1 {
         <p id="Example2-code">Java code:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 package com.puppycrawl.tools.checkstyle.filters.suppresswarningsfilter;
-
+// violation 9 lines above 'use SLF4J instead.'
 public class Example2 {
   @SuppressWarnings("checkstyle:systemout")
   public static void foo() {

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckExamplesTest.java
@@ -172,7 +172,7 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
             "47:37: " + getCheckMessage(MSG_KEY, "mySet2"),
             "50:45: " + getCheckMessage(MSG_KEY, "objects1"),
             "53:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
-            "57:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "56:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
         };
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
@@ -211,7 +211,7 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
             "42:37: " + getCheckMessage(MSG_KEY, "mySet2"),
             "45:45: " + getCheckMessage(MSG_KEY, "objects1"),
             "48:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
-            "52:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
+            "51:10: " + getCheckMessage(MSG_KEY, "shortCustomAnnotated"),
         };
 
         verifyWithInlineConfigParser(getPath("Example9.java"), expected);
@@ -229,7 +229,7 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
             "44:37: " + getCheckMessage(MSG_KEY, "mySet2"),
             "47:45: " + getCheckMessage(MSG_KEY, "objects1"),
             "50:10: " + getCheckMessage(MSG_KEY, "annotatedString"),
-            "57:17: " + getCheckMessage(MSG_KEY, "testString"),
+            "56:17: " + getCheckMessage(MSG_KEY, "testString"),
         };
 
         verifyWithInlineConfigParser(getPath("Example10.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/InvalidJavadocPositionCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/InvalidJavadocPositionCheckExamplesTest.java
@@ -34,7 +34,7 @@ public class InvalidJavadocPositionCheckExamplesTest extends AbstractExamplesMod
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_KEY),
+            "15:1: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckExamplesTest.java
@@ -38,11 +38,11 @@ public class JavadocParagraphCheckExamplesTest extends AbstractExamplesModuleTes
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "16:4: " + getCheckMessage(MSG_LINE_BEFORE),
-            "21:4: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "34:6: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "pre"),
-            "52:6: " + getCheckMessage(MSG_REDUNDANT_PARAGRAPH),
-            "62:5: " + getCheckMessage(MSG_TAG_AFTER),
+            "17:4: " + getCheckMessage(MSG_LINE_BEFORE),
+            "22:4: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "35:6: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "pre"),
+            "53:6: " + getCheckMessage(MSG_REDUNDANT_PARAGRAPH),
+            "63:5: " + getCheckMessage(MSG_TAG_AFTER),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -51,14 +51,14 @@ public class JavadocParagraphCheckExamplesTest extends AbstractExamplesModuleTes
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "18:4: " + getCheckMessage(MSG_LINE_BEFORE),
-            "20:4: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "23:4: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "36:6: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "pre"),
-            "36:6: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "55:6: " + getCheckMessage(MSG_MISPLACED_TAG),
-            "55:6: " + getCheckMessage(MSG_REDUNDANT_PARAGRAPH),
-            "64:5: " + getCheckMessage(MSG_TAG_AFTER),
+            "19:4: " + getCheckMessage(MSG_LINE_BEFORE),
+            "21:4: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "24:4: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "37:6: " + getCheckMessage(MSG_PRECEDED_BLOCK_TAG, "pre"),
+            "37:6: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "56:6: " + getCheckMessage(MSG_MISPLACED_TAG),
+            "56:6: " + getCheckMessage(MSG_REDUNDANT_PARAGRAPH),
+            "65:5: " + getCheckMessage(MSG_TAG_AFTER),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckExamplesTest.java
@@ -43,7 +43,7 @@ public class FileLengthCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "1: " + getCheckMessage(MSG_KEY, 18, 5),
+            "1: " + getCheckMessage(MSG_KEY, 19, 5),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckExamplesTest.java
@@ -34,10 +34,10 @@ public class ParameterNumberCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "16:3: " + getCheckMessage(MSG_KEY, 7, 8),
-            "20:3: " + getCheckMessage(MSG_KEY, 7, 8),
-            "25:15: " + getCheckMessage(MSG_KEY, 7, 8),
-            "33:15: " + getCheckMessage(MSG_KEY, 7, 8),
+            "15:3: " + getCheckMessage(MSG_KEY, 7, 8),
+            "19:3: " + getCheckMessage(MSG_KEY, 7, 8),
+            "23:15: " + getCheckMessage(MSG_KEY, 7, 8),
+            "31:15: " + getCheckMessage(MSG_KEY, 7, 8),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -55,9 +55,9 @@ public class ParameterNumberCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "18:3: " + getCheckMessage(MSG_KEY, 7, 8),
-            "22:3: " + getCheckMessage(MSG_KEY, 7, 8),
-            "35:15: " + getCheckMessage(MSG_KEY, 7, 8),
+            "17:3: " + getCheckMessage(MSG_KEY, 7, 8),
+            "21:3: " + getCheckMessage(MSG_KEY, 7, 8),
+            "33:15: " + getCheckMessage(MSG_KEY, 7, 8),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -66,9 +66,9 @@ public class ParameterNumberCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "22:3: " + getCheckMessage(MSG_KEY, 7, 8),
-            "27:15: " + getCheckMessage(MSG_KEY, 7, 8),
-            "35:15: " + getCheckMessage(MSG_KEY, 7, 8),
+            "21:3: " + getCheckMessage(MSG_KEY, 7, 8),
+            "25:15: " + getCheckMessage(MSG_KEY, 7, 8),
+            "33:15: " + getCheckMessage(MSG_KEY, 7, 8),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterExamplesTest.java
@@ -54,13 +54,13 @@ public class SuppressWarningsFilterExamplesTest extends AbstractExamplesModuleTe
     public void testExample2() throws Exception {
         final String[] expectedWithoutFilter = {
             "9: Dont use System.out/err, use SLF4J instead.",
-            "23: Dont use System.out/err, use SLF4J instead.",
-            "26: Dont use System.out/err, use SLF4J instead.",
+            "22: Dont use System.out/err, use SLF4J instead.",
+            "25: Dont use System.out/err, use SLF4J instead.",
         };
 
         final String[] expectedWithFilter = {
             "9: Dont use System.out/err, use SLF4J instead.",
-            "26: Dont use System.out/err, use SLF4J instead.",
+            "25: Dont use System.out/err, use SLF4J instead.",
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example2.java"),

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example10.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example10.java
@@ -51,9 +51,8 @@ class Example10 {
 
   @Deprecated
   String shortCustomAnnotated;
-
+  // violation 2 lines below 'must be private'
   @com.google.common.annotations.VisibleForTesting
-  // violation below, annotation not configured 'must be private'
   public String testString = "";
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example7.java
@@ -53,9 +53,8 @@ class Example7 {
   String annotatedString; // violation, annotation not configured 'must be private'
 
   @Deprecated
-  // violation below, annotation not configured 'must be private'
   String shortCustomAnnotated;
-
+  // violation above, annotation not configured 'must be private'
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/Example9.java
@@ -48,9 +48,8 @@ class Example9 {
   String annotatedString; // violation, annotation not configured 'must be private'
 
   @Deprecated
-  // violation below, annotation not configured 'must be private'
   String shortCustomAnnotated;
-
+  // violation above, annotation not configured 'must be private'
   @com.google.common.annotations.VisibleForTesting
   public String testString = "";
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/invalidjavadocposition/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/invalidjavadocposition/Example1.java
@@ -9,8 +9,9 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.invalidjavadocposition;
 
 // xdoc section -- start
+// violation 3 lines below 'Javadoc comment is placed in the wrong location'
 @SuppressWarnings("serial")
-// violation below, 'Javadoc comment is placed in the wrong location'
+
 /**
  * This comment looks like Javadoc but it is at an invalid location.
  * Therefore, the text will not get into TestClass.html.

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example1.java
@@ -8,7 +8,8 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
 
 // xdoc section -- start
-// violation 5 lines below '<p> tag should be preceded with an empty line'
+// violation 6 lines below '<p> tag should be preceded with an empty line'
+
 /**
  * No tag
  *
@@ -22,10 +23,10 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
  *
  * <p><b>p tag before inline tag B, this is ok</b></p>
  */
-// violation 4 lines above 'tag should be placed immediately before the first word'
 
 public class Example1 {
 
+  // violation 7 lines above 'tag should be placed immediately before the first word'
 
   // violation 4 lines below '<p> tag should not precede HTML block-tag '<pre>''
   /**

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph/Example2.java
@@ -10,7 +10,8 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
 
 // xdoc section -- start
-// violation 5 lines below '<p> tag should be preceded with an empty line'
+// violation 6 lines below '<p> tag should be preceded with an empty line'
+// violation 7 lines below 'tag should be placed immediately before the first word'
 /**
  * No tag
  *
@@ -24,9 +25,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocparagraph;
  *
  * <p><b>p tag before inline tag B, this is ok</b></p>
  */
-// violation 7 lines above 'tag should be placed immediately before the first word'
-// violation 5 lines above 'tag should be placed immediately before the first word'
+
 public class Example2 {
+  // violation 6 lines above 'tag should be placed immediately before the first word'
   // 2 violations 6 lines below:
   //  'tag should be placed immediately before the first word'
   //  '<p> tag should not precede HTML block-tag '<pre>''

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example2.java
@@ -7,6 +7,7 @@
   </module>
 </module>
 */
+
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
 // xdoc section -- start

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example5.java
@@ -9,6 +9,7 @@
   </module>
 </module>
 */
+
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 
 // xdoc section -- start

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example1.java
@@ -7,6 +7,7 @@
 package com.puppycrawl.tools.checkstyle.checks.sizes.filelength;
 
 // xdoc section -- start
+
 public class Example1 {
   public void myTest() {
     // small class with more than 5 lines less than 2000 lines

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example2.java
@@ -5,10 +5,11 @@
   </module>
 </module>
 */
-// violation first line 'File length is 18 lines (max allowed is 5)'
+
 package com.puppycrawl.tools.checkstyle.checks.sizes.filelength;
 
 // xdoc section -- start
+// violation first line 'File length is 19 lines (max allowed is 5)'
 public class Example2 {
   public void myTest() {
     // small class with more than 5 lines less than 2000 lines

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example3.java
@@ -10,6 +10,7 @@
 package com.puppycrawl.tools.checkstyle.checks.sizes.filelength;
 
 // xdoc section -- start
+
 public class Example3 {
   public void myTest() {
     // small class with more than 5 lines less than 2000 lines

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example1.java
@@ -12,19 +12,17 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
 class Example1 extends ExternalService1 {
 
   @JsonCreator
-  // violation below, 'More than 7 parameters (found 8)'
   Example1(int a, int b, int c, int d,
            int e, int f, int g, int h) {}
-
+  // violation 2 lines above 'More than 7 parameters (found 8)'
   // violation below, 'More than 7 parameters (found 8)'
   Example1(String a, String b, String c, String d,
            String e, String f, String g, String h) {}
 
   @Override
-  // violation below, 'More than 7 parameters (found 8)'
   public void processData(String a, String b, String c, String d,
                           String e, String f, String g, String h) {}
-
+  // violation 2 lines above 'More than 7 parameters (found 8)'
 }
 
 class ExternalService1 {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example2.java
@@ -15,8 +15,7 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
 class Example2 extends ExternalService2 {
 
   @JsonCreator
-  // ok below, constructor is not in tokens to check
-  Example2(int a, int b, int c, int d,
+  Example2(int a, int b, int c, int d, // ok, constructor is not in tokens to check
            int e, int f, int g, int h) {}
 
   // ok below, constructor is not in tokens to check
@@ -24,10 +23,9 @@ class Example2 extends ExternalService2 {
            String e, String f, String g, String h) {}
 
   @Override
-  // ok below, less than 10 parameters (found 8)
   public void processData(String a, String b, String c, String d,
                           String e, String f, String g, String h) {}
-
+  // ok above, less than 10 parameters (found 8)
 }
 
 class ExternalService2 {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example3.java
@@ -12,9 +12,8 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
 
 // xdoc section -- start
 class Example3 extends ExternalService3 {
-
+  // violation 2 lines below 'More than 7 parameters (found 8)'
   @JsonCreator
-  // violation below, 'More than 7 parameters (found 8)'
   Example3(int a, int b, int c, int d,
            int e, int f, int g, int h) {}
 
@@ -23,10 +22,9 @@ class Example3 extends ExternalService3 {
            String e, String f, String g, String h) {}
 
   @Override
-  // ok below, overridden method is ignored
   public void processData(String a, String b, String c, String d,
                           String e, String f, String g, String h) {}
-
+  // ok above, overridden method is ignored
 }
 
 class ExternalService3 {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/Example4.java
@@ -14,19 +14,17 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
 class Example4 extends ExternalService4 {
 
   @JsonCreator
-  // ok below, constructor annotated with JsonCreator annotation is ignored
   Example4(int a, int b, int c, int d,
            int e, int f, int g, int h) {}
-
+  // ok above, constructor annotated with JsonCreator annotation is ignored
   // violation below, 'More than 7 parameters (found 8)'
   Example4(String a, String b, String c, String d,
            String e, String f, String g, String h) {}
 
   @Override
-  // violation below, 'More than 7 parameters (found 8)'
   public void processData(String a, String b, String c, String d,
                           String e, String f, String g, String h) {}
-
+  // violation 2 lines above 'More than 7 parameters (found 8)'
 }
 
 class ExternalService4 {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/Example2.java
@@ -12,11 +12,10 @@
   <module name="SuppressWarningsFilter" />
 </module>
 */
-// violation 6 lines above 'use SLF4J instead.'
 
 // xdoc section -- start
 package com.puppycrawl.tools.checkstyle.filters.suppresswarningsfilter;
-
+// violation 9 lines above 'use SLF4J instead.'
 public class Example2 {
   @SuppressWarnings("checkstyle:systemout")
   public static void foo() {


### PR DESCRIPTION
#20382 

Both rules are now `RegexpMultiline` checks that operate on the raw source text instead of the AST, using literal `\n` in the pattern to require the annotation (or closing `*/`) to be alone on its own line, immediately followed by a line containing only the marker comment. This distinguishes:

- `@Override` alone on its line, followed by ` // violation above 'xxx'` on the next line → still flagged
- `@Override  // violation above 'xxx'` (inline) → no longer flagged
- ` // violation below 'xxx'` followed by `@Override` → unaffected, still not flagged

Both modules were moved out of `TreeWalker` into the top-level `Checker`, since they no longer need the AST , this also puts them alongside the file's other `Regexp*` rules.