### PR TITLE
Issue #20538: Switch from actions/cache to actions/artifact for site generation workflow

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -119,12 +119,13 @@ jobs:
           mvn -e --no-transfer-progress clean site -Pno-validations \
             -Dmaven.javadoc.skip=false -Djdepend.skip=false
 
-      - name: Setup local maven cache
-        uses: actions/cache/save@v6
+      - name: Upload generated site artifact
+        uses: actions/upload-artifact@v7
         with:
+          name: checkstyle-site-artifact-${{ github.run_id }}
           path: .ci-temp/checkstyle/target/site
-          key: checkstyle-site-cache-${{ github.run_id }}
-
+          retention-days: 1
+          if-no-files-found: error
 
   publish_site:
     needs: [ parse_pr_info, generate_site ]
@@ -143,11 +144,11 @@ jobs:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
 
-      - name: Setup local maven cache
-        uses: actions/cache/restore@v6
+      - name: Download generated site artifact
+        uses: actions/download-artifact@v8
         with:
+          name: checkstyle-site-artifact-${{ github.run_id }}
           path: .ci-temp/checkstyle/target/site
-          key: checkstyle-site-cache-${{ github.run_id }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
Part of issue:
- #20538 

Switches from `actions/cache` to `actions/artifact`. `actions/cache` is no longer usable due to security updates from GitHub.

**Proof that it works:**
Did a small test on my fork. Instead of uploading to AWS, I uploaded as a GitHub artifact (again) and posted link to comment:
- https://github.com/stoyanK7/checkstyle/pull/8
- https://github.com/stoyanK7/checkstyle/actions/runs/28677683501/job/85054687148
- <img width="937" height="364" alt="image" src="https://github.com/user-attachments/assets/e6fc28a8-b321-4c03-a7e3-ad86c1a6e58a" />
