### PR TITLE
Issue #18435: Fix xdocs Examples AST Consistency Test - classabstract…

### DIFF
--- a/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
+++ b/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
@@ -129,33 +129,26 @@
           The check passes without violations in the following:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation below, "Class Data Abstraction Coupling is 9 (max allowed is 7)."
 public class Example1 {
-  private Set&lt;Object&gt; set = new HashSet&lt;&gt;(); // Ignored by default
-  private Map&lt;Object,Object&gt; map = new HashMap&lt;&gt;(); // Ignored by default
-  private Object object = new Object(); // Ignored by default
+  private Set&lt;Object&gt; set = new HashSet&lt;&gt;();         // ok, ignored
+  private Map&lt;Object, Object&gt; map = new HashMap&lt;&gt;(); // ok, ignored
+  private Object object = new Object();              // ok, ignored
 
-  private Instant instant = Instant.now(); // Counted 1
-  private LocalTime localTime = LocalTime.now(); // Counted 2
-}
-</code></pre></div><hr class="example-separator"/>
+  private AtomicInteger atomicInteger = new AtomicInteger();
+  private BigInteger bigInteger = new BigInteger("0");
+  private BigDecimal bigDecimal = new BigDecimal("0");
+  private MathContext mathContext = new MathContext(0);
 
-        <p id="Example2-code">
-          The check results in a violation in the following:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-// violation below, "Class Data Abstraction Coupling is 8 (max allowed is 7)."
-public class Example2 {
-  Set set = new HashSet(); // Ignored by default
-  Map map = new HashMap(); // Ignored by default
+  private Example1 example1 = new Example1(); // ok, ignored
+  private Example2 example2 = new Example2();
 
-  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
-  BigInteger bigInteger = new BigInteger("0");
-  Example1 example1 = new Example1();
-  Example3 example3 = new Example3();
-  Example4 example4 = new Example4();
-  Example5 example5 = new Example5();
-  Example6 example6 = new Example6();
-  Example7 example7 = new Example7(); // Counted 8
+  private ByteArrayInputStream byteArrayInputStream =
+          new ByteArrayInputStream(new byte[1]);
+  private CharArrayWriter charArrayWriter = new CharArrayWriter();
+
+  private PipedReader pipedReader = new PipedReader();
+  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
 }
 </code></pre></div><hr class="example-separator"/>
 
