### PR TITLE
Issue #20523: Fix FinalClass NPE on compact source files

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -4146,14 +4146,14 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference typeDeclarations.peek()</message>
-    <lineContent>.put(ast, typeDeclarations.peek().getQualifiedName());</lineContent>
+    <lineContent>outerTypeDeclarationQualifiedName = typeDeclarations.peek().getQualifiedName();</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference typeDeclarations.peek()</message>
-    <lineContent>outerTypeDeclarationQualifiedName = typeDeclarations.peek().getQualifiedName();</lineContent>
+    <lineContent>outerTypeName = typeDeclarations.peek().getQualifiedName();</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -150,8 +150,12 @@ public class FinalClassCheck
             case TokenTypes.LITERAL_NEW -> {
                 if (ast.getFirstChild() != null
                         && ast.getLastChild().getType() == TokenTypes.OBJBLOCK) {
-                    anonInnerClassToOuterTypeDecl
-                        .put(ast, typeDeclarations.peek().getQualifiedName());
+
+                    String outerTypeName = packageName;
+                    if (!typeDeclarations.isEmpty()) {
+                        outerTypeName = typeDeclarations.peek().getQualifiedName();
+                    }
+                    anonInnerClassToOuterTypeDecl.put(ast, outerTypeName);
                 }
             }
 
@@ -192,18 +196,18 @@ public class FinalClassCheck
         if (TokenUtil.isTypeDeclaration(ast.getType())) {
             typeDeclarations.pop();
         }
-        if (TokenUtil.isRootNode(ast.getParent())) {
-            anonInnerClassToOuterTypeDecl.forEach(this::registerAnonymousInnerClassToSuperClass);
-            // First pass: mark all classes that have derived inner classes
-            innerClasses.forEach(this::registerExtendedClass);
-            // Second pass: report violation for all classes that should be declared as final
-            innerClasses.forEach((qualifiedClassName, classDesc) -> {
-                if (shouldBeDeclaredAsFinal(classDesc)) {
-                    final String className = CommonUtil.baseClassName(qualifiedClassName);
-                    log(classDesc.getTypeDeclarationAst(), MSG_KEY, className);
-                }
-            });
-        }
+    }
+
+    @Override
+    public void finishTree(DetailAST rootAST) {
+        anonInnerClassToOuterTypeDecl.forEach(this::registerAnonymousInnerClassToSuperClass);
+        innerClasses.forEach(this::registerExtendedClass);
+        innerClasses.forEach((qualifiedClassName, classDesc) -> {
+            if (shouldBeDeclaredAsFinal(classDesc)) {
+                final String className = CommonUtil.baseClassName(qualifiedClassName);
+                log(classDesc.getTypeDeclarationAst(), MSG_KEY, className);
+            }
+        });
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -112,6 +112,27 @@ public class FinalClassCheckTest
     }
 
     @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "19:1: " + getCheckMessage(MSG_KEY, "Bar"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputFinalClassCompactSourceFile.java"),
+                expected);
+    }
+
+    @Test
+    public void testCompactSourceFileAnonymousNestedResolution() throws Exception {
+        final String[] expected = {
+            "12:5: " + getCheckMessage(MSG_KEY, "Inner"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                        "InputFinalClassCompactSourceFileAnonymousNestedResolution.java"),
+                expected);
+    }
+
+    @Test
     public void testFinalClassConstructorInRecord() throws Exception {
 
         final String[] expected = {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassCompactSourceFile.java
@@ -1,0 +1,23 @@
+/*
+FinalClass
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+Runnable r = new Runnable() {
+    public void run() { }
+};
+
+Foo f = new Foo() { };
+
+class Foo {
+    private Foo() { }
+}
+
+class Bar { // violation 'Class Bar should be declared as final'
+    private Bar() { }
+}
+
+void main() { }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassCompactSourceFileAnonymousNestedResolution.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassCompactSourceFileAnonymousNestedResolution.java
@@ -1,0 +1,21 @@
+/*
+FinalClass
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+Inner obj = new Inner() { };
+
+class Outer {
+    static class Inner { // violation 'Class Inner should be declared as final'
+        private Inner() { }
+    }
+}
+
+class Inner {
+    private Inner() { }
+}
+
+void main() { }


### PR DESCRIPTION
Fixes #20523

`FinalClass` threw a `NullPointerException` on JEP 512 compact source files when a top-level anonymous class  was present, because such an anonymous class has no enclosing type declaration on the stack.
