### PR TITLE
Issue #19764: Move violation comments out of Javadoc for JavadocMissingWhitespaceAfterAsterisk

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -475,8 +475,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignTabs.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadocmissingwhitespaceafterasterisk[\\/]InputJavadocMissingWhitespaceAfterAsteriskInvalid.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentation.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationAnonymousClass.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheckTest.java
@@ -82,19 +82,19 @@ public class JavadocMissingWhitespaceAfterAsteriskCheckTest
     @Test
     public void testInvalid() throws Exception {
         final String[] expected = {
-            "10:4: " + getCheckMessage(MSG_KEY),
-            "16:7: " + getCheckMessage(MSG_KEY),
-            "21:11: " + getCheckMessage(MSG_KEY),
-            "28:11: " + getCheckMessage(MSG_KEY),
-            "33:13: " + getCheckMessage(MSG_KEY),
-            "39:7: " + getCheckMessage(MSG_KEY),
-            "44:7: " + getCheckMessage(MSG_KEY),
-            "49:7: " + getCheckMessage(MSG_KEY),
+            "11:4: " + getCheckMessage(MSG_KEY),
+            "17:7: " + getCheckMessage(MSG_KEY),
+            "23:11: " + getCheckMessage(MSG_KEY),
+            "30:11: " + getCheckMessage(MSG_KEY),
+            "35:13: " + getCheckMessage(MSG_KEY),
+            "42:7: " + getCheckMessage(MSG_KEY),
+            "48:7: " + getCheckMessage(MSG_KEY),
             "54:7: " + getCheckMessage(MSG_KEY),
-            "56:7: " + getCheckMessage(MSG_KEY),
-            "61:8: " + getCheckMessage(MSG_KEY),
-            "65:8: " + getCheckMessage(MSG_KEY),
-            "69:10: " + getCheckMessage(MSG_KEY),
+            "61:7: " + getCheckMessage(MSG_KEY),
+            "63:7: " + getCheckMessage(MSG_KEY),
+            "68:8: " + getCheckMessage(MSG_KEY),
+            "72:8: " + getCheckMessage(MSG_KEY),
+            "76:10: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocMissingWhitespaceAfterAsteriskInvalid.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/InputJavadocMissingWhitespaceAfterAsteriskInvalid.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingwhitespaceafterasterisk/InputJavadocMissingWhitespaceAfterAsteriskInvalid.java
@@ -7,24 +7,26 @@ violateExecutionOnNonTightHtml = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmissingwhitespaceafterasterisk;
 
+// violation below 'Missing a whitespace after the leading asterisk.'
 /**Some Javadoc with violation.
- * // violation above 'Missing a whitespace after the leading asterisk.'
  */
 class InputJavadocMissingWhitespaceAfterAsteriskInvalid
 {
-    /** // violation below 'Missing a whitespace after the leading asterisk.'
+    // violation 2 lines below 'Missing a whitespace after the leading asterisk.'
+    /**
      *<p>Some Javadoc with violation.
      */
     class InnerInputJavadocMissingWhitespaceAfterAsteriskInValid {
 
-        /** // violation below 'Missing a whitespace after the leading asterisk.'
+        // violation 2 lines below 'Missing a whitespace after the leading asterisk.'
+        /**
          *Some Javadoc with violation.
          */
         public static final byte NUL = 0;
 
+        // violation 3 lines below 'Missing a whitespace after the leading asterisk.'
         /**
          * Some Javadoc.
-         * // violation below 'Missing a whitespace after the leading asterisk.'
          *<p>Some Javadoc with violation.
          */
         void bar1() {}
@@ -34,25 +36,30 @@ class InputJavadocMissingWhitespaceAfterAsteriskInvalid
         void bar2() {}
     }
 
+    // violation 3 lines below 'Missing a whitespace after the leading asterisk.'
     /****
-     * Some Javadoc. // violation below 'Missing a whitespace after the leading asterisk.'
+     * Some Javadoc.
      *@see Something with violation
      ****/
     void foo1() {}
 
-    /** // violation below 'Missing a whitespace after the leading asterisk.'
+    // violation 2 lines below 'Missing a whitespace after the leading asterisk.'
+    /**
      *Some Javadoc with violation.
      **/
     public static final int foo2 = 0;
 
-    /** // violation below 'Missing a whitespace after the leading asterisk.'
+    // violation 2 lines below 'Missing a whitespace after the leading asterisk.'
+    /**
      *Some Javadoc with violation.
      */
     enum Foo3 {}
 
-    /** // violation below 'Missing a whitespace after the leading asterisk.'
+    // violation 3 lines below 'Missing a whitespace after the leading asterisk.'
+    // violation 4 lines below 'Missing a whitespace after the leading asterisk.'
+    /**
      *<pre>Some Javadoc with violation.
-     *  Some Javadoc. // violation below 'Missing a whitespace after the leading asterisk.'
+     *  Some Javadoc.
      *</pre>Some Javadoc with violation.
      **/
     interface Foo4 {}


### PR DESCRIPTION
Issue #19764

Moved the violation comments out of Javadoc blocks for the `javadocmissingwhitespaceafterasterisk` input.

Changes:
* Moved `// violation` markers outside Javadoc comments.
* Removed related `noViolationCommentsInJavadoc` suppression.
* Updated expected line numbers in the test