### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - missingjavadoc

### DIFF
--- a/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
@@ -105,13 +105,24 @@
 
         <p id="Example1-code">Example1:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/** Documented. */
 class Example1 {
-  /** Javadoc.*/
-  public class testClass0 {}
-  public class testClass1 {}
-  private class testClass2 {}
-  protected class testClass3 {}
-  class testClass4 {}
+  /** Javadoc. */
+  public class A {}
+  /** Javadoc. */
+  private class B {}
+  /** Javadoc. */
+  protected class C {}
+  /** Javadoc. */
+  class D {}
+  /** Javadoc. */
+  @SpringBootApplication
+  private class App {}
+  /** Javadoc. */
+  @Configuration
+  private class Config {}
+  /** Javadoc. */
+  private class E {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -129,13 +140,23 @@ class Example1 {
 
         <p id="Example2-code">Example2:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example2 { // violation, 'Missing a Javadoc comment'
-  /** Javadoc.*/
-  public class testClass0 {}
-  public class testClass1 {} // violation, 'Missing a Javadoc comment'
-  private class testClass2 {} // violation, 'Missing a Javadoc comment'
-  protected class testClass3 {} // violation, 'Missing a Javadoc comment'
-  class testClass4 {} // violation, 'Missing a Javadoc comment'
+class Example2 {        // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  public class A {}
+
+  private class B {}    // violation, 'Missing a Javadoc comment'
+
+  protected class C {}  // violation, 'Missing a Javadoc comment'
+
+  class D {}            // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  @SpringBootApplication
+  private class App {}
+  /** Javadoc. */
+  @Configuration
+  private class Config {}
+  /** Javadoc. */
+  private class E {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -154,13 +175,22 @@ class Example2 { // violation, 'Missing a Javadoc comment'
         <p id="Example3-code">Example3:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 {
-  /** Javadoc.*/
-  public class testClass0 {}
-  public class testClass1 {}
-  private class testClass2 {} // violation, 'Missing a Javadoc comment'
-  protected class testClass3 {}
-  class testClass4 {}
+  /** Javadoc. */
+  public class A {}
 
+  private class B {} // violation, 'Missing a Javadoc comment'
+
+  protected class C {}
+  /** Javadoc. */
+  class D {}
+  /** Javadoc. */
+  @SpringBootApplication
+  private class App {}
+  /** Javadoc. */
+  @Configuration
+  private class Config {}
+  /** Javadoc. */
+  private class E {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -182,14 +212,22 @@ class Example3 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 /** Documented. */
 class Example4 {
-  /** Javadoc.*/
+  /** Javadoc. */
+  public class A {}
+  /** Javadoc. */
+  private class B {}
+  /** Javadoc. */
+  protected class C {}
+  /** Javadoc. */
+  class D {}
+  /** Javadoc. */
   @SpringBootApplication
-  private class Application { }
-
+  private class App {}
+  /** Javadoc. */
   @Configuration
-  private class DatabaseConfiguration { }
+  private class Config {}
 
-  private class MissingDoc { } // violation, 'Missing a Javadoc comment'
+  private class E {} // violation, 'Missing a Javadoc comment'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example5-config">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -125,9 +125,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/javadoc/javadocpackage/nonlegacy/Example1",
             "checks/javadoc/javadoctagcontinuationindentation/Example3",
             "checks/javadoc/javadocvariable/Example5",
-            "checks/javadoc/missingjavadoctype/Example3",
-            "checks/javadoc/missingjavadoctype/Example4",
-            "checks/javadoc/missingjavadoctype/Example5",
             "checks/metrics/booleanexpressioncomplexity/Example2",
             "checks/metrics/booleanexpressioncomplexity/Example3",
             "checks/metrics/classdataabstractioncoupling/Example2",
@@ -254,6 +251,7 @@ public class XdocsExamplesAstConsistencyTest {
             // until https://github.com/checkstyle/checkstyle/issues/19891
             "checks/blocks/leftcurly/Example3",
             "checks/whitespace/parenpad/Example3",
+            "checks/javadoc/missingjavadoctype/Example5",
             "checks/indentation/commentsindentation/Example3",
             "checks/indentation/commentsindentation/Example4",
             "checks/indentation/commentsindentation/Example5",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckExamplesTest.java
@@ -41,11 +41,10 @@ public class MissingJavadocTypeCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "16:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "17:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "18:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "19:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -54,7 +53,7 @@ public class MissingJavadocTypeCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "18:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "19:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -63,7 +62,7 @@ public class MissingJavadocTypeCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "29:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "37:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example1.java
@@ -8,12 +8,23 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 // xdoc section -- start
+/** Documented. */
 class Example1 {
-  /** Javadoc.*/
-  public class testClass0 {}
-  public class testClass1 {}
-  private class testClass2 {}
-  protected class testClass3 {}
-  class testClass4 {}
+  /** Javadoc. */
+  public class A {}
+  /** Javadoc. */
+  private class B {}
+  /** Javadoc. */
+  protected class C {}
+  /** Javadoc. */
+  class D {}
+  /** Javadoc. */
+  @SpringBootApplication
+  private class App {}
+  /** Javadoc. */
+  @Configuration
+  private class Config {}
+  /** Javadoc. */
+  private class E {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example2.java
@@ -10,12 +10,23 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 // xdoc section -- start
-class Example2 { // violation, 'Missing a Javadoc comment'
-  /** Javadoc.*/
-  public class testClass0 {}
-  public class testClass1 {} // violation, 'Missing a Javadoc comment'
-  private class testClass2 {} // violation, 'Missing a Javadoc comment'
-  protected class testClass3 {} // violation, 'Missing a Javadoc comment'
-  class testClass4 {} // violation, 'Missing a Javadoc comment'
+
+class Example2 {        // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  public class A {}
+
+  private class B {}    // violation, 'Missing a Javadoc comment'
+
+  protected class C {}  // violation, 'Missing a Javadoc comment'
+
+  class D {}            // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  @SpringBootApplication
+  private class App {}
+  /** Javadoc. */
+  @Configuration
+  private class Config {}
+  /** Javadoc. */
+  private class E {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example3.java
@@ -11,13 +11,23 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 // xdoc section -- start
-class Example3 {
-  /** Javadoc.*/
-  public class testClass0 {}
-  public class testClass1 {}
-  private class testClass2 {} // violation, 'Missing a Javadoc comment'
-  protected class testClass3 {}
-  class testClass4 {}
 
+class Example3 {
+  /** Javadoc. */
+  public class A {}
+
+  private class B {} // violation, 'Missing a Javadoc comment'
+
+  protected class C {}
+  /** Javadoc. */
+  class D {}
+  /** Javadoc. */
+  @SpringBootApplication
+  private class App {}
+  /** Javadoc. */
+  @Configuration
+  private class Config {}
+  /** Javadoc. */
+  private class E {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example4.java
@@ -19,13 +19,21 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 // xdoc section -- start
 /** Documented. */
 class Example4 {
-  /** Javadoc.*/
+  /** Javadoc. */
+  public class A {}
+  /** Javadoc. */
+  private class B {}
+  /** Javadoc. */
+  protected class C {}
+  /** Javadoc. */
+  class D {}
+  /** Javadoc. */
   @SpringBootApplication
-  private class Application { }
-
+  private class App {}
+  /** Javadoc. */
   @Configuration
-  private class DatabaseConfiguration { }
+  private class Config {}
 
-  private class MissingDoc { } // violation, 'Missing a Javadoc comment'
+  private class E {} // violation, 'Missing a Javadoc comment'
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435

Example1 -> default
Example2 -> property -> scope
Example3 -> property -> scope + excludeScope
Example4 -> property -> scope + skipAnnotations
Example5->  property -> scope + skipAnnotations

Section1 -> Example1,2,3,4
UseCase -> Example5