### PR TITLE
Issue #16807: Specify all default properties for SuppressionCommentFilter

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -488,9 +488,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     public void testBehaviourWithChecksAndFilters() throws Exception {
 
         final String[] expected = {
-            "22:17: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern", "P",
+            "28:17: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern", "P",
                     "^[a-z][a-zA-Z0-9]*$"),
-            "17:17: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern", "I",
+            "23:17: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern", "I",
                     "^[a-z][a-zA-Z0-9]*$"),
         };
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -311,7 +311,6 @@ public final class InlineConfigParser {
      */
     private static final Set<String> SUPPRESSED_MODULES = Set.of(
             "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck",
-            "com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter",
             "com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter",
             "com.puppycrawl.tools.checkstyle.filters.SuppressionXpathSingleFilter"
     );

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerSuppressionCommentFilter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/treewalker/InputTreeWalkerSuppressionCommentFilter.java
@@ -8,7 +8,13 @@ applyToPrivate = (default)true
 
 
 com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter
+offCommentFormat = (default)CHECKSTYLE:OFF
+onCommentFormat = (default)CHECKSTYLE:ON
+checkFormat = (default).*
+messageFormat = (default)(null)
+idFormat = (default)(null)
 checkCPP = false
+checkC = (default)true
 
 */
 package com.puppycrawl.tools.checkstyle.treewalker;


### PR DESCRIPTION
Issue: #16807

## Summary

- Removed `SuppressionCommentFilter` from `InlineConfigParser` suppressed modules.
- Its input files now explicitly specify all default properties required by the inline config parser.
- Updated the TreeWalker regression input expected line numbers after adding the missing inline config defaults.

## Tests

- `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./mvnw clean -Dnet.bytebuddy.experimental=true -Dtest=SuppressionCommentFilterTest,TreeWalkerTest test`
- `git diff --check`
