### PR TITLE
Issue #19145: Exclude JavadocStyle from no-exception config validation

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -407,7 +407,7 @@ verify-no-exception-configs)
   curl -s --fail-with-body -o "$working_dir/checks-only-javadoc-error.xml" \
     -H "Authorization: token $GITHUB_TOKEN" \
     https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/checks-only-javadoc-error.xml
-  MODULES_WITH_EXTERNAL_FILES="Filter|ImportControl"
+  MODULES_WITH_EXTERNAL_FILES="Filter|ImportControl|JavadocStyle"
   xmlstarlet fo -D \
     -n $working_dir/checks-nonjavadoc-error.xml \
     | xmlstarlet sel --net --template -m .//module -n -v "@name" \


### PR DESCRIPTION
Temporary workaround for Issue #19145.

`checkstyle/contribution#1085` has already removed `JavadocStyle` from the no-exception config, but `JavadocStyle` still exists in Checkstyle until the main removal PR is merged. This makes `verify-no-exception-configs` fail on unrelated PRs because it detects `JavadocStyle` as present in Checkstyle but missing from contribution.

This excludes `JavadocStyle` from that comparison, the same way special modules like `Filter` and `ImportControl` are already excluded.