### PR TITLE
Issue #20490: Adding support for instanceof in jdkversion property

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -194,9 +194,9 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
      * This property only considers features from officially released
      * Java versions as supported. Features introduced in preview releases
      * are not considered supported until they are included in a non-preview release.
-     * Before JDK 22, named pattern variables in switch labels cannot be replaced
-     * with {@code _}, so violations on them are suppressed when jdkVersion is set
-     * below 22.
+     * Before JDK 22, named pattern variables in switch labels and instanceof
+     * record Destructuring cannot be replaced with {@code _}, so violations
+     * on them are suppressed when jdkVersion is set below 22.
      */
     private int jdkVersion = JDK_22;
 
@@ -229,9 +229,9 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
      * This property only considers features from officially released
      * Java versions as supported. Features introduced in preview releases
      * are not considered supported until they are included in a non-preview release.
-     * Before JDK 22, named pattern variables in switch labels cannot be replaced
-     * with {@code _}, so violations on them are suppressed when jdkVersion is set
-     * below 22.
+     * Before JDK 22, named pattern variables in switch labels and instanceof
+     * record Destructuring cannot be replaced with {@code _}, so violations
+     * on them are suppressed when jdkVersion is set below 22.
      *
      * @param jdkVersion the Java version.
      * @since 13.7.0
@@ -442,25 +442,20 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
         final DetailAST ident = patternVarDefAst.findFirstToken(TokenTypes.IDENT);
         final DetailAST scope = findScopeOfPatternVariable(patternVarDefAst);
         final VariableDesc desc = new VariableDesc(ident.getText(), ident, scope);
-        if (isSwitchCasePatternVariable(patternVarDefAst)) {
+        if (isForcedNamePatternVariable(patternVarDefAst)) {
             desc.registerAsNamedPatternVar();
         }
         variablesStack.push(desc);
     }
 
     /**
-     * Checks whether the pattern variable is declared in a switch labels.
+     * Checks whether the pattern variable is declared in a switch labels and instanceof.
      *
      * @param patternVarDefAst ast of type {@link TokenTypes#PATTERN_VARIABLE_DEF}
-     * @return true if the pattern variable is declared in a switch label
+     * @return true if the pattern variable is in a forced-name context
      */
