### PR TITLE
Issue #20226: Document RedundantModifier compact source limitation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -72,6 +72,10 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </ol>
  *
  * <p>
+ * ATTENTION: Top-level members of compact source files are skipped from validation by this check.
+ * </p>
+ *
+ * <p>
  * interfaces by definition are abstract so the {@code abstract} modifier is redundant on them.
  * </p>
  *

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/RedundantModifierCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/RedundantModifierCheck.xml
@@ -45,6 +45,10 @@
  &lt;/ol&gt;
 
  &lt;p&gt;
+ ATTENTION: Top-level members of compact source files are skipped from validation by this check.
+ &lt;/p&gt;
+
+ &lt;p&gt;
  interfaces by definition are abstract so the &lt;code&gt;abstract&lt;/code&gt; modifier is redundant on them.
  &lt;/p&gt;
 

--- a/src/site/xdoc/checks/modifier/redundantmodifier.xml
+++ b/src/site/xdoc/checks/modifier/redundantmodifier.xml
@@ -50,6 +50,10 @@
         </ol>
 
         <p>
+          ATTENTION: Top-level members of compact source files are skipped from validation by this check.
+        </p>
+
+        <p>
           interfaces by definition are abstract so the <code>abstract</code> modifier is redundant on them.
         </p>
 


### PR DESCRIPTION
Issue #20226

Updated the `RedundantModifier` documentation to mention that top-level members of compact source files are skipped from validation by this check.

Changes:

* Added the note in `RedundantModifierCheck` Javadoc.
* Regenerated the check metadata.
* Regenerated the RedundantModifier xdoc page.

Validation:

* `git diff --check`
* `./mvnw -e --no-transfer-progress clean compile`
* `./mvnw -e --no-transfer-progress plexus-component-metadata:generate-metadata`
* `./mvnw -e --no-transfer-progress test -Dtest=MetadataGeneratorUtilTest#testMetadataFilesGenerationAllFiles`
* `./mvnw -e --no-transfer-progress test -Dtest=XdocsPagesTest,XdocsCategoryIndexTest`