### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - patternvariable

### DIFF
--- a/src/site/xdoc/checks/naming/patternvariablename.xml
+++ b/src/site/xdoc/checks/naming/patternvariablename.xml
@@ -57,6 +57,7 @@ class Example1 {
     if (o1 instanceof Integer num_1) {}
     // violation above, 'Name 'num_1' must match pattern*.'
     if (o1 instanceof Integer n) {}
+
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -81,33 +82,9 @@ class Example2 {
     // violation above, 'Name 'STRING' must match pattern*.'
     if (o1 instanceof Integer num) {}
     if (o1 instanceof Integer num_1) {}
+
     if (o1 instanceof Integer n) {}
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example3-config">
-          An example of how to configure the check to that all variables have 3 or more
-          chars in name:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="PatternVariableName"&gt;
-      &lt;property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example3-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example3 {
-  void foo(Object o1){
-    if (o1 instanceof String STRING) {}
-    // violation above, 'Name 'STRING' must match pattern*.'
-    if (o1 instanceof Integer num) {}
-    if (o1 instanceof Integer num_1) {}
-    if (o1 instanceof Integer n) {}
-    // violation above, 'Name 'n' must match pattern*.'
+
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -146,10 +123,40 @@ class Example3 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example4 {
   void foo(Object o1){
-    if (o1 instanceof String BAD) {} // violation
-    if (o1 instanceof String good) {}
-    if (o1 instanceof final String GOOD) {}
-    if (o1 instanceof final String bad) {} // violation
+    if (o1 instanceof String STRING) {}
+    // violation above, 'Name 'STRING' must match pattern*.'
+    if (o1 instanceof Integer num) {}
+    if (o1 instanceof Integer num_1) {}
+    // violation above, 'Name 'num_1' must match pattern*.'
+    if (o1 instanceof Integer n) {}
+
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example3-config">
+          An example of how to configure the check to that all variables have 3 or more
+          chars in name:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="PatternVariableName"&gt;
+      &lt;property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">Code Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example3 {
+  void foo(Object o1){
+    if (o1 instanceof String STRING) {}
+    // violation above, 'Name 'STRING' must match pattern*.'
+    if (o1 instanceof Integer num) {}
+    if (o1 instanceof Integer num_1) {}
+
+    if (o1 instanceof Integer n) {}
+    // violation above, 'Name 'n' must match pattern*.'
   }
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/naming/patternvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/patternvariablename.xml.template
@@ -58,21 +58,6 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example2.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example3-config">
-          An example of how to configure the check to that all variables have 3 or more
-          chars in name:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example3.java"/>
-          <param name="type" value="config"/>
-        </macro>
-        <p id="Example3-code">Code Example:</p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example3.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
         <p id="Example4-config">
           An example of how to configure the check with different format for final and non-final
           pattern variables:
@@ -86,6 +71,21 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example3-config">
+          An example of how to configure the check to that all variables have 3 or more
+          chars in name:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">Code Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example3.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -123,9 +123,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/naming/catchparametername/Example2",
             "checks/naming/methodname/Example4",
             "checks/naming/packagename/Example2",
-            "checks/naming/patternvariablename/Example2",
-            "checks/naming/patternvariablename/Example3",
-            "checks/naming/patternvariablename/Example4",
             "checks/regexp/regexp/Example7",
             "checks/regexp/regexpmultiline/Example5",
             "checks/regexp/regexpsinglelinejava/Example2",
@@ -192,6 +189,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/imports/importorder/Example9",
             // until https://github.com/checkstyle/checkstyle/issues/19891
             "checks/blocks/leftcurly/Example3",
+            "checks/naming/patternvariablename/Example3",
             "checks/whitespace/parenpad/Example3",
             "checks/javadoc/missingjavadoctype/Example5",
             "checks/indentation/commentsindentation/Example3",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckExamplesTest.java
@@ -63,7 +63,7 @@ public class PatternVariableNameCheckExamplesTest extends AbstractExamplesModule
 
         final String[] expected = {
             "17:30: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
-            "21:31: " + getCheckMessage(MSG_INVALID_PATTERN, "n", pattern),
+            "22:31: " + getCheckMessage(MSG_INVALID_PATTERN, "n", pattern),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -73,8 +73,8 @@ public class PatternVariableNameCheckExamplesTest extends AbstractExamplesModule
     public void testExample4() throws Exception {
 
         final String[] expected = {
-            "37:30: " + getCheckMessage(MSG_INVALID_PATTERN, "BAD", "^([a-z][a-zA-Z0-9]*|_)$"),
-            "40:36: " + getCheckMessage(MSG_INVALID_PATTERN, "bad", "^[A-Z][A-Z0-9]*$"),
+            "37:30: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", "^([a-z][a-zA-Z0-9]*|_)$"),
+            "40:31: " + getCheckMessage(MSG_INVALID_PATTERN, "num_1", "^([a-z][a-zA-Z0-9]*|_)$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example1.java
@@ -18,6 +18,7 @@ class Example1 {
     if (o1 instanceof Integer num_1) {}
     // violation above, 'Name 'num_1' must match pattern*.'
     if (o1 instanceof Integer n) {}
+
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example2.java
@@ -18,7 +18,9 @@ class Example2 {
     // violation above, 'Name 'STRING' must match pattern*.'
     if (o1 instanceof Integer num) {}
     if (o1 instanceof Integer num_1) {}
+
     if (o1 instanceof Integer n) {}
+
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example3.java
@@ -18,6 +18,7 @@ class Example3 {
     // violation above, 'Name 'STRING' must match pattern*.'
     if (o1 instanceof Integer num) {}
     if (o1 instanceof Integer num_1) {}
+
     if (o1 instanceof Integer n) {}
     // violation above, 'Name 'n' must match pattern*.'
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example4.java
@@ -34,10 +34,13 @@ package com.puppycrawl.tools.checkstyle.checks.naming.patternvariablename;
 // xdoc section -- start
 class Example4 {
   void foo(Object o1){
-    if (o1 instanceof String BAD) {} // violation
-    if (o1 instanceof String good) {}
-    if (o1 instanceof final String GOOD) {}
-    if (o1 instanceof final String bad) {} // violation
+    if (o1 instanceof String STRING) {}
+    // violation above, 'Name 'STRING' must match pattern*.'
+    if (o1 instanceof Integer num) {}
+    if (o1 instanceof Integer num_1) {}
+    // violation above, 'Name 'num_1' must match pattern*.'
+    if (o1 instanceof Integer n) {}
+
   }
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

**Example1:** No custom properties (default configuration)

**Example2:**
- format: `^[a-z](_?[a-zA-Z0-9]+)*$`

**Example3:**
- format: `^[a-z][_a-zA-Z0-9]{2,}$`

**Example4:**
- First PatternVariableName instance:
  - id: `FinalPatternVariableName`
  - format: `^[A-Z][A-Z0-9]*$`
- Second PatternVariableName instance:
  - id: `NonFinalPatternVariableName`
  - format: `^([a-z][a-zA-Z0-9]*|_)$`
  
  
  Section1 -> Example 1,2,4
  UseCase -> Example 3