### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - illegalsymbol

### DIFF
--- a/src/site/xdoc/checks/coding/illegalsymbol.xml
+++ b/src/site/xdoc/checks/coding/illegalsymbol.xml
@@ -155,7 +155,7 @@ public class Example2 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example4 {
-  // 😀 This emoji in comment is ok
+  // ok, 😀 comment in emoji
 
   int value1 = 1;
   String value2 = "Hello 😀"; // violation 'Illegal symbol detected: '😀''

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -101,7 +101,6 @@ public class XdocsExamplesAstConsistencyTest {
      * <p>Until: <a href="https://github.com/checkstyle/checkstyle/issues/18435">...</a>
      */
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
-            "checks/coding/illegalsymbol/Example4",
             "checks/coding/onestatementperline/Example2",
             "checks/coding/packagedeclaration/Example2",
             "checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalsymbol/Example4.java
@@ -12,7 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegalsymbol;
 
 // xdoc section -- start
 public class Example4 {
-  // 😀 This emoji in comment is ok
+  // ok, 😀 comment in emoji
 
   int value1 = 1;
   String value2 = "Hello 😀"; // violation 'Illegal symbol detected: '😀''


### PR DESCRIPTION
#18435 

IllegalSymbol :

Example1 -> default configuration
Example2 -> symbolCodes
Example3 -> symbolCodes -> use case
Example4 -> symbolCodes + tokens
Example5 -> symbolCodes (additional use case)

Section1 -> Example1,2,4
UseCase -> Example 3,5