### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - uniqueproperties

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -130,7 +130,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/whitespace/whitespaceafter/Example2",
             "checks/todocomment/Example2",
             "checks/todocomment/Example3",
-            "checks/uniqueproperties/Example2",
             "checks/whitespace/emptyforiteratorpad/Example2",
             "checks/whitespace/parenpad/Example2",
             "filters/suppresswarningsfilter/Example2",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/uniqueproperties/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/uniqueproperties/Example1.java
@@ -6,6 +6,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.uniqueproperties;
 
-public class Example1 { }
 // xdoc section -- start
+public class Example1 { }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/uniqueproperties/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/uniqueproperties/Example2.java
@@ -8,6 +8,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.uniqueproperties;
 
-public class Example2 { }
 // xdoc section -- start
+public class Example2 { }
 // xdoc section -- end


### PR DESCRIPTION
#18435


**Example1.java:**
- **UniqueProperties**: No properties

**Example2.java:**
- **UniqueProperties**:
  - fileExtensions: `customProperties`
  
  Section1 -> Example1,2