### PR TITLE
Issue #15456: specify violation messages for AtClauseOrderCheck

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -202,5 +202,4 @@
 
   <suppress checks="LineLength"
             files="overloadmethodsdeclarationorder[\\/]Example2.java"/>
-
 </suppressions>

--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml
@@ -148,6 +148,7 @@ public class Example1 {
           Example:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation 11 lines below 'Block tags have to appear in the order'
 /**
 * Some javadoc.
 *
@@ -158,34 +159,34 @@ public class Example1 {
 * @throws Some javadoc.
 * @exception Some javadoc.
 * @see Some javadoc.
-* @since Some javadoc. // violation
+* @since Some javadoc.
 * @serial Some javadoc.
 * @serialField Field description.
 * @serialData
 */
 public class Example2 {
-  class Valid implements Serializable {
-  }
-
+  class Valid implements Serializable {}
+  // violation 7 lines below 'Block tags have to appear in the order'
+  // violation 7 lines below 'Block tags have to appear in the order'
   /**
    * Some javadoc.
    *
    * @version Some javadoc.
    * @see Some javadoc.
-   * @since Some javadoc. // violation
-   * @deprecated  // violation
+   * @since Some javadoc.
+   * @deprecated
    */
-  class Invalid implements Serializable {
-  }
-
+  class Invalid implements Serializable {}
+  // violation 8 lines below 'Block tags have to appear in the order'
+  // violation 8 lines below 'Block tags have to appear in the order'
   /**
    * Some javadoc.
    *
    * @author max
    * @version Some javadoc.
    * @see Some javadoc.
-   * @since Some javadoc. // violation
-   * @deprecated // violation
+   * @since Some javadoc.
+   * @deprecated
    */
   enum Test {}
 }
@@ -226,8 +227,7 @@ public class Example2 {
 * @serialData
 */
 public class Example3 {
-  class Valid implements Serializable {
-  }
+  class Valid implements Serializable {}
 
   /**
    * Some javadoc.
@@ -237,17 +237,17 @@ public class Example3 {
    * @since Some javadoc.
    * @deprecated
    */
-  class Invalid implements Serializable {
-  }
-
+  class Invalid implements Serializable {}
+  // violation 8 lines below 'Block tags have to appear in the order'
+  // violation 8 lines below 'Block tags have to appear in the order'
   /**
    * Some javadoc.
    *
    * @author Some javadoc.
    * @version Some javadoc.
    * @see Some javadoc.
-   * @since Some javadoc. // violation
-   * @deprecated // violation
+   * @since Some javadoc.
+   * @deprecated
    */
   enum Test {}
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -266,7 +266,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc."
                     + "AbstractJavadocCheckTest$TokenIsNotInAcceptablesCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
@@ -90,20 +90,20 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         final String tagOrder = "[@author, @version, @param, @return, @throws, @exception, @see,"
                 + " @since, @serial, @serialField, @serialData, @deprecated]";
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_KEY, tagOrder),
-            "22: " + getCheckMessage(MSG_KEY, tagOrder),
+            "21: " + getCheckMessage(MSG_KEY, tagOrder),
             "23: " + getCheckMessage(MSG_KEY, tagOrder),
+            "24: " + getCheckMessage(MSG_KEY, tagOrder),
             "51: " + getCheckMessage(MSG_KEY, tagOrder),
-            "61: " + getCheckMessage(MSG_KEY, tagOrder),
             "62: " + getCheckMessage(MSG_KEY, tagOrder),
             "63: " + getCheckMessage(MSG_KEY, tagOrder),
+            "64: " + getCheckMessage(MSG_KEY, tagOrder),
             "73: " + getCheckMessage(MSG_KEY, tagOrder),
             "80: " + getCheckMessage(MSG_KEY, tagOrder),
             "97: " + getCheckMessage(MSG_KEY, tagOrder),
             "98: " + getCheckMessage(MSG_KEY, tagOrder),
-            "110: " + getCheckMessage(MSG_KEY, tagOrder),
-            "111: " + getCheckMessage(MSG_KEY, tagOrder),
             "112: " + getCheckMessage(MSG_KEY, tagOrder),
+            "113: " + getCheckMessage(MSG_KEY, tagOrder),
+            "114: " + getCheckMessage(MSG_KEY, tagOrder),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAtclauseOrderIncorrect1.java"), expected);
@@ -114,20 +114,20 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         final String tagOrder = "[@author, @version, @param, @return, @throws, @exception, @see,"
                 + " @since, @serial, @serialField, @serialData, @deprecated]";
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_KEY, tagOrder),
-            "22: " + getCheckMessage(MSG_KEY, tagOrder),
             "23: " + getCheckMessage(MSG_KEY, tagOrder),
-            "33: " + getCheckMessage(MSG_KEY, tagOrder),
-            "41: " + getCheckMessage(MSG_KEY, tagOrder),
-            "42: " + getCheckMessage(MSG_KEY, tagOrder),
-            "52: " + getCheckMessage(MSG_KEY, tagOrder),
-            "53: " + getCheckMessage(MSG_KEY, tagOrder),
-            "63: " + getCheckMessage(MSG_KEY, tagOrder),
-            "64: " + getCheckMessage(MSG_KEY, tagOrder),
+            "25: " + getCheckMessage(MSG_KEY, tagOrder),
+            "26: " + getCheckMessage(MSG_KEY, tagOrder),
+            "37: " + getCheckMessage(MSG_KEY, tagOrder),
+            "47: " + getCheckMessage(MSG_KEY, tagOrder),
+            "48: " + getCheckMessage(MSG_KEY, tagOrder),
+            "60: " + getCheckMessage(MSG_KEY, tagOrder),
+            "61: " + getCheckMessage(MSG_KEY, tagOrder),
+            "73: " + getCheckMessage(MSG_KEY, tagOrder),
             "74: " + getCheckMessage(MSG_KEY, tagOrder),
-            "77: " + getCheckMessage(MSG_KEY, tagOrder),
-            "88: " + getCheckMessage(MSG_KEY, tagOrder),
-            "98: " + getCheckMessage(MSG_KEY, tagOrder),
+            "86: " + getCheckMessage(MSG_KEY, tagOrder),
+            "89: " + getCheckMessage(MSG_KEY, tagOrder),
+            "101: " + getCheckMessage(MSG_KEY, tagOrder),
+            "112: " + getCheckMessage(MSG_KEY, tagOrder),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAtclauseOrderIncorrect2.java"), expected);
@@ -138,14 +138,14 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         final String tagOrder = "[@author, @version, @param, @return, @throws, @exception, @see,"
                 + " @since, @serial, @serialField, @serialData, @deprecated]";
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_KEY, tagOrder),
-            "22: " + getCheckMessage(MSG_KEY, tagOrder),
             "23: " + getCheckMessage(MSG_KEY, tagOrder),
