### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - interfacememb…

### DIFF
--- a/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml
+++ b/src/site/xdoc/checks/modifier/interfacememberimpliedmodifier.xml
@@ -174,7 +174,7 @@ public interface Example1 {
   //    'Implied modifier 'final' should be explicit'
   //    'Implied modifier 'public' should be explicit'
   //    'Implied modifier 'static' should be explicit'
-  public static Example1 instance() { return null; }
+  public static Address instance() {return null;}
 
   public abstract Address createAddress(String addressLine, String city);
   List&lt;Address&gt; findAddresses(String city);
@@ -221,7 +221,7 @@ public interface Example2 {
   //    'Implied modifier 'final' should be explicit'
   //    'Implied modifier 'public' should be explicit'
   //    'Implied modifier 'static' should be explicit'
-  public static Example2 instance() { return null; }
+  public static Address instance() {return null;}
 
   public abstract Address createAddress(String addressLine, String city);
   List&lt;Address&gt; findAddresses(String city);
@@ -229,8 +229,8 @@ public interface Example2 {
   //    'Implied modifier 'abstract' should be explicit'
   //    'Implied modifier 'public' should be explicit'
   interface Address {
-    // ok above because of configured properties
-    // ok above because of configured properties
+    // ok, because violateImpliedPublicNested=false
+    // ok, because violateImpliedStaticNested=false
 
     String getCity();
     // 2 violations above:
@@ -265,8 +265,11 @@ public interface Example3 {
 
   public static final String UNKNOWN = "Unknown";
   String OTHER = "Other";
+  // ok, because 'violateImpliedFinalField' is false
+  // ok, because 'violateImpliedPublicField' is false
+  // ok, because 'violateImpliedStaticField' is false
 
-  public static Example3 instance() { return null; }
+  public static Address instance() {return null;}
 
   public abstract Address createAddress(String addressLine, String city);
   List&lt;Address&gt; findAddresses(String city);
@@ -313,16 +316,21 @@ public interface Example4 {
   //    'Implied modifier 'final' should be explicit'
   //    'Implied modifier 'public' should be explicit'
   //    'Implied modifier 'static' should be explicit'
-  public static Example4 instance() { return null; }
+  public static Address instance() {return null;}
 
   public abstract Address createAddress(String addressLine, String city);
   List&lt;Address&gt; findAddresses(String city);
+  // ok, because 'violateImpliedAbstractMethod' is false
+  // ok, because 'violateImpliedPublicMethod' is false
 
   interface Address {
     // 2 violations above:
     //    'Implied modifier 'public' should be explicit'
     //    'Implied modifier 'static' should be explicit'
     String getCity();
+    // ok, because 'violateImpliedAbstractMethod' is false
+    // ok, because 'violateImpliedPublicMethod' is false
+
   }
 }
 </code></pre></div>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -121,9 +121,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/Example9",
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5",
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
-            "checks/modifier/interfacememberimpliedmodifier/Example2",
-            "checks/modifier/interfacememberimpliedmodifier/Example3",
-            "checks/modifier/interfacememberimpliedmodifier/Example4",
             "checks/modifier/redundantmodifier/Example2",
             "checks/naming/abstractclassname/Example3",
             "checks/naming/abstractclassname/Example4",
@@ -888,6 +885,7 @@ public class XdocsExamplesAstConsistencyTest {
         return parent != null
                 && ast.getType() == TokenTypes.IDENT
                 && (parent.getType() == TokenTypes.CLASS_DEF
+                    || parent.getType() == TokenTypes.INTERFACE_DEF
                     || parent.getType() == TokenTypes.CTOR_DEF);
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckExamplesTest.java
@@ -67,12 +67,12 @@ public class InterfaceMemberImpliedModifierCheckExamplesTest
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "25:3: " + getCheckMessage(MSG_KEY, "abstract"),
-            "25:3: " + getCheckMessage(MSG_KEY, "public"),
-            "29:3: " + getCheckMessage(MSG_KEY, "public"),
-            "29:3: " + getCheckMessage(MSG_KEY, "static"),
-            "33:5: " + getCheckMessage(MSG_KEY, "abstract"),
-            "33:5: " + getCheckMessage(MSG_KEY, "public"),
+            "28:3: " + getCheckMessage(MSG_KEY, "abstract"),
+            "28:3: " + getCheckMessage(MSG_KEY, "public"),
+            "32:3: " + getCheckMessage(MSG_KEY, "public"),
+            "32:3: " + getCheckMessage(MSG_KEY, "static"),
+            "36:5: " + getCheckMessage(MSG_KEY, "abstract"),
+            "36:5: " + getCheckMessage(MSG_KEY, "public"),
         };
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
@@ -83,8 +83,8 @@ public class InterfaceMemberImpliedModifierCheckExamplesTest
             "19:3: " + getCheckMessage(MSG_KEY, "final"),
             "19:3: " + getCheckMessage(MSG_KEY, "public"),
             "19:3: " + getCheckMessage(MSG_KEY, "static"),
-            "29:3: " + getCheckMessage(MSG_KEY, "public"),
-            "29:3: " + getCheckMessage(MSG_KEY, "static"),
+            "31:3: " + getCheckMessage(MSG_KEY, "public"),
+            "31:3: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example1.java
@@ -18,7 +18,7 @@ public interface Example1 {
   //    'Implied modifier 'final' should be explicit'
   //    'Implied modifier 'public' should be explicit'
   //    'Implied modifier 'static' should be explicit'
-  public static Example1 instance() { return null; }
+  public static Address instance() {return null;}
 
   public abstract Address createAddress(String addressLine, String city);
   List<Address> findAddresses(String city);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example2.java
@@ -21,7 +21,7 @@ public interface Example2 {
   //    'Implied modifier 'final' should be explicit'
   //    'Implied modifier 'public' should be explicit'
   //    'Implied modifier 'static' should be explicit'
-  public static Example2 instance() { return null; }
+  public static Address instance() {return null;}
 
   public abstract Address createAddress(String addressLine, String city);
   List<Address> findAddresses(String city);
@@ -29,8 +29,8 @@ public interface Example2 {
   //    'Implied modifier 'abstract' should be explicit'
   //    'Implied modifier 'public' should be explicit'
   interface Address {
-    // ok above because of configured properties
-    // ok above because of configured properties
+    // ok, because violateImpliedPublicNested=false
+    // ok, because violateImpliedStaticNested=false
 
     String getCity();
     // 2 violations above:

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example3.java
@@ -18,8 +18,11 @@ public interface Example3 {
 
   public static final String UNKNOWN = "Unknown";
   String OTHER = "Other";
+  // ok, because 'violateImpliedFinalField' is false
+  // ok, because 'violateImpliedPublicField' is false
+  // ok, because 'violateImpliedStaticField' is false
 
-  public static Example3 instance() { return null; }
+  public static Address instance() {return null;}
 
   public abstract Address createAddress(String addressLine, String city);
   List<Address> findAddresses(String city);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/Example4.java
@@ -21,16 +21,21 @@ public interface Example4 {
   //    'Implied modifier 'final' should be explicit'
   //    'Implied modifier 'public' should be explicit'
   //    'Implied modifier 'static' should be explicit'
-  public static Example4 instance() { return null; }
+  public static Address instance() {return null;}
 
   public abstract Address createAddress(String addressLine, String city);
   List<Address> findAddresses(String city);
+  // ok, because 'violateImpliedAbstractMethod' is false
+  // ok, because 'violateImpliedPublicMethod' is false
 
   interface Address {
     // 2 violations above:
     //    'Implied modifier 'public' should be explicit'
     //    'Implied modifier 'static' should be explicit'
     String getCity();
+    // ok, because 'violateImpliedAbstractMethod' is false
+    // ok, because 'violateImpliedPublicMethod' is false
+
   }
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 


This PR updates `XdocsExamplesAstConsistencyTest` to ignore top-level interface names during AST comparison, similar to how top-level class names are already handled.

### Comparator change

Extended `isClassOrConstructorName()` to also ignore identifiers under `INTERFACE_DEF`.

```java
private static boolean isClassOrConstructorName(DetailAST ast) {
    final DetailAST parent = ast.getParent();
    return parent != null
            && ast.getType() == TokenTypes.IDENT
            && (parent.getType() == TokenTypes.CLASS_DEF
                || parent.getType() == TokenTypes.INTERFACE_DEF
                || parent.getType() == TokenTypes.CTOR_DEF);
}
```

This avoids false AST mismatches between examples such as:

```java
public interface Example1 { ... }
```

and

```java
public interface Example2 { ... }
```

where the interface names must differ to match their filenames and avoid duplicate type errors.

## Xdoc updates

Unified the `InterfaceMemberImpliedModifier` examples by keeping the code structure consistent across all examples and adding corresponding `ok` comments where violations are disabled by configuration.

### Example1

Default configuration.

### Example2

```xml
<property name="violateImpliedPublicNested" value="false"/>
<property name="violateImpliedStaticNested" value="false"/>
```

### Example3

```xml
<property name="violateImpliedPublicField" value="false"/>
<property name="violateImpliedStaticField" value="false"/>
<property name="violateImpliedFinalField" value="false"/>
```

### Example4

```xml
<property name="violateImpliedPublicMethod" value="false"/>
<property name="violateImpliedAbstractMethod" value="false"/>
```
Section1 -> Example1,2,3,4