### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - whitespaceafter

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -150,10 +150,6 @@
   <suppress checks="FileLength"
     files="illegaltype[\\/]Example\d+.*"/>
 
-  <!-- Example contains important violations that need to be shown -->
-  <suppress checks="FileLength"
-    files="whitespaceafter[\\/]Example1.java"/>
-
   <!-- Examples contains important violations that need to be shown -->
   <suppress checks="FileLength"
     files="javadocparagraph[\\/]Example1.java"/>

--- a/src/site/xdoc/checks/whitespace/whitespaceafter.xml
+++ b/src/site/xdoc/checks/whitespace/whitespaceafter.xml
@@ -139,51 +139,35 @@
         <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
+  int a = 0; int b = 1;
+  int c = 2;int d = 3; // violation 'not followed by whitespace'
+
   void example() throws Exception {
-    if (true) {
-    } else if(false) { // violation 'not followed by whitespace'
-    }
+    if (true) {} else if(false) {} // violation 'not followed by whitespace'
 
-    testOne("x", "y");
-    testOne("z","o"); // violation 'not followed by whitespace'
+    test("a", "b");
+    test("a","b"); // violation 'not followed by whitespace'
 
-    for (int i = 0; i &lt; 10; i++){}
-    for(int i = 0; i &lt; 10; i++){} // violation 'not followed by whitespace'
+    for (int i = 0; i &lt; 1; i++) {}
+    for(int i = 0; i &lt; 1; i++) {} // violation 'not followed by whitespace'
 
     try (InputStream ignored = System.in) {}
     try(InputStream ignored = System.in) {} // violation 'not followed by whitespace'
 
-    try {} catch (Exception e){}
-    try{} catch (Exception e) {} // violation ''try' is not followed by whitespace'
+    try {} catch (Exception e) {}
+    try {} catch(Exception e) {} // violation 'not followed by whitespace'
 
-    try {} finally {}
-    try {} finally{} // violation 'not followed by whitespace'
-
-    try {} catch (Error e){} finally {}
-    try {} catch (Error e){} finally{} // violation 'not followed by whitespace'
-
-    try {} catch (Exception e){}
-    try {} catch(Exception e){} // violation 'not followed by whitespace'
-
-    synchronized (this) { }
-    synchronized(this) { } // violation 'not followed by whitespace'
+    yieldExample();
   }
 