-    private static boolean isSwitchCasePatternVariable(DetailAST patternVarDefAst) {
-        DetailAST current = patternVarDefAst;
-        while (current != null
-                && current.getType() != TokenTypes.LITERAL_CASE) {
-            current = current.getParent();
-        }
-        return current != null;
+    private static boolean isForcedNamePatternVariable(DetailAST patternVarDefAst) {
+        return patternVarDefAst.getParent().getType() != TokenTypes.LITERAL_INSTANCEOF;
     }
 
     /**
@@ -493,7 +488,8 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
         final DetailAST lastChild = literalNewAst.getLastChild();
         if (lastChild != null && lastChild.getType() == TokenTypes.OBJBLOCK) {
             DetailAST currentAst = literalNewAst;
-            while (!TokenUtil.isTypeDeclaration(currentAst.getType())) {
+            while (currentAst != null
+                    && !TokenUtil.isTypeDeclaration(currentAst.getType())) {
                 if (currentAst.getType() == TokenTypes.SLIST) {
                     result = true;
                     break;
@@ -1104,8 +1100,8 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
         }
 
         /**
-         * Register the variable as a named pattern variable
-         * declared in a switch label.
+         * Register the variable as a forced-name pattern variable declared
+         * in a switch label or instanceof record Destructuring.
          */
         /* package */ void registerAsNamedPatternVar() {
             namedPatternVar = true;
@@ -1130,11 +1126,11 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
         }
 
         /**
-         * Is a named pattern variable from a switch label.
+         * Is a forced-name pattern variable from a switch label or
+         * instanceof record Destructuring.
          *
-         * @return true if this variable was declared via a
-         *         {@link TokenTypes#PATTERN_VARIABLE_DEF} with a non-underscore name
-         *         in a switch label
+         * @return true if this variable was declared in a context where
+         *         pre-JDK 22 forces a name to be given even when unused
          */
         /* package */ boolean isNamedPatternVar() {
             return namedPatternVar;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UnusedLocalVariableCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UnusedLocalVariableCheck.xml
@@ -21,7 +21,7 @@
  unnamed variables&lt;/a&gt; in Java 21+).</description>
             </property>
             <property default-value="22" name="jdkVersion" type="int">
-               <description>Set the JDK version that you are using. Old JDK version numbering is supported (e.g. 1.8 for Java 8) as well as just the major JDK version alone (e.g. 8) is supported. This property only considers features from officially released Java versions as supported. Features introduced in preview releases are not considered supported until they are included in a non-preview release. Before JDK 22, named pattern variables in switch labels cannot be replaced with &lt;code&gt;_&lt;/code&gt;, so violations on them are suppressed when jdkVersion is set below 22.</description>
+               <description>Set the JDK version that you are using. Old JDK version numbering is supported (e.g. 1.8 for Java 8) as well as just the major JDK version alone (e.g. 8) is supported. This property only considers features from officially released Java versions as supported. Features introduced in preview releases are not considered supported until they are included in a non-preview release. Before JDK 22, named pattern variables in switch labels and instanceof record Destructuring cannot be replaced with &lt;code&gt;_&lt;/code&gt;, so violations on them are suppressed when jdkVersion is set below 22.</description>
             </property>
          </properties>
          <message-keys>

--- a/src/site/xdoc/checks/coding/unusedlocalvariable.xml
+++ b/src/site/xdoc/checks/coding/unusedlocalvariable.xml
@@ -42,7 +42,7 @@
             </tr>
             <tr>
               <td><a id="jdkVersion"/><a href="#jdkVersion">jdkVersion</a></td>
-              <td>Set the JDK version that you are using. Old JDK version numbering is supported (e.g. 1.8 for Java 8) as well as just the major JDK version alone (e.g. 8) is supported. This property only considers features from officially released Java versions as supported. Features introduced in preview releases are not considered supported until they are included in a non-preview release. Before JDK 22, named pattern variables in switch labels cannot be replaced with <code>_</code>, so violations on them are suppressed when jdkVersion is set below 22.</td>
+              <td>Set the JDK version that you are using. Old JDK version numbering is supported (e.g. 1.8 for Java 8) as well as just the major JDK version alone (e.g. 8) is supported. This property only considers features from officially released Java versions as supported. Features introduced in preview releases are not considered supported until they are included in a non-preview release. Before JDK 22, named pattern variables in switch labels and instanceof record Destructuring cannot be replaced with <code>_</code>, so violations on them are suppressed when jdkVersion is set below 22.</td>
               <td><a href="../../property_types.html#int">int</a></td>
               <td><code>22</code></td>
               <td>13.7.0</td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
@@ -174,6 +174,10 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
             "48:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "l"),
             "60:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "h"),
             "63:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "v"),
+            "88:10: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "o"),
+            "97:18: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "o"),
+            "102:18: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "o"),
+            "106:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "o"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableAnonInnerClasses.java"),
@@ -484,6 +488,8 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
             "24:68: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "lr"),
             "44:33: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
             "59:34: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s1"),
+            "80:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "id"),
+            "89:14: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "_"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariablePatternVariablesCondition2.java"),
@@ -493,12 +499,14 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testUnusedLocalVariableNamedPatternVariable() throws Exception {
         final String[] expected = {
-            "14:25: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ignored"),
-            "15:26: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ignored2"),
-            "21:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "x"),
-            "22:38: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ignored"),
-            "29:30: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "y"),
-            "29:37: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "z"),
+            "21:25: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ignored"),
+            "22:26: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ignored2"),
+            "28:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "x"),
+            "29:38: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ignored"),
+            "36:30: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "y"),
+            "36:37: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "z"),
+            "42:57: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "ignoredAge"),
+            "58:43: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "inner"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableAllowNamedPatternVariables.java"),
@@ -514,6 +522,16 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedLocalVariableAllowNamedPatternVariablesTrue.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnusedLocalVariableNamedPatternVariableInstanceof() throws Exception {
+        final String[] expected = {
+            "21:38: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "s"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedLocalVariableAllowNamedPatternVariablesInstanceOf.java"),
                 expected);
     }
 
@@ -692,10 +710,31 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
             "30:32: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "c"),
             "31:32: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "r"),
             "46:35: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "s"),
