### PR TITLE
 Issue #18435: Fix xdocs Examples AST Consistency Test - javadoctagcontinuationindentation

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctagcontinuationindentation.xml
@@ -200,7 +200,6 @@ class Example2 {
    */
 class Example3 {
   // violation 3 lines above 'Unclosed HTML tag found: a'
-
   /**
    * @param input comment with
    *     indentation spacing for the tag

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -104,7 +104,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/coding/unnecessarysemicolonafteroutertypedeclaration/Example2",
             "checks/javadoc/javadocleadingasteriskalign/Example2",
             "checks/javadoc/javadocleadingasteriskalign/Example3",
-            "checks/javadoc/javadoctagcontinuationindentation/Example3",
             "checks/metrics/classdataabstractioncoupling/Example2",
             "checks/metrics/classdataabstractioncoupling/Example3",
             "checks/metrics/classdataabstractioncoupling/ignore/Example7",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckExamplesTest.java
@@ -61,11 +61,11 @@ public class JavadocTagContinuationIndentationCheckExamplesTest
     public void testExample3() throws Exception {
         final String[] expected = {
             "14: " + getCheckMessage(MSG_KEY_UNCLOSED_HTML_TAG, "a"),
-            "28: " + getCheckMessage(MSG_KEY, 4),
+            "27: " + getCheckMessage(MSG_KEY, 4),
+            "44: " + getCheckMessage(MSG_KEY, 4),
             "45: " + getCheckMessage(MSG_KEY, 4),
             "46: " + getCheckMessage(MSG_KEY, 4),
             "47: " + getCheckMessage(MSG_KEY, 4),
-            "48: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/Example3.java
@@ -15,7 +15,6 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationind
    */
 class Example3 {
   // violation 3 lines above 'Unclosed HTML tag found: a'
-
   /**
    * @param input comment with
    *     indentation spacing for the tag


### PR DESCRIPTION
#18435

**Example1.java config properties:**
- None (using default values)

**Example2.java config properties:**
- `offset`: `2`

**Example3.java config properties:**
- `violateExecutionOnNonTightHtml`: `true`

Section1 -> Example 1,2,3