### PR TITLE
Issue #11440: move  testNonMatchingColumnNumber to SuppressionXpathSingleFilterTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
@@ -126,6 +126,22 @@ public class SuppressionXpathSingleFilterTest
     }
 
     @Test
+    public void testNonMatchingColumnNumberByXpath() throws Exception {
+        final String[] expected = {
+            "22:13: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "11"),
+            "22:18: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "12"),
+        };
+
+        final String[] suppressed = {
+            "22:18: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "12"),
+        };
+
+        verifyFilterWithInlineConfigParser(
+            getPath("InputSuppressionXpathSingleFilterNonMatchingColumnNumber2.java"), expected,
+            removeSuppressed(expected, suppressed));
+    }
+
+    @Test
     public void testComplexQuery() throws Exception {
         final String[] expected = {
             "27:21: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "3.14"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
@@ -58,18 +58,6 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testNonMatchingColumnNumber() throws Exception {
-        final String xpath = "//CLASS_DEF[./IDENT[@text='InputXpathFilterElementSuppressByXpath']]";
-        final XpathFilterElement filter = new XpathFilterElement(
-                "InputXpathFilterElementSuppressByXpath", "Test", null, null, xpath);
-        final TreeWalkerAuditEvent ev = getEvent(3, 100,
-                TokenTypes.CLASS_DEF);
-        assertWithMessage("Event should be accepted")
-                .that(filter.accept(ev))
-                .isTrue();
-    }
-
-    @Test
     public void testNullFileName() {
         final XpathFilterElement filter = new XpathFilterElement(
                 "InputXpathFilterElementSuppressByXpath", "Test", null, null, null);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingColumnNumber2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterNonMatchingColumnNumber2.java
@@ -1,0 +1,24 @@
+/*
+SuppressionXpathSingleFilter
+files = InputSuppressionXpathSingleFilterNonMatchingColumnNumber2
+checks = MagicNumberCheck
+message = (default)(null)
+id = (default)(null)
+query = //NUM_INT[@text='12']
+
+com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck
+ignoreNumbers = (default)-1, 0, 1, 2
+ignoreHashCodeMethod = (default)false
+ignoreAnnotation = (default)false
+ignoreFieldDeclaration = (default)false
+ignoreAnnotationElementDefaults = (default)true
+constantWaiverParentToken = PLUS, EXPR, ASSIGN
+tokens = NUM_INT
+
+*/
+package com.puppycrawl.tools.checkstyle.filters.suppressionxpathsinglefilter;
+
+public class InputSuppressionXpathSingleFilterNonMatchingColumnNumber2 {
+    int x = 11 + 12; // violation ''11' is a magic number.'
+    // filtered violation above ''12' is a magic number.'
+}


### PR DESCRIPTION
Issue : #11440 
Replace the pure unit test `testNonMatchingColumnNumber` in `XpathFilterElementTest` with a functional  test in `SuppressionXpathSingleFilterTest`.