### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - typecastparenpad

### DIFF
--- a/src/site/xdoc/checks/whitespace/typecastparenpad.xml
+++ b/src/site/xdoc/checks/whitespace/typecastparenpad.xml
@@ -53,17 +53,21 @@
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
-  float f1 = 3.14f;
+  double d = 3.14;
 
-  int n = ( int ) f1; // 2 violations
+  int a = ( int ) d;  // 2 violations
 
-  double d = 1.234567;
+  int b = (int ) d;   // violation 'preceded with whitespace'
 
-  float f2 = (float ) d; // violation 'preceded with whitespace'
+  int c = ( int) d;   // violation 'followed by whitespace'
 
-  float f3 = (float) d;
+  int e = (int) d;
 
-  float f4 = ( float) d; // violation 'followed by whitespace'
+  double d2 = 9.8;
+
+  int f = (int) d2;
+
+  int g = ( int ) d2; // 2 violations
 }
 </code></pre></div><hr class="example-separator"/>
 
@@ -84,17 +88,21 @@ class Example1 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
-  double d1 = 3.14;
+  double d = 3.14;
 
-  int n = ( int ) d1;
+  int a = ( int ) d;
 
-  int m = (int ) d1; // violation 'not followed by whitespace'
+  int b = (int ) d; // violation 'not followed by whitespace'
+
+  int c = ( int) d; // violation 'not preceded with whitespace'
+
+  int e = (int) d;  // 2 violations
 
   double d2 = 9.8;
 
-  int x = (int) d2; // 2 violations
+  int f = (int) d2; // 2 violations
 
-  int y = ( int) d2; // violation 'not preceded with whitespace'
+  int g = ( int ) d2;
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -121,7 +121,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/sizes/lambdabodylength/Example2",
             "checks/sizes/outertypenumber/Example2",
             "checks/whitespace/singlespaceseparator/Example2",
-            "checks/whitespace/typecastparenpad/Example2",
             "checks/whitespace/emptyforiteratorpad/Example2",
             "checks/whitespace/parenpad/Example2",
             // Note: customImport/ImportOrder changes import group ORDER affecting AST structure

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadExamplesTest.java
@@ -39,8 +39,10 @@ public class TypecastParenPadExamplesTest extends AbstractExamplesModuleTestSupp
         final String[] expected = {
             "17:11: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
             "17:17: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
-            "21:21: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
-            "25:14: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
+            "19:16: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
+            "21:11: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
+            "29:11: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
+            "29:17: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -50,9 +52,11 @@ public class TypecastParenPadExamplesTest extends AbstractExamplesModuleTestSupp
     public void testExample2() throws Exception {
         final String[] expected = {
             "21:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
+            "23:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
             "25:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
             "25:15: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
-            "27:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "29:11: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
+            "29:15: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example1.java
@@ -12,16 +12,20 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.typecastparenpad;
 
 // xdoc section -- start
 class Example1 {
-  float f1 = 3.14f;
+  double d = 3.14;
 
-  int n = ( int ) f1; // 2 violations
+  int a = ( int ) d;  // 2 violations
 
-  double d = 1.234567;
+  int b = (int ) d;   // violation 'preceded with whitespace'
 
-  float f2 = (float ) d; // violation 'preceded with whitespace'
+  int c = ( int) d;   // violation 'followed by whitespace'
 
-  float f3 = (float) d;
+  int e = (int) d;
 
-  float f4 = ( float) d; // violation 'followed by whitespace'
+  double d2 = 9.8;
+
+  int f = (int) d2;
+
+  int g = ( int ) d2; // 2 violations
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad/Example2.java
@@ -14,16 +14,20 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.typecastparenpad;
 
 // xdoc section -- start
 class Example2 {
-  double d1 = 3.14;
+  double d = 3.14;
 
-  int n = ( int ) d1;
+  int a = ( int ) d;
 
-  int m = (int ) d1; // violation 'not followed by whitespace'
+  int b = (int ) d; // violation 'not followed by whitespace'
+
+  int c = ( int) d; // violation 'not preceded with whitespace'
+
+  int e = (int) d;  // 2 violations
 
   double d2 = 9.8;
 
-  int x = (int) d2; // 2 violations
+  int f = (int) d2; // 2 violations
 
-  int y = ( int) d2; // violation 'not preceded with whitespace'
+  int g = ( int ) d2;
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

**Example1.java config properties:**
- None (using default values)

**Example2.java config properties:**
- `option`: `space`

Section1 -> Example 1,2