### PR TITLE
Issue #20475: Fix failing test job in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,9 @@ steps:
     command: "./mvnw -e --no-transfer-progress clean test"
     plugins:
       - docker#v5.0.0:
-          image: "maven:3.9-eclipse-temurin-21"
+          image: "mcr.microsoft.com/openjdk/jdk:21-ubuntu"
+          drop-caps:
+            - DAC_OVERRIDE
           volumes:
             - "/tmp/buildkite-maven-cache:/root/.m2"
 

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -811,6 +811,7 @@ mavenbadge
 maxdepth
 maxmem
 maxmethods
+mcr
 mdl
 MDM
 mebigfatguy


### PR DESCRIPTION
Resolves the problem found in issue
- #20475 

https://buildkite.com/checkstyle/ci/builds/526
```
[ERROR] Failures: 
[ERROR]   MainTest.testExistingTargetFileButWithoutReadAccess:351->assertMainReturnCode:2070 
Argument(s) are different! Wanted:
runtime.exit(-1);
-> at java.base/java.lang.Runtime.exit(Runtime.java:184)
Actual invocations have different arguments:
runtime.exit(0);
-> at com.puppycrawl.tools.checkstyle.Main.main(Main.java:155)
[ERROR] Errors: 
[ERROR]   MainFrameTest » NoClassDefFound Could not initialize class com.github.caciocavallosilano.cacio.ctc.junit.CacioExtension
[ERROR]   MainTest » NoClassDefFound Could not initialize class com.github.caciocavallosilano.cacio.ctc.junit.CacioExtension
[ERROR]   TreeTableTest » UnsatisfiedLink /opt/java/openjdk/lib/libawt_xawt.so: libXext.so.6: cannot open shared object file: No such file or directory
```

Proof that it works:
<img width="1909" height="761" alt="image" src="https://github.com/user-attachments/assets/9a38dfe2-5824-4278-a633-99e3285b7d51" />