@@ -166,7 +159,7 @@ public class Example2 {
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ClassDataAbstractionCoupling"&gt;
-      &lt;property name="max" value="2"/&gt;
+      &lt;property name="max" value="9"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -179,25 +172,26 @@ public class Example2 {
           The check passes without violations in the following:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation below, "Class Data Abstraction Coupling is 10 (max allowed is 9)."
 public class Example3 {
-  Set set = new HashSet(); // Ignored by default
-  Map map = new HashMap(); // Ignored by default
-  Instant instant = Instant.now(); // Counted 1
-  LocalTime localTime = LocalTime.now(); // Counted 2
-}
-</code></pre></div><hr class="example-separator"/>
+  private Set&lt;Object&gt; set = new HashSet&lt;&gt;();         // ok, ignored
+  private Map&lt;Object, Object&gt; map = new HashMap&lt;&gt;(); // ok, ignored
+  private Object object = new Object();              // ok, ignored
 
-        <p id="Example4-code">
-          The check results in a violation in the following:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-// violation below, "Class Data Abstraction Coupling is 3 (max allowed is 2)."
-public class Example4 {
-  Set set = new HashSet(); // Ignored by default
-  Map map = new HashMap(); // Ignored by default
-  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
-  BigInteger bigInteger = new BigInteger("0");
-  BigDecimal bigDecimal = new BigDecimal("0"); // Counted 3
+  private AtomicInteger atomicInteger = new AtomicInteger();
+  private BigInteger bigInteger = new BigInteger("0");
+  private BigDecimal bigDecimal = new BigDecimal("0");
+  private MathContext mathContext = new MathContext(0);
+
+  private Example1 example1 = new Example1(); // ok, ignored
+  private Example2 example2 = new Example2();
+
+  private ByteArrayInputStream byteArrayInputStream =
+          new ByteArrayInputStream(new byte[1]);
+  private CharArrayWriter charArrayWriter = new CharArrayWriter();
+
+  private PipedReader pipedReader = new PipedReader();
+  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
 }
 </code></pre></div><hr class="example-separator"/>
 
@@ -222,38 +216,26 @@ public class Example4 {
           The check passes without violations in the following:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation below, "Class Data Abstraction Coupling is 11 (max allowed is 7)."
 public class Example5 {
-  Set set = new HashSet(); // Ignored 1
-  Map map = new HashMap(); // Ignored 2
-  Example1 example1 = new Example1(); // Ignore 3
+  private Set&lt;Object&gt; set = new HashSet&lt;&gt;();         // ok, ignored
+  private Map&lt;Object, Object&gt; map = new HashMap&lt;&gt;(); // ok, ignored
+  private Object object = new Object();              // ok, ignored
 
-  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
-  BigInteger bigInteger = new BigInteger("0");
-  Example2 example2 = new Example2();
-  Example3 example3 = new Example3();
-  Example4 example4 = new Example4();
-  Example6 example6 = new Example6();
-  Example7 example7 = new Example7(); // Counted 7
-}
-</code></pre></div><hr class="example-separator"/>
+  private AtomicInteger atomicInteger = new AtomicInteger();
+  private BigInteger bigInteger = new BigInteger("0");
+  private BigDecimal bigDecimal = new BigDecimal("0");
+  private MathContext mathContext = new MathContext(0);
 
-        <p id="Example6-code">
-          The check results in a violation in the following:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-// violation below, "Class Data Abstraction Coupling is 8 (max allowed is 7)."
-public class Example6 {
-  Set set = new HashSet(); // Ignored by default
-  Map map = new HashMap(); // Ignored by default
+  private Example1 example1 = new Example1();        // ok, ignored
+  private Example2 example2 = new Example2();
 
-  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
-  BigInteger bigInteger = new BigInteger("0");
-  Example2 example2 = new Example2();
-  Example3 example3 = new Example3();
-  Example4 example4 = new Example4();
-  Example5 example5 = new Example5();
-  Example7 example7 = new Example7();
-  Example8 example8 = new Example8(); // Counted 8
+  private ByteArrayInputStream byteArrayInputStream =
+          new ByteArrayInputStream(new byte[1]);
+  private CharArrayWriter charArrayWriter = new CharArrayWriter();
+
+  private PipedReader pipedReader = new PipedReader();
+  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
 }
 </code></pre></div><hr class="example-separator"/>
 
@@ -278,40 +260,27 @@ public class Example6 {
           The check passes without violations in the following:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example7 {
-  Set set = new HashSet(); // Ignored by default
-  Map map = new HashMap(); // Ignored by default
-
-  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
-  BigInteger bigInteger = new BigInteger("0");
-  Example1 example1 = new Example1();
-  Example2 example2 = new Example2();
-  Example3 example3 = new Example3();
-  Example4 example4 = new Example4();
-  Example5 example5 = new Example5(); // Counted 7
-
-  // Ignored using module excludeClassesRegexps property
-  BufferedReader bufferedReader = new BufferedReader(new PipedReader());
-}
-</code></pre></div><hr class="example-separator"/>
-
-        <p id="Example8-code">
-          The check results in a violation in the following:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 // violation below, "Class Data Abstraction Coupling is 8 (max allowed is 7)."
-public class Example8 {
-  Set set = new HashSet(); // Ignored by default
-  Map map = new HashMap(); // Ignored by default
+public class Example7 {
+  private Set&lt;Object&gt; set = new HashSet&lt;&gt;();         // ok, ignored
+  private Map&lt;Object, Object&gt; map = new HashMap&lt;&gt;(); // ok, ignored
+  private Object object = new Object();              // ok, ignored
 
-  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
-  BigInteger bigInteger = new BigInteger("0");
-  BigDecimal bigDecimal = new BigDecimal("0");
-  MathContext mathContext = new MathContext(0);
-  ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(new byte[1]);
-  CharArrayWriter charArrayWriter = new CharArrayWriter();
-  StringWriter stringWriter = new StringWriter();
-  File file = new File("path"); // Counted 8
+  private AtomicInteger atomicInteger = new AtomicInteger();
+  private BigInteger bigInteger = new BigInteger("0");
+  private BigDecimal bigDecimal = new BigDecimal("0");
+  private MathContext mathContext = new MathContext(0);
+
+  private Example1 example1 = new Example1();        // ok, ignored
+  private Example2 example2 = new Example2();
+
+  private ByteArrayInputStream byteArrayInputStream =
+      new ByteArrayInputStream(new byte[1]);
+  private CharArrayWriter charArrayWriter = new CharArrayWriter();
+
+  private PipedReader pipedReader = new PipedReader(); // ok, ignored
+  private BufferedReader bufferedReader =
+      new BufferedReader(pipedReader); // ok, ignored
 }
 </code></pre></div><hr class="example-separator"/>
 
@@ -336,24 +305,167 @@ public class Example8 {
           The check passes without violations in the following:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-import java.io.BufferedReader;
-
 public class Example9 {
+  private Set&lt;Object&gt; set = new HashSet&lt;&gt;();         // ok, ignored
+  private Map&lt;Object, Object&gt; map = new HashMap&lt;&gt;(); // ok, ignored
+  private Object object = new Object();              // ok, ignored
+
+  private AtomicInteger atomicInteger = new AtomicInteger();
+  private BigInteger bigInteger = new BigInteger("0");
+  private BigDecimal bigDecimal = new BigDecimal("0");
+  private MathContext mathContext = new MathContext(0);
+
+  private Example1 example1 = new Example1(); // ok, ignored
+  private Example2 example2 = new Example2();
+
+  private ByteArrayInputStream byteArrayInputStream =
+      new ByteArrayInputStream(new byte[1]); // ok, ignored
+  private CharArrayWriter charArrayWriter = new CharArrayWriter(); // ok, ignored
+
+  private PipedReader pipedReader = new PipedReader(); // ok, ignored
+  private BufferedReader bufferedReader =
+      new BufferedReader(pipedReader); // ok, ignored
+}
+</code></pre></div><hr class="example-separator"/>
+
+        <p id="Example2-config">
+          To configure the check:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ClassDataAbstractionCoupling"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+
+        <p id="Example2-code">
+          The check results in a violation in the following:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation below, "Class Data Abstraction Coupling is 8 (max allowed is 7)."
+public class Example2 {
+  Set set = new HashSet(); // Ignored by default
+  Map map = new HashMap(); // Ignored by default
+
+  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
+  BigInteger bigInteger = new BigInteger("0");
+  Example1 example1 = new Example1();
+  Example3 example3 = new Example3();
+  Example4 example4 = new Example4();
+  Example5 example5 = new Example5();
+  Example6 example6 = new Example6();
+  Example7 example7 = new Example7(); // Counted 8
+}
+</code></pre></div><hr class="example-separator"/>
+
+        <p id="Example4-config">
+          To configure the check with a threshold of 2:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ClassDataAbstractionCoupling"&gt;
+      &lt;property name="max" value="2"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+
+        <p id="Example4-code">
+          The check results in a violation in the following:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation below, "Class Data Abstraction Coupling is 3 (max allowed is 2)."
+public class Example4 {
+  Set set = new HashSet(); // Ignored by default
+  Map map = new HashMap(); // Ignored by default
+  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
+  BigInteger bigInteger = new BigInteger("0");
+  BigDecimal bigDecimal = new BigDecimal("0"); // Counted 3
+}
+</code></pre></div><hr class="example-separator"/>
+
+        <p id="Example6-config">
+          To configure the check with three excluded classes <code>HashMap</code>,
+          <code>HashSet</code> and <code>Example1</code>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ClassDataAbstractionCoupling"&gt;
+      &lt;property name="excludedClasses" value="HashMap, HashSet, Example1"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+
+        <p id="Example6-code">
+          The check results in a violation in the following:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation below, "Class Data Abstraction Coupling is 8 (max allowed is 7)."
+public class Example6 {
+  Set set = new HashSet(); // Ignored by default
+  Map map = new HashMap(); // Ignored by default
+
+  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
+  BigInteger bigInteger = new BigInteger("0");
+  Example2 example2 = new Example2();
+  Example3 example3 = new Example3();
+  Example4 example4 = new Example4();
+  Example5 example5 = new Example5();
+  Example7 example7 = new Example7();
+  Example8 example8 = new Example8(); // Counted 8
+}
+</code></pre></div><hr class="example-separator"/>
+
+        <p id="Example8-config">
+          To configure the check to exclude classes with a regular expression
+          <code>.*Reader$</code>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ClassDataAbstractionCoupling"&gt;
+      &lt;property name="excludeClassesRegexps" value=".*Reader$"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+
+        <p id="Example8-code">
+          The check results in a violation in the following:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation below, "Class Data Abstraction Coupling is 8 (max allowed is 7)."
+public class Example8 {
   Set set = new HashSet(); // Ignored by default
   Map map = new HashMap(); // Ignored by default
 
   AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
   BigInteger bigInteger = new BigInteger("0");
   BigDecimal bigDecimal = new BigDecimal("0");
-  MathContext mathContext = new MathContext(0); // Counted 4
-
-  // Ignored using module excludedPackages property
+  MathContext mathContext = new MathContext(0);
   ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(new byte[1]);
   CharArrayWriter charArrayWriter = new CharArrayWriter();
-  PipedReader pipedReader = new PipedReader();
-  BufferedReader bufferedReader = new BufferedReader(pipedReader);
+  StringWriter stringWriter = new StringWriter();
+  File file = new File("path"); // Counted 8
 }
 </code></pre></div><hr class="example-separator"/>
+
+        <p id="Example10-config">
+          To configure the check with an excluded package <code>java.io</code>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ClassDataAbstractionCoupling"&gt;
+      &lt;property name="excludedPackages" value="java.io"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
 
         <p id="Example10-code">
           The check results in a violation in the following:

--- a/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml.template
+++ b/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml.template
@@ -49,15 +49,6 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
 
-        <p id="Example2-code">
-          The check results in a violation in the following:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example2.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-
         <p id="Example3-config">
           To configure the check with a threshold of 2:
         </p>
@@ -76,15 +67,6 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example3.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-
-        <p id="Example4-code">
-          The check results in a violation in the following:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/deeper/Example4.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
 
@@ -110,15 +92,6 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
 
-        <p id="Example6-code">
-          The check results in a violation in the following:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-
         <p id="Example7-config">
           To configure the check to exclude classes with a regular expression
           <code>.*Reader$</code>:
@@ -138,15 +111,6 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/Example7.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-
-        <p id="Example8-code">
-          The check results in a violation in the following:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/Example8.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
 
@@ -171,6 +135,89 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/Example9.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
+
+        <p id="Example2-config">
+          To configure the check:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+
+        <p id="Example2-code">
+          The check results in a violation in the following:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example2.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+
+        <p id="Example4-config">
+          To configure the check with a threshold of 2:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/deeper/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+
+        <p id="Example4-code">
+          The check results in a violation in the following:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/deeper/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+
+        <p id="Example6-config">
+          To configure the check with three excluded classes <code>HashMap</code>,
+          <code>HashSet</code> and <code>Example1</code>:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6.java"/>
+          <param name="type" value="config"/>
+        </macro>
+
+        <p id="Example6-code">
+          The check results in a violation in the following:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+
+        <p id="Example8-config">
+          To configure the check to exclude classes with a regular expression
+          <code>.*Reader$</code>:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/Example8.java"/>
+          <param name="type" value="config"/>
+        </macro>
+
+        <p id="Example8-code">
+          The check results in a violation in the following:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/Example8.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+
+        <p id="Example10-config">
+          To configure the check with an excluded package <code>java.io</code>:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/Example10.java"/>
+          <param name="type" value="config"/>
+        </macro>
 
         <p id="Example10-code">
           The check results in a violation in the following:

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -101,13 +101,6 @@ public class XdocsExamplesAstConsistencyTest {
      * <p>Until: <a href="https://github.com/checkstyle/checkstyle/issues/18435">...</a>
      */
     private static final Set<String> SUPPRESSED_EXAMPLES = Set.of(
-            "checks/metrics/classdataabstractioncoupling/Example2",
-            "checks/metrics/classdataabstractioncoupling/Example3",
-            "checks/metrics/classdataabstractioncoupling/ignore/Example7",
-            "checks/metrics/classdataabstractioncoupling/ignore/Example8",
-            "checks/metrics/classdataabstractioncoupling/ignore/Example9",
-            "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5",
-            "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
             // Note: customImport/ImportOrder changes import group ORDER affecting AST structure
             "checks/imports/customimportorder/Example10",
             "checks/imports/customimportorder/Example11",
@@ -140,6 +133,12 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/javadoc/javadocvariable/Example3",
             "checks/javadoc/javadocvariable/Example5",
             "checks/whitespace/parenpad/Example3",
+            "checks/metrics/classdataabstractioncoupling/Example2",
+            "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example4",
+            "checks/metrics/classdataabstractioncoupling/ignore/deeper/Example6",
+            "checks/metrics/classdataabstractioncoupling/ignore/Example8",
+            "checks/metrics/classdataabstractioncoupling/ignore/Example10",
+            "checks/metrics/classdataabstractioncoupling/Example11",
             "checks/javadoc/missingjavadoctype/Example5",
             "checks/indentation/commentsindentation/Example3",
             "checks/indentation/commentsindentation/Example4",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckExamplesTest.java
@@ -36,7 +36,21 @@ public class ClassDataAbstractionCouplingCheckExamplesTest
 
     @Test
     public void testExample1() throws Exception {
-        final String[] expected = {};
+        final String expectedClasses = List.of(
+            "AtomicInteger",
+            "BigDecimal",
+            "BigInteger",
+            "BufferedReader",
+            "ByteArrayInputStream",
+            "CharArrayWriter",
+            "Example2",
+            "MathContext",
+            "PipedReader"
+        ).toString();
+
+        final String[] expected = {
+            "26:1: " + getCheckMessage(MSG_KEY, 9, 7, expectedClasses),
+        };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
@@ -63,7 +77,22 @@ public class ClassDataAbstractionCouplingCheckExamplesTest
 
     @Test
     public void testExample3() throws Exception {
-        final String[] expected = {};
+        final String expectedClasses = List.of(
+            "AtomicInteger",
+            "BigDecimal",
+            "BigInteger",
+            "BufferedReader",
+            "ByteArrayInputStream",
+            "CharArrayWriter",
+            "Example1",
+            "Example2",
+            "MathContext",
+            "PipedReader"
+        ).toString();
+
+        final String[] expected = {
+            "28:1: " + getCheckMessage(MSG_KEY, 10, 9, expectedClasses),
+        };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
@@ -79,7 +108,23 @@ public class ClassDataAbstractionCouplingCheckExamplesTest
 
     @Test
     public void testExample5() throws Exception {
-        final String[] expected = {};
+        final String expectedClasses = List.of(
+            "AtomicInteger",
+            "BigDecimal",
+            "BigInteger",
+            "BufferedReader",
+            "ByteArrayInputStream",
+            "CharArrayWriter",
+            "Example2",
+            "MathContext",
+            "Object",
+            "PipedReader",
+            "byte"
+        ).toString();
+
+        final String[] expected = {
+            "32:1: " + getCheckMessage(MSG_KEY, 11, 7, expectedClasses),
+        };
 
         verifyWithInlineConfigParser(getPath("ignore/deeper/Example5.java"), expected);
     }
@@ -106,7 +151,20 @@ public class ClassDataAbstractionCouplingCheckExamplesTest
 
     @Test
     public void testExample7() throws Exception {
-        final String[] expected = {};
+        final String expectedClasses = List.of(
+            "AtomicInteger",
+            "BigDecimal",
+            "BigInteger",
+            "ByteArrayInputStream",
+            "CharArrayWriter",
+            "Example1",
+            "Example2",
+            "MathContext"
+        ).toString();
+
+        final String[] expected = {
+            "31:1: " + getCheckMessage(MSG_KEY, 8, 7, expectedClasses),
+        };
 
         verifyWithInlineConfigParser(getPath("ignore/Example7.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example1.java
@@ -8,20 +8,39 @@
 
 package com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.CharArrayWriter;
+import java.io.PipedReader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.HashMap;
-import java.time.Instant;
-import java.time.LocalTime;
+import java.util.concurrent.atomic.AtomicInteger;
 
 // xdoc section -- start
+// violation below, "Class Data Abstraction Coupling is 9 (max allowed is 7)."
 public class Example1 {
-  private Set<Object> set = new HashSet<>(); // Ignored by default
-  private Map<Object,Object> map = new HashMap<>(); // Ignored by default
-  private Object object = new Object(); // Ignored by default
+  private Set<Object> set = new HashSet<>();         // ok, ignored
+  private Map<Object, Object> map = new HashMap<>(); // ok, ignored
+  private Object object = new Object();              // ok, ignored
 
-  private Instant instant = Instant.now(); // Counted 1
-  private LocalTime localTime = LocalTime.now(); // Counted 2
+  private AtomicInteger atomicInteger = new AtomicInteger();
+  private BigInteger bigInteger = new BigInteger("0");
+  private BigDecimal bigDecimal = new BigDecimal("0");
+  private MathContext mathContext = new MathContext(0);
+
+  private Example1 example1 = new Example1(); // ok, ignored
+  private Example2 example2 = new Example2();
+
+  private ByteArrayInputStream byteArrayInputStream =
+          new ByteArrayInputStream(new byte[1]);
+  private CharArrayWriter charArrayWriter = new CharArrayWriter();
+
+  private PipedReader pipedReader = new PipedReader();
+  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example3.java
@@ -2,7 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="ClassDataAbstractionCoupling">
-      <property name="max" value="2"/>
+      <property name="max" value="9"/>
     </module>
   </module>
 </module>
@@ -10,18 +10,39 @@
 
 package com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling;
 
-import java.util.Map;
-import java.util.HashMap;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.CharArrayWriter;
+import java.io.PipedReader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
 import java.util.Set;
 import java.util.HashSet;
-import java.time.Instant;
-import java.time.LocalTime;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 // xdoc section -- start
+// violation below, "Class Data Abstraction Coupling is 10 (max allowed is 9)."
 public class Example3 {
-  Set set = new HashSet(); // Ignored by default
-  Map map = new HashMap(); // Ignored by default
-  Instant instant = Instant.now(); // Counted 1
-  LocalTime localTime = LocalTime.now(); // Counted 2
+  private Set<Object> set = new HashSet<>();         // ok, ignored
+  private Map<Object, Object> map = new HashMap<>(); // ok, ignored
+  private Object object = new Object();              // ok, ignored
+
+  private AtomicInteger atomicInteger = new AtomicInteger();
+  private BigInteger bigInteger = new BigInteger("0");
+  private BigDecimal bigDecimal = new BigDecimal("0");
+  private MathContext mathContext = new MathContext(0);
+
+  private Example1 example1 = new Example1(); // ok, ignored
+  private Example2 example2 = new Example2();
+
+  private ByteArrayInputStream byteArrayInputStream =
+          new ByteArrayInputStream(new byte[1]);
+  private CharArrayWriter charArrayWriter = new CharArrayWriter();
+
+  private PipedReader pipedReader = new PipedReader();
+  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/Example7.java
@@ -12,33 +12,41 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupl
 
 import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.Example1;
 import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.Example2;
-import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.Example3;
-import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.ignore.deeper.Example4;
-import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.ignore.deeper.Example5;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.CharArrayWriter;
 import java.io.PipedReader;
+import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.HashMap;
+import java.math.MathContext;
+import java.util.Set;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
+import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 // xdoc section -- start
+// violation below, "Class Data Abstraction Coupling is 8 (max allowed is 7)."
 public class Example7 {
-  Set set = new HashSet(); // Ignored by default
-  Map map = new HashMap(); // Ignored by default
+  private Set<Object> set = new HashSet<>();         // ok, ignored
+  private Map<Object, Object> map = new HashMap<>(); // ok, ignored
+  private Object object = new Object();              // ok, ignored
 
-  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
-  BigInteger bigInteger = new BigInteger("0");
-  Example1 example1 = new Example1();
-  Example2 example2 = new Example2();
-  Example3 example3 = new Example3();
-  Example4 example4 = new Example4();
-  Example5 example5 = new Example5(); // Counted 7
+  private AtomicInteger atomicInteger = new AtomicInteger();
+  private BigInteger bigInteger = new BigInteger("0");
+  private BigDecimal bigDecimal = new BigDecimal("0");
+  private MathContext mathContext = new MathContext(0);
 
-  // Ignored using module excludeClassesRegexps property
-  BufferedReader bufferedReader = new BufferedReader(new PipedReader());
+  private Example1 example1 = new Example1();        // ok, ignored
+  private Example2 example2 = new Example2();
+
+  private ByteArrayInputStream byteArrayInputStream =
+      new ByteArrayInputStream(new byte[1]);
+  private CharArrayWriter charArrayWriter = new CharArrayWriter();
+
+  private PipedReader pipedReader = new PipedReader(); // ok, ignored
+  private BufferedReader bufferedReader =
+      new BufferedReader(pipedReader); // ok, ignored
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/Example9.java
@@ -10,35 +10,43 @@
 
 package com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.ignore;
 
+import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.Example1;
+import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.Example2;
+
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.CharArrayWriter;
 import java.io.PipedReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
-import java.util.HashMap;
+import java.util.Set;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
+import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-
 // xdoc section -- start
-import java.io.BufferedReader;
 
 public class Example9 {
-  Set set = new HashSet(); // Ignored by default
-  Map map = new HashMap(); // Ignored by default
+  private Set<Object> set = new HashSet<>();         // ok, ignored
+  private Map<Object, Object> map = new HashMap<>(); // ok, ignored
+  private Object object = new Object();              // ok, ignored
 
-  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
-  BigInteger bigInteger = new BigInteger("0");
-  BigDecimal bigDecimal = new BigDecimal("0");
-  MathContext mathContext = new MathContext(0); // Counted 4
+  private AtomicInteger atomicInteger = new AtomicInteger();
+  private BigInteger bigInteger = new BigInteger("0");
+  private BigDecimal bigDecimal = new BigDecimal("0");
+  private MathContext mathContext = new MathContext(0);
 
-  // Ignored using module excludedPackages property
-  ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(new byte[1]);
-  CharArrayWriter charArrayWriter = new CharArrayWriter();
-  PipedReader pipedReader = new PipedReader();
-  BufferedReader bufferedReader = new BufferedReader(pipedReader);
+  private Example1 example1 = new Example1(); // ok, ignored
+  private Example2 example2 = new Example2();
+
+  private ByteArrayInputStream byteArrayInputStream =
+      new ByteArrayInputStream(new byte[1]); // ok, ignored
+  private CharArrayWriter charArrayWriter = new CharArrayWriter(); // ok, ignored
+
+  private PipedReader pipedReader = new PipedReader(); // ok, ignored
+  private BufferedReader bufferedReader =
+      new BufferedReader(pipedReader); // ok, ignored
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5.java
@@ -12,8 +12,6 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupl
 
 import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.Example1;
 import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.Example2;
-import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.Example3;
-import com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.ignore.Example7;
 
 import java.math.BigInteger;
 import java.util.HashMap;
@@ -22,18 +20,33 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-// xdoc section -- start
-public class Example5 {
-  Set set = new HashSet(); // Ignored 1
-  Map map = new HashMap(); // Ignored 2
-  Example1 example1 = new Example1(); // Ignore 3
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.CharArrayWriter;
+import java.io.PipedReader;
+import java.math.BigDecimal;
+import java.math.MathContext;
 
-  AtomicInteger atomicInteger = new AtomicInteger(); // Counted 1
-  BigInteger bigInteger = new BigInteger("0");
-  Example2 example2 = new Example2();
-  Example3 example3 = new Example3();
-  Example4 example4 = new Example4();
-  Example6 example6 = new Example6();
-  Example7 example7 = new Example7(); // Counted 7
+// xdoc section -- start
+// violation below, "Class Data Abstraction Coupling is 11 (max allowed is 7)."
+public class Example5 {
+  private Set<Object> set = new HashSet<>();         // ok, ignored
+  private Map<Object, Object> map = new HashMap<>(); // ok, ignored
+  private Object object = new Object();              // ok, ignored
+
+  private AtomicInteger atomicInteger = new AtomicInteger();
+  private BigInteger bigInteger = new BigInteger("0");
+  private BigDecimal bigDecimal = new BigDecimal("0");
+  private MathContext mathContext = new MathContext(0);
+
+  private Example1 example1 = new Example1();        // ok, ignored
+  private Example2 example2 = new Example2();
+
+  private ByteArrayInputStream byteArrayInputStream =
+          new ByteArrayInputStream(new byte[1]);
+  private CharArrayWriter charArrayWriter = new CharArrayWriter();
+
+  private PipedReader pipedReader = new PipedReader();
+  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
 }
 // xdoc section -- end


### PR DESCRIPTION
#18435 

- **Example1**: No custom properties (uses default configuration with max=7)
- **Example2**: No custom properties (uses default configuration with max=7)
- **Example3**: `max = 2`
- **Example4**: `max = 2`
- **Example5**: `excludedClasses = "HashMap, HashSet, Example1"`
- **Example6**: `excludedClasses = "HashMap, HashSet, Example1"`
- **Example7**: `excludeClassesRegexps = ".*Reader$"`
- **Example8**: `excludeClassesRegexps = ".*Reader$"`
- **Example9**: `excludedPackages = "java.io"`
- **Example10**: `excludedPackages = "java.io"`
- **Example11**: `excludedPackages = "com.puppycrawl.tools.checkstyle.checks.metrics.classdataabstractioncoupling.ignore"`

Section1 -> Example 1,3,5,7,9
UseCase - Example 2,4,6,8,10,11

