### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - atclauseorder

### DIFF
--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml
@@ -102,30 +102,32 @@
 * @serialField Field description.
 * @serialData
 */
-public class Example1 {}
+public class Example1 {
+  class Valid implements Serializable {
+  }
 
-class Valid1 implements Serializable {}
+  /**
+   * Some javadoc.
+   *
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc.
+   * @deprecated
+   */
+  class Invalid implements Serializable {
+  }
 
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc. // violation
- * @deprecated
- * @see Some javadoc. // violation
- */
-class Invalid1 implements Serializable {}
-
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc. // violation
- * @deprecated
- * @see Some javadoc. // violation
- * @author max // violation
- */
-enum Test1 {}
+  /**
+   * Some javadoc.
+   *
+   * @author max
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc.
+   * @deprecated
+   */
+  enum Test {}
+}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
             To configure the check such that it checks in the custom order:
@@ -161,30 +163,32 @@ enum Test1 {}
 * @serialField Field description.
 * @serialData
 */
-public class Example2 {}
+public class Example2 {
+  class Valid implements Serializable {
+  }
 
-class Valid2 implements Serializable {}
+  /**
+   * Some javadoc.
+   *
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc. // violation
+   * @deprecated  // violation
+   */
+  class Invalid implements Serializable {
+  }
 
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc.
- * @deprecated
- * @see Some javadoc.
- */
-class Invalid2 implements Serializable {}
-
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc.
- * @deprecated Some javadoc.
- * @see Some javadoc.
- * @author max // violation
- */
-enum Test2 {}
+  /**
+   * Some javadoc.
+   *
+   * @author max
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc. // violation
+   * @deprecated // violation
+   */
+  enum Test {}
+}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
             To configure the check such that it targets only enums:
@@ -221,30 +225,32 @@ enum Test2 {}
 * @serialField Field description.
 * @serialData
 */
-public class Example3 {}
+public class Example3 {
+  class Valid implements Serializable {
+  }
 
-class Valid3 implements Serializable {}
+  /**
+   * Some javadoc.
+   *
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc.
+   * @deprecated
+   */
+  class Invalid implements Serializable {
+  }
 
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc.
- * @deprecated
- * @see Some javadoc.
- */
-class Invalid3 implements Serializable {}
-
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc.
- * @deprecated
- * @see Some javadoc.
- * @author Some javadoc. // violation
- */
-enum Test3 {}
+  /**
+   * Some javadoc.
+   *
+   * @author Some javadoc.
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc. // violation
+   * @deprecated // violation
+   */
+  enum Test {}
+}
 </code></pre></div>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -116,8 +116,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/imports/importcontrol/someImports/Example6",
             "checks/imports/importcontrol/someImports/Example7",
             "checks/indentation/indentation/Example7",
-            "checks/javadoc/atclauseorder/Example2",
-            "checks/javadoc/atclauseorder/Example3",
             "checks/javadoc/javadoccontentlocation/Example2",
             "checks/javadoc/javadocleadingasteriskalign/Example2",
             "checks/javadoc/javadocleadingasteriskalign/Example3",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckExamplesTest.java
@@ -33,17 +33,8 @@ public class AtclauseOrderCheckExamplesTest extends AbstractExamplesModuleTestSu
 
     @Test
     public void testExample1() throws Exception {
-        final String tagOrder = "[@author, @version, @param, @return, @throws"
-            + ", @exception, @see,"
-            + " @since, @serial, @serialField, @serialData, @deprecated]";
 
-        final String[] expected = {
-            "42: " + getCheckMessage(MSG_KEY, tagOrder),
-            "44: " + getCheckMessage(MSG_KEY, tagOrder),
-            "52: " + getCheckMessage(MSG_KEY, tagOrder),
-            "54: " + getCheckMessage(MSG_KEY, tagOrder),
-            "55: " + getCheckMessage(MSG_KEY, tagOrder),
-        };
+        final String[] expected = {};
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
@@ -56,7 +47,10 @@ public class AtclauseOrderCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         final String[] expected = {
             "29: " + getCheckMessage(MSG_KEY, tagOrder),
+            "43: " + getCheckMessage(MSG_KEY, tagOrder),
+            "44: " + getCheckMessage(MSG_KEY, tagOrder),
             "55: " + getCheckMessage(MSG_KEY, tagOrder),
+            "56: " + getCheckMessage(MSG_KEY, tagOrder),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -70,6 +64,7 @@ public class AtclauseOrderCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         final String[] expected = {
             "55: " + getCheckMessage(MSG_KEY, tagOrder),
+            "56: " + getCheckMessage(MSG_KEY, tagOrder),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example1.java
@@ -6,11 +6,6 @@
 </module>
 */
 
-
-
-
-
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 
 import java.io.Serializable;
@@ -31,28 +26,30 @@ import java.io.Serializable;
 * @serialField Field description.
 * @serialData
 */
-public class Example1 {}
+public class Example1 {
+  class Valid implements Serializable {
+  }
 
-class Valid1 implements Serializable {}
+  /**
+   * Some javadoc.
+   *
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc.
+   * @deprecated
+   */
+  class Invalid implements Serializable {
+  }
 
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc. // violation
- * @deprecated
- * @see Some javadoc. // violation
- */
-class Invalid1 implements Serializable {}
-
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc. // violation
- * @deprecated
- * @see Some javadoc. // violation
- * @author max // violation
- */
-enum Test1 {}
+  /**
+   * Some javadoc.
+   *
+   * @author max
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc.
+   * @deprecated
+   */
+  enum Test {}
+}
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example2.java
@@ -31,28 +31,30 @@ import java.io.Serializable;
 * @serialField Field description.
 * @serialData
 */
-public class Example2 {}
+public class Example2 {
+  class Valid implements Serializable {
+  }
 
-class Valid2 implements Serializable {}
+  /**
+   * Some javadoc.
+   *
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc. // violation
+   * @deprecated  // violation
+   */
+  class Invalid implements Serializable {
+  }
 
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc.
- * @deprecated
- * @see Some javadoc.
- */
-class Invalid2 implements Serializable {}
-
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc.
- * @deprecated Some javadoc.
- * @see Some javadoc.
- * @author max // violation
- */
-enum Test2 {}
+  /**
+   * Some javadoc.
+   *
+   * @author max
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc. // violation
+   * @deprecated // violation
+   */
+  enum Test {}
+}
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example3.java
@@ -31,28 +31,30 @@ import java.io.Serializable;
 * @serialField Field description.
 * @serialData
 */
-public class Example3 {}
+public class Example3 {
+  class Valid implements Serializable {
+  }
 
-class Valid3 implements Serializable {}
+  /**
+   * Some javadoc.
+   *
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc.
+   * @deprecated
+   */
+  class Invalid implements Serializable {
+  }
 
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc.
- * @deprecated
- * @see Some javadoc.
- */
-class Invalid3 implements Serializable {}
-
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- * @version Some javadoc.
- * @deprecated
- * @see Some javadoc.
- * @author Some javadoc. // violation
- */
-enum Test3 {}
+  /**
+   * Some javadoc.
+   *
+   * @author Some javadoc.
+   * @version Some javadoc.
+   * @see Some javadoc.
+   * @since Some javadoc. // violation
+   * @deprecated // violation
+   */
+  enum Test {}
+}
 // xdoc section -- end


### PR DESCRIPTION
#18435 

Example1 -> default
Example2 -> tagOrder
Example3 -> tagOrder + target

Section1 -> Example1,2,3