-  public String testOne(String a, String b) {
-    return (a + b);
-  }
-  public String testTwo(String a, String b) {
+  String test(String a, String b) {
     return(a + b); // violation 'not followed by whitespace'
   }
 
-  void switchExample() {
-    int a = switch ("hello") {
-      case "got":
-        yield (1); // ok, followed by whitespace
-      case "my":
-        yield(3); // violation ''yield' is not followed by whitespace'
-      default:
-        yield 2;
+  void yieldExample() {
+    int x = switch ("a") {
+      case "a" -&gt; { yield(1); } // violation ''yield' is not followed by whitespace'
+      default -&gt; { yield 2; }
     };
   }
 }
@@ -205,16 +189,37 @@ class Example1 {
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
-  void example() {
-    int a = 0; int b = 1;
-    int c = 2;int d = 3; // violation 'not followed by whitespace'
+  int a = 0; int b = 1;
+  int c = 2;int d = 3; // violation 'not followed by whitespace'
 
-    testMethod(a, b);
-    testMethod(c,d); // violation 'not followed by whitespace'
+  void example() throws Exception {
+    if (true) {} else if(false) {}
 
-    for(;;) {}
+    test("a", "b");
+    test("a","b"); // violation 'not followed by whitespace'
+
+    for (int i = 0; i &lt; 1; i++) {}
+    for(int i = 0; i &lt; 1; i++) {}
+
+    try (InputStream ignored = System.in) {}
+    try(InputStream ignored = System.in) {}
+
+    try {} catch (Exception e) {}
+    try {} catch(Exception e) {}
+
+    yieldExample();
   }
-  void testMethod(int a, int b) { }
+
+  String test(String a, String b) {
+    return(a + b);
+  }
+
+  void yieldExample() {
+    int x = switch ("a") {
+      case "a" -&gt; { yield(1); }
+      default -&gt; { yield 2; }
+    };
+  }
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -127,7 +127,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/sizes/outertypenumber/Example2",
             "checks/whitespace/singlespaceseparator/Example2",
             "checks/whitespace/typecastparenpad/Example2",
-            "checks/whitespace/whitespaceafter/Example2",
             "checks/todocomment/Example2",
             "checks/todocomment/Example3",
             "checks/whitespace/emptyforiteratorpad/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterExamplesTest.java
@@ -34,17 +34,14 @@ public class WhitespaceAfterExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "19:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "if"),
-            "23:16: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ","),
-            "26:5: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "for"),
-            "29:5: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "try"),
-            "32:5: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "try"),
-            "35:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "finally"),
-            "38:30: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "finally"),
-            "41:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "catch"),
-            "44:5: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "synchronized"),
-            "51:5: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "return"),
-            "59:9: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "yield"),
+            "18:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ";"),
+            "21:23: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "if"),
+            "24:13: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ","),
+            "27:5: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "for"),
+            "30:5: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "try"),
+            "33:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "catch"),
+            "39:5: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "return"),
+            "44:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "yield"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -53,8 +50,8 @@ public class WhitespaceAfterExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "19:14: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ";"),
-            "22:17: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ","),
+            "20:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ";"),
+            "26:13: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ","),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/Example1.java
@@ -14,51 +14,35 @@ import java.io.InputStream;
 
 // xdoc section -- start
 class Example1 {
+  int a = 0; int b = 1;
+  int c = 2;int d = 3; // violation 'not followed by whitespace'
+
   void example() throws Exception {
-    if (true) {
-    } else if(false) { // violation 'not followed by whitespace'
-    }
+    if (true) {} else if(false) {} // violation 'not followed by whitespace'
 
-    testOne("x", "y");
-    testOne("z","o"); // violation 'not followed by whitespace'
+    test("a", "b");
+    test("a","b"); // violation 'not followed by whitespace'
 
-    for (int i = 0; i < 10; i++){}
-    for(int i = 0; i < 10; i++){} // violation 'not followed by whitespace'
+    for (int i = 0; i < 1; i++) {}
+    for(int i = 0; i < 1; i++) {} // violation 'not followed by whitespace'
 
     try (InputStream ignored = System.in) {}
     try(InputStream ignored = System.in) {} // violation 'not followed by whitespace'
 
-    try {} catch (Exception e){}
-    try{} catch (Exception e) {} // violation ''try' is not followed by whitespace'
+    try {} catch (Exception e) {}
+    try {} catch(Exception e) {} // violation 'not followed by whitespace'
 
-    try {} finally {}
-    try {} finally{} // violation 'not followed by whitespace'
-
-    try {} catch (Error e){} finally {}
-    try {} catch (Error e){} finally{} // violation 'not followed by whitespace'
-
-    try {} catch (Exception e){}
-    try {} catch(Exception e){} // violation 'not followed by whitespace'
-
-    synchronized (this) { }
-    synchronized(this) { } // violation 'not followed by whitespace'
+    yieldExample();
   }
 
-  public String testOne(String a, String b) {
-    return (a + b);
-  }
-  public String testTwo(String a, String b) {
+  String test(String a, String b) {
     return(a + b); // violation 'not followed by whitespace'
   }
 
-  void switchExample() {
-    int a = switch ("hello") {
-      case "got":
-        yield (1); // ok, followed by whitespace
-      case "my":
-        yield(3); // violation ''yield' is not followed by whitespace'
-      default:
-        yield 2;
+  void yieldExample() {
+    int x = switch ("a") {
+      case "a" -> { yield(1); } // violation ''yield' is not followed by whitespace'
+      default -> { yield 2; }
     };
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter/Example2.java
@@ -12,17 +12,40 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespaceafter;
 
+import java.io.InputStream;
+
 // xdoc section -- start
 class Example2 {
-  void example() {
-    int a = 0; int b = 1;
-    int c = 2;int d = 3; // violation 'not followed by whitespace'
+  int a = 0; int b = 1;
+  int c = 2;int d = 3; // violation 'not followed by whitespace'
 
-    testMethod(a, b);
-    testMethod(c,d); // violation 'not followed by whitespace'
+  void example() throws Exception {
+    if (true) {} else if(false) {}
 
-    for(;;) {}
+    test("a", "b");
+    test("a","b"); // violation 'not followed by whitespace'
+
+    for (int i = 0; i < 1; i++) {}
+    for(int i = 0; i < 1; i++) {}
+
+    try (InputStream ignored = System.in) {}
+    try(InputStream ignored = System.in) {}
+
+    try {} catch (Exception e) {}
+    try {} catch(Exception e) {}
+
+    yieldExample();
   }
-  void testMethod(int a, int b) { }
+
+  String test(String a, String b) {
+    return(a + b);
+  }
+
+  void yieldExample() {
+    int x = switch ("a") {
+      case "a" -> { yield(1); }
+      default -> { yield 2; }
+    };
+  }
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 


**Example1.java**
- No properties (uses default configuration)

**Example2.java**
- `tokens`: `COMMA, SEMI`

Section1 -> Example1,2