### PR TITLE
escape control characters in generated xpath suppression queries

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java
@@ -379,8 +379,31 @@ public class XpathQueryGenerator {
             case '\'' -> "&apos;&apos;";
             case '\"' -> "&quot;";
             case '&' -> "&amp;";
-            default -> String.valueOf(chr);
+            default -> encodeControlCharacter(chr);
         };
+    }
+
+    /**
+     * Renders control characters that are illegal in XML 1.0 as a {@code #x}-prefixed
+     * hexadecimal escape so the value stays well-formed when written into an XML attribute,
+     * mirroring
+     * {@link com.puppycrawl.tools.checkstyle.XMLLogger#encode}. Tab is legal in XML 1.0 and
+     * kept as is. Line feed and carriage return never reach here as they are already replaced
+     * with the literal {@code \n} and {@code \r} text earlier by
+     * {@link XpathUtil#getTextAttributeValue}.
+     *
+     * @param chr the character to render.
+     * @return the rendered character.
+     */
+    private static String encodeControlCharacter(char chr) {
+        final String result;
+        if (chr != '\t' && Character.isISOControl(chr)) {
+            result = "#x" + Integer.toHexString(chr) + ";";
+        }
+        else {
+            result = String.valueOf(chr);
+        }
+        return result;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
@@ -585,6 +585,32 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testEscapeControlCharacter() throws Exception {
+        // a block comment can carry a raw C0 control character (here a form feed); it is
+        // illegal in XML 1.0, so writing it verbatim into the query attribute makes the
+        // generated suppressions file non-well-formed. It is rendered as a hexadecimal
+        // #x escape instead. A tab is legal in XML 1.0 and is kept as is.
+        final char formFeed = '\f';
+        final FileText testFileText = new FileText(new File("Test.java"), Arrays.asList(
+                "class Test {",
+                "    /* a" + formFeed + "b\tc */",
+                "    int field;",
+                "}"));
+        final DetailAST detailAst =
+                JavaParser.parseFileText(testFileText, JavaParser.Options.WITH_COMMENTS);
+        final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(detailAst,
+                2, 5, testFileText, DEFAULT_TAB_WIDTH);
+        final List<String> actual = queryGenerator.generate();
+        final List<String> expected = Collections.singletonList(
+                "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='Test']]/OBJBLOCK/VARIABLE_DEF"
+                        + "[./IDENT[@text='field']]/TYPE/BLOCK_COMMENT_BEGIN"
+                        + "[./COMMENT_CONTENT[@text=' a#xc;b\tc ']]");
+        assertWithMessage("Control character must be escaped in generated query")
+            .that(actual)
+            .isEqualTo(expected);
+    }
+
+    @Test
     public void testTextBlocks() throws Exception {
         final File testFile = new File(getPath(
                 "InputXpathQueryGeneratorTextBlock.java"));


### PR DESCRIPTION
    Unable to parse suppressions.xml - An invalid XML character (Unicode: 0xc)
    was found in the value of attribute "query" and element is "suppress-xpath".

Hit this while generating an xpath suppressions file for a tree that had a form
feed inside a block comment. `checkstyle -g` wrote a suppressions.xml that would
no longer load.

Traced it to `XpathQueryGenerator.encodeCharacter`. It escapes `&`, `<`, `>`,
`'` and `"` in the `@text` values but passes every other character through
untouched. Comment and text-block tokens keep their content verbatim, so a C0
control character (form feed, vertical tab and friends) in the analysed source
lands raw in the `query="..."` attribute. Those bytes are legal in Java comments
but illegal in XML 1.0, so the generated file is not well-formed and
`SuppressionXpathFilter` aborts the whole audit when it reads it back.

The sibling `files="..."` attribute a few lines over already goes through
`XMLLogger.encode`, which drops control characters, so only the query attribute
was exposed. `encodeCharacter` now renders those control characters as `#xNN;`
text the same way `XMLLogger.encode` does. Tab, line feed and carriage return
stay as they are (line feed and carriage return are already normalised upstream
in `XpathUtil.getTextAttributeValue`).

Repro, with a real form feed byte written into a `TODO` comment:

    class Demo {
        /* TODO fix<FF>this */
        int x;
    }

    $ checkstyle -c cfg.xml -g -o suppressions.xml Demo.java   # TodoComment, format="TODO"

before, `suppressions.xml` carries the raw byte and no longer parses:

    query="...COMMENT_CONTENT[@text=' TODO fix<FF>this ']"

    $ checkstyle -c withSuppressionXpathFilter.xml Demo.java
    ... Unable to parse suppressions.xml - An invalid XML character
    (Unicode: 0xc) was found in the value of attribute "query" ...

after:

    query="...COMMENT_CONTENT[@text=' TODO fix#xc;this ']"

the file is well-formed and loads.
