### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - lambdabodylength

### DIFF
--- a/src/site/xdoc/checks/sizes/lambdabodylength.xml
+++ b/src/site/xdoc/checks/sizes/lambdabodylength.xml
@@ -58,16 +58,11 @@
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
-  Runnable r = () -&gt; { // ok, length is 10
-    System.out.println(2); // line 2 of lambda
+  Runnable r = () -&gt; { // ok, length is 5
+    System.out.println(2);
     System.out.println(3);
     System.out.println(4);
-    System.out.println(5);
-    System.out.println(6);
-    System.out.println(7);
-    System.out.println(8);
-    System.out.println(9);
-  }; // line 10
+  };
   // violation below 'Lambda body length is 11 lines (max allowed is 10).'
   Runnable r2 = () -&gt; {
     System.out.println(2); // line 2 of lambda
@@ -117,21 +112,31 @@ class Example2 {
     System.out.println(3);
     System.out.println(4);
   };
-  // violation below 'Lambda body length is 6 lines (max allowed is 5).'
+  // violation below 'Lambda body length is 11 lines (max allowed is 5).'
   Runnable r2 = () -&gt; {
     System.out.println(2); // line 2 of lambda
     System.out.println(3);
     System.out.println(4);
     System.out.println(5);
-  };
-  // violation below 'Lambda body length is 6 lines (max allowed is 5).'
+    System.out.println(6);
+    System.out.println(7);
+    System.out.println(8);
+    System.out.println(9);
+    System.out.println(10);
+  }; // line 11
+  // violation below 'Lambda body length is 11 lines (max allowed is 5).'
   Runnable r3 = () -&gt;
-    "someString".concat("1")
+    "someString".concat("1") // line 1 of lambda
                 .concat("2")
                 .concat("3")
                 .concat("4")
                 .concat("5")
-                .concat("6");
+                .concat("6")
+                .concat("7")
+                .concat("8")
+                .concat("9")
+                .concat("10")
+                .concat("11"); // line 11
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -113,7 +113,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5",
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
             "checks/regexp/regexp/Example7",
-            "checks/sizes/lambdabodylength/Example2",
             "checks/sizes/outertypenumber/Example2",
             "checks/whitespace/singlespaceseparator/Example2",
             "checks/whitespace/typecastparenpad/Example2",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LambdaBodyLengthExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LambdaBodyLengthExamplesTest.java
@@ -36,8 +36,8 @@ public class LambdaBodyLengthExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "26:20: " + getCheckMessage(MSG_KEY, 11, DEFAULT_MAX),
-            "38:20: " + getCheckMessage(MSG_KEY, 11, DEFAULT_MAX),
+            "21:20: " + getCheckMessage(MSG_KEY, 11, DEFAULT_MAX),
+            "33:20: " + getCheckMessage(MSG_KEY, 11, DEFAULT_MAX),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -48,8 +48,8 @@ public class LambdaBodyLengthExamplesTest extends AbstractExamplesModuleTestSupp
         final int max = 5;
 
         final String[] expected = {
-            "23:20: " + getCheckMessage(MSG_KEY, 6, max),
-            "30:20: " + getCheckMessage(MSG_KEY, 6, max),
+            "23:20: " + getCheckMessage(MSG_KEY, 11, max),
+            "35:20: " + getCheckMessage(MSG_KEY, 11, max),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/lambdabodylength/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/lambdabodylength/Example1.java
@@ -12,16 +12,11 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.lambdabodylength;
 
 // xdoc section -- start
 class Example1 {
-  Runnable r = () -> { // ok, length is 10
-    System.out.println(2); // line 2 of lambda
+  Runnable r = () -> { // ok, length is 5
+    System.out.println(2);
     System.out.println(3);
     System.out.println(4);
-    System.out.println(5);
-    System.out.println(6);
-    System.out.println(7);
-    System.out.println(8);
-    System.out.println(9);
-  }; // line 10
+  };
   // violation below 'Lambda body length is 11 lines (max allowed is 10).'
   Runnable r2 = () -> {
     System.out.println(2); // line 2 of lambda

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/lambdabodylength/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/lambdabodylength/Example2.java
@@ -19,20 +19,30 @@ class Example2 {
     System.out.println(3);
     System.out.println(4);
   };
-  // violation below 'Lambda body length is 6 lines (max allowed is 5).'
+  // violation below 'Lambda body length is 11 lines (max allowed is 5).'
   Runnable r2 = () -> {
     System.out.println(2); // line 2 of lambda
     System.out.println(3);
     System.out.println(4);
     System.out.println(5);
-  };
-  // violation below 'Lambda body length is 6 lines (max allowed is 5).'
+    System.out.println(6);
+    System.out.println(7);
+    System.out.println(8);
+    System.out.println(9);
+    System.out.println(10);
+  }; // line 11
+  // violation below 'Lambda body length is 11 lines (max allowed is 5).'
   Runnable r3 = () ->
-    "someString".concat("1")
+    "someString".concat("1") // line 1 of lambda
                 .concat("2")
                 .concat("3")
                 .concat("4")
                 .concat("5")
-                .concat("6");
+                .concat("6")
+                .concat("7")
+                .concat("8")
+                .concat("9")
+                .concat("10")
+                .concat("11"); // line 11
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

**Example1.java config properties:**
- None (using default values)

**Example2.java config properties:**
- `max`: `5`

Section1 -> Example1,2