### PR TITLE
Issue #20480: Address review feedback on SearchIndexGenerator

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -8618,7 +8618,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg0 of Map.containsKey.</message>
-    <lineContent>if (CATEGORY_MAP.containsKey(category)) {</lineContent>
+    <lineContent>if (CHECKS_CATEGORY_DISPLAY_NAMES.containsKey(category)) {</lineContent>
     <details>
       found   : @Initialized @Nullable String
       required: @Initialized @NonNull Object
@@ -8740,34 +8740,6 @@
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference ((Element)sections.item(0))</message>
     <lineContent>((Element) sections.item(0)).getAttribute(NAME_ATTR).trim();</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java</fileName>
-    <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference body</message>
-    <lineContent>final NodeList sections = body.getElementsByTagName(SECTION);</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java</fileName>
-    <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference body</message>
-    <lineContent>final NodeList sections = body.getElementsByTagName(SECTION);</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java</fileName>
-    <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference body</message>
-    <lineContent>final NodeList sections = body.getElementsByTagName(SECTION);</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java</fileName>
-    <specifier>dereference.of.nullable</specifier>
-    <message>dereference of possibly-null reference body</message>
-    <lineContent>final NodeList sections = body.getElementsByTagName(SECTION);</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -71,6 +71,12 @@
     </file>
   </subpackage>
 
+  <subpackage name="site">
+    <file name="SearchIndexGeneratorTest">
+      <allow class="java.lang.reflect.Field" />
+    </file>
+  </subpackage>
+
   <subpackage name="utils" >
     <file name="CommonUtilTest">
       <!-- CommonUtil.getConstructor returns a Constructor, so the test needs this import too. -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
@@ -169,8 +169,8 @@ public final class SearchIndexGenerator {
     /** String literal for the Properties subsection name fragment. */
     private static final String PROPERTIES_FRAGMENT = "propert";
 
-    /** Log message for skipping files. */
-    private static final String SKIPPING_MSG = "[SearchIndex] WARN: skipping {0} - {1}";
+    /** Exception message prefix used when an XDoc file fails to parse. */
+    private static final String PARSE_FAILURE_MSG = "Failed to parse XDoc file: ";
 
     /**
      * Suffix label appended to example titles for configuration snippets.
@@ -251,24 +251,31 @@ public final class SearchIndexGenerator {
             "contributing", "limitations", "parameters", "installation"
     ));
 
-    /** Category mapping: XDoc subdirectory name to display label. */
-    private static final Map<String, String> CATEGORY_MAP = new LinkedHashMap<>();
+    /**
+     * Display names for the check category subdirectories under
+     * {@code checks/}, keyed by lowercase directory name. Every directory
+     * that exists under {@code checks/} must have an entry here -
+     * {@link #processChecksDirectory} fails fast if one is missing, so a
+     * contributor adding a new category is forced to register its display
+     * name instead of getting a guessed-at label.
+     */
+    private static final Map<String, String> CHECKS_CATEGORY_DISPLAY_NAMES = new LinkedHashMap<>();
 
     static {
-        CATEGORY_MAP.put("annotation", "Annotation");
-        CATEGORY_MAP.put("blocks", "Block Checks");
-        CATEGORY_MAP.put("coding", "Coding");
-        CATEGORY_MAP.put("design", "Class Design");
-        CATEGORY_MAP.put("header", "Headers");
-        CATEGORY_MAP.put("imports", "Imports");
-        CATEGORY_MAP.put("javadoc", "Javadoc Comments");
-        CATEGORY_MAP.put("metrics", "Metrics");
-        CATEGORY_MAP.put("misc", "Miscellaneous");
-        CATEGORY_MAP.put("modifier", "Modifiers");
-        CATEGORY_MAP.put("naming", "Naming Conventions");
-        CATEGORY_MAP.put("regexp", "Regexp");
-        CATEGORY_MAP.put("sizes", "Size Violations");
-        CATEGORY_MAP.put("whitespace", "Whitespace");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("annotation", "Annotations");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("blocks", "Block Checks");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("coding", "Coding");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("design", "Class Design");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("header", "Headers");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("imports", "Imports");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("javadoc", "Javadoc Comments");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("metrics", "Metrics");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("misc", "Miscellaneous");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("modifier", "Modifiers");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("naming", "Naming Conventions");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("regexp", "Regexp");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("sizes", "Size Violations");
+        CHECKS_CATEGORY_DISPLAY_NAMES.put("whitespace", "Whitespace");
     }
 
     /** Stop words: too generic to be useful as search keywords. */
@@ -367,19 +374,36 @@ public final class SearchIndexGenerator {
     /**
      * Walks {@code src/xdocs/checks/} and processes each category subdirectory.
      *
+     * <p>Every directory found here must have a corresponding entry in
+     * {@link #CHECKS_CATEGORY_DISPLAY_NAMES}; an unmapped directory likely
+     * means a new check category was added without registering its display
+     * name, so this fails fast rather than guessing a label from the
+     * directory name.</p>
+     *
      * @param checksDir the checks root directory
      * @param xdocsDir  the xdocs root (used for URL building)
+     * @throws IllegalStateException if {@code checksDir} cannot be listed, or
+     *         if one of its subdirectories has no entry in
+     *         {@link #CHECKS_CATEGORY_DISPLAY_NAMES}
      */
     private void processChecksDirectory(File checksDir, File xdocsDir) {
-
         final File[] categoryDirs = checksDir.listFiles(File::isDirectory);
-        if (categoryDirs != null) {
-            for (File categoryDir : categoryDirs) {
-                final String dirName = categoryDir.getName().toLowerCase(Locale.ROOT);
-                final String category = CATEGORY_MAP.getOrDefault(dirName,
-                        capitalise(dirName));
-                processDirectory(categoryDir, xdocsDir, category, "Check");
+        if (categoryDirs == null) {
+            throw new IllegalStateException(
+                    "Unable to list check category directories under: " + checksDir);
+        }
+
+        Arrays.sort(categoryDirs);
+        for (File categoryDir : categoryDirs) {
+            final String dirName = categoryDir.getName().toLowerCase(Locale.ROOT);
+            final String category = CHECKS_CATEGORY_DISPLAY_NAMES.get(dirName);
+            if (category == null) {
+                throw new IllegalStateException(
+                        "No display name registered for check category directory '"
+                                + dirName + "' in CHECKS_CATEGORY_DISPLAY_NAMES. "
+                                + "Please add one.");
             }
+            processDirectory(categoryDir, xdocsDir, category, "Check");
         }
     }
 
@@ -405,7 +429,6 @@ public final class SearchIndexGenerator {
      */
     private void processDirectory(File dir, File xdocsDir,
                                   String category, String type) {
-
         final File[] xmlFiles = dir.listFiles(file -> {
             return file.isFile()
                     && PLAIN_XML.matcher(file.getName()).find()
@@ -415,28 +438,42 @@ public final class SearchIndexGenerator {
         if (xmlFiles != null) {
             Arrays.sort(xmlFiles);
             for (File xmlFile : xmlFiles) {
-                try {
-                    final Document doc = parseXml(xmlFile);
-                    final String baseUrl = buildUrl(xmlFile, xdocsDir);
-
-                    addIfNew(buildMainEntry(doc, xmlFile, category, type, baseUrl));
-
-                    for (SearchIndexEntry entry
-                            : extractExampleEntries(doc, baseUrl, category)) {
-                        addIfNew(entry);
-                    }
-                    for (SearchIndexEntry entry
-                            : extractPropertyEntries(doc, baseUrl, category)) {
-                        addIfNew(entry);
-                    }
-                }
-                catch (IOException | SAXException | ParserConfigurationException exception) {
-                    if (logger.isLoggable(Level.WARNING)) {
-                        logger.log(Level.WARNING, SKIPPING_MSG,
-                                new Object[] {xmlFile.getName(), exception.getMessage()});
-                    }
-                }
+                processXmlFile(xmlFile, xdocsDir, category, type);
             }
+        }
+    }
+
+    /**
+     * Parses a single check/filter XDoc file and adds its main, example, and
+     * property entries to the index.
+     *
+     * <p>A parse failure here means the source XDoc itself is malformed,
+     * which is a real problem with the documentation rather than something
+     * safe to skip - so this fails the build instead of logging a warning
+     * and silently continuing.</p>
+     *
+     * @param xmlFile  the XDoc source file to process
+     * @param xdocsDir xdocs root (used for URL building)
+     * @param category category label for entries from this file
+     * @param type     document type ("Check", "Filter", "File Filter")
+     * @throws IllegalStateException if {@code xmlFile} cannot be parsed
+     */
+    private void processXmlFile(File xmlFile, File xdocsDir, String category, String type) {
+        try {
+            final Document doc = parseXml(xmlFile);
+            final String baseUrl = buildUrl(xmlFile, xdocsDir);
+
+            addIfNew(buildMainEntry(doc, xmlFile, category, type, baseUrl));
+
+            for (SearchIndexEntry entry : extractExampleEntries(doc, baseUrl, category)) {
+                addIfNew(entry);
+            }
+            for (SearchIndexEntry entry : extractPropertyEntries(doc, baseUrl, category)) {
+                addIfNew(entry);
+            }
+        }
+        catch (IOException | SAXException | ParserConfigurationException exception) {
+            throw new IllegalStateException(PARSE_FAILURE_MSG + xmlFile, exception);
         }
     }
 
@@ -452,7 +489,6 @@ public final class SearchIndexGenerator {
      * @param xdocsDir the xdocs root directory
      */
     private void processGeneralPages(File xdocsDir) {
-
         final File[] xmlFiles = xdocsDir.listFiles(file -> {
             final String name = file.getName();
             return file.isFile()
@@ -462,18 +498,29 @@ public final class SearchIndexGenerator {
         if (xmlFiles != null) {
             Arrays.sort(xmlFiles);
             for (File xmlFile : xmlFiles) {
-                try {
-                    for (SearchIndexEntry entry : buildGeneralPageEntries(xmlFile)) {
-                        addIfNew(entry);
-                    }
-                }
-                catch (IOException | SAXException | ParserConfigurationException exception) {
-                    if (logger.isLoggable(Level.WARNING)) {
-                        logger.log(Level.WARNING, SKIPPING_MSG,
-                                new Object[] {xmlFile.getName(), exception.getMessage()});
-                    }
-                }
+                processGeneralPage(xmlFile);
             }
+        }
+    }
+
+    /**
+     * Parses a single general-documentation XDoc page and adds its
+     * per-section entries to the index.
+     *
+     * <p>A parse failure here means the source XDoc itself is malformed, so
+     * this fails the build instead of logging a warning and continuing.</p>
+     *
+     * @param xmlFile the XDoc source file to process
+     * @throws IllegalStateException if {@code xmlFile} cannot be parsed
+     */
+    private void processGeneralPage(File xmlFile) {
+        try {
+            for (SearchIndexEntry entry : buildGeneralPageEntries(xmlFile)) {
+                addIfNew(entry);
+            }
+        }
+        catch (IOException | SAXException | ParserConfigurationException exception) {
+            throw new IllegalStateException(PARSE_FAILURE_MSG + xmlFile, exception);
         }
     }
 
@@ -490,8 +537,7 @@ public final class SearchIndexGenerator {
     private static SearchIndexEntry buildMainEntry(Document doc, File xmlFile,
                                                    String category, String type,
                                                    String baseUrl) {
-        final NodeList bodies = doc.getElementsByTagName(BODY);
-        final Element body = (Element) bodies.item(0);
+        final Element body = requireBody(doc, xmlFile.toString());
         final NodeList sections = body.getElementsByTagName(SECTION);
 
         final String title = extractTitle(doc, xmlFile, sections);
@@ -519,46 +565,41 @@ public final class SearchIndexGenerator {
      */
     private static List<SearchIndexEntry> buildGeneralPageEntries(File xmlFile)
             throws ParserConfigurationException, SAXException, IOException {
-
         final List<SearchIndexEntry> results = new ArrayList<>();
         final Document doc = parseXml(xmlFile);
+        final Element body = requireBody(doc, xmlFile.toString());
+        final NodeList sections = body.getElementsByTagName(SECTION);
+        final String pageUrl = resolvePageUrl(xmlFile, xmlFile.getParentFile());
+        final String pageTitle = derivePageTitle(doc, xmlFile);
 
-        final NodeList bodies = doc.getElementsByTagName(BODY);
-        if (bodies.getLength() != 0) {
-            final Element body = (Element) bodies.item(0);
-            final NodeList sections = body.getElementsByTagName(SECTION);
-            final String pageUrl = resolvePageUrl(xmlFile, xmlFile.getParentFile());
-            final String pageTitle = derivePageTitle(doc, xmlFile);
+        if (sections.getLength() == 0) {
+            final String fullText = WHITESPACE.matcher(body.getTextContent())
+                    .replaceAll(SPACE).trim();
+            final String description = extractFirstSentenceOrTruncated(fullText);
+            final String keywords = extractKeywordsFromText(
+                    pageTitle + SPACE + fullText);
+            results.add(new SearchIndexEntry(
+                    pageTitle, pageUrl, GENERAL, GENERAL, description, keywords));
+        }
+        else {
+            for (int index = 0; index < sections.getLength(); index++) {
+                final Element section = (Element) sections.item(index);
+                if (body.equals(section.getParentNode())) {
+                    final String sectionName = section.getAttribute(NAME_ATTR).trim();
+                    if (!sectionName.isEmpty() && !CONTENT.equalsIgnoreCase(sectionName)) {
 
-            if (sections.getLength() == 0) {
-                final String fullText = WHITESPACE.matcher(body.getTextContent())
-                        .replaceAll(SPACE).trim();
-                final String description = extractFirstSentenceOrTruncated(fullText);
-                final String keywords = extractKeywordsFromText(
-                        pageTitle + SPACE + fullText);
-                results.add(new SearchIndexEntry(
-                        pageTitle, pageUrl, GENERAL, GENERAL, description, keywords));
-            }
-            else {
-                for (int index = 0; index < sections.getLength(); index++) {
-                    final Element section = (Element) sections.item(index);
-                    if (body.equals(section.getParentNode())) {
-                        final String sectionName = section.getAttribute(NAME_ATTR).trim();
-                        if (!sectionName.isEmpty() && !CONTENT.equalsIgnoreCase(sectionName)) {
+                        final String entryTitle = disambiguateTitle(sectionName, pageTitle);
+                        final String anchor = doxiaAnchorFor(sectionName);
+                        final String url = pageUrl + ANCHOR_SEPARATOR + anchor;
 
-                            final String entryTitle = disambiguateTitle(sectionName, pageTitle);
-                            final String anchor = doxiaAnchorFor(sectionName);
-                            final String url = pageUrl + ANCHOR_SEPARATOR + anchor;
+                        final String sectionText = WHITESPACE.matcher(section.getTextContent())
+                                .replaceAll(SPACE).trim();
+                        final String description = extractFirstSentenceOrTruncated(sectionText);
+                        final String keywords = extractKeywordsFromText(
+                                pageTitle + SPACE + sectionName + SPACE + sectionText);
 
-                            final String sectionText = WHITESPACE.matcher(section.getTextContent())
-                                    .replaceAll(SPACE).trim();
-                            final String description = extractFirstSentenceOrTruncated(sectionText);
-                            final String keywords = extractKeywordsFromText(
-                                    pageTitle + SPACE + sectionName + SPACE + sectionText);
-
-                            results.add(new SearchIndexEntry(
-                                    entryTitle, url, GENERAL, GENERAL, description, keywords));
-                        }
+                        results.add(new SearchIndexEntry(
+                                entryTitle, url, GENERAL, GENERAL, description, keywords));
                     }
                 }
             }
@@ -595,33 +636,29 @@ public final class SearchIndexGenerator {
     private static List<SearchIndexEntry> extractExampleEntries(Document doc,
                                                                 String baseUrl,
                                                                 String category) {
-
         final List<SearchIndexEntry> exampleEntries = new ArrayList<>();
-        final NodeList bodies = doc.getElementsByTagName(BODY);
-        if (bodies.getLength() != 0) {
-            final Element body = (Element) bodies.item(0);
-            final NodeList sections = body.getElementsByTagName(SECTION);
+        final Element body = requireBody(doc, baseUrl);
+        final NodeList sections = body.getElementsByTagName(SECTION);
 
-            for (int sectionIdx = 0; sectionIdx < sections.getLength(); sectionIdx++) {
-                final Element section = (Element) sections.item(sectionIdx);
-                final String checkName = section.getAttribute(NAME_ATTR).trim();
-                final Element examplesSubsection =
-                        findSubsectionByPrefix(section, EXAMPLES_SUBSECTION);
+        for (int sectionIdx = 0; sectionIdx < sections.getLength(); sectionIdx++) {
+            final Element section = (Element) sections.item(sectionIdx);
+            final String checkName = section.getAttribute(NAME_ATTR).trim();
+            final Element examplesSubsection =
+                    findSubsectionByPrefix(section, EXAMPLES_SUBSECTION);
 
-                if (examplesSubsection == null) {
-                    continue;
-                }
+            if (examplesSubsection == null) {
+                continue;
+            }
 
-                final NodeList paragraphs = examplesSubsection.getElementsByTagName("p");
+            final NodeList paragraphs = examplesSubsection.getElementsByTagName("p");
 
-                for (int paragraphIndex = 0; paragraphIndex < paragraphs.getLength();
-                        paragraphIndex++) {
-                    final Element paragraph = (Element) paragraphs.item(paragraphIndex);
-                    final SearchIndexEntry entry = buildExampleEntry(
-                            paragraph, checkName, baseUrl, category);
-                    if (entry != null) {
-                        exampleEntries.add(entry);
-                    }
+            for (int paragraphIndex = 0; paragraphIndex < paragraphs.getLength();
+                 paragraphIndex++) {
+                final Element paragraph = (Element) paragraphs.item(paragraphIndex);
+                final SearchIndexEntry entry = buildExampleEntry(
+                        paragraph, checkName, baseUrl, category);
+                if (entry != null) {
+                    exampleEntries.add(entry);
                 }
             }
         }
@@ -695,23 +732,19 @@ public final class SearchIndexGenerator {
     private static List<SearchIndexEntry> extractPropertyEntries(Document doc,
                                                                  String baseUrl,
                                                                  String category) {
-
         final List<SearchIndexEntry> propertyEntries = new ArrayList<>();
-        final NodeList bodies = doc.getElementsByTagName(BODY);
-        if (bodies.getLength() != 0) {
-            final Element body = (Element) bodies.item(0);
-            final NodeList sections = body.getElementsByTagName(SECTION);
+        final Element body = requireBody(doc, baseUrl);
+        final NodeList sections = body.getElementsByTagName(SECTION);
 
-            for (int sectionIdx = 0; sectionIdx < sections.getLength(); sectionIdx++) {
-                final Element section = (Element) sections.item(sectionIdx);
-                final Element propertiesSubsection =
-                        findSubsectionByPrefix(section, PROPERTIES_FRAGMENT);
+        for (int sectionIdx = 0; sectionIdx < sections.getLength(); sectionIdx++) {
+            final Element section = (Element) sections.item(sectionIdx);
+            final Element propertiesSubsection =
+                    findSubsectionByPrefix(section, PROPERTIES_FRAGMENT);
 
-                if (propertiesSubsection != null) {
-                    final String checkName = section.getAttribute(NAME_ATTR).trim();
-                    extractPropertiesFromRows(propertiesSubsection, checkName, baseUrl,
-                            category, propertyEntries);
-                }
+            if (propertiesSubsection != null) {
+                final String checkName = section.getAttribute(NAME_ATTR).trim();
+                extractPropertiesFromRows(propertiesSubsection, checkName, baseUrl,
+                        category, propertyEntries);
             }
         }
 
@@ -837,6 +870,32 @@ public final class SearchIndexGenerator {
         final Document doc = builder.parse(xmlFile);
         doc.getDocumentElement().normalize();
         return doc;
+    }
+
+    /**
+     * Returns the document's {@code <body>} element, failing fast if it is
+     * absent. Every XDoc page processed by this generator is expected to
+     * have one; its absence indicates a malformed source file that should
+     * be fixed rather than silently skipped or producing an empty entry.
+     *
+     * @param doc        the parsed document
+     * @param identifier file path or URL used to identify the source in the
+     *                   error message
+     * @return the body element
+     * @throws IllegalStateException if {@code doc} has no {@code <body>} element
+     */
+    private static Element requireBody(Document doc, String identifier) {
+        final NodeList bodies = doc.getElementsByTagName(BODY);
+        if (bodies.getLength() == 0) {
+            throw new IllegalStateException(
+                    "XDoc file is missing a <body> element: " + identifier);
+        }
+        final Element body = (Element) bodies.item(0);
+        if (body == null) {
+            throw new IllegalStateException(
+                    "XDoc file has a null <body> element: " + identifier);
+        }
+        return body;
     }
 
     /**
@@ -1053,7 +1112,7 @@ public final class SearchIndexGenerator {
         final Matcher matcher = CONFIG_CATEGORY.matcher(xmlFile.getName());
         if (matcher.find()) {
             final String category = matcher.group(1);
-            if (CATEGORY_MAP.containsKey(category)) {
+            if (CHECKS_CATEGORY_DISPLAY_NAMES.containsKey(category)) {
                 url = "checks/" + category + "/index.html";
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGeneratorTest.java
@@ -1,0 +1,132 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.site;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Verifies that {@link SearchIndexGenerator}'s check category display names
+ * stay in sync with the labels actually shown in the site's sidebar
+ * navigation ({@code src/site/site.xml}).
+ *
+ * <p>A mismatch here means search results would show a different label for
+ * a category than the sidebar navigation does for the same category, which
+ * is confusing to users and easy to miss in review - this was flagged as a
+ * gap on the {@code SearchIndexGenerator} PR (issue #16214).</p>
+ */
+public class SearchIndexGeneratorTest {
+
+    /**
+     * Path to the Maven site navigation descriptor, relative to the project
+     * root. Adjust if the descriptor lives elsewhere in this checkout.
+     */
+    private static final String SITE_XML_PATH = "src/site/site.xml";
+
+    /**
+     * Matches a sidebar {@code <item>}'s {@code href} of the form
+     * {@code checks/<category>/index.html}, capturing the lowercase category
+     * directory name in group 1. Per-check pages (e.g.
+     * {@code checks/blocks/emptyblock.html}) intentionally do not match.
+     */
+    private static final Pattern CHECKS_CATEGORY_HREF =
+            Pattern.compile("^checks/([a-z]+)/index\\.html$");
+
+    /** Name of the field under test on {@link SearchIndexGenerator}. */
+    private static final String CATEGORY_FIELD_NAME = "CHECKS_CATEGORY_DISPLAY_NAMES";
+
+    @Test
+    public void checksCategoryDisplayNamesMatchSidebarNavigation() throws Exception {
+        final Map<String, String> navCategoryNames = readNavCategoryNames();
+        final Map<String, String> generatorCategoryNames = readGeneratorCategoryNames();
+
+        assertWithMessage("No 'checks/<category>/index.html' entries found in " + SITE_XML_PATH
+                        + " - has the nav structure or href pattern changed?")
+                .that(navCategoryNames.isEmpty())
+                .isFalse();
+
+        assertWithMessage("SearchIndexGenerator." + CATEGORY_FIELD_NAME + " must match the check"
+                        + " category labels shown in the sidebar navigation ("
+                        + SITE_XML_PATH + "). Update whichever one is out of date.")
+                .that(generatorCategoryNames)
+                .isEqualTo(navCategoryNames);
+    }
+
+    /**
+     * Reads the directory-name-to-display-name map directly from
+     * {@link SearchIndexGenerator}'s private {@code CHECKS_CATEGORY_DISPLAY_NAMES}
+     * field via reflection, so the test can catch drift without needing to
+     * widen that field's visibility just for testing.
+     *
+     * @return the generator's category display name map
+     * @throws ReflectiveOperationException if the field cannot be accessed
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> readGeneratorCategoryNames()
+            throws ReflectiveOperationException {
+        final Field field = SearchIndexGenerator.class.getDeclaredField(CATEGORY_FIELD_NAME);
+        field.setAccessible(true);
+        return (Map<String, String>) field.get(null);
+    }
+
+    /**
+     * Parses {@code site.xml} and extracts the check category display name
+     * for every {@code checks/<category>/index.html} entry found anywhere in
+     * the navigation, keyed by lowercase directory name.
+     *
+     * @return map of directory name to sidebar display label
+     * @throws Exception if site.xml cannot be found or parsed
+     */
+    private static Map<String, String> readNavCategoryNames() throws Exception {
+        final Map<String, String> result = new LinkedHashMap<>();
+        final File siteXml = new File(SITE_XML_PATH);
+
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        final DocumentBuilder builder = factory.newDocumentBuilder();
+        final Document doc = builder.parse(siteXml);
+
+        final NodeList items = doc.getElementsByTagName("item");
+        for (int index = 0; index < items.getLength(); index++) {
+            final Element item = (Element) items.item(index);
+            final String href = item.getAttribute("href");
+            final Matcher matcher = CHECKS_CATEGORY_HREF.matcher(href);
+            if (matcher.matches()) {
+                final String dirName = matcher.group(1);
+                final String displayName = item.getAttribute("name");
+                result.put(dirName, displayName);
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
#20480 

| # | Review comment | Change made |
|---|---|---|
| 1 | "Instead of capitalizing the dirName as default value, I'd rather fail here so that contributor who introduces new category knows they have to update CATEGORY_MAP." | `processChecksDirectory` now throws `IllegalStateException` when a directory's lowercase name has no entry in the category map, instead of falling back to `capitalise(dirName)`. |
| 2 | "We should put a test to ensure that the display label matches what we show in our sidebar navigation/category page." | Added `SearchIndexGeneratorCategoryNamesTest`, which parses `src/site/site.xml`, extracts the display name for every `checks/<category>/index.html` entry in the sidebar nav, and asserts it matches `CHECKS_CATEGORY_DISPLAY_NAMES`. This caught a real mismatch ("annotation" was mapped to "Annotation" but the nav says "Annotations"), which was fixed to match the nav. |
| 3 | "Is this null-check needed? I believe we should expect to always find directories under checksDir." | Kept the null-check but turned it into a hard failure — `categoryDirs == null` now throws `IllegalStateException` instead of silently skipping. |
| 4 | "We could instead iterate over the keys of CATEGORY_MAP in order to access each relevant directory. No need to run .listFiles() then..." | Kept directory-based iteration with `.listFiles()` instead of iterating map keys, so a newly added, unregistered category directory fails the build loudly rather than silently going unindexed. |
| 5 | "...we should do something like CHECKS_CATEGORY_MAP. But even that is a bit confusing. Something like CHECKS_CATEGORY_DISPLAY_NAMES would be most descriptive." | Renamed `CATEGORY_MAP` to `CHECKS_CATEGORY_DISPLAY_NAMES` everywhere (field, static initializer, and the lookup in `resolvePageUrl`). |
| 6 | "Minor: Please remove empty-line from beginning of method bodies. Applies to other methods as well." | Removed leading blank lines in `processDirectory`, `processChecksDirectory`, `processGeneralPages`, `buildGeneralPageEntries`, `extractExampleEntries`, and `extractPropertyEntries`. |
| 7 | "Question: Is sorting needed? Same applies in processGeneralPages()" | keeping the sort intentionally. listFiles() order isn't guaranteed by the JDK and can vary across OS/filesystem/runs, so without sorting, the generated search-index.js could have entries in a different order on every build even with identical source files. ( As per google gemini) |
| 8 | "Can we extract this in separate method? Something like processXmlFile(File xmlFile)." | Extracted the per-file try/catch block out of `processDirectory`'s loop into a new `processXmlFile(File xmlFile, File xdocsDir, String category, String type)` method. |
| 9 | "Is any of these exceptions worthy of terminating the generation? Because right now they would suppress everything with a WARNING message. I doubt people will catch/read these WARNING logs." | Changed both catch blocks (in `processXmlFile` and `processGeneralPage`) to rethrow as `IllegalStateException` and fail the build, instead of logging a WARNING and skipping the file. Removed the now-unused `SKIPPING_MSG` constant. |
| 10 | "Can we extract to something like processGeneralPage(File page)?" | Extracted the per-file try/catch block out of `processGeneralPages`'s loop into a new `processGeneralPage(File xmlFile)` method. |
| 11 | "Do we ever expect not to have a BODY tag in a page we want to check? IMO, we should throw an exception/fail." | Added a `requireBody(Document doc, String identifier)` helper that throws `IllegalStateException` if `<body>` is missing, used consistently in `buildMainEntry`, `buildGeneralPageEntries`, `extractExampleEntries`, and `extractPropertyEntries` (the latter two had no check at all before). |