### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - regexp

### DIFF
--- a/src/site/xdoc/checks/regexp/regexp.xml
+++ b/src/site/xdoc/checks/regexp/regexp.xml
@@ -217,8 +217,8 @@ public class Example6 {
 // This code is copyrighted.
 public class Example7 {
 
-  private void foo() {
-    System.out.println(""); // violation, 'Line matches the illegal pattern'
+  private void foo() {  // violation below 'Line matches the illegal pattern'
+    System.out.println("");
     // System.out.println("debug");
     // fix me.
     // fix me.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -111,7 +111,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/Example9",
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5",
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
-            "checks/regexp/regexp/Example7",
             "checks/sizes/outertypenumber/Example2",
             "checks/whitespace/parenpad/Example2",
             // Note: customImport/ImportOrder changes import group ORDER affecting AST structure

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example7.java
@@ -20,8 +20,8 @@ package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 // This code is copyrighted.
 public class Example7 {
 
-  private void foo() {
-    System.out.println(""); // violation, 'Line matches the illegal pattern'
+  private void foo() {  // violation below 'Line matches the illegal pattern'
+    System.out.println("");
     // System.out.println("debug");
     // fix me.
     // fix me.


### PR DESCRIPTION
#18435

Example0 — default config (no properties)
Example1 — format (required pattern present) → unique
Example2 — format (same as Example1, missing pattern) → same property, different scenario → Use Case
Example3 — format with multiline \n → same property as Example1 → Use Case
Example4 — format + duplicateLimit → unique (duplicateLimit)
Example5 — format + message → same property as Example1 → Use Case
Example6 — format + illegalPattern=true → unique (illegalPattern)
Example7 — format + illegalPattern=true + ignoreComments=true → unique (ignoreComments)
Example8 — format + illegalPattern=true + message → same as Example5+6 combo → Use Case
Example9 — format + illegalPattern=true → same as Example6 → Use Case
Example10 — format + illegalPattern=true + errorLimit → unique (errorLimit)
Example11 — format multiline → same as Example3 → Use Case

Section 1: Example0, Example1, Example4, Example6, Example7, Example10
Use Cases: Example2, Example3, Example5, Example8, Example9, Example11