### PR TITLE
Issue #15456: specify violation messages for NPathComplexityCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -272,7 +272,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck",
-            "com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -61,11 +61,11 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
             "83:5: " + getCheckMessage(MSG_KEY, 3, 0),
             "95:5: " + getCheckMessage(MSG_KEY, 3, 0),
             "111:13: " + getCheckMessage(MSG_KEY, 2, 0),
-            "120:5: " + getCheckMessage(MSG_KEY, 48, 0),
-            "130:5: " + getCheckMessage(MSG_KEY, 1, 0),
-            "131:5: " + getCheckMessage(MSG_KEY, 1, 0),
-            "137:17: " + getCheckMessage(MSG_KEY, 3, 0),
-            "151:21: " + getCheckMessage(MSG_KEY, 3, 0),
+            "121:5: " + getCheckMessage(MSG_KEY, 48, 0),
+            "132:5: " + getCheckMessage(MSG_KEY, 1, 0),
+            "134:5: " + getCheckMessage(MSG_KEY, 1, 0),
+            "140:17: " + getCheckMessage(MSG_KEY, 3, 0),
+            "156:21: " + getCheckMessage(MSG_KEY, 3, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -83,12 +83,12 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
             "72:5: " + getCheckMessage(MSG_KEY, 15, 0),
             "97:5: " + getCheckMessage(MSG_KEY, 11, 0),
             "107:5: " + getCheckMessage(MSG_KEY, 8, 0),
-            "120:5: " + getCheckMessage(MSG_KEY, 120, 0),
-            "132:5: " + getCheckMessage(MSG_KEY, 6, 0),
-            "142:5: " + getCheckMessage(MSG_KEY, 21, 0),
-            "155:5: " + getCheckMessage(MSG_KEY, 35, 0),
-            "163:5: " + getCheckMessage(MSG_KEY, 25, 0),
-            "178:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "121:5: " + getCheckMessage(MSG_KEY, 120, 0),
+            "134:5: " + getCheckMessage(MSG_KEY, 6, 0),
+            "145:5: " + getCheckMessage(MSG_KEY, 21, 0),
+            "159:5: " + getCheckMessage(MSG_KEY, 35, 0),
+            "168:5: " + getCheckMessage(MSG_KEY, 25, 0),
+            "184:5: " + getCheckMessage(MSG_KEY, 2, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -98,7 +98,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testCalculation3() throws Exception {
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_KEY, 64, 0),
+            "13:5: " + getCheckMessage(MSG_KEY, 64, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -111,7 +111,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
         final long largerThanMaxInt = 3_486_784_401L;
 
         final String[] expected = {
-            "20:5: " + getCheckMessage(MSG_KEY, largerThanMaxInt, 0),
+            "21:5: " + getCheckMessage(MSG_KEY, largerThanMaxInt, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -196,10 +196,10 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
         final int max = 1;
 
         final String[] expected = {
-            "15:5: " + getCheckMessage(MSG_KEY, 3, max),
-            "25:9: " + getCheckMessage(MSG_KEY, 2, max),
-            "30:21: " + getCheckMessage(MSG_KEY, 2, max),
-            "44:9: " + getCheckMessage(MSG_KEY, 3, max),
+            "16:5: " + getCheckMessage(MSG_KEY, 3, max),
+            "26:9: " + getCheckMessage(MSG_KEY, 2, max),
+            "31:21: " + getCheckMessage(MSG_KEY, 2, max),
+            "46:9: " + getCheckMessage(MSG_KEY, 3, max),
         };
 
         verifyWithInlineConfigParser(
@@ -212,10 +212,10 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
         final int max = 1;
 
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_KEY, 5, max),
-            "29:5: " + getCheckMessage(MSG_KEY, 5, max),
-            "44:5: " + getCheckMessage(MSG_KEY, 6, max),
-            "60:5: " + getCheckMessage(MSG_KEY, 6, max),
+            "13:5: " + getCheckMessage(MSG_KEY, 5, max),
+            "31:5: " + getCheckMessage(MSG_KEY, 5, max),
+            "47:5: " + getCheckMessage(MSG_KEY, 6, max),
+            "64:5: " + getCheckMessage(MSG_KEY, 6, max),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexity.java
@@ -8,21 +8,21 @@ max = 0
 package com.puppycrawl.tools.checkstyle.checks.metrics.npathcomplexity;
 // Advise: for lack of ambiguity try to make all factors prime numbers
 public class InputNPathComplexity {
-    //NP = 5
-    void testIfWithExpression() { // violation
+    // violation below 'NPath Complexity is 5 (max allowed is 0).'
+    void testIfWithExpression() {
         // NP = (if-range=1) + 1 + (expr=3) = 5
         if (true && true || (true || true)) { }
     }
 
-    //NP = 5
-    void testIfElseWithExpression() { // violation
+    // violation below 'NPath Complexity is 5 (max allowed is 0).'
+    void testIfElseWithExpression() {
         // NP = (if-range=1) + (else-range=1) + (expr=3) = 5
         if (true && true || (true || true)) { }
         else { }
     }
 
-    //NP = 4
-    int testSimpleSwitch() { // violation
+    // violation below 'NPath Complexity is 4 (max allowed is 0).'
+    int testSimpleSwitch() {
         int a = 0;
         // NP = (case-range[1]=1) + (case-range[2]=1) + (case-range[3]=1)
         //         + (default-range=1) + (expr=0) = 4
@@ -36,8 +36,8 @@ public class InputNPathComplexity {
         return a;
     }
 
-    //NP = 4
-    void testSimpleSwitchWithDefault() { // violation
+    // violation below 'NPath Complexity is 4 (max allowed is 0).'
+    void testSimpleSwitchWithDefault() {
         int a = 0;
         // NP = (case-range[1]=1) + (case-range[2]=1) + (case-range[3]=1)
         //         + (default-range=1) + (expr=0) = 4
@@ -52,8 +52,8 @@ public class InputNPathComplexity {
         }
     }
 
-    //NP = 6
-    void testSwitchWithExpression() { // violation
+    // violation below 'NPath Complexity is 6 (max allowed is 0).'
+    void testSwitchWithExpression() {
         int a = 0;
         // NP = (case-range[1]=1) + (case-range[2]=1) + (case-range[3]=1)
         //         + (default-range=1) + (expr=2) = 6
@@ -68,8 +68,8 @@ public class InputNPathComplexity {
         }
     }
 
-    //NP = 15
-    void testComplexSwitch() { // violation
+    // violation below 'NPath Complexity is 15 (max allowed is 0).'
+    void testComplexSwitch() {
         int a = 0;
         // NP = (case-range[1]=2) + (case-range[2]=5*2) + (case-range[3]=2)
         //         + (default-range=1) + (expr=0) = 15
@@ -93,8 +93,8 @@ public class InputNPathComplexity {
         }
     }
 
-    // NP = 11
-    void testComplexIfElse() { // violation
+    // violation below 'NPath Complexity is 11 (max allowed is 0).'
+    void testComplexIfElse() {
         // NP = (if-range=1) + (else-range=9) + (expr=1) = 11
         if (true && true) { }
         // NP(else-range) = (if-range=1) + (else-range=6) + (expr=2) = 9
@@ -103,8 +103,8 @@ public class InputNPathComplexity {
         else if (true && true && true || true || true) { }
     }
 
-    // NP = 8
-    boolean testComplexReturn() { // violation
+    // violation below 'NPath Complexity is 8 (max allowed is 0).'
+    boolean testComplexReturn() {
         // NP = (if-range=3) + (else-range=4) + (expr=1) = 8
         if (true && true) {
             // NP(if-range) = 3
@@ -117,7 +117,8 @@ public class InputNPathComplexity {
 
     // NP = (for-statement[1]=2) * (for-statement[2]=3)
     //         * (for-statement[3]=4) * (for-statement[4]=5) = 120
-    void testForCyclesComplex() { // violation
+    // violation below 'NPath Complexity is 120 (max allowed is 0).'
+    void testForCyclesComplex() {
         // NP(for-statement) = (for-range=1) + (expr(1)=0) + (expr(2)=0) + (expr(3)=0) + 1 = 2
         for (int i = 0; i < 10; i++);
         // NP(for-statement) = (for-range=1) + (expr(1)=0) + (expr(2)=1) + (expr(3)=0) + 1 = 3
@@ -129,7 +130,8 @@ public class InputNPathComplexity {
     }
 
     // NP = (while-statement[1]=2) * (while-statement[2]=3) = 6
-    boolean testWhileCyclesComplex() { // violation
+    // violation below 'NPath Complexity is 6 (max allowed is 0).'
+    boolean testWhileCyclesComplex() {
         int a = 0;
         // NP(while-statement) = (while-range=1) + (expr=0) + 1 = 2
         while (a != 0) { }
@@ -139,7 +141,8 @@ public class InputNPathComplexity {
     }
 
     // NP = (do-statement[1]=6) * (do-statement[2]=3) = 21
-    void testDoWhileCyclesComplex() { // violation
+    // violation below 'NPath Complexity is 21 (max allowed is 0).'
+    void testDoWhileCyclesComplex() {
         int a = 0;
         // NP(do-statement) = (do-range=1) + (expr=1) + 1 = 3
         do { } while (a < 10 && true);
@@ -152,7 +155,8 @@ public class InputNPathComplexity {
     }
 
     // NP = (question-statement[1]=5) * (question-statement[2]=7) = 35
-    void testComplexTernaryOperator() { // violation
+    // violation below 'NPath Complexity is 35 (max allowed is 0).'
+    void testComplexTernaryOperator() {
         // NP(question-statement) = (expr(1)=0) + (expr(2)=2) + (expr(3)=1+2) + 2 = 7
         boolean a = true ? (true ? true : true) : (false ? (true || false) : true);
         // NP(question-statement) = (expr(1)=0) + (expr(2)=2) + (expr(3)=1) + 2 = 5;
@@ -160,7 +164,8 @@ public class InputNPathComplexity {
     }
 
     // NP = (if-expression[1]=5) * (if-expression[2]=5) = 25
-    void testSimpleTernaryBadFormatting() { // violation
+    // violation below 'NPath Complexity is 25 (max allowed is 0).'
+    void testSimpleTernaryBadFormatting() {
         // NP(if-expression) = (if-range=2) + 1 + (expr=2) = 5
         if(
            true ? true : true
@@ -175,7 +180,8 @@ public class InputNPathComplexity {
 
     //Calculation for try-catch is wrong now
     //See issue #3814 https://github.com/checkstyle/checkstyle/issues/3814
-    void testTryCatch() { // violation
+    // violation below 'NPath Complexity is 2 (max allowed is 0).'
+    void testTryCatch() {
        try {
        }
        catch (Exception e) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityCheckSwitchExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityCheckSwitchExpression.java
@@ -9,7 +9,8 @@ max = 1
 package com.puppycrawl.tools.checkstyle.checks.metrics.npathcomplexity;
 
 public class InputNPathComplexityCheckSwitchExpression {
-    void howMany1(Nums k) { // violation
+    // violation below 'NPath Complexity is 5 (max allowed is 1).'
+    void howMany1(Nums k) {
         switch (k) {
             case ONE: {
                 System.out.println("case two");
@@ -26,7 +27,8 @@ public class InputNPathComplexityCheckSwitchExpression {
         }
     }
 
-    void howMany2(Nums k) { // violation
+    // violation below 'NPath Complexity is 5 (max allowed is 1).'
+    void howMany2(Nums k) {
         switch (k) {
             case ONE -> {
                 System.out.println("case one");
@@ -41,7 +43,8 @@ public class InputNPathComplexityCheckSwitchExpression {
         }
     }
 
-    int howMany3(Nums k) { // violation
+    // violation below 'NPath Complexity is 6 (max allowed is 1).'
+    int howMany3(Nums k) {
         return switch (k) {
             case ONE:
                 yield 3;
@@ -57,7 +60,8 @@ public class InputNPathComplexityCheckSwitchExpression {
         };
     }
 
-    int howMany4(Nums k) { // violation
+    // violation below 'NPath Complexity is 6 (max allowed is 1).'
+    int howMany4(Nums k) {
         return switch (k) {
             case ONE -> {
                 yield 4;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityDefault.java
@@ -8,13 +8,13 @@ max = 0
 package com.puppycrawl.tools.checkstyle.checks.metrics.npathcomplexity;
 
 public class InputNPathComplexityDefault {
-    // NP = 2
-    public void foo() { // violation
+    // violation below 'NPath Complexity is 2 (max allowed is 0).'
+    public void foo() {
         //NP(while-statement) = (while-range=1) + (expr=0) + 1 = 2
         while (true) {
             Runnable runnable = new Runnable() {
-               // NP = 2
-                public void run() { // violation
+               // violation below 'NPath Complexity is 2 (max allowed is 0).'
+                public void run() {
                     // NP(while-statement) = (while-range=1) + (expr=0) + 1 = 2
                     while (true) {
                     }
@@ -25,8 +25,8 @@ public class InputNPathComplexityDefault {
         }
     }
 
-    // NP = 10
-    public void bar() { // violation
+    // violation below 'NPath Complexity is 10 (max allowed is 0).'
+    public void bar() {
         // NP = (if-range=3*3) + (expr=0) + 1 = 10
         if (System.currentTimeMillis() == 0) {
             //NP = (if-range=1) + 1 + (expr=1) = 3
@@ -38,8 +38,8 @@ public class InputNPathComplexityDefault {
         }
     }
 
-    // NP = 3
-    public void simpleElseIf() { // violation
+    // violation below 'NPath Complexity is 3 (max allowed is 0).'
+    public void simpleElseIf() {
         // NP = (if-range=1) + (else-range=2) + 0 = 3
         if (System.currentTimeMillis() == 0) {
         // NP(else-range) = (if-range=1) + (else-range=1) + (expr=0) = 2
@@ -48,8 +48,8 @@ public class InputNPathComplexityDefault {
         }
     }
 
-    // NP = 7
-    public void stupidElseIf() { // violation
+    // violation below 'NPath Complexity is 7 (max allowed is 0).'
+    public void stupidElseIf() {
         // NP = (if-range=1) + (else-range=3*2) + (expr=0) = 7
         if (System.currentTimeMillis() == 0) {
         } else {
@@ -66,8 +66,8 @@ public class InputNPathComplexityDefault {
         }
     }
 
-    // NP = 3
-    public InputNPathComplexityDefault() // violation
+    // violation below 'NPath Complexity is 3 (max allowed is 0).'
+    public InputNPathComplexityDefault()
     {
         int i = 1;
         // NP = (if-range=1) + (else-range=2) + 0 = 3
@@ -79,8 +79,8 @@ public class InputNPathComplexityDefault {
     }
 
     // STATIC_INIT
-    // NP = 3
-    static { // violation
+    // violation below 'NPath Complexity is 3 (max allowed is 0).'
+    static {
         int i = 1;
         // NP = (if-range=1) + (else-range=2) + 0 = 3
         if (System.currentTimeMillis() == 0) {
@@ -91,8 +91,8 @@ public class InputNPathComplexityDefault {
     }
 
     // INSTANCE_INIT
-    // NP = 3
-    { // violation
+    // violation below 'NPath Complexity is 3 (max allowed is 0).'
+    {
         int i = 1;
         // NP = (if-range=1) + (else-range=2) + 0 = 3
         if (System.currentTimeMillis() == 0) {
@@ -107,8 +107,8 @@ public class InputNPathComplexityDefault {
     public InputNPathComplexityDefault(int aParam)
     {
         Runnable runnable = new Runnable() {
-            // NP = 2
-            public void run() { // violation
+            // violation below 'NPath Complexity is 2 (max allowed is 0).'
+            public void run() {
                 // NP(while-statement) = (while-range=1) + (expr=0) + 1 = 2
                 while (true) {
                 }
@@ -117,7 +117,8 @@ public class InputNPathComplexityDefault {
         new Thread(runnable).start();
     }
 
-    public void InputNestedTernaryCheck() { // violation
+    // violation below 'NPath Complexity is 48 (max allowed is 0).'
+    public void InputNestedTernaryCheck() {
         double x = (getSomething() || Math.random() == 5) ? null : (int) Math
                 .cos(400 * (10 + 40)); // good
         double y = (0.2 == Math.random()) ? (0.3 == Math.random()) ? null : (int) Math
@@ -127,14 +128,17 @@ public class InputNPathComplexityDefault {
                         .sin(300 * (12 + 30))); // bad (nested in second
                                                 // position)
     }
-    public boolean getSomething() { return true; }; // violation
-    public int apply(Object o) { return 0; } // violation
+    // violation below 'NPath Complexity is 1 (max allowed is 0).'
+    public boolean getSomething() { return true; };
+    // violation below 'NPath Complexity is 1 (max allowed is 0).'
+    public int apply(Object o) { return 0; }
 
     public void inClass(int type, Short s, int color) {
         switch (type) {
         case 3:
             new Object() {
-                public void anonymousMethod() { // violation
+                public void anonymousMethod() {
+                    // violation above 'NPath Complexity is 3 (max allowed is 0).'
                     {
                         switch (s) {
                         case 5:
@@ -148,7 +152,8 @@ public class InputNPathComplexityDefault {
         default:
             new Object() {
                 class SwitchClass {
-                    { // violation
+                    // violation below 'NPath Complexity is 3 (max allowed is 0).'
+                    {
                         switch (color) {
                         case 5:
                             switch (type) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityDefault3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityDefault3.java
@@ -9,7 +9,8 @@ max = 0
 package com.puppycrawl.tools.checkstyle.checks.metrics.npathcomplexity;
 
 public class InputNPathComplexityDefault3 {
-    @java.lang.SuppressWarnings({(false) ? "unchecked" : // violation
+    // violation below 'NPath Complexity is 64 (max allowed is 0).'
+    @java.lang.SuppressWarnings({(false) ? "unchecked" :
             ("" == "") ? (false) ? (true) ? "" : "foo" : "   " : "unused",
         (false) ? "unchecked" : ("" == "") ? (false) ? (true) ? "" : "foo" : "   " : "unused"})
     public void seriously() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityOverflow.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityOverflow.java
@@ -17,7 +17,8 @@ public class InputNPathComplexityOverflow {
      *          (if-range[5]=9) * (if-range[6]=9) * (if-range[7]=9) * (if-range[8]=9)
      *          (if-range[9]=9) * (if-range[10]=9) = 3486784401
      */
-    public void provokeNpathIntegerOverflow() // violation
+    // violation below 'NPath Complexity is 3,486,784,401 (max allowed is 0).'
+    public void provokeNpathIntegerOverflow()
     {
         // NP = (if-range=8) + 1 + (expr=0) = 9
         if (true) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/InputNPathComplexityRecords.java
@@ -12,7 +12,8 @@ public class InputNPathComplexityRecords {
 
     // in compact ctor, NP=3
     record MyRecord1(boolean t, boolean f) {
-    public MyRecord1 { // violation
+        // violation below 'NPath Complexity is 3 (max allowed is 1).'
+    public MyRecord1 {
             int i = 1;
             // NP = (if-range=1) + (else-range=2) + 0 = 3
             if (t) {
@@ -21,13 +22,13 @@ public class InputNPathComplexityRecords {
             }
         }
 
-        // in method, NP=2
-        public void foo() { // violation
+        // violation below 'NPath Complexity is 2 (max allowed is 1).'
+        public void foo() {
             //NP(while-statement) = (while-range=1) + (expr=0) + 1 = 2
             while (true) {
                 Runnable runnable = new Runnable() {
-                    // NP = 2
-                    public void run() { // violation
+                    // violation below 'NPath Complexity is 2 (max allowed is 1).'
+                    public void run() {
                         // NP(while-statement) = (while-range=1) + (expr=0) + 1 = 2
                         while (true) {
                         }
@@ -41,7 +42,8 @@ public class InputNPathComplexityRecords {
 
     // in ctor NP=3
     record MyRecord2(boolean a, boolean b) {
-        MyRecord2() { // violation
+        // violation below 'NPath Complexity is 3 (max allowed is 1).'
+        MyRecord2() {
             this(true, false);
             int i = 1;
             // NP = (if-range=1) + (else-range=2) + 0 = 3


### PR DESCRIPTION
Issue #15456 
### summary

- Removed NPathComplexityCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in NPathComplexityCheckTest
- Defined violation messages in InputNPathComplexity files