### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - nestedfordepth

### DIFF
--- a/src/site/xdoc/checks/coding/nestedfordepth.xml
+++ b/src/site/xdoc/checks/coding/nestedfordepth.xml
@@ -55,7 +55,6 @@ public class Example1 {
       for(int j=0; j&lt;i; j++) {
       }
     }
-
     // violation 3 lines below 'Nested for depth is 2 (max allowed is 1).'
     for(int i=0; i&lt;10; i++) {
       for(int j=0; j&lt;i; j++) {
@@ -63,7 +62,6 @@ public class Example1 {
         }
       }
     }
-
     // violation 4 lines below 'Nested for depth is 2 (max allowed is 1).'
     // violation 4 lines below 'Nested for depth is 3 (max allowed is 1).'
     for(int i=0; i&lt;10; i++) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -102,7 +102,6 @@ public class XdocsExamplesAstConsistencyTest {
      */
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
             "checks/coding/illegalsymbol/Example4",
-            "checks/coding/nestedfordepth/Example2",
             "checks/coding/onestatementperline/Example2",
             "checks/coding/packagedeclaration/Example2",
             "checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckExamplesTest.java
@@ -34,9 +34,9 @@ public class NestedForDepthCheckExamplesTest extends AbstractExamplesModuleTestS
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "22:9: " + getCheckMessage(MSG_KEY, 2, 1),
-            "31:9: " + getCheckMessage(MSG_KEY, 2, 1),
-            "32:11: " + getCheckMessage(MSG_KEY, 3, 1),
+            "21:9: " + getCheckMessage(MSG_KEY, 2, 1),
+            "29:9: " + getCheckMessage(MSG_KEY, 2, 1),
+            "30:11: " + getCheckMessage(MSG_KEY, 3, 1),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth/Example1.java
@@ -15,7 +15,6 @@ public class Example1 {
       for(int j=0; j<i; j++) {
       }
     }
-
     // violation 3 lines below 'Nested for depth is 2 (max allowed is 1).'
     for(int i=0; i<10; i++) {
       for(int j=0; j<i; j++) {
@@ -23,7 +22,6 @@ public class Example1 {
         }
       }
     }
-
     // violation 4 lines below 'Nested for depth is 2 (max allowed is 1).'
     // violation 4 lines below 'Nested for depth is 3 (max allowed is 1).'
     for(int i=0; i<10; i++) {


### PR DESCRIPTION
#18435

Example1 -> default
Example2 -> max

Section1 -> Example1,2