### PR TITLE
Issue #20512: fix anchor name and upgrade junit test

### DIFF
--- a/src/site/xdoc/checks/coding/unusedtryresourceshouldbeunnamed.xml
+++ b/src/site/xdoc/checks/coding/unusedtryresourceshouldbeunnamed.xml
@@ -116,7 +116,8 @@ public class Example1 {
           to learn how to.
         </p>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+               id="UnusedTryResourceShouldBeUnnamed_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedTryResourceShouldBeUnnamedCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/site/xdoc/checks/coding/unusedtryresourceshouldbeunnamed.xml.template
+++ b/src/site/xdoc/checks/coding/unusedtryresourceshouldbeunnamed.xml.template
@@ -54,7 +54,8 @@
           to learn how to.
         </p>
       </subsection>
-      <subsection name="Fully Qualified Name" id="Fully_Qualified_Name">
+      <subsection name="Fully Qualified Name"
+               id="UnusedTryResourceShouldBeUnnamed_Fully_Qualified_Name">
         <p>com.puppycrawl.tools.checkstyle.checks.coding.UnusedTryResourceShouldBeUnnamedCheck</p>
         <p>
           Use this fully qualified class name in configuration when an exact class reference is

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -693,11 +693,6 @@ public class XdocsPagesTest {
                     sectionName = "Documentation Comments";
                     expectedId = (sectionName + "_" + nameString).replace(' ', '_');
                 }
-                else if ((path.toString().contains("filters")
-                        || path.toString().contains("checks"))
-                        && !subsectionId.startsWith(sectionName)) {
-                    expectedId = nameString.replace(' ', '_');
-                }
                 else {
                     expectedId = (sectionName + "_" + nameString).replace(' ', '_');
                 }


### PR DESCRIPTION
Issue #20512 

- prefix the anchor name with Section name 
-  update the junit test the problem was the second condition: `!subsectionId.startsWith(sectionName`). This was meant as a safe fallback  if the ID doesn't follow the `{SectionName}_ prefix `convention, just let it through. now when removed all subsection IDs must now strictly follow the` {SectionName}_{SubsectionName} `pattern.