### PR TITLE
Issue #20547: fix imported types inside generics

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1387,6 +1387,7 @@ tngtech
 toc
 todo
 todocomment
+tokenization
 tokenizer
 tokentype
 tolist

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -19,8 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -332,12 +334,34 @@ public class UnusedImportsCheck extends AbstractJavadocCheck {
      * @param ast the Javadoc parameter type node
      */
     private void processParameterType(DetailNode ast) {
-        String parameterTypeText = stripTypeArguments(ast.getText());
-        parameterTypeText = topLevelType(parameterTypeText);
-        if (parameterTypeText.endsWith("[]")) {
-            parameterTypeText = parameterTypeText.substring(0, parameterTypeText.length() - 2);
+        addReferencedTypesFromType(ast.getText());
+    }
+
+    /**
+     * Recursively registers all type names referenced in a type string.
+     * Handles generic type arguments, wildcard bounds, and array suffixes.
+     *
+     * @param type the type string to process
+     */
+    private void addReferencedTypesFromType(String type) {
+        String currentType = type;
+        if (currentType.endsWith("[]")) {
+            currentType = currentType.substring(0, currentType.length() - 2);
         }
-        currentFrame.addReferencedType(parameterTypeText);
+        String outerType = stripTypeArguments(currentType);
+        outerType = stripTrailingGt(outerType);
+        outerType = topLevelType(outerType);
+        currentFrame.addReferencedType(outerType);
+        final int openIndex = currentType.indexOf('<');
+        if (openIndex != -1) {
+            final int closeIndex = findMatchingCloseAngle(currentType, openIndex);
+            if (closeIndex != -1) {
+                final String typeArgs = currentType.substring(openIndex + 1, closeIndex);
+                for (String arg : splitTypeArguments(typeArgs)) {
+                    addReferencedTypesFromType(arg);
+                }
+            }
+        }
     }
 
     /**
@@ -385,6 +409,63 @@ public class UnusedImportsCheck extends AbstractJavadocCheck {
         else {
             result = type.substring(0, index);
         }
+        return result;
+    }
+
+    /**
+     * Strips trailing {@code >} characters from a type string.
+     * This handles tokenization artifacts where the closing angle bracket
+     * of an enclosing generic is attached to the last parameter type.
+     *
+     * @param type A type string possibly ending with {@code >}
+     * @return The type string with trailing {@code >} characters removed
+     */
+    private static String stripTrailingGt(String type) {
+        String result = type;
+        while (result.endsWith(">")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+
+    /**
+     * Finds the matching close angle bracket for the angle bracket at the given index.
+     * Correctly handles nested angle brackets by tracking depth.
+     *
+     * @param str the string to search in
+     * @param openIndex the index of the opening angle bracket
+     * @return the index of the matching close angle bracket, or -1 if not found
+     */
+    private static int findMatchingCloseAngle(String str, int openIndex) {
+        int depth = 0;
+        int result = -1;
+        for (int idx = openIndex; idx < str.length(); idx++) {
+            if (str.charAt(idx) == '<') {
+                depth++;
+            }
+            else if (str.charAt(idx) == '>') {
+                depth--;
+                if (depth == 0) {
+                    result = idx;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Splits a type argument string into individual type argument strings.
+     * Comma handling is deferred to a follow-up issue that absorbs commas into
+     * PARAMETER_TYPE; currently commas are token boundaries so only one type
+     * argument ever appears here.
+     *
+     * @param typeArgs the type argument string (content between angle brackets)
+     * @return the list of individual type argument strings
+     */
+    private static List<String> splitTypeArguments(String typeArgs) {
+        final List<String> result = new ArrayList<>();
+        result.add(typeArgs);
         return result;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -153,6 +153,30 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testProcessJavadocWithLinkAndGenericMethodParametersWithInnerTypes()
+            throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedImportsWithLinkAndGenericMethodParameters2.java"), expected);
+    }
+
+    @Test
+    public void testProcessJavadocWithLinkAndGenericMethodParametersWithInnerTypesOnly()
+            throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedImportsWithLinkAndGenericMethodParameters3.java"), expected);
+    }
+
+    @Test
+    public void testProcessJavadocWithLinkAndGenericMethodParametersMultipleArgs()
+            throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedImportsWithLinkAndGenericMethodParameters4.java"), expected);
+    }
+
+    @Test
     public void testAnnotations() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkAndGenericMethodParameters2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkAndGenericMethodParameters2.java
@@ -1,0 +1,28 @@
+/*
+UnusedImports
+processJavadoc = (default)true
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * {@link #method(List<BigDecimal>)}
+ * {@link #method(Set<List<Integer>>)}
+ * {@link #method(Class<? extends BigDecimal>)}
+ * {@link #method(Class<? super RoundingMode>)}
+ */
+public class InputUnusedImportsWithLinkAndGenericMethodParameters2 {
+
+    public int calculate() {
+        return 0;
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkAndGenericMethodParameters3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkAndGenericMethodParameters3.java
@@ -1,0 +1,25 @@
+/*
+UnusedImports
+processJavadoc = (default)true
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * {@link #method(List<DecimalFormat>)}
+ * {@link #method(Set<List<NumberFormat>>)}
+ */
+public class InputUnusedImportsWithLinkAndGenericMethodParameters3 {
+
+    public int calculate() {
+        return 0;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkAndGenericMethodParameters4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsWithLinkAndGenericMethodParameters4.java
@@ -1,0 +1,27 @@
+/*
+UnusedImports
+processJavadoc = (default)true
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.NumberFormat;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * {@link #method(List<BigDecimal>, List<RoundingMode>)}
+ * {@link #method(Set<List<BigDecimal>>, List<NumberFormat>)}
+ * {@link #method(List<BigDecimal>, List<RoundingMode>, List<NumberFormat>)}
+ */
+public class InputUnusedImportsWithLinkAndGenericMethodParameters4 {
+
+    public int calculate() {
+        return 0;
+    }
+}


### PR DESCRIPTION
closes #20547 

 Problem : 
`PARAMETER_TYPE` tokens like `List<BigDecimal>` were processed by `stripTypeArguments` which reduced them to only the outer type (`List`). Imported types appearing inside the angle brackets were silently dropped and reported as unused.

Solution :
Replaced the single-type registration in `processParameterType` with a recursive approach
