### PR TITLE
Issue #15456: specify violation messages for InnerTypeLastCheck

### DIFF
--- a/src/site/xdoc/checks/design/innertypelast.xml
+++ b/src/site/xdoc/checks/design/innertypelast.xml
@@ -32,13 +32,15 @@
 class Test1 {
   private String s;
   class InnerTest1 {}
-  public void test() {} // violation
+  // violation below, 'fields and methods should be before inner types'
+  public void test() {}
 }
 
 class Test2 {
   static {};
   class InnerTest1 {}
-  public Test2() {} // violation
+  // violation below, 'fields and methods should be before inner types'
+  public Test2() {}
 }
 
 class Example1 {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -264,8 +264,6 @@ public final class InlineConfigParser {
      */
     private static final Set<String> SUPPRESSED_CHECKS = Set.of(
             "com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck",
-
-            "com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc."
                     + "AbstractJavadocCheckTest$TokenIsNotInAcceptablesCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheckTest.java
@@ -54,11 +54,11 @@ public class InnerTypeLastCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMembersBeforeInner() throws Exception {
         final String[] expected = {
-            "50:9: " + getCheckMessage(MSG_KEY),
-            "71:9: " + getCheckMessage(MSG_KEY),
-            "75:9: " + getCheckMessage(MSG_KEY),
-            "84:5: " + getCheckMessage(MSG_KEY),
-            "101:9: " + getCheckMessage(MSG_KEY),
+            "51:9: " + getCheckMessage(MSG_KEY),
+            "73:9: " + getCheckMessage(MSG_KEY),
+            "78:9: " + getCheckMessage(MSG_KEY),
+            "88:9: " + getCheckMessage(MSG_KEY),
+            "106:17: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInnerTypeLastClass.java"), expected);
@@ -92,9 +92,9 @@ public class InnerTypeLastCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testInnerTypeBeforeCtor() throws Exception {
         final String[] expected = {
-            "13:5: " + getCheckMessage(MSG_KEY),
-            "22:5: " + getCheckMessage(MSG_KEY),
-            "31:5: " + getCheckMessage(MSG_KEY),
+            "14:5: " + getCheckMessage(MSG_KEY),
+            "24:5: " + getCheckMessage(MSG_KEY),
+            "34:5: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInnerTypeLastClassCtorsInitBlocks.java"), expected);
@@ -104,13 +104,13 @@ public class InnerTypeLastCheckTest extends AbstractModuleTestSupport {
     public void testInnerTypeLastRecords() throws Exception {
 
         final String[] expected = {
-            "17:9: " + getCheckMessage(MSG_KEY),
-            "21:5: " + getCheckMessage(MSG_KEY),
-            "30:9: " + getCheckMessage(MSG_KEY),
-            "40:13: " + getCheckMessage(MSG_KEY),
-            "46:13: " + getCheckMessage(MSG_KEY),
-            "50:9: " + getCheckMessage(MSG_KEY),
-            "52:9: " + getCheckMessage(MSG_KEY),
+            "18:9: " + getCheckMessage(MSG_KEY),
+            "23:5: " + getCheckMessage(MSG_KEY),
+            "33:9: " + getCheckMessage(MSG_KEY),
+            "44:13: " + getCheckMessage(MSG_KEY),
+            "51:13: " + getCheckMessage(MSG_KEY),
+            "56:9: " + getCheckMessage(MSG_KEY),
+            "59:9: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInnerTypeLastRecords.java"), expected);
@@ -119,10 +119,10 @@ public class InnerTypeLastCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testInnerTypeLastCstyleArray() throws Exception {
         final String[] expected = {
-            "11:5: " + getCheckMessage(MSG_KEY),
             "12:5: " + getCheckMessage(MSG_KEY),
-            "13:5: " + getCheckMessage(MSG_KEY),
             "14:5: " + getCheckMessage(MSG_KEY),
+            "16:5: " + getCheckMessage(MSG_KEY),
+            "18:5: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInnerTypeLastArray.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/InputInnerTypeLastArray.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/InputInnerTypeLastArray.java
@@ -8,8 +8,12 @@ package com.puppycrawl.tools.checkstyle.checks.design.innertypelast;
 
 public class InputInnerTypeLastArray {
     static class P {}
-    int[] x; // violation
-    int y[]; // violation
-    P p0 = new P(), p1[] = {p0}, p2[][] = {p1}; // violation
-    P []p3 = new P[0], p4 = {p0}, p5 = {p0};  // violation
+    // violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+    int[] x;
+    // violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+    int y[];
+    // violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+    P p0 = new P(), p1[] = {p0}, p2[][] = {p1};
+    // violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+    P []p3 = new P[0], p4 = {p0}, p5 = {p0};
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/InputInnerTypeLastClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/InputInnerTypeLastClass.java
@@ -47,7 +47,8 @@ public class InputInnerTypeLastClass {
 		}
 	}
 
-	void methodTest2() { // violation
+	// violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+	void methodTest2() {
 		System.identityHashCode("test2");
 	}
 }
@@ -68,11 +69,13 @@ class Temp2 {
 		}
 	}
 
-	void methodTest2() { // violation
+	// violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+	void methodTest2() {
 		System.identityHashCode("test2");
 	}
 
-	private int i = 0; // violation
+	// violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+	private int i = 0;
 }
 
 class Temp3 {
@@ -81,7 +84,8 @@ class Temp3 {
         private int I = 0;
     }
 
-    public int[] getDefaultTokens() // violation
+	// violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+	public int[] getDefaultTokens()
     {
         return new int[]{1, };
     }
@@ -98,6 +102,7 @@ class Temp4 {
             private int a = 0;
         }
 
-        private int I = 0; // violation
+		// violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+		private int I = 0;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/InputInnerTypeLastClassCtorsInitBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/InputInnerTypeLastClassCtorsInitBlocks.java
@@ -10,7 +10,8 @@ public class InputInnerTypeLastClassCtorsInitBlocks {
     public class Inner {
     }
 
-    public InputInnerTypeLastClassCtorsInitBlocks() { // violation
+    // violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+    public InputInnerTypeLastClassCtorsInitBlocks() {
     }
 }
 
@@ -19,7 +20,8 @@ class BeforeInitBlock {
     public class Inner2 {
     }
 
-    {} // violation
+    // violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+    {}
 
 }
 
@@ -28,5 +30,6 @@ class BeforeStaticInitBlock {
     public interface Inner3 {
     }
 
-    static {} // violation
+    // violation below 'Init blocks, constructors, fields and methods should be before inner types.'
+    static {}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/InputInnerTypeLastRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/InputInnerTypeLastRecords.java
@@ -14,11 +14,13 @@ public class InputInnerTypeLastRecords {
         record InnerTest1() {
         }
 
-        public void test() { // violation
+        // violation below 'Init blocks, constructors, fields and methods should be.*'
+        public void test() {
         }
     }
 
-    public void test() { // violation
+    // violation below 'Init blocks, constructors, fields and methods should be.*'
+    public void test() {
     }
 
     record Test3() {
@@ -27,7 +29,8 @@ public class InputInnerTypeLastRecords {
         class InnerTest1 {
         }
 
-        public void test() { // violation
+        // violation below 'Init blocks, constructors, fields and methods should be.*'
+        public void test() {
         }
     }
 
@@ -37,19 +40,23 @@ public class InputInnerTypeLastRecords {
         record MyInnerRecord() {
             void foo() {}
             class InnerInnerClass{}
-            public MyInnerRecord{} // violation
+            // violation below 'Init blocks, constructors, fields and methods should be.*'
+            public MyInnerRecord{}
         }
 
         class MyInnerClass {
             void foo (){}
             class InnerInnerClass{}
-            public MyInnerClass(){} // violation
+            // violation below 'Init blocks, constructors, fields and methods should be.*'
+            public MyInnerClass(){}
 
         }
 
-        static Test3 innerRecord = new Test3(); // violation
+        // violation below 'Init blocks, constructors, fields and methods should be.*'
+        static Test3 innerRecord = new Test3();
 
-        public void test() { // violation
+        // violation below 'Init blocks, constructors, fields and methods should be.*'
+        public void test() {
         }
     }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheckExamplesTest.java
@@ -34,8 +34,8 @@ public class InnerTypeLastCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "14:3: " + getCheckMessage(MSG_KEY),
-            "20:3: " + getCheckMessage(MSG_KEY),
+            "15:3: " + getCheckMessage(MSG_KEY),
+            "22:3: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/innertypelast/Example1.java
@@ -11,13 +11,15 @@ package com.puppycrawl.tools.checkstyle.checks.design.innertypelast;
 class Test1 {
   private String s;
   class InnerTest1 {}
-  public void test() {} // violation
+  // violation below, 'fields and methods should be before inner types'
+  public void test() {}
 }
 
 class Test2 {
   static {};
   class InnerTest1 {}
-  public Test2() {} // violation
+  // violation below, 'fields and methods should be before inner types'
+  public Test2() {}
 }
 
 class Example1 {


### PR DESCRIPTION
Issue #15456 
### Summary

- Removed InnerTypeLastCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in InnerTypeLastCheckTest
- Defined violation messages in innertypelast.xml
- Defined violation messages in InputInnerTypeLast files
- Modified line numbers of violation messages in InnerTypeLastCheckExamplesTest.java
- Defined violation messages for innertypelast/Example files.

