### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - todocomment

### DIFF
--- a/src/site/xdoc/checks/misc/todocomment.xml
+++ b/src/site/xdoc/checks/misc/todocomment.xml
@@ -66,7 +66,9 @@ public class Example1 {
   public void test() {
     // violation below 'matches to-do format'
     i++;   // TODO: do differently in future
+
     i++;   // todo: do differently in future
+
     i=i/x; // FIXME: handle x = 0 case
     i=i/x; // FIX :  handle x = 0 case
   }
@@ -89,7 +91,6 @@ public class Example1 {
           Example:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-// violation first line 'matches to-do format'
 public class Example2 {
   int i;
   int x;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -124,8 +124,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/sizes/outertypenumber/Example2",
             "checks/whitespace/singlespaceseparator/Example2",
             "checks/whitespace/typecastparenpad/Example2",
-            "checks/todocomment/Example2",
-            "checks/todocomment/Example3",
             "checks/whitespace/emptyforiteratorpad/Example2",
             "checks/whitespace/parenpad/Example2",
             // Note: customImport/ImportOrder changes import group ORDER affecting AST structure
@@ -275,7 +273,8 @@ public class XdocsExamplesAstConsistencyTest {
             "filters/suppresswithnearbycommentfilter/Example8",
             "filters/suppressioncommentfilter/Example4",
             "filters/suppressioncommentfilter/Example5",
-            "filters/suppressioncommentfilter/Example7"
+            "filters/suppressioncommentfilter/Example7",
+            "checks/todocomment/Example3"
             );
 
     /**

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example1.java
@@ -14,7 +14,9 @@ public class Example1 {
   public void test() {
     // violation below 'matches to-do format'
     i++;   // TODO: do differently in future
+
     i++;   // todo: do differently in future
+
     i=i/x; // FIXME: handle x = 0 case
     i=i/x; // FIX :  handle x = 0 case
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/Example2.java
@@ -10,8 +10,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.todocomment;
 
-// xdoc section -- start
 // violation first line 'matches to-do format'
+// xdoc section -- start
 public class Example2 {
   int i;
   int x;


### PR DESCRIPTION
#18435 



**Example1.java**
- No properties (uses default configuration)

**Example2.java**
- `format`: `(?i)(TODO)|(FIXME)`

**Example3.java**
- `id`: `BoxComments`
- `format`: `^\s*([*=#])\1{8,}\s*$`
- `message key="todo.match"`: `Comment uses box-like repetitive character pattern.`

Section1 -> Example1,2
UseCase -> Example 3