### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - packagename

### DIFF
--- a/src/site/xdoc/checks/naming/packagename.xml
+++ b/src/site/xdoc/checks/naming/packagename.xml
@@ -81,7 +81,6 @@ public class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.naming.packagename;
 // violation above 'must match pattern'
-
 public class Example2 {
 }
 </code></pre></div>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -117,7 +117,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5",
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
             "checks/naming/methodname/Example4",
-            "checks/naming/packagename/Example2",
             "checks/regexp/regexp/Example7",
             "checks/regexp/regexpmultiline/Example5",
             "checks/sizes/lambdabodylength/Example2",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/packagename/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/packagename/Example2.java
@@ -12,7 +12,6 @@
 // xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.naming.packagename;
 // violation above 'must match pattern'
-
 public class Example2 {
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435

**Example1.java**
- Default configuration (no properties specified)

**Example2.java**
- `format`: `^[A-Z]+(\.[a-z][a-z0-9]*)*$`

Section1-> Example 1,2