### PR TITLE
Issue #20601: fixing broken links in Search

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
@@ -145,6 +145,15 @@ public final class SearchIndexGenerator {
     /** String literal for index.xml. */
     private static final String INDEX_XML = "index.xml";
 
+    /** Constant for the filters directory. */
+    private static final String FILTERS_DIR = "filters";
+
+    /** Constant for the filefilters directory. */
+    private static final String FILEFILTERS_DIR = "filefilters";
+
+    /** Constant for the index file name. */
+    private static final String INDEX_HTML = "index.html";
+
     /** String literal for Content. */
     private static final String CONTENT = "Content";
 
@@ -165,6 +174,9 @@ public final class SearchIndexGenerator {
 
     /** String literal for anchor separator. */
     private static final String ANCHOR_SEPARATOR = "#";
+
+    /** String literal for path separator in URLs. */
+    private static final String PATH_SEPARATOR = "/";
 
     /** String literal for the Properties subsection name fragment. */
     private static final String PROPERTIES_FRAGMENT = "propert";
@@ -350,13 +362,13 @@ public final class SearchIndexGenerator {
             processChecksDirectory(checksPath.toFile(), xdocsDir);
         }
 
-        final Path filtersPath = xdocsPath.resolve("filters");
+        final Path filtersPath = xdocsPath.resolve(FILTERS_DIR);
         if (Files.exists(filtersPath)) {
             processDirectory(filtersPath.toFile(), xdocsDir,
                     "Filters", "Filter");
         }
 
-        final Path fileFiltersPath = xdocsPath.resolve("filefilters");
+        final Path fileFiltersPath = xdocsPath.resolve(FILEFILTERS_DIR);
         if (Files.exists(fileFiltersPath)) {
             processDirectory(fileFiltersPath.toFile(), xdocsDir,
                     "File Filters", "File Filter");
@@ -1113,7 +1125,10 @@ public final class SearchIndexGenerator {
         if (matcher.find()) {
             final String category = matcher.group(1);
             if (CHECKS_CATEGORY_DISPLAY_NAMES.containsKey(category)) {
-                url = "checks/" + category + "/index.html";
+                url = CHECKS + PATH_SEPARATOR + category + PATH_SEPARATOR + INDEX_HTML;
+            }
+            else if (FILTERS_DIR.equals(category) || FILEFILTERS_DIR.equals(category)) {
+                url = category + PATH_SEPARATOR + INDEX_HTML;
             }
         }
         return url;


### PR DESCRIPTION
Fixes #20601

Searching for "filter" in the Checkstyle documentation search bar returned two broken results:

- "Filters Checks" pointing to `config_filters.html` (does not exist)
- "File Filters Checks" pointing to `config_filefilters.html` (does not exist)

The root cause was in `SearchIndexGenerator.resolvePageUrl()`. The method already handled `config_.xml` stubs for check categories (e.g. `config_annotation.xml` → `checks/annotation/index.html`), but had no equivalent mapping for `config_filters.xml` and `config_filefilters.xml`. These two files are also redirect stubs, but they point to `filters/index.html`
and `filefilters/index.html` respectively not to a `checks/` subdirectory. Without a mapping, `resolvePageUrl` fell through to `buildUrl`, which produced the file-based path `config_filters.html` — a page that does not exist on the live site.


```java
private static final String FILTERS_DIR    = "filters";
private static final String FILEFILTERS_DIR = "filefilters";
private static final String INDEX_HTML      = "index.html";
private static final String PATH_SEPARATOR  = "/";
```

An `else if` branch is added in `resolvePageUrl()` to handle the filter and filefilter cases explicitly:

```java
else if (FILTERS_DIR.equals(category) || FILEFILTERS_DIR.equals(category)) {
    url = category + PATH_SEPARATOR + INDEX_HTML;
}
```

This maps:
- `config_filters.xml`     → `filters/index.html`    
- `config_filefilters.xml` → `filefilters/index.html` 

The existing check-category handling and all other URL resolution paths are unchanged.