### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - indentation

### DIFF
--- a/src/site/xdoc/checks/misc/indentation.xml
+++ b/src/site/xdoc/checks/misc/indentation.xml
@@ -490,7 +490,7 @@ class Example7 {
     }
 
     void handleValue(String aFooString,
-                     int aFooInt) {             // indent:8 ; expected: &gt; 4;
+                     int aFooInt) {
 
         boolean cond1,cond2,cond3,cond4,cond5,cond6;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -104,7 +104,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/coding/packagedeclaration/Example2",
             "checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2",
             "checks/imports/importcontrol/filters/Example9",
-            "checks/indentation/indentation/Example7",
             "checks/javadoc/javadoccontentlocation/Example2",
             "checks/javadoc/javadocleadingasteriskalign/Example2",
             "checks/javadoc/javadocleadingasteriskalign/Example3",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/Example7.java
@@ -40,7 +40,7 @@ class Example7 {
     }
 
     void handleValue(String aFooString,
-                     int aFooInt) {             // indent:8 ; expected: > 4;
+                     int aFooInt) {
 
         boolean cond1,cond2,cond3,cond4,cond5,cond6;
 


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/18435

checks/indentation/indentation :
Example 1-9 - show different properties excluding example4

use case example:
example4

Properties each example demonstrates:

Example1 — default config
Example2 — caseIndent=0
Example3 — forceStrictCondition=true
Example4 — default config (same as Example1!) but showing violations
Example5 — basicOffset=2
Example6 — lineWrappingIndentation=8
Example7 — throwsIndent=8 (complex use case)
Example8 — arrayInitIndent=2
Example9 — braceAdjustment=2