### PR TITLE
Issue #15456: specify violation messages for ClassFanOutComplexityCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -270,7 +270,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
-            "com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -50,8 +50,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     public void test() throws Exception {
 
         final String[] expected = {
-            "27:1: " + getCheckMessage(MSG_KEY, 3, 0),
-            "59:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "28:1: " + getCheckMessage(MSG_KEY, 3, 0),
+            "61:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -61,7 +61,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testExcludedPackagesDirectPackages() throws Exception {
         final String[] expected = {
-            "29:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "30:1: " + getCheckMessage(MSG_KEY, 2, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -71,9 +71,9 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testExcludedPackagesCommonPackages() throws Exception {
         final String[] expected = {
-            "28:1: " + getCheckMessage(MSG_KEY, 2, 0),
-            "32:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "38:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "29:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "34:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "41:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityExcludedPackagesCommonPackage.java"), expected);
@@ -113,7 +113,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     public void test15() throws Exception {
 
         final String[] expected = {
-            "29:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "30:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -159,8 +159,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     public void testRegularExpression() throws Exception {
 
         final String[] expected = {
-            "44:1: " + getCheckMessage(MSG_KEY, 2, 0),
-            "76:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "45:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "78:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -171,8 +171,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     public void testEmptyRegularExpression() throws Exception {
 
         final String[] expected = {
-            "44:1: " + getCheckMessage(MSG_KEY, 3, 0),
-            "76:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "45:1: " + getCheckMessage(MSG_KEY, 3, 0),
+            "78:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -198,7 +198,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testExtends() throws Exception {
         final String[] expected = {
-            "23:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "24:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityExtends.java"), expected);
@@ -207,7 +207,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testImplements() throws Exception {
         final String[] expected = {
-            "23:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "24:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityImplements.java"), expected);
@@ -216,13 +216,13 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAnnotation() throws Exception {
         final String[] expected = {
-            "29:1: " + getCheckMessage(MSG_KEY, 2, 0),
-            "45:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "54:5: " + getCheckMessage(MSG_KEY, 3, 0),
-            "64:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "79:1: " + getCheckMessage(MSG_KEY, 1, 0),
-            "99:1: " + getCheckMessage(MSG_KEY, 1, 0),
-            "102:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "30:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "47:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "57:5: " + getCheckMessage(MSG_KEY, 3, 0),
+            "68:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "84:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "105:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "109:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityAnnotations.java"), expected);
@@ -231,7 +231,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testImplementsAndNestedCount() throws Exception {
         final String[] expected = {
-            "26:1: " + getCheckMessage(MSG_KEY, 3, 0),
+            "27:1: " + getCheckMessage(MSG_KEY, 3, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityImplementsAndNestedCount.java"), expected);
@@ -240,8 +240,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testClassFanOutComplexityRecords() throws Exception {
         final String[] expected = {
-            "32:1: " + getCheckMessage(MSG_KEY, 4, 2),
-            "53:1: " + getCheckMessage(MSG_KEY, 4, 2),
+            "33:1: " + getCheckMessage(MSG_KEY, 4, 2),
+            "55:1: " + getCheckMessage(MSG_KEY, 4, 2),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityRecords.java"), expected);
@@ -272,7 +272,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testClassFanOutComplexityMultiCatchBitwiseOr() throws Exception {
         final String[] expected = {
-            "27:1: " + getCheckMessage(MSG_KEY, 5, 4),
+            "28:1: " + getCheckMessage(MSG_KEY, 5, 4),
         };
 
         verifyWithInlineConfigParser(
@@ -389,7 +389,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testLambdaNew() throws Exception {
         final String[] expected = {
-            "29:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "30:1: " + getCheckMessage(MSG_KEY, 2, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityLambdaNew.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity.java
@@ -24,7 +24,8 @@ import javax.naming.*;
 import java.util.*;
 import java.util.stream.*;
 
-public class InputClassFanOutComplexity { // violation
+// violation below 'Class Fan-Out Complexity is 3 (max allowed is 0).'
+public class InputClassFanOutComplexity {
     private class InnerClass { //singleline comment
         public List _list = new ArrayList();
     }
@@ -56,7 +57,8 @@ enum InnerEnum {
     private Map map2;
 }
 
-class InputThrows { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+class InputThrows {
 
     public void get() throws NamingException, IllegalArgumentException {
         new java.lang.ref.ReferenceQueue<Integer>();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity15Extensions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity15Extensions.java
@@ -26,7 +26,8 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
     int version();
 }
 
-@MyAnnotation1(name = "ABC", version = 1) // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+@MyAnnotation1(name = "ABC", version = 1)
 public class InputClassFanOutComplexity15Extensions
 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity3.java
@@ -41,7 +41,8 @@ import java.util.stream.Stream;
 
 import javax.naming.NamingException;
 
-public class InputClassFanOutComplexity3 { // violation
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+public class InputClassFanOutComplexity3 {
     private class InnerClass { //singleline comment
         public List _list = new ArrayList();
     }
@@ -73,7 +74,8 @@ enum InnerEnum3 {
     private Map map2;
 }
 
-class InputThrows3 { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+class InputThrows3 {
 
     public void get() throws NamingException, IllegalArgumentException {
         new java.lang.ref.ReferenceQueue<Integer>();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity4.java
@@ -41,7 +41,8 @@ import java.util.stream.Stream;
 
 import javax.naming.NamingException;
 
-public class InputClassFanOutComplexity4 { // violation
+// violation below 'Class Fan-Out Complexity is 3 (max allowed is 0).'
+public class InputClassFanOutComplexity4 {
     private class InnerClass { //singleline comment
         public List _list = new ArrayList();
     }
@@ -73,7 +74,8 @@ enum InnerEnum4 {
     private Map map2;
 }
 
-class InputThrows4 { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+class InputThrows4 {
 
     public void get() throws NamingException, IllegalArgumentException {
         new java.lang.ref.ReferenceQueue<Integer>();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityAnnotations.java
@@ -26,7 +26,8 @@ import java.lang.annotation.Target;
 import java.util.Calendar;
 
 /* This input file is intended to be used on strict configuration: max=0 */
-public class InputClassFanOutComplexityAnnotations { // violation
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+public class InputClassFanOutComplexityAnnotations {
 
     private int dayOfWeek = Calendar.MONDAY;
 
@@ -42,7 +43,8 @@ public class InputClassFanOutComplexityAnnotations { // violation
         return super.toString();
     }
 
-    @MyAnnotation // violation
+    // violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+    @MyAnnotation
     public class InnerClass {
 
         @MyAnnotation
@@ -51,7 +53,8 @@ public class InputClassFanOutComplexityAnnotations { // violation
 
     }
 
-    public class InnerClass2 { // violation
+    // violation below 'Class Fan-Out Complexity is 3 (max allowed is 0).'
+    public class InnerClass2 {
 
         @MethodAnnotation
         @MyAnnotation
@@ -61,7 +64,8 @@ public class InputClassFanOutComplexityAnnotations { // violation
 
     }
 
-    public class InnerClass3 { // violation
+    // violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+    public class InnerClass3 {
 
         @TypeAnnotation
         private final String warningsType = "boxing";
@@ -76,7 +80,8 @@ public class InputClassFanOutComplexityAnnotations { // violation
 
 }
 
-class OuterClass { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+class OuterClass {
 
     private static final String name = "1";
 
@@ -96,10 +101,12 @@ class OuterClass { // violation
 @Target(ElementType.METHOD)
 @interface MethodAnnotation {}
 
-@MyAnnotation // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+@MyAnnotation
 class MyClass {}
 
-@MyAnnotation // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+@MyAnnotation
 interface MyInterface {}
 
 @interface MyAnnotation {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExcludedPackagesCommonPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExcludedPackagesCommonPackage.java
@@ -25,16 +25,19 @@ import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inpu
 import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inputs.b.BClass;
 import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inputs.c.CClass;
 
-public class InputClassFanOutComplexityExcludedPackagesCommonPackage { // violation
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+public class InputClassFanOutComplexityExcludedPackagesCommonPackage {
     public AAClass aa;
     public ABClass ab;
 
-    class Inner { // violation
+    // violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+    class Inner {
         public BClass b;
         public CClass c;
     }
 }
 
-class InputClassFanOutComplexityExcludedPackagesCommonPackageHidden { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+class InputClassFanOutComplexityExcludedPackagesCommonPackageHidden {
     public CClass c;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExcludedPackagesDirectPackages.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExcludedPackagesDirectPackages.java
@@ -26,7 +26,8 @@ import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inpu
 import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inputs.b.BClass;
 import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inputs.c.CClass;
 
-public class InputClassFanOutComplexityExcludedPackagesDirectPackages { // violation
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+public class InputClassFanOutComplexityExcludedPackagesDirectPackages {
     public AAClass aa;
     public ABClass ab;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExtends.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExtends.java
@@ -20,7 +20,8 @@ excludedPackages = (default)
 
 package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 
-public class InputClassFanOutComplexityExtends extends ParentClass { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+public class InputClassFanOutComplexityExtends extends ParentClass {
 }
 
 class ParentClass {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityImplements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityImplements.java
@@ -20,6 +20,7 @@ excludedPackages = (default)
 
 package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 
-public class InputClassFanOutComplexityImplements implements Interface {} // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+public class InputClassFanOutComplexityImplements implements Interface {}
 
 interface Interface {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityImplementsAndNestedCount.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityImplementsAndNestedCount.java
@@ -23,7 +23,8 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 import java.io.Serializable;
 import java.util.RandomAccess;
 
-public class InputClassFanOutComplexityImplementsAndNestedCount // violation 'Complexity is 3'
+// violation below 'Class Fan-Out Complexity is 3 (max allowed is 0).'
+public class InputClassFanOutComplexityImplementsAndNestedCount
     extends Outer.Nested implements Serializable, RandomAccess {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityLambdaNew.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityLambdaNew.java
@@ -26,7 +26,8 @@ import java.util.ArrayList;
 import java.io.File;
 import java.util.Random;
 
-public class InputClassFanOutComplexityLambdaNew { // violation 'Complexity is 2'
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+public class InputClassFanOutComplexityLambdaNew {
     public void testMethod(Map<String, List<String>> entry) {
         List<File> files = new ArrayList<>();
         String string = "";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityMultiCatchBitwiseOr.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityMultiCatchBitwiseOr.java
@@ -24,7 +24,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class InputClassFanOutComplexityMultiCatchBitwiseOr { // violation 'Complexity is 5'
+// violation below 'Class Fan-Out Complexity is 5 (max allowed is 4).'
+public class InputClassFanOutComplexityMultiCatchBitwiseOr {
     public static void main(String[] args) {
         try {
             System.out.println(args[7]);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityRecords.java
@@ -29,7 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-class InputClassFanOutComplexityRecords { // violation
+// violation below 'Class Fan-Out Complexity is 4 (max allowed is 2).'
+class InputClassFanOutComplexityRecords {
     private class InnerClass {
         public List _list = new ArrayList();
     }
@@ -50,7 +51,8 @@ class InputClassFanOutComplexityRecords { // violation
     }
 }
 
-record MyRecord1(boolean a, boolean b) { // violation
+// violation below 'Class Fan-Out Complexity is 4 (max allowed is 2).'
+record MyRecord1(boolean a, boolean b) {
     private class InnerClass {
         public List _list = new ArrayList();
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexitySealedClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexitySealedClasses.java
@@ -21,14 +21,14 @@ excludedPackages = (default)
 
 package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 
-// violation below, 'Class Fan-Out Complexity is 2 (max allowed is 0)'
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0)'
 public class InputClassFanOutComplexitySealedClasses implements I, J {
 }
 
 // ok below, sealed classes don't rely on the permitted subclasses
 sealed class A permits B { }
 
-// violation below, 'Class Fan-Out Complexity is 1 (max allowed is 0)'
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0)'
 final class B extends A { }
 
 interface I {


### PR DESCRIPTION
Issue #15456 
### Summary

- Removed ClassFanOutComplexityCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in ClassFanOutComplexityCheckTest
- Defined violation messages in InputClassFanOutComplexity files