### PR TITLE
Issue #15456: Specify violation messages for OneTopLevelClassCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -266,7 +266,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck",
 
             "com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck",
-            "com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc."
                     + "AbstractJavadocCheckTest$TokenIsNotInAcceptablesCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckTest.java
@@ -63,11 +63,11 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
         };
 
         final List<String> expectedFirstInput = Arrays.asList(
-            "16:1: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderEnum"),
-            "26:1: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderAnnotation"));
+            "17:1: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderEnum"),
+            "28:1: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderAnnotation"));
         final List<String> expectedSecondInput = Arrays.asList(
-            "9:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner1"),
-            "17:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner2"));
+            "10:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner1"),
+            "19:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner2"));
 
         verify(createChecker(checkConfig), inputs,
             ImmutableMap.of(firstInputFilePath, expectedFirstInput,
@@ -114,7 +114,7 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFileWithNoPublicTopLevelClass() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassNoPublic2"),
+            "15:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassNoPublic2"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneTopLevelClassNoPublic.java"), expected);
@@ -123,8 +123,8 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFileWithThreeTopLevelInterface() throws Exception {
         final String[] expected = {
-            "9:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface3inner1"),
-            "17:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface3inner2"),
+            "10:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface3inner1"),
+            "19:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface3inner2"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneTopLevelClassInterface3.java"), expected);
@@ -133,8 +133,8 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFileWithThreeTopLevelEnum() throws Exception {
         final String[] expected = {
-            "9:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassEnum2inner1"),
-            "17:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassEnum2inner2"),
+            "10:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassEnum2inner1"),
+            "19:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassEnum2inner2"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneTopLevelClassEnum2.java"), expected);
@@ -143,8 +143,8 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFileWithThreeTopLevelAnnotation() throws Exception {
         final String[] expected = {
-            "15:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassAnnotation2A"),
-            "20:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassAnnotation2B"),
+            "16:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassAnnotation2A"),
+            "22:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassAnnotation2B"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneTopLevelClassAnnotation2.java"), expected);
@@ -153,13 +153,13 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFileWithFewTopLevelClasses() throws Exception {
         final String[] expected = {
-            "31:1: " + getCheckMessage(MSG_KEY, "NoSuperClone"),
-            "35:1: " + getCheckMessage(MSG_KEY, "InnerClone"),
-            "39:1: " + getCheckMessage(MSG_KEY, "CloneWithTypeArguments"),
-            "43:1: " + getCheckMessage(MSG_KEY, "CloneWithTypeArgumentsAndNoSuper"),
-            "47:1: " + getCheckMessage(MSG_KEY, "MyClassWithGenericSuperMethod"),
-            "51:1: " + getCheckMessage(MSG_KEY, "AnotherClass"),
-            "54:1: " + getCheckMessage(MSG_KEY, "NativeTest"),
+            "32:1: " + getCheckMessage(MSG_KEY, "NoSuperClone"),
+            "37:1: " + getCheckMessage(MSG_KEY, "InnerClone"),
+            "42:1: " + getCheckMessage(MSG_KEY, "CloneWithTypeArguments"),
+            "47:1: " + getCheckMessage(MSG_KEY, "CloneWithTypeArgumentsAndNoSuper"),
+            "52:1: " + getCheckMessage(MSG_KEY, "MyClassWithGenericSuperMethod"),
+            "57:1: " + getCheckMessage(MSG_KEY, "AnotherClass"),
+            "61:1: " + getCheckMessage(MSG_KEY, "NativeTest"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneTopLevelClassClone.java"), expected);
@@ -168,8 +168,8 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFileWithSecondEnumTopLevelClass() throws Exception {
         final String[] expected = {
-            "16:1: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderEnum2"),
-            "26:1: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderAnnotation2"),
+            "17:1: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderEnum2"),
+            "28:1: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderAnnotation2"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneTopLevelClassDeclarationOrder2.java"), expected);
@@ -185,7 +185,7 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFileWithMultipleSameLine() throws Exception {
         final String[] expected = {
-            "9:47: " + getCheckMessage(MSG_KEY, "ViolatingSecondType"),
+            "10:47: " + getCheckMessage(MSG_KEY, "ViolatingSecondType"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneTopLevelClassSameLine.java"), expected);
@@ -194,9 +194,9 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFileWithIndentation() throws Exception {
         final String[] expected = {
-            "13:2: " + getCheckMessage(MSG_KEY, "ViolatingIndentedClass1"),
-            "17:5: " + getCheckMessage(MSG_KEY, "ViolatingIndentedClass2"),
-            "21:1: " + getCheckMessage(MSG_KEY, "ViolatingNonIndentedInterface"),
+            "14:2: " + getCheckMessage(MSG_KEY, "ViolatingIndentedClass1"),
+            "18:5: " + getCheckMessage(MSG_KEY, "ViolatingIndentedClass2"),
+            "22:1: " + getCheckMessage(MSG_KEY, "ViolatingNonIndentedInterface"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneTopLevelClassIndentation.java"), expected);
@@ -205,8 +205,8 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testOneTopLevelClassRecords() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_KEY, "TestRecord1"),
-            "17:1: " + getCheckMessage(MSG_KEY, "TestRecord2"),
+            "14:1: " + getCheckMessage(MSG_KEY, "TestRecord1"),
+            "19:1: " + getCheckMessage(MSG_KEY, "TestRecord2"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOneTopLevelClassRecords.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClass.java
@@ -10,33 +10,26 @@ public class InputOneTopLevelClass
 {
     static final int FOO2 = 3;
 
-    // violation : public before package
     public static final int FOO = 3;
 
     private static final int FOO3 = 3;
 
-    // violation : public before package and private
     public static final int FOO4 = 3;
 
     private static final String ERROR = "error";
 
-    // violation : protected before private
     protected static final String ERROR1 = "error";
 
-    // violation : public before private
     public static final String WARNING = "warning";
 
     private int mMaxInitVars = 3;
 
-    // violation : statics should be before instance members
-    // violation : publics before private
     public static final int MAX_ITER_VARS = 3;
 
     private class InnerClass
     {
         private static final int INNER_FOO = 2;
 
-        // violation : public before private
         public static final int INNER_FOO2 = 2;
 
         public InnerClass()
@@ -46,8 +39,6 @@ public class InputOneTopLevelClass
             foo += INNER_FOO3;
         }
 
-        // violation : member variables should be before methods or ctors
-        // violation : public before private
         public static final int INNER_FOO3 = 2;
     }
 
@@ -56,7 +47,6 @@ public class InputOneTopLevelClass
         return mFoo;
     }
 
-    // violation : ctors before methods
     public InputOneTopLevelClass()
     {
         String foo = ERROR;
@@ -82,6 +72,5 @@ public class InputOneTopLevelClass
         return 14;
     }
 
-    // violation : member variables should be before methods or ctors
     private int mFoo = 0;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassAnnotation2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassAnnotation2.java
@@ -12,12 +12,14 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-@interface InputOneTopLevelClassAnnotation2A { // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+@interface InputOneTopLevelClassAnnotation2A {
    String author();
    String date();
 }
 
-@CheckForNull // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+@CheckForNull
 @TypeQualifierDefault(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @interface InputOneTopLevelClassAnnotation2B {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassClone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassClone.java
@@ -28,29 +28,36 @@ public class InputOneTopLevelClassClone
     }
 }
 
-class NoSuperClone // violation
+// violation below 'Top-level class NoSuperClone has to reside in its own source file.'
+class NoSuperClone
 {
 }
 
-class InnerClone // violation
+// violation below 'Top-level class InnerClone has to reside in its own source file.'
+class InnerClone
 {
 }
 
-class CloneWithTypeArguments<T> extends CloneWithTypeArgumentsAndNoSuper<T> // violation
+// violation below 'Top-level class CloneWithTypeArguments has to reside in its own source file.'
+class CloneWithTypeArguments<T> extends CloneWithTypeArgumentsAndNoSuper<T>
 {
 }
 
-class CloneWithTypeArgumentsAndNoSuper<T> // violation
+// violation below 'Top-level class Clone.* has to reside in its own source file.'
+class CloneWithTypeArgumentsAndNoSuper<T>
 {
 }
 
-class MyClassWithGenericSuperMethod // violation
+// violation below 'Top-level class My.* has to reside in its own source file.'
+class MyClassWithGenericSuperMethod
 {
 }
 
-class AnotherClass { // violation
+// violation below 'Top-level class AnotherClass has to reside in its own source file.'
+class AnotherClass {
 }
 
-class NativeTest { // violation
+// violation below 'Top-level class NativeTest has to reside in its own source file.'
+class NativeTest {
     public native Object clone();
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassDeclarationOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassDeclarationOrder.java
@@ -13,7 +13,8 @@ public class InputOneTopLevelClassDeclarationOrder
     }
 }
 
-enum InputDeclarationOrderEnum // violation
+// violation below 'Top-level class InputDeclarationOrderEnum has to reside in its own source file.'
+enum InputDeclarationOrderEnum
 {
     ENUM_VALUE_1;
 
@@ -23,7 +24,8 @@ enum InputDeclarationOrderEnum // violation
     }
 }
 
-@interface InputDeclarationOrderAnnotation // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+@interface InputDeclarationOrderAnnotation
 {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassDeclarationOrder2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassDeclarationOrder2.java
@@ -13,7 +13,8 @@ public class InputOneTopLevelClassDeclarationOrder2
     }
 }
 
-enum InputDeclarationOrderEnum2 // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+enum InputDeclarationOrderEnum2
 {
     ENUM_VALUE_1;
 
@@ -23,7 +24,8 @@ enum InputDeclarationOrderEnum2 // violation
     }
 }
 
-@interface InputDeclarationOrderAnnotation2 // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+@interface InputDeclarationOrderAnnotation2
 {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassEnum2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassEnum2.java
@@ -6,7 +6,8 @@ OneTopLevelClass
 
 package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
 
-enum InputOneTopLevelClassEnum2inner1 { // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+enum InputOneTopLevelClassEnum2inner1 {
     VALUE1, VALUE2;
 }
 
@@ -14,6 +15,7 @@ public enum InputOneTopLevelClassEnum2 {
     VALUE1, VALUE2;
 }
 
-enum InputOneTopLevelClassEnum2inner2 { // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+enum InputOneTopLevelClassEnum2inner2 {
     VALUE1, VALUE2;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassIndentation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassIndentation.java
@@ -10,14 +10,15 @@ public class InputOneTopLevelClassIndentation {
     // methods
 }
 
- class ViolatingIndentedClass1 { // violation
+// violation below 'Top-level class ViolatingIndentedClass1 has to reside in its own source file.'
+ class ViolatingIndentedClass1 {
     // methods
  }
-
-    class ViolatingIndentedClass2 { // violation
+// violation below 'Top-level class ViolatingIndentedClass2 has to reside in its own source file.'
+    class ViolatingIndentedClass2 {
         // methods
     }
-
-interface ViolatingNonIndentedInterface { // violation
+// violation below 'Top-level class Violating.* has to reside in its own source file.'
+interface ViolatingNonIndentedInterface {
     // methods
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassInterface2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassInterface2.java
@@ -6,7 +6,8 @@ OneTopLevelClass
 
 package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
 
-interface InputOneTopLevelClassInterface2inner1 { // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+interface InputOneTopLevelClassInterface2inner1 {
     int foo();
 }
 
@@ -14,6 +15,7 @@ public interface InputOneTopLevelClassInterface2 {
     int foo();
 }
 
-interface InputOneTopLevelClassInterface2inner2 { // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+interface InputOneTopLevelClassInterface2inner2 {
     int foo();
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassInterface3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassInterface3.java
@@ -6,7 +6,8 @@ OneTopLevelClass
 
 package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
 
-interface InputOneTopLevelClassInterface3inner1 { // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+interface InputOneTopLevelClassInterface3inner1 {
     int foo();
 }
 
@@ -14,6 +15,7 @@ public interface InputOneTopLevelClassInterface3 {
     int foo();
 }
 
-interface InputOneTopLevelClassInterface3inner2 { // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+interface InputOneTopLevelClassInterface3inner2 {
     int foo();
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassNoPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassNoPublic.java
@@ -11,7 +11,8 @@ class InputOneTopLevelClassNoPublic
 
 }
 
-class InputOneTopLevelClassNoPublic2 // violation
+// violation below 'Top-level class Input.* has to reside in its own source file.'
+class InputOneTopLevelClassNoPublic2
 {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassRecords.java
@@ -10,10 +10,12 @@ package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
 public record InputOneTopLevelClassRecords() {
 }
 
-record TestRecord1() { // violation
+// violation below 'Top-level class TestRecord1 has to reside in its own source file.'
+record TestRecord1() {
 
 }
 
-record TestRecord2() { // violation
+// violation below 'Top-level class TestRecord2 has to reside in its own source file.'
+record TestRecord2() {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassSameLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassSameLine.java
@@ -6,4 +6,5 @@ OneTopLevelClass
 
 package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
 
-public class InputOneTopLevelClassSameLine {} enum ViolatingSecondType {} // violation
+// violation below 'Top-level class ViolatingSecondType has to reside in its own source file.'
+public class InputOneTopLevelClassSameLine {} enum ViolatingSecondType {}


### PR DESCRIPTION
Issue #15456 

### Summary

- Removed OneTopLevelClassCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in OneTopLevelClassCheckTest
- Defined violation messages in InputOneTopLevelClass files