-            "33: " + getCheckMessage(MSG_KEY, tagOrder),
-            "40: " + getCheckMessage(MSG_KEY, tagOrder),
-            "48: " + getCheckMessage(MSG_KEY, tagOrder),
-            "61: " + getCheckMessage(MSG_KEY, tagOrder),
+            "25: " + getCheckMessage(MSG_KEY, tagOrder),
+            "26: " + getCheckMessage(MSG_KEY, tagOrder),
+            "37: " + getCheckMessage(MSG_KEY, tagOrder),
+            "45: " + getCheckMessage(MSG_KEY, tagOrder),
+            "54: " + getCheckMessage(MSG_KEY, tagOrder),
             "68: " + getCheckMessage(MSG_KEY, tagOrder),
+            "76: " + getCheckMessage(MSG_KEY, tagOrder),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAtclauseOrderIncorrect3.java"), expected);
@@ -156,21 +156,21 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         final String tagOrder = "[@author, @version, @param, @return, @throws, @exception, @see,"
                 + " @since, @serial, @serialField, @serialData, @deprecated]";
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_KEY, tagOrder),
-            "22: " + getCheckMessage(MSG_KEY, tagOrder),
+            "21: " + getCheckMessage(MSG_KEY, tagOrder),
             "23: " + getCheckMessage(MSG_KEY, tagOrder),
