### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - catchparameter

### DIFF
--- a/src/site/xdoc/checks/naming/catchparametername.xml
+++ b/src/site/xdoc/checks/naming/catchparametername.xml
@@ -70,6 +70,7 @@ public class Example1 {
     try {
       throw new InterruptedException();
     } catch (ArithmeticException e) {
+
     } catch (ArrayIndexOutOfBoundsException ex) {
     } catch (IndexOutOfBoundsException e123) {
       // violation above, 'Name 'e123' must match pattern'
@@ -82,6 +83,7 @@ public class Example1 {
     } catch (Exception EighthException) {
       // violation above, 'Name 'EighthException' must match pattern'
     } catch (Throwable t) {
+
     }
   }
 }
@@ -110,9 +112,12 @@ public class Example2 {
       // violation above, 'Name 'e' must match pattern'
     } catch (ArrayIndexOutOfBoundsException ex) {
     } catch (IndexOutOfBoundsException e123) {
+
     } catch (NullPointerException ab) {
+
     } catch (ArrayStoreException abc) {
     } catch (InterruptedException aBC) {
+
     } catch (RuntimeException abC) {
     } catch (Exception EighthException) {
       // violation above, 'Name 'EighthException' must match pattern'

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -118,7 +118,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5",
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
             "checks/modifier/redundantmodifier/Example2",
-            "checks/naming/catchparametername/Example2",
             "checks/naming/methodname/Example4",
             "checks/naming/packagename/Example2",
             "checks/regexp/regexp/Example7",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheckExamplesTest.java
@@ -38,13 +38,13 @@ public class CatchParameterNameCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "18:40: " + getCheckMessage(MSG_INVALID_PATTERN, "e123",
+            "19:40: " + getCheckMessage(MSG_INVALID_PATTERN, "e123",
                     CATCH_PARAM_NAME_PATTERN_1),
-            "20:35: " + getCheckMessage(MSG_INVALID_PATTERN, "ab",
+            "21:35: " + getCheckMessage(MSG_INVALID_PATTERN, "ab",
                     CATCH_PARAM_NAME_PATTERN_1),
-            "23:35: " + getCheckMessage(MSG_INVALID_PATTERN, "aBC",
+            "24:35: " + getCheckMessage(MSG_INVALID_PATTERN, "aBC",
                     CATCH_PARAM_NAME_PATTERN_1),
-            "26:24: " + getCheckMessage(MSG_INVALID_PATTERN, "EighthException",
+            "27:24: " + getCheckMessage(MSG_INVALID_PATTERN, "EighthException",
                     CATCH_PARAM_NAME_PATTERN_1),
         };
 
@@ -56,9 +56,9 @@ public class CatchParameterNameCheckExamplesTest extends AbstractExamplesModuleT
         final String[] expected = {
             "18:34: " + getCheckMessage(MSG_INVALID_PATTERN, "e",
                     CATCH_PARAM_NAME_PATTERN_2),
-            "26:24: " + getCheckMessage(MSG_INVALID_PATTERN, "EighthException",
+            "29:24: " + getCheckMessage(MSG_INVALID_PATTERN, "EighthException",
                     CATCH_PARAM_NAME_PATTERN_2),
-            "28:24: " + getCheckMessage(MSG_INVALID_PATTERN, "t",
+            "31:24: " + getCheckMessage(MSG_INVALID_PATTERN, "t",
                     CATCH_PARAM_NAME_PATTERN_2),
         };
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/Example1.java
@@ -14,6 +14,7 @@ public class Example1 {
     try {
       throw new InterruptedException();
     } catch (ArithmeticException e) {
+
     } catch (ArrayIndexOutOfBoundsException ex) {
     } catch (IndexOutOfBoundsException e123) {
       // violation above, 'Name 'e123' must match pattern'
@@ -26,6 +27,7 @@ public class Example1 {
     } catch (Exception EighthException) {
       // violation above, 'Name 'EighthException' must match pattern'
     } catch (Throwable t) {
+
     }
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/Example2.java
@@ -19,9 +19,12 @@ public class Example2 {
       // violation above, 'Name 'e' must match pattern'
     } catch (ArrayIndexOutOfBoundsException ex) {
     } catch (IndexOutOfBoundsException e123) {
+
     } catch (NullPointerException ab) {
+
     } catch (ArrayStoreException abc) {
     } catch (InterruptedException aBC) {
+
     } catch (RuntimeException abC) {
     } catch (Exception EighthException) {
       // violation above, 'Name 'EighthException' must match pattern'


### PR DESCRIPTION
#18435 



**Example1.java**
- No properties (uses default configuration)

**Example2.java**
- `format`: `^[a-z][a-zA-Z0-9]+$`

Section1 -> Example1,2