### PR TITLE
Issue #16807: Specify all default properties in AnnotationUtil tests

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -806,11 +806,7 @@ public final class InlineConfigParser {
         "filters/suppresswithnearbytextfilter/"
             + "InputSuppressWithNearbyTextFilterNearbyTextPatternCompactVariableCheckPattern.java",
         "treewalker/InputTreeWalkerSuppressionCommentFilter.java",
-        "treewalker/InputTreeWalkerSuppressionXpathFilterAbsolute.java",
-        "utils/annotationutil/InputAnnotationUtil1.java",
-        "utils/annotationutil/InputAnnotationUtil2.java",
-        "utils/annotationutil/InputAnnotationUtilNoMatchingAnnotation.java"
-
+        "treewalker/InputTreeWalkerSuppressionXpathFilterAbsolute.java"
     );
 
     // This is a hack until https://github.com/checkstyle/checkstyle/issues/13845

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/annotationutil/InputAnnotationUtil1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/annotationutil/InputAnnotationUtil1.java
@@ -3,7 +3,7 @@ com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck
 format = ^unchecked$*
 tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
          ENUM_CONSTANT_DEF, PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, CTOR_DEF, \
-         COMPACT_CTOR_DEF, RECORD_DEF
+         COMPACT_CTOR_DEF, RECORD_DEF, PATTERN_VARIABLE_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/annotationutil/InputAnnotationUtil2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/annotationutil/InputAnnotationUtil2.java
@@ -3,7 +3,7 @@ com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck
 format = (default)^\\s*+$
 tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
          ENUM_CONSTANT_DEF, PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, CTOR_DEF, \
-         COMPACT_CTOR_DEF, RECORD_DEF
+         COMPACT_CTOR_DEF, RECORD_DEF, PATTERN_VARIABLE_DEF
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/annotationutil/InputAnnotationUtilNoMatchingAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/annotationutil/InputAnnotationUtilNoMatchingAnnotation.java
@@ -3,7 +3,7 @@ com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck
 format = ^unchecked$*
 tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
          ENUM_CONSTANT_DEF, PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, CTOR_DEF, \
-         COMPACT_CTOR_DEF, RECORD_DEF
+         COMPACT_CTOR_DEF, RECORD_DEF, PATTERN_VARIABLE_DEF
 
 
 */


### PR DESCRIPTION
Part of issue
- #16807

---

- Specified all default `tokens` of [SuppressWarningsCheck](https://checkstyle.sourceforge.io/checks/annotation/suppresswarnings.html#Properties) in `AnnotationUtil`'s tests. The default tokens are:
https://github.com/checkstyle/checkstyle/blob/e111596aa8e33a904919e48b118d138627984ed4/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java#L117-L138
- Removed default property check suppressions from `InlineConfigParser`