### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - redundantmodi…

### DIFF
--- a/src/site/xdoc/checks/modifier/redundantmodifier.xml
+++ b/src/site/xdoc/checks/modifier/redundantmodifier.xml
@@ -235,7 +235,6 @@ public class ClassExtending extends ClassExample {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
-
   void test() {
     // violation below, 'Redundant 'final' modifier'
     try (final var a = lock()) {
@@ -244,7 +243,6 @@ public class Example1 {
 
     }
   }
-
   // violation below, 'Redundant 'abstract' modifier'
   abstract interface I {
     public abstract void m();
@@ -255,16 +253,14 @@ public class Example1 {
   }
 
   static enum E { // violation, 'Redundant 'static' modifier'
-        A, B, C
+    A, B, C
   }
-
   // violation below, 'Redundant 'strictfp' modifier'
   public strictfp class Test { }
 
   AutoCloseable lock() {
     return null;
   }
-
 }
 </code></pre></div><hr class="example-separator"/>
 
@@ -285,8 +281,8 @@ public class Example1 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
-
   void test() {
+
     try (final var a = lock()) {
 
     } catch (Exception e) {
@@ -303,7 +299,7 @@ public class Example2 {
   }
 
   static enum E {
-        A, B, C
+    A, B, C
   }
 
   public strictfp class Test { }
@@ -330,7 +326,6 @@ public class Example2 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example3 {
-
   void test() {
     // violation below, 'Redundant 'final' modifier'
     try (final var a = lock()) {
@@ -339,7 +334,6 @@ public class Example3 {
 
     }
   }
-
   // violation below, 'Redundant 'abstract' modifier'
   abstract interface I {
     public abstract void m();
@@ -350,16 +344,14 @@ public class Example3 {
   }
 
   static enum E { // violation, 'Redundant 'static' modifier'
-        A, B, C
+    A, B, C
   }
-
   // ok below, 'strictfp' is not redundant before JDK 17
   public strictfp class Test { }
 
   AutoCloseable lock() {
     return null;
   }
-
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -116,7 +116,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/Example9",
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5",
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
-            "checks/modifier/redundantmodifier/Example2",
             "checks/naming/methodname/Example4",
             "checks/naming/packagename/Example2",
             "checks/regexp/regexp/Example7",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckExamplesTest.java
@@ -34,13 +34,13 @@ public class RedundantModifierCheckExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "16:10: " + getCheckMessage(MSG_KEY, "final"),
-            "24:3: " + getCheckMessage(MSG_KEY, "abstract"),
-            "25:5: " + getCheckMessage(MSG_KEY, "public"),
-            "25:12: " + getCheckMessage(MSG_KEY, "abstract"),
-            "29:5: " + getCheckMessage(MSG_KEY, "public"),
-            "32:3: " + getCheckMessage(MSG_KEY, "static"),
-            "37:10: " + getCheckMessage(MSG_KEY, "strictfp"),
+            "15:10: " + getCheckMessage(MSG_KEY, "final"),
+            "22:3: " + getCheckMessage(MSG_KEY, "abstract"),
+            "23:5: " + getCheckMessage(MSG_KEY, "public"),
+            "23:12: " + getCheckMessage(MSG_KEY, "abstract"),
+            "27:5: " + getCheckMessage(MSG_KEY, "public"),
+            "30:3: " + getCheckMessage(MSG_KEY, "static"),
+            "34:10: " + getCheckMessage(MSG_KEY, "strictfp"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -59,12 +59,12 @@ public class RedundantModifierCheckExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "18:10: " + getCheckMessage(MSG_KEY, "final"),
-            "26:3: " + getCheckMessage(MSG_KEY, "abstract"),
-            "27:5: " + getCheckMessage(MSG_KEY, "public"),
-            "27:12: " + getCheckMessage(MSG_KEY, "abstract"),
-            "31:5: " + getCheckMessage(MSG_KEY, "public"),
-            "34:3: " + getCheckMessage(MSG_KEY, "static"),
+            "17:10: " + getCheckMessage(MSG_KEY, "final"),
+            "24:3: " + getCheckMessage(MSG_KEY, "abstract"),
+            "25:5: " + getCheckMessage(MSG_KEY, "public"),
+            "25:12: " + getCheckMessage(MSG_KEY, "abstract"),
+            "29:5: " + getCheckMessage(MSG_KEY, "public"),
+            "32:3: " + getCheckMessage(MSG_KEY, "static"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/Example1.java
@@ -10,7 +10,6 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 
 // xdoc section -- start
 public class Example1 {
-
   void test() {
     // violation below, 'Redundant 'final' modifier'
     try (final var a = lock()) {
@@ -19,7 +18,6 @@ public class Example1 {
 
     }
   }
-
   // violation below, 'Redundant 'abstract' modifier'
   abstract interface I {
     public abstract void m();
@@ -30,15 +28,13 @@ public class Example1 {
   }
 
   static enum E { // violation, 'Redundant 'static' modifier'
-        A, B, C
+    A, B, C
   }
-
   // violation below, 'Redundant 'strictfp' modifier'
   public strictfp class Test { }
 
   AutoCloseable lock() {
     return null;
   }
-
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/Example2.java
@@ -12,8 +12,8 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 
 // xdoc section -- start
 public class Example2 {
-
   void test() {
+
     try (final var a = lock()) {
 
     } catch (Exception e) {
@@ -30,7 +30,7 @@ public class Example2 {
   }
 
   static enum E {
-        A, B, C
+    A, B, C
   }
 
   public strictfp class Test { }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/Example3.java
@@ -12,7 +12,6 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 
 // xdoc section -- start
 public class Example3 {
-
   void test() {
     // violation below, 'Redundant 'final' modifier'
     try (final var a = lock()) {
@@ -21,7 +20,6 @@ public class Example3 {
 
     }
   }
-
   // violation below, 'Redundant 'abstract' modifier'
   abstract interface I {
     public abstract void m();
@@ -32,15 +30,13 @@ public class Example3 {
   }
 
   static enum E { // violation, 'Redundant 'static' modifier'
-        A, B, C
+    A, B, C
   }
-
   // ok below, 'strictfp' is not redundant before JDK 17
   public strictfp class Test { }
 
   AutoCloseable lock() {
     return null;
   }
-
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435

**Example1.java**
- No properties (uses default configuration)

**Example2.java**
- `tokens`: `METHOD_DEF`

**Example3.java**
- `jdkVersion`: `11`

Section1 -> Example 1,2,3