+            "57:14: " + getCheckMessage(MSG_UNUSED_NAMED_LOCAL_VARIABLE, "id"),
         };
         verifyWithInlineConfigParser(
                 getPath(
                     "InputUnusedLocalVariablePatternVariablesAllowUnnamed.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnusedLocalVariablePatternVariablesUnnamedTry() throws Exception {
+        final String[] expected = {
+            "28:17: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "_"),
+        };
+        verifyWithInlineConfigParser(
+                getPath(
+                    "InputUnusedLocalVariableUnnamedTryCatch.java"),
+                expected);
+    }
+
+    @Test
+    public void testUnusedLocalVariablePatternVariablesAllowUnnamedTry() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath(
+                    "InputUnusedLocalVariableAllowUnnamedTryCatch.java"),
                 expected);
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableCompactSourceFile.java
@@ -15,4 +15,8 @@ void m() {
     System.out.println(used);
 }
 
+Runnable r = new Runnable() {
+    public void run() {}
+};
+
 void main() { }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowNamedPatternVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowNamedPatternVariables.java
@@ -8,6 +8,13 @@ package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
 
 public class InputUnusedLocalVariableAllowNamedPatternVariables {
     record Ignored(int x, int y) {}
+    sealed interface Customer {}
+    record Person(String name, int age) implements Customer {}
+    record Company(String name) implements Customer {}
+    sealed interface Maybe<T> {}
+    record None<T>() implements Maybe<T> {}
+    record Some<T>(T value) implements Maybe<T> {}
+
 
     String whatClass(Object object) {
         return switch (object) {
@@ -30,4 +37,28 @@ public class InputUnusedLocalVariableAllowNamedPatternVariables {
             default -> "other";
         };
     }
+
+    String nameWithoutIgnored(Customer customer) { // violation below, 'Unused local variable'
+        if (customer instanceof Person(String name, int ignoredAge)) {
+            return name;
+        } else if (customer instanceof Company(String companyName)) {
+            return companyName;
+        }
+
+        if (customer instanceof Person nameWithoutIgnored) {
+            return nameWithoutIgnored.name();
+        }
+        else if (customer instanceof Company company) {
+            return company.name();
+        }
+        throw new IllegalStateException();
+    }
+
+    boolean isNested(Maybe<?> maybe) {
+        if (maybe instanceof Some(Some<?> inner)) { // violation, 'Unused local variable'
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowNamedPatternVariablesInstanceOf.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowNamedPatternVariablesInstanceOf.java
@@ -1,0 +1,57 @@
+/*
+UnusedLocalVariable
+allowUnnamedVariables = false
+jdkVersion = 21
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+public class InputUnusedLocalVariableAllowNamedPatternVariablesInstanceOf {
+
+    sealed interface Customer {}
+    record Person(String name, int age) implements Customer {}
+    record Company(String name) implements Customer {}
+    record Organization(String orgName, Person contactPerson) {}
+
+    sealed interface Maybe<T> {}
+    record None<T>() implements Maybe<T> {}
+    record Some<T>(T value) implements Maybe<T> {}
+
+    void method(Object object) {
+        if (object instanceof String s) { // violation, 'Unused local variable'
+            System.out.println("string");
+        }
+    }
+    String name(Customer customer) {
+        if (customer instanceof Person(String name, int ignoredAge)) {
+            return name;
+        } else if (customer instanceof Company(String companyName)) {
+            return companyName;
+        }
+        throw new IllegalStateException();
+    }
+
+    boolean isNested(Maybe<?> maybe) {
+        if (maybe instanceof Some(Some<?> inner)) {
+            return true;
+        }
+        return false;
+    }
+
+    void traditionalSwitchRecord(Object object) {
+    switch (object) {
+        case Person(String name, int ignoredAge):
+            System.out.println(name);
+            break;
+        default:
+            break;
+    }
+    }
+
+    void nestedRecordPattern(Object object) {
+        if (object instanceof Organization(String orgName,
+                                           Person(String name, int nestedAge))) {
+            System.out.println("org name");
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowUnnamedTryCatch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowUnnamedTryCatch.java
@@ -1,0 +1,53 @@
+/*
+UnusedLocalVariable
+allowUnnamedVariables = (default)true
+jdkVersion = (default)22
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.stream.Collectors;
+
+public class InputUnusedLocalVariableAllowUnnamedTryCatch {
+        record Point(double x, double y) {}
+    record UniqueRectangle(String id,
+                           Point upperLeft, Point lowerRight) {}
+    record Caller(String phoneNumber) { }
+    static List everyFifthCaller(Queue<Caller> q, int prizes) {
+        var winners = new ArrayList<Caller>();
+        try {
+            while (prizes > 0) {
+                Caller _ = q.remove();
+                winners.add(q.remove());
+                prizes--;
+            }
+        } catch (NoSuchElementException _) {
+
+        }
+        return winners;
+    }
+
+    static void doesFileExist(String path) {
+        try (var _ = new FileReader(path)) {
+            System.out.println("try");
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    static Map getIDs(List<UniqueRectangle> r) {
+        return r.stream()
+                .collect(
+                Collectors.toMap(
+                    UniqueRectangle::id,
+                    _ -> "NODATA"));
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAnonInnerClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAnonInnerClasses.java
@@ -83,5 +83,28 @@ public class InputUnusedLocalVariableAnonInnerClasses {
         protected int m = 11;
         int l = 14;
     }
+         void m() {
+         class InnerClassInMethod { }
+         Object o = new Object() { }; // violation, 'Unused local variable'
 
+         class C {
+             class MemberClass {
+                 class NestedMemberClass { }
+            }
+
+             {
+                 class InnerClassInInit { }
+                 Object o = new Object() { }; // violation, 'Unused local variable'
+             }
+
+             C(Object unused) {
+                 class InnerClassInConstr { }
+                 Object o = new Object() { }; // violation, 'Unused local variable'
+             }
+             void m() {
+                 class InnerClassInMethod { }
+                Object o = new Object() { }; // violation, 'Unused local variable'
+             }
+         }
+     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesAllowUnnamed.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesAllowUnnamed.java
@@ -51,5 +51,22 @@ public class InputUnusedLocalVariablePatternVariablesAllowUnnamed {
         }
     }
 
+   void namedloops() {
+        int[] orderIDs = {34, 45, 23, 27, 15};
+        int total = 0;
+        for (int id : orderIDs) { // violation, unused named local variable 'id'
+            total++;
+        }
+        System.out.println("Total: " + total);
+   }
+   void unnamedloops() {
+        int[] orderIDs = {34, 45, 23, 27, 15};
+        int total = 0;
+        for (int _ : orderIDs) {
+            total++;
+        }
+        System.out.println("Total: " + total);
+   }
+
     void process(Object o) {}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesCondition2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesCondition2.java
@@ -73,4 +73,22 @@ public class InputUnusedLocalVariablePatternVariablesCondition2 {
             }
         }
     }
+
+   void namedloops() {
+        int[] orderIDs = {34, 45, 23, 27, 15};
+        int total = 0;
+        for (int id : orderIDs) { // violation, 'Unused local variable'
+            total++;
+        }
+        System.out.println("Total: " + total);
+   }
+
+   void unnamedloops() {
+        int[] orderIDs = {34, 45, 23, 27, 15};
+        int total = 0;
+        for (int _ : orderIDs) { // violation, unused named local variable '_'
+            total++;
+        }
+        System.out.println("Total: " + total);
+   }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableUnnamedTryCatch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableUnnamedTryCatch.java
@@ -1,0 +1,53 @@
+/*
+UnusedLocalVariable
+allowUnnamedVariables = false
+jdkVersion = (default)22
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.stream.Collectors;
+
+public class InputUnusedLocalVariableUnnamedTryCatch {
+    record Point(double x, double y) {}
+    record UniqueRectangle(String id,
+                       Point upperLeft, Point lowerRight) {}
+    record Caller(String phoneNumber) { }
+    static List everyFifthCaller(Queue<Caller> q, int prizes) {
+        var winners = new ArrayList<Caller>();
+        try {
+            while (prizes > 0) {
+                Caller _ = q.remove(); // violation, unused local variable '_'
+                winners.add(q.remove());
+                prizes--;
+            }
+        } catch (NoSuchElementException _) {
+
+        }
+        return winners;
+    }
+
+    static void doesFileExist(String path) {
+        try (var _ = new FileReader(path)) {
+            System.out.println("try");
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    static Map getIDs(List<UniqueRectangle> r) {
+        return r.stream()
+                .collect(
+                Collectors.toMap(
+                    UniqueRectangle::id,
+                    _ -> "NODATA"));
+    }
+}


### PR DESCRIPTION
Fixes #20490
 Adding support for `instanceof` in jdkversion property.

Diff Regression config: https://gist.githubusercontent.com/ZaheerAhmadDev/ee401562fc60316f636d1e7f77bac085/raw/b63be3029b631a368bc7aa10901c914b653d3eff/check.xml

Diff Regression patch config: https://gist.githubusercontent.com/ZaheerAhmadDev/13a98af5f27abdcd1942860faf3dee0d/raw/3839c1eb0ad8cbe9d7ca91143103faa9e766242f/checkpatch.xml