### PR TITLE
Issue #20470: Fix multiple semicolon in enum body

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -3514,9 +3514,13 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInEnumerationCheck.java</fileName>
-    <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference enumBlock</message>
-    <lineContent>final DetailAST semicolon = enumBlock.findFirstToken(TokenTypes.SEMI);</lineContent>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter enumBlock of UnnecessarySemicolonInEnumerationCheck.hasMembersAfterConstants.</message>
+    <lineContent>final boolean hasMembers = hasMembersAfterConstants(enumBlock);</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -5,6 +5,7 @@ abstractcheck
 abstractclassname
 abstractfileset
 abstractjavadoc
+abstractsemicolon
 ABx
 ACEM
 Acheckstyle

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInEnumerationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInEnumerationCheck.java
@@ -61,19 +61,51 @@ public final class UnnecessarySemicolonInEnumerationCheck extends AbstractCheck 
     @Override
     public void visitToken(DetailAST ast) {
         final DetailAST enumBlock = ast.findFirstToken(TokenTypes.OBJBLOCK);
-        final DetailAST semicolon = enumBlock.findFirstToken(TokenTypes.SEMI);
-        if (semicolon != null && isEndOfEnumerationAfter(semicolon)) {
-            log(semicolon, MSG_SEMI);
+        final boolean hasMembers = hasMembersAfterConstants(enumBlock);
+        DetailAST sibling = enumBlock.getFirstChild();
+        while (sibling != null) {
+            if (sibling.getType() == TokenTypes.SEMI
+                    && (!hasMembers || isPrecededBySemi(sibling))) {
+                log(sibling, MSG_SEMI);
+            }
+            sibling = sibling.getNextSibling();
         }
     }
 
     /**
-     * Checks if enum body has no code elements after enum constants semicolon.
+     * Checks if enum body contains any member (method, constructor, field, etc.)
+     * in addition to enum constants and semicolons.
      *
-     * @param ast semicolon in enum constants definition end
-     * @return true if there is no code elements, false otherwise.
+     * @param enumBlock the enum body to check
+     * @return true if enum body has members, false if it only has constants and semicolons.
      */
-    private static boolean isEndOfEnumerationAfter(DetailAST ast) {
-        return ast.getNextSibling().getType() == TokenTypes.RCURLY;
+    private static boolean hasMembersAfterConstants(DetailAST enumBlock) {
+        boolean result = false;
+        DetailAST sibling = enumBlock.getFirstChild();
+        while (sibling != null) {
+            final int type = sibling.getType();
+            if (type != TokenTypes.LCURLY
+                    && type != TokenTypes.RCURLY
+                    && type != TokenTypes.ENUM_CONSTANT_DEF
+                    && type != TokenTypes.SEMI
+                    && type != TokenTypes.COMMA) {
+                result = true;
+                break;
+            }
+            sibling = sibling.getNextSibling();
+        }
+        return result;
+    }
+
+    /**
+     * Checks if semicolon is immediately preceded by another semicolon,
+     * making it a redundant duplicate.
+     *
+     * @param ast semicolon to check
+     * @return true if previous sibling is also a semicolon, false otherwise.
+     */
+    private static boolean isPrecededBySemi(DetailAST ast) {
+        final DetailAST prev = ast.getPreviousSibling();
+        return prev.getType() == TokenTypes.SEMI;
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInEnumerationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInEnumerationCheckTest.java
@@ -61,6 +61,39 @@ public class UnnecessarySemicolonInEnumerationCheckTest extends AbstractModuleTe
     }
 
     @Test
+    public void doubleSemicolon() throws Exception {
+
+        final String[] expected = {
+            "11:10: " + getCheckMessage(MSG_SEMI),
+            "11:11: " + getCheckMessage(MSG_SEMI),
+            "15:12: " + getCheckMessage(MSG_SEMI),
+            "16:9: " + getCheckMessage(MSG_SEMI),
+            "19:10: " + getCheckMessage(MSG_SEMI),
+            "19:11: " + getCheckMessage(MSG_SEMI),
+            "19:12: " + getCheckMessage(MSG_SEMI),
+            "23:9: " + getCheckMessage(MSG_SEMI),
+            "23:10: " + getCheckMessage(MSG_SEMI),
+            "27:13: " + getCheckMessage(MSG_SEMI),
+            "27:14: " + getCheckMessage(MSG_SEMI),
+            "37:6: " + getCheckMessage(MSG_SEMI),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputUnnecessarySemicolonInEnumeration2.java"), expected);
+    }
+
+    @Test
+    public void abstractsemicolon() throws Exception {
+
+        final String[] expected = {
+            "18:5: " + getCheckMessage(MSG_SEMI),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputUnnecessarySemicolonInEnumerationWithAbstractMethod.java"), expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final UnnecessarySemicolonInEnumerationCheck check =
                 new UnnecessarySemicolonInEnumerationCheck();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicoloninenumeration/InputUnnecessarySemicolonInEnumeration2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicoloninenumeration/InputUnnecessarySemicolonInEnumeration2.java
@@ -1,0 +1,42 @@
+/*
+UnnecessarySemicolonInEnumeration
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarysemicoloninenumeration;
+
+public class InputUnnecessarySemicolonInEnumeration2 {
+    enum DoubleSemicolon {
+        A;; // violation 'Unnecessary semicolon'
+            // violation above 'Unnecessary semicolon'
+    }
+    enum DoubleSemicolonNextLine {
+        A,B; // violation 'Unnecessary semicolon'
+        ; // violation 'Unnecessary semicolon'
+    }
+    enum TripleSemicolon { // violation below 'Unnecessary semicolon'
+        A;;; // violation 'Unnecessary semicolon'
+             // violation above 'Unnecessary semicolon'
+    }
+    enum DoubleSemicolonNoConstants {
+        ;; // violation 'Unnecessary semicolon'
+           // violation above 'Unnecessary semicolon'
+    }
+    enum DoubleSemicolonWithComma {
+        A,B,;; // violation 'Unnecessary semicolon'
+              // violation above 'Unnecessary semicolon'
+    }
+    enum Semi{
+     A,
+     b,
+     c,
+     d,
+     e;
+
+     ; // violation 'Unnecessary semicolon'
+     void semi(){
+
+     }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicoloninenumeration/InputUnnecessarySemicolonInEnumerationWithAbstractMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicoloninenumeration/InputUnnecessarySemicolonInEnumerationWithAbstractMethod.java
@@ -1,0 +1,20 @@
+/*
+UnnecessarySemicolonInEnumeration
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarysemicoloninenumeration;
+
+enum InputUnnecessarySemicolonInEnumerationWithAbstractMethod {
+    A() {
+        @Override
+        public void method() {}
+    },
+    B() {
+        @Override
+        public void method() {}
+    };
+    ;  // violation 'Unnecessary semicolon'
+    public abstract void method();
+}


### PR DESCRIPTION
Closes #20470
Solves false negative related to multiple semicolon in `UnnecessarySemicolonInEnumerationCheck` in enum body. 