### PR TITLE
Issue #19764: Move violation comments out of Javadoc for IllegalToken

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -462,8 +462,6 @@
             files="[\\/]chapter7javadoc[\\/]rule713atclauses[\\/]InputJavaDocTagContinuationIndentation.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity[\\/]InputClassFanOutComplexityRemoveIncorrectAnnotationToken.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckCommentsContent.java"/>
 
 
   <suppress id="noViolationCommentsInJavadoc"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
@@ -71,13 +71,14 @@ public class IllegalTokenCheckTest
             "1:3: " + getCheckMessage(MSG_KEY,
                         "\\nIllegalToken\\ntokens = COMMENT_CONTENT\\n\\n\\n"),
             "10:3: " + getCheckMessage(MSG_KEY,
-                        "*\\n * // violation first"
-                            + " line 'is not allowed'\\n"
-                            + " * // violation 2 lines above 'is not allowed'\\n"
-                            + " * Test for illegal tokens\\n "),
-            "40:29: " + getCheckMessage(MSG_KEY,
+                        "\\n// violation first line 'is not allowed'\\n"
+                            + "// violation 2 lines above 'is not allowed'\\n"
+                            + "// violation 2 lines below 'is not allowed'\\n"),
+            "15:3: " + getCheckMessage(MSG_KEY,
+                        "*\\n * Test for illegal tokens\\n "),
+            "43:29: " + getCheckMessage(MSG_KEY,
                         " some comment href // violation, 'is not allowed'\\n"),
-            "44:28: " + getCheckMessage(MSG_KEY,
+            "47:28: " + getCheckMessage(MSG_KEY,
                         " some a href // violation, 'is not allowed'\\n"),
         };
         verifyWithInlineConfigParser(path, expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/InputIllegalTokensCheckCommentsContent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/InputIllegalTokensCheckCommentsContent.java
@@ -7,9 +7,12 @@ tokens = COMMENT_CONTENT
 
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltoken;
 
+/*
+// violation first line 'is not allowed'
+// violation 2 lines above 'is not allowed'
+// violation 2 lines below 'is not allowed'
+*/
 /**
- * // violation first line 'is not allowed'
- * // violation 2 lines above 'is not allowed'
  * Test for illegal tokens
  */
 


### PR DESCRIPTION
Issue #19764

Updated `InputIllegalTokensCheckCommentsContent.java` so the violation markers are no longer inside Javadoc.

This file is a special case because `IllegalToken` checks `COMMENT_CONTENT`, so moving the markers into normal standalone comments makes those marker comments get checked too. I changed the affected Javadoc block to a regular block comment instead and updated the expected message.