### PR TITLE
minor: point to more precise issue in until-comment

### DIFF
--- a/config/projects-to-test/openjdk25-excluded.files
+++ b/config/projects-to-test/openjdk25-excluded.files
@@ -32,7 +32,7 @@
   <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]processing[\\/]model[\\/]util[\\/]elements[\\/]TestGetDocComment_Line.java$"/>
 </module>
 
-<!-- until https://github.com/checkstyle/checkstyle/issues/18462 -->
+<!-- until https://github.com/checkstyle/checkstyle/issues/19971 -->
 <module name="BeforeExecutionExclusionFileFilter">
   <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]diags[\\/]examples[\\/]ImplicitClass.java$"/>
 </module>


### PR DESCRIPTION
Resolves https://github.com/checkstyle/checkstyle/issues/18462#issuecomment-4802072037

> please change link suppression comment to point to more precise issue

Issue https://github.com/checkstyle/checkstyle/issues/18462 got replaced by https://github.com/checkstyle/checkstyle/issues/19971 since @vivek-0509 took ownership of the JDK 25 GSoC project (along with the NPEs). He had to create a new issue so he could describe in detail what needs to be done. Hence the change.

TODO after merging:
- Close https://github.com/checkstyle/checkstyle/issues/18462