### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - singlespacese…

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -124,7 +124,7 @@
     files="avoidstarimport[\\/]Example[1-6].java"/>
 
   <suppress checks="CommentsIndentation"
-    files="singlespaceseparator[\\/]Example2.java"/>
+    files="singlespaceseparator[\\/]Example[12].java"/>
 
   <!-- violation required by to show behavior of Check -->
   <suppress checks="CommentsIndentation"

--- a/src/site/xdoc/checks/whitespace/singlespaceseparator.xml
+++ b/src/site/xdoc/checks/whitespace/singlespaceseparator.xml
@@ -76,12 +76,21 @@ public long toMicros(long d) { return d / (C1 / C0); }
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
   int foo()   { // violation 'Use a single space'
-    return  1; // violation 'Use a single space'
+    return  1;  // violation 'Use a single space'
   }
-  int fun1() {
-    return 3;
-  }
-  void  fun2() {} // violation 'Use a single space'
+
+  void fun1() {}
+  // violation below 'Use a single space'
+  void  fun2() { return; }  /* 2 whitespaces before the comment starts */
+
+  /* 2 whitespaces after the comment ends */  int a;
+
+  String s; /* OK, 1 whitespace */
+
+  /**
+   * This is a Javadoc comment
+   */  int b;
+
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -100,10 +109,13 @@ class Example1 {
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
-  // violation below 'Use a single space'
-  void fun1() {}  // 2 whitespaces before the comment starts
-  // violation below 'Use a single space'
-  void fun2() { return; }  /* 2 whitespaces before the comment starts */
+  int foo()   { // violation 'Use a single space'
+    return  1; // violation 'Use a single space'
+  }
+
+  void fun1() {}
+  // 2 violations below
+  void  fun2() { return; }  /* 2 whitespaces before the comment starts */
   // violation below 'Use a single space'
   /* 2 whitespaces after the comment ends */  int a;
 
@@ -111,13 +123,8 @@ class Example2 {
 
   /**
    * This is a Javadoc comment
-   */  int b; // 2 whitespaces after the javadoc comment ends
+   */  int b;
   // violation above 'Use a single space'
-  float f1;
-
-  /**
-   * OK, 1 white space after the doc comment ends
-   */ float f2;
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -114,7 +114,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
             "checks/regexp/regexp/Example7",
             "checks/sizes/outertypenumber/Example2",
-            "checks/whitespace/singlespaceseparator/Example2",
             "checks/whitespace/emptyforiteratorpad/Example2",
             "checks/whitespace/parenpad/Example2",
             // Note: customImport/ImportOrder changes import group ORDER affecting AST structure

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorExamplesTest.java
@@ -45,10 +45,12 @@ public class SingleSpaceSeparatorExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "18:19: " + getCheckMessage(MSG_KEY),
-            "20:28: " + getCheckMessage(MSG_KEY),
-            "22:47: " + getCheckMessage(MSG_KEY),
-            "28:8: " + getCheckMessage(MSG_KEY),
+            "17:15: " + getCheckMessage(MSG_KEY),
+            "18:13: " + getCheckMessage(MSG_KEY),
+            "23:9: " + getCheckMessage(MSG_KEY),
+            "23:29: " + getCheckMessage(MSG_KEY),
+            "25:47: " + getCheckMessage(MSG_KEY),
+            "31:8: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example1.java
@@ -13,11 +13,20 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.singlespaceseparator;
 // xdoc section -- start
 class Example1 {
   int foo()   { // violation 'Use a single space'
-    return  1; // violation 'Use a single space'
+    return  1;  // violation 'Use a single space'
   }
-  int fun1() {
-    return 3;
-  }
-  void  fun2() {} // violation 'Use a single space'
+
+  void fun1() {}
+  // violation below 'Use a single space'
+  void  fun2() { return; }  /* 2 whitespaces before the comment starts */
+
+  /* 2 whitespaces after the comment ends */  int a;
+
+  String s; /* OK, 1 whitespace */
+
+  /**
+   * This is a Javadoc comment
+   */  int b;
+
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example2.java
@@ -14,10 +14,13 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.singlespaceseparator;
 
 // xdoc section -- start
 class Example2 {
-  // violation below 'Use a single space'
-  void fun1() {}  // 2 whitespaces before the comment starts
-  // violation below 'Use a single space'
-  void fun2() { return; }  /* 2 whitespaces before the comment starts */
+  int foo()   { // violation 'Use a single space'
+    return  1; // violation 'Use a single space'
+  }
+
+  void fun1() {}
+  // 2 violations below
+  void  fun2() { return; }  /* 2 whitespaces before the comment starts */
   // violation below 'Use a single space'
   /* 2 whitespaces after the comment ends */  int a;
 
@@ -25,12 +28,7 @@ class Example2 {
 
   /**
    * This is a Javadoc comment
-   */  int b; // 2 whitespaces after the javadoc comment ends
+   */  int b;
   // violation above 'Use a single space'
-  float f1;
-
-  /**
-   * OK, 1 white space after the doc comment ends
-   */ float f2;
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435

**Example1.java config properties:**
- None (using default values)

**Example2.java config properties:**
- `validateComments`: `true`

Section1 -> Example 1,2