### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - javadocconten…

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoccontentlocation.xml
@@ -114,19 +114,18 @@ public void method();
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
-
   // violation below 'Javadoc content should start from the next line.'
-  /** This comment causes a violation because it starts from the first line
-   * and spans several lines.
+  /** This is a multi-line Javadoc.
+   * Additional description.
    */
   private int field1;
 
   /**
-   * This comment is OK because it starts from the second line.
+   * This is another multi-line Javadoc.
    */
-  private int field12;
+  private int field2;
 
-  /** This comment is OK because it is on the single-line. */
+  /** This is a single-line Javadoc. */
   private int field3;
 
 }
@@ -150,18 +149,17 @@ class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
 
-  /** This comment is OK because it starts on the first line.
-   * There may be additional text.
+  /** This is a multi-line Javadoc.
+   * Additional description.
    */
   private int field1;
-
-  // violation below, 'Javadoc content should start from the same line.'
+  // violation below 'Javadoc content should start from the same line.'
   /**
-   * This comment causes a violation because it starts on the second line.
+   * This is another multi-line Javadoc.
    */
   private int field2;
 
-  /** This single-line comment also is OK. */
+  /** This is a single-line Javadoc. */
   private int field3;
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -103,7 +103,6 @@ public class XdocsExamplesAstConsistencyTest {
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
             "checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2",
             "checks/imports/importcontrol/filters/Example9",
-            "checks/javadoc/javadoccontentlocation/Example2",
             "checks/javadoc/javadocleadingasteriskalign/Example2",
             "checks/javadoc/javadocleadingasteriskalign/Example3",
             "checks/javadoc/javadocpackage/legacywithboth/Example3",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckExamplesTest.java
@@ -35,7 +35,7 @@ public class JavadocContentLocationCheckExamplesTest extends AbstractExamplesMod
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "15:3: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
+            "14:3: " + getCheckMessage(MSG_JAVADOC_CONTENT_SECOND_LINE),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -44,7 +44,7 @@ public class JavadocContentLocationCheckExamplesTest extends AbstractExamplesMod
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "22:3: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
+            "21:3: " + getCheckMessage(MSG_JAVADOC_CONTENT_FIRST_LINE),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/Example1.java
@@ -10,19 +10,18 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoccontentlocation;
 
 // xdoc section -- start
 class Example1 {
-
   // violation below 'Javadoc content should start from the next line.'
-  /** This comment causes a violation because it starts from the first line
-   * and spans several lines.
+  /** This is a multi-line Javadoc.
+   * Additional description.
    */
   private int field1;
 
   /**
-   * This comment is OK because it starts from the second line.
+   * This is another multi-line Javadoc.
    */
-  private int field12;
+  private int field2;
 
-  /** This comment is OK because it is on the single-line. */
+  /** This is a single-line Javadoc. */
   private int field3;
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation/Example2.java
@@ -13,18 +13,17 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoccontentlocation;
 // xdoc section -- start
 class Example2 {
 
-  /** This comment is OK because it starts on the first line.
-   * There may be additional text.
+  /** This is a multi-line Javadoc.
+   * Additional description.
    */
   private int field1;
-
-  // violation below, 'Javadoc content should start from the same line.'
+  // violation below 'Javadoc content should start from the same line.'
   /**
-   * This comment causes a violation because it starts on the second line.
+   * This is another multi-line Javadoc.
    */
   private int field2;
 
-  /** This single-line comment also is OK. */
+  /** This is a single-line Javadoc. */
   private int field3;
 
 }


### PR DESCRIPTION
#18435

**Example1.java:**
- Module: `JavadocContentLocation`
- Properties: None (uses default configuration)

**Example2.java:**
- Module: `JavadocContentLocation`
- Properties:
  - `location` = `"first_line"`

Section1 -> Example1,2