### PR TITLE
checkstyle#18435: Fix xdocs Examples AST Consistency Test - legacywithboth

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -104,7 +104,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2",
             "checks/javadoc/javadocleadingasteriskalign/Example2",
             "checks/javadoc/javadocleadingasteriskalign/Example3",
-            "checks/javadoc/javadocpackage/legacywithboth/Example3",
             "checks/javadoc/javadocpackage/nonlegacy/Example1",
             "checks/javadoc/javadoctagcontinuationindentation/Example3",
             "checks/javadoc/javadocvariable/Example5",


### PR DESCRIPTION
#18435 

Example3 -> allowLegacy

Section1 -> Example3
