### PR TITLE
Issue #9834: rename getMessages to getViolations and FileMessages to …

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -178,10 +178,10 @@ public final class DefaultConfiguration implements Configuration {
      * Returns an unmodifiable map instance containing the custom messages
      * for this configuration.
      *
-     * @return unmodifiable map containing custom messages
+     * @return unmodifiable map containing custom violation messages
      */
     @Override
-    public Map<String, String> getMessages() {
+    public Map<String, String> getViolations() {
         return new HashMap<>(messages);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -63,8 +63,8 @@ public final class XMLLogger
     /** Close output stream in auditFinished. */
     private final boolean closeStream;
 
-    /** Holds all messages for the given file. */
-    private final Map<String, FileMessages> fileMessages =
+    /** Holds all violations for the given file. */
+    private final Map<String, FileViolations> fileViolations =
             new HashMap<>();
 
     /**
@@ -138,29 +138,29 @@ public final class XMLLogger
 
     @Override
     public void fileStarted(AuditEvent event) {
-        fileMessages.put(event.getFileName(), new FileMessages());
+        fileViolations.put(event.getFileName(), new FileViolations());
     }
 
     @Override
     public void fileFinished(AuditEvent event) {
         final String fileName = event.getFileName();
-        final FileMessages messages = fileMessages.remove(fileName);
-        writeFileMessages(fileName, messages);
+        final FileViolations violations = fileViolations.remove(fileName);
+        writeFileViolations(fileName, violations);
     }
 
     /**
      * Prints the file section with all file errors and exceptions.
      *
      * @param fileName The file name, as should be printed in the opening file tag.
-     * @param messages The file messages.
+     * @param violations The file violations.
      */
-    private void writeFileMessages(String fileName, FileMessages messages) {
+    private void writeFileViolations(String fileName, FileViolations violations) {
         writeFileOpeningTag(fileName);
-        if (messages != null) {
-            for (AuditEvent errorEvent : messages.getErrors()) {
+        if (violations != null) {
+            for (AuditEvent errorEvent : violations.getErrors()) {
                 writeFileError(errorEvent);
             }
-            for (Throwable exception : messages.getExceptions()) {
+            for (Throwable exception : violations.getExceptions()) {
                 writeException(exception);
             }
         }
@@ -187,9 +187,9 @@ public final class XMLLogger
     public void addError(AuditEvent event) {
         if (event.getSeverityLevel() != SeverityLevel.IGNORE) {
             final String fileName = event.getFileName();
-            final FileMessages messages = fileMessages.get(fileName);
-            if (messages != null) {
-                messages.addError(event);
+            final FileViolations violations = fileViolations.get(fileName);
+            if (violations != null) {
+                violations.addError(event);
             }
             else {
                 writeFileError(event);
@@ -229,9 +229,9 @@ public final class XMLLogger
     @Override
     public void addException(AuditEvent event, Throwable throwable) {
         final String fileName = event.getFileName();
-        final FileMessages messages = fileMessages.get(fileName);
-        if (messages != null) {
-            messages.addException(throwable);
+        final FileViolations violations = fileViolations.get(fileName);
+        if (violations != null) {
+            violations.addException(throwable);
         }
         else {
             writeException(throwable);
@@ -336,9 +336,9 @@ public final class XMLLogger
     }
 
     /**
-     * The registered file messages.
+     * The registered file violations.
      */
-    private static final class FileMessages {
+    private static final class FileViolations {
 
         /** The file error events. */
         private final List<AuditEvent> errors = new ArrayList<>();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java
@@ -102,7 +102,7 @@ public abstract class AbstractViolationReporter
      * @return unmodifiable map containing custom messages
      */
     protected Map<String, String> getCustomMessages() {
-        return getConfiguration().getMessages();
+        return getConfiguration().getViolations();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
@@ -82,11 +82,11 @@ public interface Configuration extends Serializable {
     String getName();
 
     /**
-     * Returns an unmodifiable map instance containing the custom messages
+     * Returns an unmodifiable map instance containing the custom violation messages
      * for this configuration.
      *
-     * @return unmodifiable map containing custom messages
+     * @return unmodifiable map containing custom violation messages
      */
-    Map<String, String> getMessages();
+    Map<String, String> getViolations();
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -426,12 +426,12 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
 
         final Configuration[] children = config.getChildren();
         final Configuration[] grandchildren = children[0].getChildren();
-        final List<String> messages = new ArrayList<>(grandchildren[0].getMessages().values());
+        final List<String> messages = new ArrayList<>(grandchildren[0].getViolations().values());
         final String expectedKey = "name.invalidPattern";
         final List<String> expectedMessages = Collections
                 .singletonList("Member ''{0}'' must start with ''m'' (checked pattern ''{1}'').");
         assertWithMessage("Messages should contain key: %s", expectedKey)
-                .that(grandchildren[0].getMessages())
+                .that(grandchildren[0].getViolations())
                 .containsKey(expectedKey);
         assertWithMessage("Message is not expected")
                 .that(messages)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
@@ -109,7 +109,7 @@ public class DefaultConfigurationTest {
         final Map<String, String> expected = new TreeMap<>();
         expected.put("key", "value");
         assertWithMessage("Invalid message map")
-            .that(config.getMessages())
+            .that(config.getViolations())
             .isEqualTo(expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -1013,7 +1013,7 @@ public final class InlineConfigParser {
             }
         }
 
-        final Map<String, String> messages = module.getMessages();
+        final Map<String, String> messages = module.getViolations();
         for (final Map.Entry<String, String> entry : messages.entrySet()) {
             final String key = entry.getKey();
             final String value = entry.getValue();


### PR DESCRIPTION
Resolves #9834

Renamed:
- `getMessages()` to `getViolations()` in `Configuration` interface and its implementations
- `FileMessages` to `FileViolations` in `XMLLogger`