### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - methodlength

### DIFF
--- a/src/site/xdoc/checks/sizes/methodlength.xml
+++ b/src/site/xdoc/checks/sizes/methodlength.xml
@@ -111,14 +111,13 @@ public class Example1 {
   }
 
   public void secondMethod() {
-    // comments are counted by default
+
     System.out.println("line 3");
   }
-
   // violation below, 'Method thirdMethod length is 5 lines (max allowed is 4)'
   public void thirdMethod() {
 
-    // empty line above is counted by default,just like this comment
+    // ok, empty line above is counted by default,just like this comment
     System.out.println("line 4");
   }
 
@@ -172,14 +171,13 @@ public class Example2 {
   }
 
   public void secondMethod() {
-    // comments are counted by default
+
     System.out.println("line 3");
   }
-
   // violation below, 'Method thirdMethod length is 5 lines (max allowed is 4)'
   public void thirdMethod() {
 
-    // empty line above is counted by default,just like this comment
+    // ok, empty line above is counted by default,just like this comment
     System.out.println("line 4");
   }
 
@@ -234,13 +232,13 @@ public class Example3 {
   }
 
   public void secondMethod() {
-    // countEmpty property is false,so this line doesn't count
+    // ok, countEmpty property is false,so this line doesn't count
     System.out.println("line 3");
   }
 
   public void thirdMethod() {
 
-    // countEmpty property is false,so this line and the line above don't count
+    // ok, countEmpty property is false,so this line and the line above don't count
     System.out.println("line 4");
   }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -133,7 +133,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/regexp/regexpsinglelinejava/Example4",
             "checks/regexp/regexpsinglelinejava/Example5",
             "checks/sizes/lambdabodylength/Example2",
-            "checks/sizes/methodlength/Example3",
             "checks/sizes/outertypenumber/Example2",
             "checks/whitespace/singlespaceseparator/Example2",
             "checks/whitespace/typecastparenpad/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckExamplesTest.java
@@ -39,8 +39,8 @@ public class MethodLengthCheckExamplesTest extends AbstractExamplesModuleTestSup
         final String[] expected = {
             "18:3: " + getCheckMessage(MSG_KEY, 5, max, "Example1"),
             "31:3: " + getCheckMessage(MSG_KEY, 6, max, "firstMethod"),
-            "44:3: " + getCheckMessage(MSG_KEY, 5, max, "thirdMethod"),
-            "52:5: " + getCheckMessage(MSG_KEY, 5, max, "MyBadRecord"),
+            "43:3: " + getCheckMessage(MSG_KEY, 5, max, "thirdMethod"),
+            "51:5: " + getCheckMessage(MSG_KEY, 5, max, "MyBadRecord"),
         };
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
@@ -52,7 +52,7 @@ public class MethodLengthCheckExamplesTest extends AbstractExamplesModuleTestSup
 
         final String[] expected = {
             "32:3: " + getCheckMessage(MSG_KEY, 6, max, "firstMethod"),
-            "45:3: " + getCheckMessage(MSG_KEY, 5, max, "thirdMethod"),
+            "44:3: " + getCheckMessage(MSG_KEY, 5, max, "thirdMethod"),
         };
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example1.java
@@ -36,14 +36,13 @@ public class Example1 {
   }
 
   public void secondMethod() {
-    // comments are counted by default
+
     System.out.println("line 3");
   }
-
   // violation below, 'Method thirdMethod length is 5 lines (max allowed is 4)'
   public void thirdMethod() {
 
-    // empty line above is counted by default,just like this comment
+    // ok, empty line above is counted by default,just like this comment
     System.out.println("line 4");
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example2.java
@@ -37,14 +37,13 @@ public class Example2 {
   }
 
   public void secondMethod() {
-    // comments are counted by default
+
     System.out.println("line 3");
   }
-
   // violation below, 'Method thirdMethod length is 5 lines (max allowed is 4)'
   public void thirdMethod() {
 
-    // empty line above is counted by default,just like this comment
+    // ok, empty line above is counted by default,just like this comment
     System.out.println("line 4");
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example3.java
@@ -38,13 +38,13 @@ public class Example3 {
   }
 
   public void secondMethod() {
-    // countEmpty property is false,so this line doesn't count
+    // ok, countEmpty property is false,so this line doesn't count
     System.out.println("line 3");
   }
 
   public void thirdMethod() {
 
-    // countEmpty property is false,so this line and the line above don't count
+    // ok, countEmpty property is false,so this line and the line above don't count
     System.out.println("line 4");
   }
 


### PR DESCRIPTION
#18435

**Example1.java:**
- **MethodLength**:
  - max: `4`

**Example2.java:**
- **MethodLength**:
  - tokens: `METHOD_DEF`
  - max: `4`

**Example3.java:**
- **MethodLength**:
  - tokens: `METHOD_DEF`
  - max: `4`
  - countEmpty: `false`
  
  
  Section 1 -> Example 1,2,3