### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - suppressfilter

### DIFF
--- a/src/site/xdoc/filters/suppresswarningsfilter.xml
+++ b/src/site/xdoc/filters/suppresswarningsfilter.xml
@@ -52,7 +52,10 @@
 </code></pre></div>
         <p id="Example1-code">Java code:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+package com.puppycrawl.tools.checkstyle.filters.suppresswarningsfilter;
+
 public class Example1 {
+
   @SuppressWarnings("memberName")
   int J; // filtered violation 'must match pattern'
   int JJ; // violation 'must match pattern'
@@ -60,9 +63,16 @@ public class Example1 {
   @SuppressWarnings({"MemberName", "NoWhitespaceAfter"})
   int [] ARRAY; // filtered violation
   // filtered violation above
-
   int [] ARRAY2; // violation
   // violation above
+  @SuppressWarnings("checkstyle:systemout")
+  public static void foo() {
+    System.out.println("Debug info.");
+  }
+
+  public static void boo() {
+    System.out.println("Some info.");
+  }
 }
 </code></pre></div>
         <hr class="example-separator"/>
@@ -93,10 +103,21 @@ public class Example1 {
 package com.puppycrawl.tools.checkstyle.filters.suppresswarningsfilter;
 // violation 9 lines above 'use SLF4J instead.'
 public class Example2 {
+
+  @SuppressWarnings("memberName")
+  int J;
+  int JJ;
+
+  @SuppressWarnings({"MemberName", "NoWhitespaceAfter"})
+  int [] ARRAY;
+
+  int [] ARRAY2;
+
   @SuppressWarnings("checkstyle:systemout")
   public static void foo() {
     System.out.println("Debug info."); // filtered violation 'use SLF4J instead.'
   }
+
   public static void boo() {
     System.out.println("Some info."); // violation 'use SLF4J instead.'
   }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -132,7 +132,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/todocomment/Example3",
             "checks/whitespace/emptyforiteratorpad/Example2",
             "checks/whitespace/parenpad/Example2",
-            "filters/suppresswarningsfilter/Example2",
             // Note: customImport/ImportOrder changes import group ORDER affecting AST structure
             "checks/imports/customimportorder/Example10",
             "checks/imports/customimportorder/Example11",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterExamplesTest.java
@@ -32,16 +32,16 @@ public class SuppressWarningsFilterExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample1() throws Exception {
         final String[] expectedWithoutFilter = {
-            "16:7: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "17:7: Name 'JJ' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "20:7: 'int' is followed by whitespace.",
-            "20:10: Name 'ARRAY' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "17:7: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "18:7: Name 'JJ' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "21:7: 'int' is followed by whitespace.",
+            "21:10: Name 'ARRAY' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "23:7: 'int' is followed by whitespace.",
             "23:10: Name 'ARRAY2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         };
 
         final String[] expectedWithFilter = {
-            "17:7: Name 'JJ' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "18:7: Name 'JJ' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
             "23:7: 'int' is followed by whitespace.",
             "23:10: Name 'ARRAY2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
         };
@@ -54,13 +54,13 @@ public class SuppressWarningsFilterExamplesTest extends AbstractExamplesModuleTe
     public void testExample2() throws Exception {
         final String[] expectedWithoutFilter = {
             "9: Dont use System.out/err, use SLF4J instead.",
-            "22: Dont use System.out/err, use SLF4J instead.",
-            "25: Dont use System.out/err, use SLF4J instead.",
+            "32: Dont use System.out/err, use SLF4J instead.",
+            "36: Dont use System.out/err, use SLF4J instead.",
         };
 
         final String[] expectedWithFilter = {
             "9: Dont use System.out/err, use SLF4J instead.",
-            "25: Dont use System.out/err, use SLF4J instead.",
+            "36: Dont use System.out/err, use SLF4J instead.",
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example2.java"),

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/Example1.java
@@ -8,10 +8,11 @@
   <module name="SuppressWarningsFilter" />
 </module>
 */
-
-package com.puppycrawl.tools.checkstyle.filters.suppresswarningsfilter;
 // xdoc section -- start
+package com.puppycrawl.tools.checkstyle.filters.suppresswarningsfilter;
+
 public class Example1 {
+
   @SuppressWarnings("memberName")
   int J; // filtered violation 'must match pattern'
   int JJ; // violation 'must match pattern'
@@ -19,8 +20,15 @@ public class Example1 {
   @SuppressWarnings({"MemberName", "NoWhitespaceAfter"})
   int [] ARRAY; // filtered violation
   // filtered violation above
-
   int [] ARRAY2; // violation
   // violation above
+  @SuppressWarnings("checkstyle:systemout")
+  public static void foo() {
+    System.out.println("Debug info.");
+  }
+
+  public static void boo() {
+    System.out.println("Some info.");
+  }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/Example2.java
@@ -17,10 +17,21 @@
 package com.puppycrawl.tools.checkstyle.filters.suppresswarningsfilter;
 // violation 9 lines above 'use SLF4J instead.'
 public class Example2 {
+
+  @SuppressWarnings("memberName")
+  int J;
+  int JJ;
+
+  @SuppressWarnings({"MemberName", "NoWhitespaceAfter"})
+  int [] ARRAY;
+
+  int [] ARRAY2;
+
   @SuppressWarnings("checkstyle:systemout")
   public static void foo() {
     System.out.println("Debug info."); // filtered violation 'use SLF4J instead.'
   }
+
   public static void boo() {
     System.out.println("Some info."); // violation 'use SLF4J instead.'
   }


### PR DESCRIPTION
#18435


**Example1.java:**
- **SuppressWarningsHolder**: No properties
- **MemberName**: No properties
- **NoWhitespaceAfter**: No properties
- **SuppressWarningsFilter**: No properties

**Example2.java:**
- **SuppressWarningsHolder**: No properties
- **RegexpSinglelineJava**:
  - id: `systemout`
  - format: `^.*System\.(out|err).*$`
  - message: `Don't use System.out/err, use SLF4J instead.`
- **SuppressWarningsFilter**: No properties


Example 1,2 -> Section1