### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - suppresscomme…

### DIFF
--- a/src/site/xdoc/filters/suppressioncommentfilter.xml
+++ b/src/site/xdoc/filters/suppressioncommentfilter.xml
@@ -128,36 +128,34 @@
 </code></pre></div>
         <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example1
-{
+class Example1 {
+
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CHECKSTYLE:OFF
   int VAR2; // filtered violation 'must match pattern'
   //CHECKSTYLE:ON
 
-  public static final int var3 = 1;
-  // violation above, 'must match pattern'
+  //stop constant check
+  public static final int var3 = 1; // violation 'must match pattern'
+  //resume constant check
 
-  //CHECKSTYLE:OFF
-  public static final int var4 = 1; // filtered violation 'must match pattern'
-  //CHECKSTYLE:ON
-
-  public void method1()
-  {
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-
-    //CHECKSTYLE:OFF
-
-    try {}
-    catch(Exception ex) {}
-    // filtered violation above 'Catching 'Exception' is not allowed'
-    catch(Error err) {}
-    // filtered violation above 'Catching 'Error' is not allowed'
-
-    //CHECKSTYLE:ON
+  //ILLEGAL OFF: Exception
+  void method1() {
+    try {
+    }
+    catch (Exception ex) { } // violation, Catching 'Exception' is not allowed.
+    catch (Error err) { }    // violation, Catching 'Exception' is not allowed.
   }
+  //ILLEGAL ON: Exception
+
+  //CSOFF MemberID
+  int VAR4;   // violation, Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'
+  //CSON MemberID
+
+  /*CHECKSTYLE:OFF*/
+  public static final int varC = 1; // filtered violation 'must match pattern'
+  /*CHECKSTYLE:ON*/
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -181,34 +179,34 @@ class Example1
 </code></pre></div>
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example2
-{
+class Example2 {
+
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
-  //stop constant check
+  //CHECKSTYLE:OFF
   int VAR2; // violation, Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'
-  //resume constant check
-
-  public static final int var3 = 1;
-  // violation above, Name 'must match pattern'
+  //CHECKSTYLE:ON
 
   //stop constant check
-  public static final int var4 = 1; // filtered violation 'must match pattern'
+  public static final int var3 = 1; // filtered violation 'must match pattern'
   //resume constant check
 
-  public void method1()
-  {
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-
-    //stop constant check
-
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-    catch(Error err) {} // violation, Catching 'Error' is not allowed
-
-    //resume constant check
+  //ILLEGAL OFF: Exception
+  void method1() {
+    try {
+    }
+    catch (Exception ex) { }  // violation, Catching 'Exception' is not allowed
+    catch (Error err) { }     // violation, Catching 'Error' is not allowed
   }
+  //ILLEGAL ON: Exception
+
+  //CSOFF MemberID
+  int VAR4;   // violation, Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'
+  //CSON MemberID
+
+  /*CHECKSTYLE:OFF*/
+  public static final int varC = 1; // violation, 'must match pattern'
+  /*CHECKSTYLE:ON*/
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -234,36 +232,34 @@ class Example2
 </code></pre></div>
         <p id="Example3-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example3
-{
+class Example3 {
+
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
-  //ILLEGAL OFF: Exception
+  //CHECKSTYLE:OFF
   int VAR2; // violation, Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'
-  //ILLEGAL ON: Exception
+  //CHECKSTYLE:ON
 
-  public static final int var3 = 1;
-  // violation above, 'must match pattern'
+  //stop constant check
+  public static final int var3 = 1; // violation, 'must match pattern'
+  //resume constant check
 
   //ILLEGAL OFF: Exception
-  public static final int var4 = 1;
-  // violation above,  Name 'must match pattern'
+  void method1() {
+    try {
+    } // filtered violation below 'Catching 'Exception' is not allowed'
+    catch (Exception ex) { }
+    catch (Error err) { }     // violation, Catching 'Error' is not allowed
+  }
   //ILLEGAL ON: Exception
 
-  public void method1()
-  {
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
+  //CSOFF MemberID
+  int VAR4;   // violation, Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'
+  //CSON MemberID
 
-    //ILLEGAL OFF: Exception
-
-    try {}
-    catch(Exception ex) {}
-    // filtered violation above 'Catching 'Exception' is not allowed'
-    catch(Error err) {} // violation, Catching 'Error' is not allowed
-
-    //ILLEGAL ON: Exception
-  }
+  /*CHECKSTYLE:OFF*/
+  public static final int varC = 1; // violation, 'must match pattern'
+  /*CHECKSTYLE:ON*/
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -404,36 +400,34 @@ class Example5
 </code></pre></div>
         <p id="Example6-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example6
-{
+class Example6 {
+
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
-  //CSOFF MemberID
-  int VAR2; // filtered violation 'must match pattern'
-  //CSON: MemberID
+  //CHECKSTYLE:OFF
+  int VAR2; // violation, Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'
+  //CHECKSTYLE:ON
 
-  public static final int var3 = 1;
-  // violation above, 'must match pattern'
+  //stop constant check
+  public static final int var3 = 1; // violation, 'must match pattern'
+  //resume constant check
 
-  //CSOFF ConstantID
-  public static final int var4 = 1; // filtered violation 'must match pattern'
-  //CSON ConstantID
-
-  public void method1()
-  {
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-
-    //CSOFF IllegalID
-
-    try {}
-    catch(Exception ex) {}
-    // filtered violation above 'Catching 'Exception' is not allowed'
-    catch(Error err) {}
-    // filtered violation above 'Catching 'Error' is not allowed'
-
-    //CSON IllegalID
+  //ILLEGAL OFF: Exception
+  void method1() {
+    try {
+    }
+    catch (Exception ex) { }  // violation, Catching 'Exception' is not allowed
+    catch (Error err) { }     // violation, Catching 'Error' is not allowed
   }
+  //ILLEGAL ON: Exception
+
+  //CSOFF MemberID
+  int VAR4;   // filtered violation 'must match pattern'
+  //CSON MemberID
+
+  /*CHECKSTYLE:OFF*/
+  public static final int varC = 1;  // violation, 'must match pattern'
+  /*CHECKSTYLE:ON*/
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example7-config">
@@ -507,34 +501,34 @@ class Example7
 </code></pre></div>
         <p id="Example8-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example8
-{
+class Example8 {
+
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CHECKSTYLE:OFF
   int VAR2; // violation, Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'
   //CHECKSTYLE:ON
 
-  public static final int var3 = 1;
-  // violation above, Name 'must match pattern'
+  //stop constant check
+  public static final int var3 = 1;  // violation, 'must match pattern'
+  //resume constant check
+
+  //ILLEGAL OFF: Exception
+  void method1() {
+    try {
+    }
+    catch (Exception ex) { }  // violation, Catching 'Exception' is not allowed
+    catch (Error err) { }     // violation, Catching 'Error' is not allowed
+  }
+  //ILLEGAL ON: Exception
+
+  //CSOFF MemberID
+  int VAR4;   // violation, Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'
+  //CSON MemberID
 
   /*CHECKSTYLE:OFF*/
-  public static final int var4 = 1; // filtered violation 'must match pattern'
+  public static final int varC = 1; // filtered violation 'must match pattern'
   /*CHECKSTYLE:ON*/
-
-  public void method1()
-  {
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-
-    //CHECKSTYLE:OFF
-
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-    catch(Error err) {} // violation, Catching 'Error' is not allowed
-
-    //CHECKSTYLE:ON
-  }
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -174,13 +174,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/uniqueproperties/Example2",
             "checks/whitespace/emptyforiteratorpad/Example2",
             "checks/whitespace/parenpad/Example2",
-            "filters/suppressioncommentfilter/Example2",
-            "filters/suppressioncommentfilter/Example3",
-            "filters/suppressioncommentfilter/Example4",
-            "filters/suppressioncommentfilter/Example5",
-            "filters/suppressioncommentfilter/Example6",
-            "filters/suppressioncommentfilter/Example7",
-            "filters/suppressioncommentfilter/Example8",
             "filters/suppressionsinglefilter/Example2",
             "filters/suppressionsinglefilter/Example3",
             "filters/suppressionsinglefilter/Example4",
@@ -334,7 +327,10 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/descendanttoken/Example11",
             "checks/descendanttoken/Example13",
             "checks/descendanttoken/Example15",
-            "checks/descendanttoken/Example16"
+            "checks/descendanttoken/Example16",
+            "filters/suppressioncommentfilter/Example4",
+            "filters/suppressioncommentfilter/Example5",
+            "filters/suppressioncommentfilter/Example7"
             );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterExamplesTest.java
@@ -34,17 +34,19 @@ public class SuppressionCommentFilterExamplesTest extends AbstractExamplesModule
         final String[] expectedWithoutFilter = {
             "16:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "19:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "22:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "26:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "32:5: Catching 'Exception' is not allowed.",
-            "37:5: Catching 'Exception' is not allowed.",
-            "39:5: Catching 'Error' is not allowed.",
+            "23:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "30:5: Catching 'Exception' is not allowed.",
+            "31:5: Catching 'Error' is not allowed.",
+            "36:7: Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "40:27: Name 'varC' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
         };
 
         final String[] expectedWithFilter = {
             "16:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "22:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "32:5: Catching 'Exception' is not allowed.",
+            "23:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "30:5: Catching 'Exception' is not allowed.",
+            "31:5: Catching 'Error' is not allowed.",
+            "36:7: Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example1.java"),
@@ -56,20 +58,20 @@ public class SuppressionCommentFilterExamplesTest extends AbstractExamplesModule
         final String[] expectedWithoutFilter = {
             "21:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "24:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "27:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "31:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "37:5: Catching 'Exception' is not allowed.",
-            "42:5: Catching 'Exception' is not allowed.",
-            "43:5: Catching 'Error' is not allowed.",
+            "28:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "35:5: Catching 'Exception' is not allowed.",
+            "36:5: Catching 'Error' is not allowed.",
+            "41:7: Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "45:27: Name 'varC' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
         };
 
         final String[] expectedWithFilter = {
             "21:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "24:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "27:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "37:5: Catching 'Exception' is not allowed.",
-            "42:5: Catching 'Exception' is not allowed.",
-            "43:5: Catching 'Error' is not allowed.",
+            "35:5: Catching 'Exception' is not allowed.",
+            "36:5: Catching 'Error' is not allowed.",
+            "41:7: Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "45:27: Name 'varC' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example2.java"),
@@ -81,20 +83,20 @@ public class SuppressionCommentFilterExamplesTest extends AbstractExamplesModule
         final String[] expectedWithoutFilter = {
             "21:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "24:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "27:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "31:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "38:5: Catching 'Exception' is not allowed.",
-            "43:5: Catching 'Exception' is not allowed.",
-            "45:5: Catching 'Error' is not allowed.",
+            "28:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "35:5: Catching 'Exception' is not allowed.",
+            "36:5: Catching 'Error' is not allowed.",
+            "41:7: Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "45:27: Name 'varC' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
         };
 
         final String[] expectedWithFilter = {
             "21:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "24:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "27:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "31:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "38:5: Catching 'Exception' is not allowed.",
-            "45:5: Catching 'Error' is not allowed.",
+            "28:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "36:5: Catching 'Error' is not allowed.",
+            "41:7: Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "45:27: Name 'varC' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example3.java"),
@@ -151,17 +153,20 @@ public class SuppressionCommentFilterExamplesTest extends AbstractExamplesModule
         final String[] expectedWithoutFilter = {
             "25:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "28:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "31:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "35:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "41:5: Catching 'Exception' is not allowed.",
-            "46:5: Catching 'Exception' is not allowed.",
-            "48:5: Catching 'Error' is not allowed.",
+            "32:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "39:5: Catching 'Exception' is not allowed.",
+            "40:5: Catching 'Error' is not allowed.",
+            "45:7: Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "49:27: Name 'varC' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
         };
 
         final String[] expectedWithFilter = {
             "25:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "31:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "41:5: Catching 'Exception' is not allowed.",
+            "28:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "32:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "39:5: Catching 'Exception' is not allowed.",
+            "40:5: Catching 'Error' is not allowed.",
+            "49:27: Name 'varC' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example6.java"),
@@ -194,20 +199,20 @@ public class SuppressionCommentFilterExamplesTest extends AbstractExamplesModule
         final String[] expectedWithoutFilter = {
             "18:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "21:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "24:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "28:27: Name 'var4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "34:5: Catching 'Exception' is not allowed.",
-            "39:5: Catching 'Exception' is not allowed.",
-            "40:5: Catching 'Error' is not allowed.",
+            "25:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "32:5: Catching 'Exception' is not allowed.",
+            "33:5: Catching 'Error' is not allowed.",
+            "38:7: Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "42:27: Name 'varC' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
         };
 
         final String[] expectedWithFilter = {
             "18:7: Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "21:7: Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "24:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "34:5: Catching 'Exception' is not allowed.",
-            "39:5: Catching 'Exception' is not allowed.",
-            "40:5: Catching 'Error' is not allowed.",
+            "25:27: Name 'var3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "32:5: Catching 'Exception' is not allowed.",
+            "33:5: Catching 'Error' is not allowed.",
+            "38:7: Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example8.java"),

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example1.java
@@ -11,35 +11,33 @@
 
 package com.puppycrawl.tools.checkstyle.filters.suppressioncommentfilter;
 // xdoc section -- start
-class Example1
-{
+class Example1 {
+
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CHECKSTYLE:OFF
   int VAR2; // filtered violation 'must match pattern'
   //CHECKSTYLE:ON
 
-  public static final int var3 = 1;
-  // violation above, 'must match pattern'
+  //stop constant check
+  public static final int var3 = 1; // violation 'must match pattern'
+  //resume constant check
 
-  //CHECKSTYLE:OFF
-  public static final int var4 = 1; // filtered violation 'must match pattern'
-  //CHECKSTYLE:ON
-
-  public void method1()
-  {
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-
-    //CHECKSTYLE:OFF
-
-    try {}
-    catch(Exception ex) {}
-    // filtered violation above 'Catching 'Exception' is not allowed'
-    catch(Error err) {}
-    // filtered violation above 'Catching 'Error' is not allowed'
-
-    //CHECKSTYLE:ON
+  //ILLEGAL OFF: Exception
+  void method1() {
+    try {
+    }
+    catch (Exception ex) { } // violation, Catching 'Exception' is not allowed.
+    catch (Error err) { }    // violation, Catching 'Exception' is not allowed.
   }
+  //ILLEGAL ON: Exception
+
+  //CSOFF MemberID
+  int VAR4;   // violation, Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'
+  //CSON MemberID
+
+  /*CHECKSTYLE:OFF*/
+  public static final int varC = 1; // filtered violation 'must match pattern'
+  /*CHECKSTYLE:ON*/
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example2.java
@@ -16,33 +16,33 @@
 package com.puppycrawl.tools.checkstyle.filters.suppressioncommentfilter;
 
 // xdoc section -- start
-class Example2
-{
+class Example2 {
+
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
-  //stop constant check
+  //CHECKSTYLE:OFF
   int VAR2; // violation, Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'
-  //resume constant check
-
-  public static final int var3 = 1;
-  // violation above, Name 'must match pattern'
+  //CHECKSTYLE:ON
 
   //stop constant check
-  public static final int var4 = 1; // filtered violation 'must match pattern'
+  public static final int var3 = 1; // filtered violation 'must match pattern'
   //resume constant check
 
-  public void method1()
-  {
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-
-    //stop constant check
-
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-    catch(Error err) {} // violation, Catching 'Error' is not allowed
-
-    //resume constant check
+  //ILLEGAL OFF: Exception
+  void method1() {
+    try {
+    }
+    catch (Exception ex) { }  // violation, Catching 'Exception' is not allowed
+    catch (Error err) { }     // violation, Catching 'Error' is not allowed
   }
+  //ILLEGAL ON: Exception
+
+  //CSOFF MemberID
+  int VAR4;   // violation, Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'
+  //CSON MemberID
+
+  /*CHECKSTYLE:OFF*/
+  public static final int varC = 1; // violation, 'must match pattern'
+  /*CHECKSTYLE:ON*/
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example3.java
@@ -16,35 +16,33 @@
 package com.puppycrawl.tools.checkstyle.filters.suppressioncommentfilter;
 
 // xdoc section -- start
-class Example3
-{
+class Example3 {
+
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
-  //ILLEGAL OFF: Exception
+  //CHECKSTYLE:OFF
   int VAR2; // violation, Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'
-  //ILLEGAL ON: Exception
+  //CHECKSTYLE:ON
 
-  public static final int var3 = 1;
-  // violation above, 'must match pattern'
+  //stop constant check
+  public static final int var3 = 1; // violation, 'must match pattern'
+  //resume constant check
 
   //ILLEGAL OFF: Exception
-  public static final int var4 = 1;
-  // violation above,  Name 'must match pattern'
+  void method1() {
+    try {
+    } // filtered violation below 'Catching 'Exception' is not allowed'
+    catch (Exception ex) { }
+    catch (Error err) { }     // violation, Catching 'Error' is not allowed
+  }
   //ILLEGAL ON: Exception
 
-  public void method1()
-  {
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
+  //CSOFF MemberID
+  int VAR4;   // violation, Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'
+  //CSON MemberID
 
-    //ILLEGAL OFF: Exception
-
-    try {}
-    catch(Exception ex) {}
-    // filtered violation above 'Catching 'Exception' is not allowed'
-    catch(Error err) {} // violation, Catching 'Error' is not allowed
-
-    //ILLEGAL ON: Exception
-  }
+  /*CHECKSTYLE:OFF*/
+  public static final int varC = 1; // violation, 'must match pattern'
+  /*CHECKSTYLE:ON*/
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example6.java
@@ -20,35 +20,33 @@
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressioncommentfilter;
 // xdoc section -- start
-class Example6
-{
+class Example6 {
+
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
-  //CSOFF MemberID
-  int VAR2; // filtered violation 'must match pattern'
-  //CSON: MemberID
+  //CHECKSTYLE:OFF
+  int VAR2; // violation, Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'
+  //CHECKSTYLE:ON
 
-  public static final int var3 = 1;
-  // violation above, 'must match pattern'
+  //stop constant check
+  public static final int var3 = 1; // violation, 'must match pattern'
+  //resume constant check
 
-  //CSOFF ConstantID
-  public static final int var4 = 1; // filtered violation 'must match pattern'
-  //CSON ConstantID
-
-  public void method1()
-  {
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-
-    //CSOFF IllegalID
-
-    try {}
-    catch(Exception ex) {}
-    // filtered violation above 'Catching 'Exception' is not allowed'
-    catch(Error err) {}
-    // filtered violation above 'Catching 'Error' is not allowed'
-
-    //CSON IllegalID
+  //ILLEGAL OFF: Exception
+  void method1() {
+    try {
+    }
+    catch (Exception ex) { }  // violation, Catching 'Exception' is not allowed
+    catch (Error err) { }     // violation, Catching 'Error' is not allowed
   }
+  //ILLEGAL ON: Exception
+
+  //CSOFF MemberID
+  int VAR4;   // filtered violation 'must match pattern'
+  //CSON MemberID
+
+  /*CHECKSTYLE:OFF*/
+  public static final int varC = 1;  // violation, 'must match pattern'
+  /*CHECKSTYLE:ON*/
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter/Example8.java
@@ -13,33 +13,33 @@
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressioncommentfilter;
 // xdoc section -- start
-class Example8
-{
+class Example8 {
+
   int VAR1; // violation, Name 'VAR1' must match pattern '^[a-z][a-zA-Z0-9]*$'
 
   //CHECKSTYLE:OFF
   int VAR2; // violation, Name 'VAR2' must match pattern '^[a-z][a-zA-Z0-9]*$'
   //CHECKSTYLE:ON
 
-  public static final int var3 = 1;
-  // violation above, Name 'must match pattern'
+  //stop constant check
+  public static final int var3 = 1;  // violation, 'must match pattern'
+  //resume constant check
+
+  //ILLEGAL OFF: Exception
+  void method1() {
+    try {
+    }
+    catch (Exception ex) { }  // violation, Catching 'Exception' is not allowed
+    catch (Error err) { }     // violation, Catching 'Error' is not allowed
+  }
+  //ILLEGAL ON: Exception
+
+  //CSOFF MemberID
+  int VAR4;   // violation, Name 'VAR4' must match pattern '^[a-z][a-zA-Z0-9]*$'
+  //CSON MemberID
 
   /*CHECKSTYLE:OFF*/
-  public static final int var4 = 1; // filtered violation 'must match pattern'
+  public static final int varC = 1; // filtered violation 'must match pattern'
   /*CHECKSTYLE:ON*/
-
-  public void method1()
-  {
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-
-    //CHECKSTYLE:OFF
-
-    try {}
-    catch(Exception ex) {} // violation, Catching 'Exception' is not allowed
-    catch(Error err) {} // violation, Catching 'Error' is not allowed
-
-    //CHECKSTYLE:ON
-  }
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435



| Example | SuppressionCommentFilter Properties |
|---------|--------------------------------------|
| **Example1** | **Default configuration** (uses the default `CHECKSTYLE:OFF` / `CHECKSTYLE:ON` comments). |
| **Example2** | `offCommentFormat="stop constant check"`<br>`onCommentFormat="resume constant check"`<br>`checkFormat="ConstantNameCheck"` |
| **Example3** | `offCommentFormat="ILLEGAL OFF: (\w+)"`<br>`onCommentFormat="ILLEGAL ON: (\w+)"`<br>`checkFormat="IllegalCatch"`<br>`messageFormat="^Catching '$1' is not allowed.$"` |
| **Example4** | `offCommentFormat="CSOFF: ([\w\|]+)"`<br>`onCommentFormat="CSON: ([\w\|]+)"`<br>`checkFormat="$1"` *(suppresses checks by check name captured from the comment).* |
| **Example5** | `offCommentFormat="CHECKSTYLE_OFF: ALMOST_ALL"`<br>`onCommentFormat="CHECKSTYLE_ON: ALMOST_ALL"`<br>`checkFormat="^((?!(ConstantName)).)*$"`  |
| **Example6** | `offCommentFormat="CSOFF (\w+)"`<br>`onCommentFormat="CSON (\w+)"`<br>`idFormat="$1"` *(suppresses checks by check ID instead of check name).* |
| **Example7** | `offCommentFormat="csoff (\w+)"`<br>`onCommentFormat="cson (\w+)"`<br>`checkFormat="$1"` |
| **Example8** | `checkC="true"`<br>`checkCPP="false"` *(`/*CHECKSTYLE:OFF*/`; C++-style `//CHECKSTYLE:OFF` comments are ignored).* |

Section1 -> Example 1,2,3,6,8
UseCase -> Example 4,5,7

