### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - emptyforiterator

### DIFF
--- a/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml
+++ b/src/site/xdoc/checks/whitespace/emptyforiteratorpad.xml
@@ -61,9 +61,9 @@ class Example1 {
   Map&lt;String, String&gt; map = new HashMap&lt;&gt;();
   void example() {
     for (Iterator it = map.entrySet().iterator();  it.hasNext(););
+
     for (Iterator it = map.entrySet().iterator();  it.hasNext(); );
     // violation above '';' is followed by whitespace'
-
     for (Iterator foo = map.entrySet().iterator();
          foo.hasNext();
          );

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -114,7 +114,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
             "checks/regexp/regexp/Example7",
             "checks/sizes/outertypenumber/Example2",
-            "checks/whitespace/emptyforiteratorpad/Example2",
             "checks/whitespace/parenpad/Example2",
             // Note: customImport/ImportOrder changes import group ORDER affecting AST structure
             "checks/imports/customimportorder/Example10",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadExamplesTest.java
@@ -35,7 +35,7 @@ public class EmptyForIteratorPadExamplesTest extends AbstractExamplesModuleTestS
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "22:66: " + getCheckMessage(MSG_WS_FOLLOWED, ";"),
+            "23:66: " + getCheckMessage(MSG_WS_FOLLOWED, ";"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/Example1.java
@@ -19,9 +19,9 @@ class Example1 {
   Map<String, String> map = new HashMap<>();
   void example() {
     for (Iterator it = map.entrySet().iterator();  it.hasNext(););
+
     for (Iterator it = map.entrySet().iterator();  it.hasNext(); );
     // violation above '';' is followed by whitespace'
-
     for (Iterator foo = map.entrySet().iterator();
          foo.hasNext();
          );


### PR DESCRIPTION
#18435


**Example1.java config properties:**
- None (using default values)

**Example2.java config properties:**
- `option`: `space`

Section1 -> Example 1,2