-            "33: " + getCheckMessage(MSG_KEY, tagOrder),
-            "40: " + getCheckMessage(MSG_KEY, tagOrder),
-            "50: " + getCheckMessage(MSG_KEY, tagOrder),
-            "52: " + getCheckMessage(MSG_KEY, tagOrder),
-            "65: " + getCheckMessage(MSG_KEY, tagOrder),
-            "66: " + getCheckMessage(MSG_KEY, tagOrder),
-            "76: " + getCheckMessage(MSG_KEY, tagOrder),
-            "78: " + getCheckMessage(MSG_KEY, tagOrder),
-            "91: " + getCheckMessage(MSG_KEY, tagOrder),
-            "93: " + getCheckMessage(MSG_KEY, tagOrder),
-            "94: " + getCheckMessage(MSG_KEY, tagOrder),
-            "104: " + getCheckMessage(MSG_KEY, tagOrder),
+            "24: " + getCheckMessage(MSG_KEY, tagOrder),
+            "34: " + getCheckMessage(MSG_KEY, tagOrder),
+            "42: " + getCheckMessage(MSG_KEY, tagOrder),
+            "53: " + getCheckMessage(MSG_KEY, tagOrder),
+            "55: " + getCheckMessage(MSG_KEY, tagOrder),
+            "68: " + getCheckMessage(MSG_KEY, tagOrder),
+            "69: " + getCheckMessage(MSG_KEY, tagOrder),
+            "81: " + getCheckMessage(MSG_KEY, tagOrder),
+            "83: " + getCheckMessage(MSG_KEY, tagOrder),
+            "98: " + getCheckMessage(MSG_KEY, tagOrder),
+            "100: " + getCheckMessage(MSG_KEY, tagOrder),
+            "101: " + getCheckMessage(MSG_KEY, tagOrder),
+            "111: " + getCheckMessage(MSG_KEY, tagOrder),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAtclauseOrderIncorrect4.java"), expected);
@@ -189,7 +189,7 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         final String tagOrder = "[@since, @version, @param, @return, @throws, @exception,"
                 + " @deprecated, @see, @serial, @serialField, @serialData, @author]";
         final String[] expected = {
-            "30: " + getCheckMessage(MSG_KEY, tagOrder),
+            "31: " + getCheckMessage(MSG_KEY, tagOrder),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAtclauseOrderIncorrectCustom2.java"), expected);
@@ -200,7 +200,7 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         final String tagOrder = "[@since, @version, @param, @return, @throws, @exception,"
                 + " @deprecated, @see, @serial, @serialField, @serialData, @author]";
         final String[] expected = {
-            "30: " + getCheckMessage(MSG_KEY, tagOrder),
+            "31: " + getCheckMessage(MSG_KEY, tagOrder),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAtclauseOrderIncorrectCustom3.java"), expected);
@@ -211,7 +211,7 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         final String tagOrder = "[@since, @version, @param, @return, @throws, @exception,"
                 + " @deprecated, @see, @serial, @serialField, @serialData, @author]";
         final String[] expected = {
-            "30: " + getCheckMessage(MSG_KEY, tagOrder),
+            "31: " + getCheckMessage(MSG_KEY, tagOrder),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAtclauseOrderIncorrectCustom4.java"), expected);
@@ -236,9 +236,9 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
             "42: " + getCheckMessage(MSG_KEY, tagOrder),
             "54: " + getCheckMessage(MSG_KEY, tagOrder),
             "55: " + getCheckMessage(MSG_KEY, tagOrder),
-            "65: " + getCheckMessage(MSG_KEY, tagOrder),
-            "86: " + getCheckMessage(MSG_KEY, tagOrder),
-            "103: " + getCheckMessage(MSG_KEY, tagOrder),
+            "64: " + getCheckMessage(MSG_KEY, tagOrder),
+            "85: " + getCheckMessage(MSG_KEY, tagOrder),
+            "102: " + getCheckMessage(MSG_KEY, tagOrder),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAtclauseOrderRecords.java"), expected);
@@ -294,27 +294,27 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         final String tagOrder = "[@author, @version, @param, @return, @throws, @exception, @see,"
                 + " @since, @serial, @serialField, @serialData, @deprecated]";
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_KEY, tagOrder),
-            "21: " + getCheckMessage(MSG_KEY, tagOrder),
             "22: " + getCheckMessage(MSG_KEY, tagOrder),
-            "32: " + getCheckMessage(MSG_KEY, tagOrder),
-            "33: " + getCheckMessage(MSG_KEY, tagOrder),
-            "34: " + getCheckMessage(MSG_KEY, tagOrder),
-            "44: " + getCheckMessage(MSG_KEY, tagOrder),
-            "45: " + getCheckMessage(MSG_KEY, tagOrder),
-            "46: " + getCheckMessage(MSG_KEY, tagOrder),
-            "59: " + getCheckMessage(MSG_KEY, tagOrder),
-            "60: " + getCheckMessage(MSG_KEY, tagOrder),
-            "61: " + getCheckMessage(MSG_KEY, tagOrder),
-            "73: " + getCheckMessage(MSG_KEY, tagOrder),
-            "74: " + getCheckMessage(MSG_KEY, tagOrder),
-            "75: " + getCheckMessage(MSG_KEY, tagOrder),
-            "88: " + getCheckMessage(MSG_KEY, tagOrder),
-            "89: " + getCheckMessage(MSG_KEY, tagOrder),
-            "90: " + getCheckMessage(MSG_KEY, tagOrder),
+            "23: " + getCheckMessage(MSG_KEY, tagOrder),
+            "24: " + getCheckMessage(MSG_KEY, tagOrder),
+            "37: " + getCheckMessage(MSG_KEY, tagOrder),
+            "38: " + getCheckMessage(MSG_KEY, tagOrder),
+            "39: " + getCheckMessage(MSG_KEY, tagOrder),
+            "52: " + getCheckMessage(MSG_KEY, tagOrder),
+            "53: " + getCheckMessage(MSG_KEY, tagOrder),
+            "54: " + getCheckMessage(MSG_KEY, tagOrder),
+            "68: " + getCheckMessage(MSG_KEY, tagOrder),
+            "69: " + getCheckMessage(MSG_KEY, tagOrder),
+            "70: " + getCheckMessage(MSG_KEY, tagOrder),
+            "82: " + getCheckMessage(MSG_KEY, tagOrder),
+            "83: " + getCheckMessage(MSG_KEY, tagOrder),
+            "84: " + getCheckMessage(MSG_KEY, tagOrder),
+            "99: " + getCheckMessage(MSG_KEY, tagOrder),
             "100: " + getCheckMessage(MSG_KEY, tagOrder),
             "101: " + getCheckMessage(MSG_KEY, tagOrder),
-            "102: " + getCheckMessage(MSG_KEY, tagOrder),
+            "114: " + getCheckMessage(MSG_KEY, tagOrder),
+            "115: " + getCheckMessage(MSG_KEY, tagOrder),
+            "116: " + getCheckMessage(MSG_KEY, tagOrder),
         };
 
         verifyWithInlineConfigParser(
@@ -327,11 +327,11 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
                 + " @since, @serial, @serialField, @serialData, @deprecated]";
 
         final String[] expected = {
-            "41: " + getCheckMessage(MSG_KEY, tagOrder),
-            "58: " + getCheckMessage(MSG_KEY, tagOrder),
-            "78: " + getCheckMessage(MSG_KEY, tagOrder),
-            "79: " + getCheckMessage(MSG_KEY, tagOrder),
-            "80: " + getCheckMessage(MSG_KEY, tagOrder),
+            "42: " + getCheckMessage(MSG_KEY, tagOrder),
+            "60: " + getCheckMessage(MSG_KEY, tagOrder),
+            "83: " + getCheckMessage(MSG_KEY, tagOrder),
+            "84: " + getCheckMessage(MSG_KEY, tagOrder),
+            "85: " + getCheckMessage(MSG_KEY, tagOrder),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -130,6 +130,8 @@ public class XdocsExamplesAstConsistencyTest {
             // until https://github.com/checkstyle/checkstyle/issues/19891
             "checks/blocks/leftcurly/Example3",
             "checks/naming/patternvariablename/Example3",
+            "checks/javadoc/atclauseorder/Example2",
+            "checks/javadoc/atclauseorder/Example3",
             "checks/javadoc/javadocvariable/Example3",
             "checks/javadoc/javadocvariable/Example5",
             "checks/whitespace/parenpad/Example3",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect1.java
@@ -8,22 +8,22 @@ tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
 
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 /** Javadoc for import */
 import java.io.Serializable;
-
+// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
 /**
  * Some javadoc.
  *
  * @since Some javadoc.
- * @version 1.0 // violation
+ * @version 1.0
  * @deprecated Some javadoc.
- * @see Some javadoc. // violation
- * @author max // violation
+ * @see Some javadoc.
+ * @author max
  */
-class InputAtclauseOrderIncorrect1 implements Serializable
-{
+class InputAtclauseOrderIncorrect1 implements Serializable {
     /**
      * The client's first name.
      * @serial
@@ -41,43 +41,43 @@ class InputAtclauseOrderIncorrect1 implements Serializable
      * @serialField
      */
     private String tThirdName;
-
+    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some text.
      * @param aString Some text.
      * @return Some text.
      * @serialData Some javadoc.
      * @deprecated Some text.
-     * @throws Exception Some text. // violation
+     * @throws Exception Some text.
      */
-    String method(String aString) throws Exception
-    {
+    String method(String aString) throws Exception {
         return "null";
     }
-
+    // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some text.
      * @serialData Some javadoc.
-     * @return Some text. // violation
-     * @param aString Some text. // violation
-     * @throws Exception Some text. // violation
+     * @return Some text.
+     * @param aString Some text.
+     * @throws Exception Some text.
      */
-    String method1(String aString) throws Exception
-    {
+    String method1(String aString) throws Exception {
         return "null";
     }
-
+    // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some text.
      * @throws Exception Some text.
-     * @param aString Some text. // violation
+     * @param aString Some text.
      */
     void method2(String aString) throws Exception {}
-
+    // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some text.
      * @deprecated Some text.
-     * @throws Exception Some text. // violation
+     * @throws Exception Some text.
      */
     void method3() throws Exception {}
 
@@ -86,34 +86,35 @@ class InputAtclauseOrderIncorrect1 implements Serializable
      * @return Some text.
      * @throws Exception Some text.
      */
-    String method4() throws Exception
-    {
+    String method4() throws Exception {
         return "null";
     }
-
+    // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some text.
      * @deprecated Some text.
-     * @return Some text. // violation
-     * @param aString Some text. // violation
+     * @return Some text.
+     * @param aString Some text.
      */
     String method5(String aString)
     {
         return "null";
     }
-
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some text.
      * @param aString Some text.
      * @return Some text.
      * @serialData Some javadoc.
-     * @param aInt Some text. // violation
-     * @throws Exception Some text. // violation
-     * @param aBoolean Some text. // violation
+     * @param aInt Some text.
+     * @throws Exception Some text.
+     * @param aBoolean Some text.
      * @deprecated Some text.
      */
-    String method6(String aString, int aInt, boolean aBoolean) throws Exception
-    {
+    String method6(String aString, int aInt, boolean aBoolean) throws Exception {
         return "null";
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect2.java
@@ -13,89 +13,103 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 /** Javadoc for import */
 import java.io.Serializable;
 
+// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
 /**
  * Some javadoc.
  *
  * @since Some javadoc.
- * @version 1.0 // violation
+ * @version 1.0
  * @deprecated Some javadoc.
- * @see Some javadoc. // violation
- * @author max // violation
+ * @see Some javadoc.
+ * @author max
  */
 class InputAtclauseOrderIncorrect2 implements Serializable
 {
+    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some javadoc.
      *
      * @version 1.0
      * @since Some javadoc.
      * @serialData Some javadoc.
-     * @author max // violation
+     * @author max
      */
     class InnerClassWithAnnotations2
     {
+        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @return Some text.
          * @deprecated Some text.
-         * @param aString Some text. // violation
-         * @throws Exception Some text. // violation
+         * @param aString Some text.
+         * @throws Exception Some text.
          */
         String method(String aString) throws Exception
         {
             return "null";
         }
 
+        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @throws Exception Some text.
-         * @return Some text. // violation
-         * @param aString Some text. // violation
+         * @return Some text.
+         * @param aString Some text.
          */
         String method1(String aString) throws Exception
         {
             return "null";
         }
 
+        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @serialData Some javadoc.
-         * @param aString Some text. // violation
-         * @throws Exception Some text. // violation
+         * @param aString Some text.
+         * @throws Exception Some text.
          */
         void method2(String aString) throws Exception {}
     }
 
     InnerClassWithAnnotations2 anon = new InnerClassWithAnnotations2()
     {
+        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @throws Exception Some text.
-         * @param aString Some text. // violation
+         * @param aString Some text.
          * @serialData Some javadoc.
          * @deprecated Some text.
-         * @return Some text. // violation
+         * @return Some text.
          */
         String method(String aString) throws Exception
         {
             return "null";
         }
 
+        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @param aString Some text.
          * @throws Exception Some text.
-         * @return Some text. // violation
+         * @return Some text.
          */
         String method1(String aString) throws Exception
         {
             return "null";
         }
 
+        // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @throws Exception Some text.
-         * @param aString Some text. // violation
+         * @param aString Some text.
          */
         void method2(String aString) throws Exception {}
     };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect3.java
@@ -13,39 +13,45 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 /** Javadoc for import */
 import java.io.Serializable;
 
+// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
 /**
  * Some javadoc.
  *
  * @since Some javadoc.
- * @version 1.0 // violation
+ * @version 1.0
  * @deprecated Some javadoc.
- * @see Some javadoc. // violation
- * @author max // violation
+ * @see Some javadoc.
+ * @author max
  */
 class InputAtclauseOrderIncorrect3 implements Serializable
 {
+    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some javadoc.
      *
      * @version 1.0
      * @since Some javadoc.
      * @serialData Some javadoc.
-     * @author max // violation
+     * @author max
      */
     class InnerClassWithAnnotations3
     {
+        // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @deprecated Some text.
-         * @throws Exception Some text. // violation
+         * @throws Exception Some text.
          */
         void method3() throws Exception {}
 
+        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @throws Exception Some text.
          * @serialData Some javadoc.
-         * @return Some text. // violation
+         * @return Some text.
          */
         String method4() throws Exception
         {
@@ -55,17 +61,19 @@ class InputAtclauseOrderIncorrect3 implements Serializable
 
     InnerClassWithAnnotations3 anon = new InnerClassWithAnnotations3()
     {
+        // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @deprecated Some text.
-         * @throws Exception Some text. // violation
+         * @throws Exception Some text.
          */
         void method3() throws Exception {}
 
+        // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @throws Exception Some text.
-         * @return Some text. // violation
+         * @return Some text.
          */
         String method4() throws Exception
         {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect4.java
@@ -8,74 +8,79 @@ tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
 
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 /** Javadoc for import */
 import java.io.Serializable;
-
+// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
 /**
  * Some javadoc.
  *
  * @since Some javadoc.
- * @version 1.0 // violation
+ * @version 1.0
  * @deprecated Some javadoc.
- * @see Some javadoc. // violation
- * @author max // violation
+ * @see Some javadoc.
+ * @author max
  */
-class InputAtclauseOrderIncorrect4 implements Serializable
-{
+class InputAtclauseOrderIncorrect4 implements Serializable {
+    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some javadoc.
      *
      * @version 1.0
      * @since Some javadoc.
      * @serialData Some javadoc.
-     * @author max // violation
+     * @author max
      */
+    // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
     class InnerClassWithAnnotations4 {
         /**
          * Some text.
          * @param aString Some text.
          * @deprecated Some text.
-         * @return Some text. // violation
+         * @return Some text.
          */
         String method5(String aString) {
             return "null";
         }
-
+        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @param aString Some text.
          * @return Some text.
-         * @param aInt Some text. // violation
+         * @param aInt Some text.
          * @throws Exception Some text.
-         * @param aBoolean Some text. // violation
+         * @param aBoolean Some text.
          * @deprecated Some text.
          */
         String method6(String aString, int aInt, boolean aBoolean) throws Exception {
             return "null";
         }
     }
-
-    InnerClassWithAnnotations4 anon = new InnerClassWithAnnotations4()
-    {
+    InnerClassWithAnnotations4 anon = new InnerClassWithAnnotations4() {
+        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @deprecated Some text.
-         * @return Some text. // violation
-         * @param aString Some text. // violation
+         * @return Some text.
+         * @param aString Some text.
          */
         String method5(String aString) {
             return "null";
         }
 
+        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @param aString Some text.
          * @return Some text.
-         * @param aInt Some text. // violation
+         * @param aInt Some text.
          * @throws Exception Some text.
-         * @param aBoolean Some text. // violation
+         * @param aBoolean Some text.
          * @deprecated Some text.
          */
         String method6(String aString, int aInt, boolean aBoolean) throws Exception {
@@ -83,25 +88,27 @@ class InputAtclauseOrderIncorrect4 implements Serializable
         }
     };
 }
-
+// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
 /**
  * Some javadoc.
  *
  * @since Some javadoc.
- * @version 1.0 // violation
+ * @version 1.0
  * @deprecated Some javadoc.
- * @see Some javadoc. // violation
- * @author max // violation
+ * @see Some javadoc.
+ * @author max
  */
 enum Foo4 {}
-
+// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
 /**
  * Some javadoc.
  *
  * @version 1.0
  * @since Some javadoc.
  * @serialData Some javadoc.
- * @author max // violation
+ * @author max
  */
 interface FooIn {
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom2.java
@@ -23,11 +23,12 @@ import java.io.Serializable;
  */
 class InputAtclauseOrderIncorrectCustom2 implements Serializable
 {
+    // violation 5 lines below 'Block tags have to appear in the order .\[@since.*'
     /**
      * Some javadoc.
      *
      * @version 1.0
-     * @since Some javadoc. // violation
+     * @since Some javadoc.
      * @serialData Some javadoc.
      * @author max
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom3.java
@@ -23,11 +23,12 @@ import java.io.Serializable;
  */
 class InputAtclauseOrderIncorrectCustom3 implements Serializable
 {
+    // violation 5 lines below 'Block tags have to appear in the order .\[@since.*'
     /**
      * Some javadoc.
      *
      * @version 1.0
-     * @since Some javadoc. // violation
+     * @since Some javadoc.
      * @serialData Some javadoc.
      * @author max
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom4.java
@@ -23,11 +23,12 @@ import java.io.Serializable;
  */
 class InputAtclauseOrderIncorrectCustom4 implements Serializable
 {
+    // violation 5 lines below 'Block tags have to appear in the order .\[@since.*'
     /**
      * Some javadoc.
      *
      * @version 1.0
-     * @since Some javadoc. // violation
+     * @since Some javadoc.
      * @serialData Some javadoc.
      * @author max
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderMethodReturningArrayType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderMethodReturningArrayType.java
@@ -13,7 +13,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 import java.sql.SQLException;
 
 public interface InputAtclauseOrderMethodReturningArrayType {
-    // violation 5 lines below 'Block tags have to appear in the order'
+    // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * @return int array
      * @exception SQLException
@@ -25,8 +25,8 @@ public interface InputAtclauseOrderMethodReturningArrayType {
      */
     int[] executeBatch() throws SQLException;
 
-    // violation 7 lines below 'Block tags have to appear in the order'
-    // violation 7 lines below 'Block tags have to appear in the order'
+    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
       * {@code selected} is an array that will contain
       * the indices of items that have been selected.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderNewArrayDeclaratorStructure.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderNewArrayDeclaratorStructure.java
@@ -22,6 +22,7 @@ import javax.transaction.xa.Xid;
 
 public interface InputAtclauseOrderNewArrayDeclaratorStructure
         <D extends GenericDeclaration> extends Type, AnnotatedElement {
+    // violation 17 lines below 'Block tags have to appear in the order .\[@author.*'
      /**
       * Returns an array of {@code Type} objects representing the
       * upper bound(s) of this type variable.  If no upper bound is
@@ -38,11 +39,12 @@ public interface InputAtclauseOrderNewArrayDeclaratorStructure
       * @throws MalformedParameterizedTypeException if any of the
       *     bounds refer to a parameterized type that cannot be instantiated
       *     for any reason
-      * @return an array of {@code Type}s representing the upper  // violation
+      * @return an array of {@code Type}s representing the upper
       *     bound(s) of this type variable
       */
      Type[] getBounds();
 
+     // violation 13 lines below 'Block tags have to appear in the order .\[@author.*'
       /**
        * Obtains a list of prepared transaction branches from a resource
        * manager. The transaction manager calls this method during recovery
@@ -55,7 +57,7 @@ public interface InputAtclauseOrderNewArrayDeclaratorStructure
        * @exception XAException An error has occurred. Possible values are
        * XAER_RMERR, XAER_RMFAIL, XAER_INVAL, and XAER_PROTO.
        *
-       * @return The resource manager returns zero or more XIDs of the   // violation
+       * @return The resource manager returns zero or more XIDs of the
        * transaction branches that are currently in a prepared or
        * heuristically completed state. If an error occurs during the
        * operation, the resource manager should throw the appropriate
@@ -66,6 +68,9 @@ public interface InputAtclauseOrderNewArrayDeclaratorStructure
 }
 
 class Other {
+    // violation 12 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 12 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 12 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * The focus traversal keys. These keys will generate focus traversal
      * behavior for Components for which focus traversal keys are enabled. If a
@@ -75,9 +80,9 @@ class Other {
      * KeyboardFocusManager's default traversal key is used.
      *
      * @serial
-     * @see #setFocusTraversalKeys      // violation
-     * @see #getFocusTraversalKeys      // violation
-     * @since 1.4                       // violation
+     * @see #setFocusTraversalKeys
+     * @see #getFocusTraversalKeys
+     * @since 1.4
      */
     Set<AWTKeyStroke>[] focusTraversalKeys;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
@@ -30,9 +30,9 @@ public class InputAtclauseOrderRecords {
             return "null";
         }
 
-        // violation 7 lines below 'Block tags have to appear in the order'
-        // violation 7 lines below 'Block tags have to appear in the order'
-        // violation 7 lines below 'Block tags have to appear in the order'
+        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          *
@@ -45,8 +45,8 @@ public class InputAtclauseOrderRecords {
             return "null";
         }
 
-        // violation 6 lines below 'Block tags have to appear in the order'
-        // violation 6 lines below 'Block tags have to appear in the order'
+        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          *
@@ -57,8 +57,7 @@ public class InputAtclauseOrderRecords {
          */
         void method2(String aString) throws Exception {
         }
-
-        // violation 4 lines below 'Block tags have to appear in the order'
+        // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * Some text.
          * @since since
@@ -80,7 +79,7 @@ public class InputAtclauseOrderRecords {
  * @since Some javadoc.
  */
 record myOtherOtherRecord() {
-    // violation 3 lines below 'Block tags have to appear in the order'
+    // violation 3 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * @since Some javadoc.
      * @author max
@@ -97,7 +96,7 @@ record myOtherOtherRecord() {
  * @since Some javadoc.
  */
 class myOtherOtherClass {
-        // violation 3 lines below 'Block tags have to appear in the order'
+    // violation 3 lines below 'Block tags have to appear in the order .\[@author.*'
         /**
          * @since Some javadoc.
          * @author max

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderWithAnnotationsOutsideJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderWithAnnotationsOutsideJavadoc.java
@@ -8,98 +8,112 @@ tagOrder = (default)@author, @deprecated, @exception, @param, @return, \
 
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 
 public class InputAtclauseOrderWithAnnotationsOutsideJavadoc {
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some javadoc.
      *
      * @author max
      * @deprecated Some javadoc.
-     * @see Some javadoc.   // violation
-     * @version 1.0         // violation
-     * @since Some javadoc. // violation
+     * @see Some javadoc.
+     * @version 1.0
+     * @since Some javadoc.
      */
     @Deprecated
     public boolean branchContains(int type) { return true; }
 
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some javadoc.
      *
      * @author max
      * @deprecated Some javadoc.
-     * @see Some javadoc.   // violation
-     * @version 1.0         // violation
-     * @since Some javadoc. // violation
+     * @see Some javadoc.
+     * @version 1.0
+     * @since Some javadoc.
      */
     public boolean branchContains2(int type) { return true; }
 }
 
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
 /**
  * Some javadoc.
  *
  * @author max
  * @deprecated Some javadoc.
- * @see Some javadoc.   // violation
- * @version 1.0         // violation
- * @since Some javadoc. // violation
+ * @see Some javadoc.
+ * @version 1.0
+ * @since Some javadoc.
  */
 @Deprecated
-class TestClass {
-
-}
+class TestClass {}
 
 class TestInnerClasses extends InputAtclauseOrderWithAnnotationsOutsideJavadoc{
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some javadoc.
      *
      * @author max
      * @deprecated Some javadoc.
-     * @see Some javadoc.   // violation
-     * @version 1.0         // violation
-     * @since Some javadoc. // violation
+     * @see Some javadoc.
+     * @version 1.0
+     * @since Some javadoc.
      */
     @Deprecated
-    TestClass one = new TestClass(){
-
-    };
-
+    TestClass one = new TestClass(){};
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
     /**
      * Some javadoc.
      *
      * @author max
      * @deprecated Some javadoc.
-     * @see Some javadoc.   // violation
-     * @version 1.0         // violation
-     * @since Some javadoc. // violation
+     * @see Some javadoc.
+     * @version 1.0
+     * @since Some javadoc.
      */
     @Override
     public boolean branchContains(int type) {
         return false;
     }
 }
-
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
 /**
  * Some javadoc.
  *
  * @author max
  * @deprecated Some javadoc.
- * @see Some javadoc.   // violation
- * @version 1.0         // violation
- * @since Some javadoc. // violation
+ * @see Some javadoc.
+ * @version 1.0
+ * @since Some javadoc.
  */
 @Deprecated
 enum TestEnums {}
 
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
 /**
  * Some javadoc.
  *
  * @author max
  * @deprecated Some javadoc.
- * @see Some javadoc.   // violation
- * @version 1.0         // violation
- * @since Some javadoc. // violation
+ * @see Some javadoc.
+ * @version 1.0
+ * @since Some javadoc.
  */
 @Deprecated
 interface TestInterfaces {}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckExamplesTest.java
@@ -63,8 +63,8 @@ public class AtclauseOrderCheckExamplesTest extends AbstractExamplesModuleTestSu
             + " @deprecated, @see, @serial, @serialField, @serialData]";
 
         final String[] expected = {
+            "54: " + getCheckMessage(MSG_KEY, tagOrder),
             "55: " + getCheckMessage(MSG_KEY, tagOrder),
-            "56: " + getCheckMessage(MSG_KEY, tagOrder),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example2.java
@@ -10,12 +10,12 @@
   </module>
 </module>
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 
 import java.io.Serializable;
 
 // xdoc section -- start
+// violation 11 lines below 'Block tags have to appear in the order'
 /**
 * Some javadoc.
 *
@@ -26,34 +26,34 @@ import java.io.Serializable;
 * @throws Some javadoc.
 * @exception Some javadoc.
 * @see Some javadoc.
-* @since Some javadoc. // violation
+* @since Some javadoc.
 * @serial Some javadoc.
 * @serialField Field description.
 * @serialData
 */
 public class Example2 {
-  class Valid implements Serializable {
-  }
-
+  class Valid implements Serializable {}
+  // violation 7 lines below 'Block tags have to appear in the order'
+  // violation 7 lines below 'Block tags have to appear in the order'
   /**
    * Some javadoc.
    *
    * @version Some javadoc.
    * @see Some javadoc.
-   * @since Some javadoc. // violation
-   * @deprecated  // violation
+   * @since Some javadoc.
+   * @deprecated
    */
-  class Invalid implements Serializable {
-  }
-
+  class Invalid implements Serializable {}
+  // violation 8 lines below 'Block tags have to appear in the order'
+  // violation 8 lines below 'Block tags have to appear in the order'
   /**
    * Some javadoc.
    *
    * @author max
    * @version Some javadoc.
    * @see Some javadoc.
-   * @since Some javadoc. // violation
-   * @deprecated // violation
+   * @since Some javadoc.
+   * @deprecated
    */
   enum Test {}
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example3.java
@@ -32,8 +32,7 @@ import java.io.Serializable;
 * @serialData
 */
 public class Example3 {
-  class Valid implements Serializable {
-  }
+  class Valid implements Serializable {}
 
   /**
    * Some javadoc.
@@ -43,17 +42,17 @@ public class Example3 {
    * @since Some javadoc.
    * @deprecated
    */
-  class Invalid implements Serializable {
-  }
-
+  class Invalid implements Serializable {}
+  // violation 8 lines below 'Block tags have to appear in the order'
+  // violation 8 lines below 'Block tags have to appear in the order'
   /**
    * Some javadoc.
    *
    * @author Some javadoc.
    * @version Some javadoc.
    * @see Some javadoc.
-   * @since Some javadoc. // violation
-   * @deprecated // violation
+   * @since Some javadoc.
+   * @deprecated
    */
   enum Test {}
 }


### PR DESCRIPTION
Issue #15456 

### Summary

- Removed AtclauseOrderCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in AtclauseOrderCheckTest
- Defined violation messages in atclauseorder.xml
- added Example2 and Example 3 to SUPPRESSED_EXAMPLES of XdocsExamplesAstConsistencyTest
- Defined violation messages in InputAtClauseOrder files
- Modified line numbers of violation messages in AtclauseOrderCheckExamplesTest
- Defined violation messages for atclauseorder/Example files.
- added file length violations to suppressions list