### PR TITLE
Issue #15456: Specify violation messages for MultipleStringLiteralsCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -263,7 +263,6 @@ public final class InlineConfigParser {
      *  Until <a href="https://github.com/checkstyle/checkstyle/issues/15456">#15456</a>.
      */
     private static final Set<String> SUPPRESSED_CHECKS = Set.of(
-            "com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck",
             "com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck",
 
             "com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckTest.java
@@ -44,9 +44,9 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     public void testIt() throws Exception {
 
         final String[] expected = {
-            "14:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
-            "17:17: " + getCheckMessage(MSG_KEY, "\"\"", 4),
-            "19:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
+            "15:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
+            "19:17: " + getCheckMessage(MSG_KEY, "\"\"", 4),
+            "22:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
         };
 
         verifyWithInlineConfigParser(
@@ -58,8 +58,8 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     public void testItIgnoreEmpty() throws Exception {
 
         final String[] expected = {
-            "14:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
-            "19:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
+            "15:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
+            "21:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
         };
 
         verifyWithInlineConfigParser(
@@ -79,8 +79,8 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
         final File[] inputs = {new File(firstInput), new File(secondInput)};
 
         final List<String> expectedFirstInput = Arrays.asList(
-            "14:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
-            "19:23: " + getCheckMessage(MSG_KEY, "\", \"", 3)
+            "15:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
+            "21:23: " + getCheckMessage(MSG_KEY, "\", \"", 3)
         );
         final List<String> expectedSecondInput = Arrays.asList(CommonUtil.EMPTY_STRING_ARRAY);
 
@@ -93,7 +93,7 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     public void testItIgnoreEmptyAndComspace() throws Exception {
 
         final String[] expected = {
-            "14:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
+            "15:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
         };
 
         verifyWithInlineConfigParser(
@@ -105,7 +105,7 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     public void testItWithoutIgnoringAnnotations() throws Exception {
 
         final String[] expected = {
-            "28:23: " + getCheckMessage(MSG_KEY, "\"unchecked\"", 4),
+            "29:23: " + getCheckMessage(MSG_KEY, "\"unchecked\"", 4),
         };
 
         verifyWithInlineConfigParser(
@@ -130,9 +130,9 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDefaultConfiguration() throws Exception {
         final String[] expected = {
-            "14:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
-            "16:17: " + getCheckMessage(MSG_KEY, "\"DoubleString\"", 2),
-            "19:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
+            "15:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
+            "18:17: " + getCheckMessage(MSG_KEY, "\"DoubleString\"", 2),
+            "22:23: " + getCheckMessage(MSG_KEY, "\", \"", 3),
         };
 
         verifyWithInlineConfigParser(
@@ -143,7 +143,7 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIgnores() throws Exception {
         final String[] expected = {
-            "28:23: " + getCheckMessage(MSG_KEY, "\"unchecked\"", 4),
+            "29:23: " + getCheckMessage(MSG_KEY, "\"unchecked\"", 4),
         };
 
         verifyWithInlineConfigParser(
@@ -154,19 +154,19 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMultipleStringLiteralsTextBlocks1() throws Exception {
         final String[] expected = {
-            "14:22: " + getCheckMessage(MSG_KEY, "\"string\"", 3),
-            "19:25: " + getCheckMessage(MSG_KEY, "\"other string\"", 2),
-            "23:25: " + getCheckMessage(MSG_KEY, "\"other string\\n\"", 2),
-            "30:25: " + getCheckMessage(MSG_KEY, "\"<html>\\u000D\\u000A\\n\\u2000\\n "
+            "15:22: " + getCheckMessage(MSG_KEY, "\"string\"", 3),
+            "21:25: " + getCheckMessage(MSG_KEY, "\"other string\"", 2),
+            "26:25: " + getCheckMessage(MSG_KEY, "\"other string\\n\"", 2),
+            "33:25: " + getCheckMessage(MSG_KEY, "\"<html>\\u000D\\u000A\\n\\u2000\\n "
                 + "   <body>\\u000D\\u000A\\n\\u2000\\n        <p>Hello, world</p>\\u000D\\"
                 + "u000A\\n\\u2000\\n    </body>\\u000D\\u000A\\n\\u2000\\n</html>\\u000D\\"
                 + "u000A\\u2000\\n\"", 2),
-            "37:34: " + getCheckMessage(MSG_KEY, "\"fun with\\n\\n whitespace\\t"
+            "41:34: " + getCheckMessage(MSG_KEY, "\"fun with\\n\\n whitespace\\t"
                 + "\\r\\n and other escapes \\\"\"\"\\n\"", 2),
-            "42:34: " + getCheckMessage(MSG_KEY, "\"\\b \\f \\\\ \\0 \\1 \\2 "
+            "47:34: " + getCheckMessage(MSG_KEY, "\"\\b \\f \\\\ \\0 \\1 \\2 "
                 + "\\r \\r\\n \\\\r\\\\n \\\\''\\n\\\\11 \\\\57 \\n\\\\n\\n\\\\\\n\\n \\\\ \"\"a "
                 + "\"a\\n\\\\' \\\\\\' \\'\\n\"", 2),
-            "65:20: " + getCheckMessage(MSG_KEY, "\"foo\"", 4),
+            "71:20: " + getCheckMessage(MSG_KEY, "\"foo\"", 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMultipleStringLiteralsTextBlocks1.java"),
@@ -176,10 +176,10 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMultipleStringLiteralsTextBlocks2() throws Exception {
         final String[] expected = {
-            "14:19: " + getCheckMessage(MSG_KEY, "\"another test\"", 2),
-            "18:20: " + getCheckMessage(MSG_KEY, "\"\"", 6),
-            "29:23: " + getCheckMessage(MSG_KEY, "\"        .\\n         .\\n.\\n\"", 2),
-            "45:24: " + getCheckMessage(MSG_KEY, "\"             foo\\n\\n\\n "
+            "15:19: " + getCheckMessage(MSG_KEY, "\"another test\"", 2),
+            "20:20: " + getCheckMessage(MSG_KEY, "\"\"", 6),
+            "31:23: " + getCheckMessage(MSG_KEY, "\"        .\\n         .\\n.\\n\"", 2),
+            "47:24: " + getCheckMessage(MSG_KEY, "\"             foo\\n\\n\\n "
                 + "       bar\"", 2),
         };
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals.java
@@ -11,12 +11,15 @@ package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiterals
 {   /*string literals*/
-    String m = "StringContents"; // violation
+    // violation below 'The String "StringContents" appears 3 times in the file.'
+    String m = "StringContents";
     String m1 = "SingleString";
     String m2 = "DoubleString" + "DoubleString";
-    String m3 = "" + ""; // violation
+    // violation below, 'The String "" appears 4 times in the file.'
+    String m3 = "" + "";
     String m4 = "" + "";
-    String debugStr = ", " + ", " + ", "; // violation
+    // violation below, 'The String ", " appears 3 times in the file.'
+    String debugStr = ", " + ", " + ", ";
 
     void method1() {
         String a1 = "StringContents";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals2.java
@@ -11,12 +11,14 @@ package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiterals2
 {   /*string literals*/
-    String m = "StringContents"; // violation
+    // violation below 'The String "StringContents" appears 3 times in the file.'
+    String m = "StringContents";
     String m1 = "SingleString";
     String m2 = "DoubleString" + "DoubleString";
     String m3 = "" + "";
     String m4 = "" + "";
-    String debugStr = ", " + ", " + ", "; // violation
+    // violation below 'The String ", " appears 3 times in the file.'
+    String debugStr = ", " + ", " + ", ";
 
     void method1() {
         String a1 = "StringContents";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals3.java
@@ -11,11 +11,13 @@ package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiterals3
 {   /*string literals*/
-    String m = "StringContents"; // violation
+    // violation below 'The String "StringContents" appears 3 times in the file.'
+    String m = "StringContents";
     String m1 = "SingleString";
     String m2 = "DoubleString" + "DoubleString";
     String m3 = "" + "";
     String m4 = "" + "";
+    // violation below 'The String ", " appears 3 times in the file.'
     String debugStr = ", " + ", " + ", ";
 
     void method1() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals4.java
@@ -11,7 +11,8 @@ package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiterals4
 {   /*string literals*/
-    String m = "StringContents"; // violation
+    // violation below 'The String "StringContents" appears 3 times in the file.'
+    String m = "StringContents";
     String m1 = "SingleString";
     String m2 = "DoubleString" + "DoubleString";
     String m3 = "" + "";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals5.java
@@ -25,7 +25,8 @@ public class InputMultipleStringLiterals5
         String a2 = "String" + "Contents";
     }
 
-    @SuppressWarnings("unchecked") // violation
+    // violation below 'The String "unchecked" appears 4 times in the file.'
+    @SuppressWarnings("unchecked")
     void method2(){}
 
     @SuppressWarnings("unchecked")

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals6.java
@@ -11,12 +11,15 @@ package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiterals6
 {   /*string literals*/
-    String m = "StringContents"; // violation
+    // violation below 'The String "StringContents" appears 3 times in the file.'
+    String m = "StringContents";
     String m1 = "SingleString";
-    String m2 = "DoubleString" + "DoubleString"; // violation
+    // violation below 'The String "DoubleString" appears 2 times in the file.'
+    String m2 = "DoubleString" + "DoubleString";
     String m3 = "" + "";
     String m4 = "" + "";
-    String debugStr = ", " + ", " + ", "; // violation
+    // violation below 'The String ", " appears 3 times in the file.'
+    String debugStr = ", " + ", " + ", ";
 
     void method1() {
         String a1 = "StringContents";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiterals7.java
@@ -25,7 +25,8 @@ public class InputMultipleStringLiterals7
         String a2 = "String" + "Contents";
     }
 
-    @SuppressWarnings("unchecked") // violation
+    // violation below 'The String "unchecked" appears 4 times in the file.'
+    @SuppressWarnings("unchecked")
     void method2(){}
 
     @SuppressWarnings("unchecked")

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
@@ -11,34 +11,39 @@ ignoreOccurrenceContext = (default)ANNOTATION
 package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiteralsTextBlocks1 {
-    String string1 = "string"; // occurrence #1 // violation
+    // violation below 'The String "string" appears 3 times in the file.'
+    String string1 = "string"; // occurrence #1
     String string2a = "string"; // violation #1
     String string2b = """
             string"""; // violation #2
 
+    // violation below 'The String "other string" appears 2 times in the file.'
     String string3 = """
-            other string"""; // occurrence #1 // violation above
+            other string"""; // occurrence #1
     String string4 = """
-            other string"""; // violation below
+            other string"""; // violation #1
+    // violation below 'The String "other string\\n" appears 2 times.*'
     String string5 = """
             other string
             """; // occurrence #1
     String string6 = """
             other string
-            """;
-     // violation below
+            """; // violation #1
+    // violation below 'The String "<html>.*" appears 2 times in the file.'
     String escape1 = """
             <html>\u000D\u000A\n\u2000
                 <body>\u000D\u000A\n\u2000
                     <p>Hello, world</p>\u000D\u000A\n\u2000
                 </body>\u000D\u000A\n\u2000
             </html>\u000D\u000A\u2000
-            """; // occurrence #1 // violation below
+            """; // occurrence #1
+    // violation below 'The String "fun with.*" appears 2 times in the file.'
     String testMoreEscapes1 = """
             fun with\n
              whitespace\t\r
              and other escapes \"""
-            """; // occurrence #1 // violation below
+            """; // occurrence #1
+    // violation below 'The String "\\b \\f.*" appears 2 times in the file.'
     String evenMoreEscapes1 = """
             \b \f \\ \0 \1 \2 \r \r\n \\r\\n \\''
             \\11 \\57 \n\\n\n\\\n\n \\ ""a "a
@@ -62,7 +67,8 @@ public class InputMultipleStringLiteralsTextBlocks1 {
             \\' \\\' \'
             """; // violation #1
 
-    String str1a = "foo"; // occurrence #1 // violation
+    // violation below 'The String "foo" appears 4 times in the file.'
+    String str1a = "foo"; // occurrence #1
     String str1b = "foo"; // violation #1
     String str2a = """
             foo"""; // violation #2

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks2.java
@@ -11,11 +11,13 @@ ignoreOccurrenceContext = (default)ANNOTATION
 package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 
 public class InputMultipleStringLiteralsTextBlocks2 {
-    String str3 = "another test"; // occurrence #1 // violation
+    // violation below 'The String "another test" appears 2 times in the file.'
+    String str3 = "another test"; // occurrence #1
     String str4 = """
             another test"""; // violation #1
 
-    String str5a = ""; // occurrence #1 // violation
+    // violation below 'The String "" appears 6 times in the file.'
+    String str5a = ""; // occurrence #1
     String str5b = """
             """; // violation #1
     String str6 = """
@@ -25,7 +27,7 @@ public class InputMultipleStringLiteralsTextBlocks2 {
 
     String str8 = """
                              """; // violation #4
-     // violation below
+    // violation below 'The String "        .\\n         .\\n.\\n" appears 2 times in the file.'
     String str8b = """
         .
          .
@@ -41,7 +43,7 @@ public class InputMultipleStringLiteralsTextBlocks2 {
     String str9a = """
             test    """; // trailing whitespace removed per javac result
     String str9b = "test    "; // trailing whitespace not removed, strings are not equal!
-     // violation below
+    // violation below 'The String "             foo\\n\\n\\n.*" appears 2 times in the file.'
     String str10a = """
              foo
 


### PR DESCRIPTION
Issue: #15456 

### Summary

- Removed MultipleStringLiteralsCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in MultipleStringLiteralsCheckTest
- Defined violation messages in InputMultipleStringLiterals files