### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - regexpmultiline

### DIFF
--- a/src/site/xdoc/checks/regexp/regexpmultiline.xml
+++ b/src/site/xdoc/checks/regexp/regexpmultiline.xml
@@ -316,16 +316,16 @@ class Example5 {
     // violation below, 'Line matches the illegal pattern'
     System.out.println("Test #1: this is a test string");
 
-    System.out.println("TEST #2: This is a test string");
+    System.out.println("TeSt #2: This is a test string");
 
     System.out.println("TEST #3: This is a test string");
     int i = 5;
 
     System.out.println("Value of i: " + i);
     // violation below, 'Line matches the illegal pattern'
-    System.out.println("Test #3: This is a test string");
-    // violation below, 'Line matches the illegal pattern'
     System.out.println("Test #4: This is a test string");
+
+    System.out.println("TEst #5: This is a test string");
   }
 }
 </code></pre></div><hr class="example-separator"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -117,7 +117,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
             "checks/naming/methodname/Example4",
             "checks/regexp/regexp/Example7",
-            "checks/regexp/regexpmultiline/Example5",
             "checks/sizes/lambdabodylength/Example2",
             "checks/sizes/outertypenumber/Example2",
             "checks/whitespace/singlespaceseparator/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckExamplesTest.java
@@ -80,7 +80,6 @@ public class RegexpMultilineCheckExamplesTest extends AbstractExamplesModuleTest
         final String[] expected = {
             "30: " + getCheckMessage(MSG_ILLEGAL_REGEXP, "Test #[0-9]+:[A-Za-z ]+"),
             "39: " + getCheckMessage(MSG_ILLEGAL_REGEXP, "Test #[0-9]+:[A-Za-z ]+"),
-            "41: " + getCheckMessage(MSG_ILLEGAL_REGEXP, "Test #[0-9]+:[A-Za-z ]+"),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example5.java
@@ -29,16 +29,16 @@ class Example5 {
     // violation below, 'Line matches the illegal pattern'
     System.out.println("Test #1: this is a test string");
 
-    System.out.println("TEST #2: This is a test string");
+    System.out.println("TeSt #2: This is a test string");
 
     System.out.println("TEST #3: This is a test string");
     int i = 5;
 
     System.out.println("Value of i: " + i);
     // violation below, 'Line matches the illegal pattern'
-    System.out.println("Test #3: This is a test string");
-    // violation below, 'Line matches the illegal pattern'
     System.out.println("Test #4: This is a test string");
+
+    System.out.println("TEst #5: This is a test string");
   }
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 



**Example1.java**
- Default configuration (no properties specified)

**Example2.java**
- `format`: `System\.(out)|(err)\.print(ln)?\(`

**Example3.java**
- `matchAcrossLines`: `true`
- `format`: `System\.out.*?print\(`

**Example4.java**
- `format`: `Test #[0-9]+:[A-Za-z ]+`
- `ignoreCase`: `true`
- `maximum`: `3`

**Example5.java**
- `format`: `Test #[0-9]+:[A-Za-z ]+`
- `minimum`: `2`


Section1 -> Example 1,2,3,4.5