### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - javadocvariable

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml
@@ -132,45 +132,6 @@ public class Example2 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example3-config">
-          To configure the check for fields which are in <code>private</code> or
-          <code>package</code> access modifier:
-        </p>
-
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="JavadocVariable"&gt;
-      &lt;property name="accessModifiers" value="private,package"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example3-code">
-          This setting will report a violation if there is no
-          javadoc for <code>private</code>  or <code>package</code> field.
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example3 {
-  private int a; // violation, 'Missing a Javadoc comment'
-
-  /**
-   * Some description here
-   */
-  private int b;
-  protected int c;
-  public int d;
-  /*package*/ int e; // violation, 'Missing a Javadoc comment'
-
-  public enum PublicEnum {
-    CONSTANT
-  }
-
-  private enum PrivateEnum {
-    CONSTANT // violation, 'Missing a Javadoc comment'
-  }
-}
-</code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
           To ignore absence of Javadoc comments for fields with names <code>log</code> or
           <code>logger</code>:
@@ -211,17 +172,69 @@ public class Example4 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check for fields which are in <code>private</code> or
+          <code>package</code> access modifier:
+        </p>
 
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocVariable"&gt;
+      &lt;property name="accessModifiers" value="private,package"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">
+          This setting will report a violation if there is no
+          javadoc for <code>private</code>  or <code>package</code> field.
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example3 {
+  private int a; // violation, 'Missing a Javadoc comment'
+
+  /**
+   * Some description here
+   */
+  private int b;
+  protected int c;
+  public int d;
+  /*package*/ int e; // violation, 'Missing a Javadoc comment'
+
+  public enum PublicEnum {
+    CONSTANT
+  }
+
+  private enum PrivateEnum {
+    CONSTANT // violation, 'Missing a Javadoc comment'
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check for fields which are in <code>public</code>,
+          <code>protected</code>, <code>package</code> or <code>private</code>
+          access modifier:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocVariable"&gt;
+      &lt;property name="accessModifiers" value="public,protected,package,private"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
         <p id="Example5-code">
           This check will not report a violation for local and
            anonymous inner classes with any configuration.
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example5 {
-  public int variablePublic; // violation, 'Missing a Javadoc comment'
+  public int variablePublic;       // violation, 'Missing a Javadoc comment'
   protected int variableProtected; // violation, 'Missing a Javadoc comment'
-  int variablePackage; // violation, 'Missing a Javadoc comment'
-  private int variablePrivate; // violation, 'Missing a Javadoc comment'
+  int variablePackage;             // violation, 'Missing a Javadoc comment'
+  private int variablePrivate;     // violation, 'Missing a Javadoc comment'
 
   public enum PublicEnum {
     CONSTANT // violation, 'Missing a Javadoc comment'

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
@@ -64,25 +64,6 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example2.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example3-config">
-          To configure the check for fields which are in <code>private</code> or
-          <code>package</code> access modifier:
-        </p>
-
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java"/>
-          <param name="type" value="config"/>
-        </macro>
-        <p id="Example3-code">
-          This setting will report a violation if there is no
-          javadoc for <code>private</code>  or <code>package</code> field.
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
         <p id="Example4-config">
           To ignore absence of Javadoc comments for fields with names <code>log</code> or
           <code>logger</code>:
@@ -103,7 +84,35 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example4.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check for fields which are in <code>private</code> or
+          <code>package</code> access modifier:
+        </p>
 
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">
+          This setting will report a violation if there is no
+          javadoc for <code>private</code>  or <code>package</code> field.
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check for fields which are in <code>public</code>,
+          <code>protected</code>, <code>package</code> or <code>private</code>
+          access modifier:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
         <p id="Example5-code">
           This check will not report a violation for local and
            anonymous inner classes with any configuration.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -108,7 +108,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/javadoc/javadocpackage/legacywithboth/Example3",
             "checks/javadoc/javadocpackage/nonlegacy/Example1",
             "checks/javadoc/javadoctagcontinuationindentation/Example3",
-            "checks/javadoc/javadocvariable/Example5",
             "checks/metrics/classdataabstractioncoupling/Example2",
             "checks/metrics/classdataabstractioncoupling/Example3",
             "checks/metrics/classdataabstractioncoupling/ignore/Example7",
@@ -157,6 +156,8 @@ public class XdocsExamplesAstConsistencyTest {
             // until https://github.com/checkstyle/checkstyle/issues/19891
             "checks/blocks/leftcurly/Example3",
             "checks/naming/patternvariablename/Example3",
+            "checks/javadoc/javadocvariable/Example3",
+            "checks/javadoc/javadocvariable/Example5",
             "checks/whitespace/parenpad/Example3",
             "checks/javadoc/missingjavadoctype/Example5",
             "checks/indentation/commentsindentation/Example3",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckExamplesTest.java
@@ -82,12 +82,12 @@ public class JavadocVariableCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "12:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "13:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "14:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "15:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "17:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example5.java
@@ -1,7 +1,9 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="JavadocVariable"/>
+    <module name="JavadocVariable">
+      <property name="accessModifiers" value="public,protected,package,private"/>
+    </module>
   </module>
 </module>
 */
@@ -9,10 +11,10 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
 
 // xdoc section -- start
 public class Example5 {
-  public int variablePublic; // violation, 'Missing a Javadoc comment'
+  public int variablePublic;       // violation, 'Missing a Javadoc comment'
   protected int variableProtected; // violation, 'Missing a Javadoc comment'
-  int variablePackage; // violation, 'Missing a Javadoc comment'
-  private int variablePrivate; // violation, 'Missing a Javadoc comment'
+  int variablePackage;             // violation, 'Missing a Javadoc comment'
+  private int variablePrivate;     // violation, 'Missing a Javadoc comment'
 
   public enum PublicEnum {
     CONSTANT // violation, 'Missing a Javadoc comment'


### PR DESCRIPTION
#18435 



**Example1.java**
- Default configuration (no properties specified)

**Example2.java**
- `accessModifiers`: `public`

**Example3.java**
- `accessModifiers`: `private,package`

**Example4.java**
- `ignoreNamePattern`: `log|logger`

**Example5.java**
- `accessModifiers`: `public,protected,package,private`

Section 1 -> Example 1,2,4
UseCase -> Example 3, 5