### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - illegalthrows

### DIFF
--- a/src/site/xdoc/checks/coding/illegalthrows.xml
+++ b/src/site/xdoc/checks/coding/illegalthrows.xml
@@ -70,6 +70,7 @@ public class Example1 {
   void f2() throws Exception {}
   void f3() throws Error {}  // violation, 'Throwing 'Error' is not allowed'
   void f4() throws Throwable {} // violation, 'Throwing 'Throwable' is not allowed'
+
   void f5() throws NullPointerException {}
   @Override
   public String toString() throws Error {
@@ -93,6 +94,7 @@ public class Example1 {
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
+
   void f1() throws RuntimeException {}
   void f2() throws Exception {}
   void f3() throws Error {}
@@ -121,10 +123,12 @@ public class Example2 {
         <p id="Example3-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example3 {
+
   void f1() throws RuntimeException {}
   void f2() throws Exception {}
   void f3() throws Error {} // violation, 'Throwing 'Error' is not allowed'
   void f4() throws Throwable {} // violation, 'Throwing 'Throwable' is not allowed'
+
   void f5() throws NullPointerException {}
   @Override
   public String toString() throws Error {
@@ -153,6 +157,7 @@ public class Example4 {
   void f2() throws Exception {}
   void f3() throws Error {}  // violation, 'Throwing 'Error' is not allowed'
   void f4() throws Throwable {} // violation, 'Throwing 'Throwable' is not allowed'
+
   void f5() throws NullPointerException {}
   @Override // violation below, 'Throwing 'Error' is not allowed'
   public String toString() throws Error {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -104,8 +104,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/coding/equalsavoidnull/Example2",
             "checks/coding/explicitinitialization/Example2",
             "checks/coding/illegalsymbol/Example4",
-            "checks/coding/illegalthrows/Example2",
-            "checks/coding/illegalthrows/Example3",
             "checks/coding/nestedfordepth/Example2",
             "checks/coding/nestedifdepth/Example2",
             "checks/coding/onestatementperline/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheckExamplesTest.java
@@ -45,7 +45,7 @@ public class IllegalThrowsCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "19:20: " + getCheckMessage(MSG_KEY, "NullPointerException"),
+            "20:20: " + getCheckMessage(MSG_KEY, "NullPointerException"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -54,8 +54,8 @@ public class IllegalThrowsCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "16:20: " + getCheckMessage(MSG_KEY, "Error"),
-            "17:20: " + getCheckMessage(MSG_KEY, "Throwable"),
+            "17:20: " + getCheckMessage(MSG_KEY, "Error"),
+            "18:20: " + getCheckMessage(MSG_KEY, "Throwable"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -67,7 +67,7 @@ public class IllegalThrowsCheckExamplesTest extends AbstractExamplesModuleTestSu
             "15:20: " + getCheckMessage(MSG_KEY, "RuntimeException"),
             "17:20: " + getCheckMessage(MSG_KEY, "Error"),
             "18:20: " + getCheckMessage(MSG_KEY, "Throwable"),
-            "21:35: " + getCheckMessage(MSG_KEY, "Error"),
+            "22:35: " + getCheckMessage(MSG_KEY, "Error"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows/Example1.java
@@ -14,6 +14,7 @@ public class Example1 {
   void f2() throws Exception {}
   void f3() throws Error {}  // violation, 'Throwing 'Error' is not allowed'
   void f4() throws Throwable {} // violation, 'Throwing 'Throwable' is not allowed'
+
   void f5() throws NullPointerException {}
   @Override
   public String toString() throws Error {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows/Example2.java
@@ -11,6 +11,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegalthrows;
 
 // xdoc section -- start
 public class Example2 {
+
   void f1() throws RuntimeException {}
   void f2() throws Exception {}
   void f3() throws Error {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows/Example3.java
@@ -11,10 +11,12 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegalthrows;
 
 // xdoc section -- start
 public class Example3 {
+
   void f1() throws RuntimeException {}
   void f2() throws Exception {}
   void f3() throws Error {} // violation, 'Throwing 'Error' is not allowed'
   void f4() throws Throwable {} // violation, 'Throwing 'Throwable' is not allowed'
+
   void f5() throws NullPointerException {}
   @Override
   public String toString() throws Error {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows/Example4.java
@@ -16,6 +16,7 @@ public class Example4 {
   void f2() throws Exception {}
   void f3() throws Error {}  // violation, 'Throwing 'Error' is not allowed'
   void f4() throws Throwable {} // violation, 'Throwing 'Throwable' is not allowed'
+
   void f5() throws NullPointerException {}
   @Override // violation below, 'Throwing 'Error' is not allowed'
   public String toString() throws Error {


### PR DESCRIPTION
#18435

Example1 -> default
Example2 -> illegalClassNames
Example3 -> ignoredMethodNames
Example4 -> ignoreOverriddenMethods

Section1 -> Example1,2,3,4