### PR TITLE
Issue #15456: specify violation messages for ClassMemberImpliedModifierCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -50,8 +50,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     public void test() throws Exception {
 
         final String[] expected = {
-            "27:1: " + getCheckMessage(MSG_KEY, 3, 0),
-            "59:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "28:1: " + getCheckMessage(MSG_KEY, 3, 0),
+            "61:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -61,7 +61,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testExcludedPackagesDirectPackages() throws Exception {
         final String[] expected = {
-            "29:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "30:1: " + getCheckMessage(MSG_KEY, 2, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -71,9 +71,9 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testExcludedPackagesCommonPackages() throws Exception {
         final String[] expected = {
-            "28:1: " + getCheckMessage(MSG_KEY, 2, 0),
-            "32:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "38:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "29:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "34:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "41:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityExcludedPackagesCommonPackage.java"), expected);
@@ -113,7 +113,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     public void test15() throws Exception {
 
         final String[] expected = {
-            "29:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "30:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -159,8 +159,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     public void testRegularExpression() throws Exception {
 
         final String[] expected = {
-            "44:1: " + getCheckMessage(MSG_KEY, 2, 0),
-            "76:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "45:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "78:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -171,8 +171,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     public void testEmptyRegularExpression() throws Exception {
 
         final String[] expected = {
-            "44:1: " + getCheckMessage(MSG_KEY, 3, 0),
-            "76:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "45:1: " + getCheckMessage(MSG_KEY, 3, 0),
+            "78:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -198,7 +198,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testExtends() throws Exception {
         final String[] expected = {
-            "23:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "24:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityExtends.java"), expected);
@@ -207,7 +207,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testImplements() throws Exception {
         final String[] expected = {
-            "23:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "24:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityImplements.java"), expected);
@@ -216,13 +216,13 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAnnotation() throws Exception {
         final String[] expected = {
-            "29:1: " + getCheckMessage(MSG_KEY, 2, 0),
-            "45:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "54:5: " + getCheckMessage(MSG_KEY, 3, 0),
-            "64:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "79:1: " + getCheckMessage(MSG_KEY, 1, 0),
-            "99:1: " + getCheckMessage(MSG_KEY, 1, 0),
-            "102:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "30:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "47:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "57:5: " + getCheckMessage(MSG_KEY, 3, 0),
+            "68:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "84:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "105:1: " + getCheckMessage(MSG_KEY, 1, 0),
+            "109:1: " + getCheckMessage(MSG_KEY, 1, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityAnnotations.java"), expected);
@@ -231,7 +231,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testImplementsAndNestedCount() throws Exception {
         final String[] expected = {
-            "26:1: " + getCheckMessage(MSG_KEY, 3, 0),
+            "27:1: " + getCheckMessage(MSG_KEY, 3, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityImplementsAndNestedCount.java"), expected);
@@ -240,8 +240,8 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testClassFanOutComplexityRecords() throws Exception {
         final String[] expected = {
-            "32:1: " + getCheckMessage(MSG_KEY, 4, 2),
-            "53:1: " + getCheckMessage(MSG_KEY, 4, 2),
+            "33:1: " + getCheckMessage(MSG_KEY, 4, 2),
+            "55:1: " + getCheckMessage(MSG_KEY, 4, 2),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityRecords.java"), expected);
@@ -272,7 +272,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testClassFanOutComplexityMultiCatchBitwiseOr() throws Exception {
         final String[] expected = {
-            "27:1: " + getCheckMessage(MSG_KEY, 5, 4),
+            "28:1: " + getCheckMessage(MSG_KEY, 5, 4),
         };
 
         verifyWithInlineConfigParser(
@@ -389,7 +389,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testLambdaNew() throws Exception {
         final String[] expected = {
-            "29:1: " + getCheckMessage(MSG_KEY, 2, 0),
+            "30:1: " + getCheckMessage(MSG_KEY, 2, 0),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassFanOutComplexityLambdaNew.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
@@ -41,12 +41,12 @@ public class ClassMemberImpliedModifierCheckTest
     @Test
     public void testMethodsOnClass() throws Exception {
         final String[] expected = {
-            "51:9: " + getCheckMessage(MSG_KEY, "static"),
-            "58:9: " + getCheckMessage(MSG_KEY, "static"),
-            "62:5: " + getCheckMessage(MSG_KEY, "static"),
-            "69:9: " + getCheckMessage(MSG_KEY, "static"),
-            "76:9: " + getCheckMessage(MSG_KEY, "static"),
-            "83:5: " + getCheckMessage(MSG_KEY, "static"),
+            "52:9: " + getCheckMessage(MSG_KEY, "static"),
+            "60:9: " + getCheckMessage(MSG_KEY, "static"),
+            "65:5: " + getCheckMessage(MSG_KEY, "static"),
+            "73:9: " + getCheckMessage(MSG_KEY, "static"),
+            "81:9: " + getCheckMessage(MSG_KEY, "static"),
+            "89:5: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassMemberImpliedModifierOnClass.java"),
@@ -70,9 +70,9 @@ public class ClassMemberImpliedModifierCheckTest
     @Test
     public void testMethodsOnClassNoImpliedStaticEnum() throws Exception {
         final String[] expected = {
-            "59:9: " + getCheckMessage(MSG_KEY, "static"),
-            "77:9: " + getCheckMessage(MSG_KEY, "static"),
-            "84:5: " + getCheckMessage(MSG_KEY, "static"),
+            "60:9: " + getCheckMessage(MSG_KEY, "static"),
+            "79:9: " + getCheckMessage(MSG_KEY, "static"),
+            "87:5: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassMemberImpliedModifierOnClassSetEnumFalse.java"),
@@ -82,9 +82,9 @@ public class ClassMemberImpliedModifierCheckTest
     @Test
     public void testMethodsOnClassNoImpliedStaticInterface() throws Exception {
         final String[] expected = {
-            "52:9: " + getCheckMessage(MSG_KEY, "static"),
-            "63:5: " + getCheckMessage(MSG_KEY, "static"),
-            "70:9: " + getCheckMessage(MSG_KEY, "static"),
+            "53:9: " + getCheckMessage(MSG_KEY, "static"),
+            "65:5: " + getCheckMessage(MSG_KEY, "static"),
+            "73:9: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassMemberImpliedModifierOnClassSetInterfaceFalse.java"),
@@ -102,12 +102,12 @@ public class ClassMemberImpliedModifierCheckTest
     @Test
     public void testMethodsOnInterface() throws Exception {
         final String[] expected = {
-            "60:13: " + getCheckMessage(MSG_KEY, "static"),
-            "67:13: " + getCheckMessage(MSG_KEY, "static"),
-            "71:9: " + getCheckMessage(MSG_KEY, "static"),
-            "78:13: " + getCheckMessage(MSG_KEY, "static"),
-            "85:13: " + getCheckMessage(MSG_KEY, "static"),
-            "92:9: " + getCheckMessage(MSG_KEY, "static"),
+            "61:13: " + getCheckMessage(MSG_KEY, "static"),
+            "69:13: " + getCheckMessage(MSG_KEY, "static"),
+            "74:9: " + getCheckMessage(MSG_KEY, "static"),
+            "82:13: " + getCheckMessage(MSG_KEY, "static"),
+            "90:13: " + getCheckMessage(MSG_KEY, "static"),
+            "98:9: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputClassMemberImpliedModifierOnInterface.java"),

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierNoViolationRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierNoViolationRecords.java
@@ -12,12 +12,12 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.classmemberimpliedmodifi
 
 public class InputClassMemberImpliedModifierNoViolationRecords {
     public static interface GoodInterface {}
-    // Implied modifier 'static' should be explicit. [ClassMemberImpliedModifier]
-    public interface BadInterface {} // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public interface BadInterface {}
 
     public static enum GoodEnum {}
-    // Implied modifier 'static' should be explicit. [ClassMemberImpliedModifier]
-    public enum BadEnum {} // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public enum BadEnum {}
 
     public static record GoodRecord() {}
 
@@ -29,12 +29,12 @@ public class InputClassMemberImpliedModifierNoViolationRecords {
         public record InnerRecord2(){}
 
         public static interface InnerInterface1 {}
-        // Implied modifier 'static' should be explicit. [ClassMemberImpliedModifier]
-        public interface InnerInterface2 {} // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        public interface InnerInterface2 {}
 
         public static enum InnerEnum1{}
-        // Implied modifier 'static' should be explicit. [ClassMemberImpliedModifier]
-        public enum InnerEnum2{} // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        public enum InnerEnum2{}
     }
 
     Object obj = new Object() {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierRecords.java
@@ -12,34 +12,34 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.classmemberimpliedmodifi
 
 public class InputClassMemberImpliedModifierRecords {
     public static interface GoodInterface {}
-    // Implied modifier 'static' should be explicit. [ClassMemberImpliedModifier]
-    public interface BadInterface {} // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public interface BadInterface {}
 
     public static enum GoodEnum {}
-    // Implied modifier 'static' should be explicit. [ClassMemberImpliedModifier]
-    public enum BadEnum {} // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public enum BadEnum {}
 
     public static record GoodRecord() {}
-    // Implied modifier 'static' should be explicit. [ClassMemberImpliedModifier]
-    public record BadRecord() {} // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public record BadRecord() {}
 
     public static record OuterRecord() {
         public static record InnerRecord1(){}
-        // Implied modifier 'static' should be explicit. [ClassMemberImpliedModifier]
-        public record InnerRecord2(){} // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        public record InnerRecord2(){}
 
         public static interface InnerInterface1 {}
-        // Implied modifier 'static' should be explicit. [ClassMemberImpliedModifier]
-        public interface InnerInterface2 {} // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        public interface InnerInterface2 {}
 
         public static enum InnerEnum1{}
-        // Implied modifier 'static' should be explicit. [ClassMemberImpliedModifier]
-        public enum InnerEnum2{} // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        public enum InnerEnum2{}
     }
 
     Object obj = new Object() {
-        // Implied modifier 'static' should be explicit. [ClassMemberImpliedModifier]
-        public record BadRecord() {} // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        public record BadRecord() {}
         public static record OkRecord() {}
     };
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity.java
@@ -24,7 +24,8 @@ import javax.naming.*;
 import java.util.*;
 import java.util.stream.*;
 
-public class InputClassFanOutComplexity { // violation
+// violation below 'Class Fan-Out Complexity is 3 (max allowed is 0).'
+public class InputClassFanOutComplexity {
     private class InnerClass { //singleline comment
         public List _list = new ArrayList();
     }
@@ -56,7 +57,8 @@ enum InnerEnum {
     private Map map2;
 }
 
-class InputThrows { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+class InputThrows {
 
     public void get() throws NamingException, IllegalArgumentException {
         new java.lang.ref.ReferenceQueue<Integer>();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity15Extensions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity15Extensions.java
@@ -26,7 +26,8 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
     int version();
 }
 
-@MyAnnotation1(name = "ABC", version = 1) // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+@MyAnnotation1(name = "ABC", version = 1)
 public class InputClassFanOutComplexity15Extensions
 {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity3.java
@@ -41,7 +41,8 @@ import java.util.stream.Stream;
 
 import javax.naming.NamingException;
 
-public class InputClassFanOutComplexity3 { // violation
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+public class InputClassFanOutComplexity3 {
     private class InnerClass { //singleline comment
         public List _list = new ArrayList();
     }
@@ -73,7 +74,8 @@ enum InnerEnum3 {
     private Map map2;
 }
 
-class InputThrows3 { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+class InputThrows3 {
 
     public void get() throws NamingException, IllegalArgumentException {
         new java.lang.ref.ReferenceQueue<Integer>();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexity4.java
@@ -41,7 +41,8 @@ import java.util.stream.Stream;
 
 import javax.naming.NamingException;
 
-public class InputClassFanOutComplexity4 { // violation
+// violation below 'Class Fan-Out Complexity is 3 (max allowed is 0).'
+public class InputClassFanOutComplexity4 {
     private class InnerClass { //singleline comment
         public List _list = new ArrayList();
     }
@@ -73,7 +74,8 @@ enum InnerEnum4 {
     private Map map2;
 }
 
-class InputThrows4 { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+class InputThrows4 {
 
     public void get() throws NamingException, IllegalArgumentException {
         new java.lang.ref.ReferenceQueue<Integer>();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityAnnotations.java
@@ -26,7 +26,8 @@ import java.lang.annotation.Target;
 import java.util.Calendar;
 
 /* This input file is intended to be used on strict configuration: max=0 */
-public class InputClassFanOutComplexityAnnotations { // violation
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+public class InputClassFanOutComplexityAnnotations {
 
     private int dayOfWeek = Calendar.MONDAY;
 
@@ -42,7 +43,8 @@ public class InputClassFanOutComplexityAnnotations { // violation
         return super.toString();
     }
 
-    @MyAnnotation // violation
+    // violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+    @MyAnnotation
     public class InnerClass {
 
         @MyAnnotation
@@ -51,7 +53,8 @@ public class InputClassFanOutComplexityAnnotations { // violation
 
     }
 
-    public class InnerClass2 { // violation
+    // violation below 'Class Fan-Out Complexity is 3 (max allowed is 0).'
+    public class InnerClass2 {
 
         @MethodAnnotation
         @MyAnnotation
@@ -61,7 +64,8 @@ public class InputClassFanOutComplexityAnnotations { // violation
 
     }
 
-    public class InnerClass3 { // violation
+    // violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+    public class InnerClass3 {
 
         @TypeAnnotation
         private final String warningsType = "boxing";
@@ -76,7 +80,8 @@ public class InputClassFanOutComplexityAnnotations { // violation
 
 }
 
-class OuterClass { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+class OuterClass {
 
     private static final String name = "1";
 
@@ -96,10 +101,12 @@ class OuterClass { // violation
 @Target(ElementType.METHOD)
 @interface MethodAnnotation {}
 
-@MyAnnotation // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+@MyAnnotation
 class MyClass {}
 
-@MyAnnotation // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+@MyAnnotation
 interface MyInterface {}
 
 @interface MyAnnotation {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExcludedPackagesCommonPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExcludedPackagesCommonPackage.java
@@ -25,16 +25,19 @@ import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inpu
 import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inputs.b.BClass;
 import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inputs.c.CClass;
 
-public class InputClassFanOutComplexityExcludedPackagesCommonPackage { // violation
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+public class InputClassFanOutComplexityExcludedPackagesCommonPackage {
     public AAClass aa;
     public ABClass ab;
 
-    class Inner { // violation
+    // violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+    class Inner {
         public BClass b;
         public CClass c;
     }
 }
 
-class InputClassFanOutComplexityExcludedPackagesCommonPackageHidden { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+class InputClassFanOutComplexityExcludedPackagesCommonPackageHidden {
     public CClass c;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExcludedPackagesDirectPackages.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExcludedPackagesDirectPackages.java
@@ -26,7 +26,8 @@ import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inpu
 import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inputs.b.BClass;
 import com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.inputs.c.CClass;
 
-public class InputClassFanOutComplexityExcludedPackagesDirectPackages { // violation
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+public class InputClassFanOutComplexityExcludedPackagesDirectPackages {
     public AAClass aa;
     public ABClass ab;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExtends.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityExtends.java
@@ -20,7 +20,8 @@ excludedPackages = (default)
 
 package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 
-public class InputClassFanOutComplexityExtends extends ParentClass { // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+public class InputClassFanOutComplexityExtends extends ParentClass {
 }
 
 class ParentClass {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityImplements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityImplements.java
@@ -20,6 +20,7 @@ excludedPackages = (default)
 
 package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 
-public class InputClassFanOutComplexityImplements implements Interface {} // violation
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0).'
+public class InputClassFanOutComplexityImplements implements Interface {}
 
 interface Interface {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityImplementsAndNestedCount.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityImplementsAndNestedCount.java
@@ -23,7 +23,8 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 import java.io.Serializable;
 import java.util.RandomAccess;
 
-public class InputClassFanOutComplexityImplementsAndNestedCount // violation 'Complexity is 3'
+// violation below 'Class Fan-Out Complexity is 3 (max allowed is 0).'
+public class InputClassFanOutComplexityImplementsAndNestedCount
     extends Outer.Nested implements Serializable, RandomAccess {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityLambdaNew.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityLambdaNew.java
@@ -26,7 +26,8 @@ import java.util.ArrayList;
 import java.io.File;
 import java.util.Random;
 
-public class InputClassFanOutComplexityLambdaNew { // violation 'Complexity is 2'
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0).'
+public class InputClassFanOutComplexityLambdaNew {
     public void testMethod(Map<String, List<String>> entry) {
         List<File> files = new ArrayList<>();
         String string = "";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityMultiCatchBitwiseOr.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityMultiCatchBitwiseOr.java
@@ -24,7 +24,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class InputClassFanOutComplexityMultiCatchBitwiseOr { // violation 'Complexity is 5'
+// violation below 'Class Fan-Out Complexity is 5 (max allowed is 4).'
+public class InputClassFanOutComplexityMultiCatchBitwiseOr {
     public static void main(String[] args) {
         try {
             System.out.println(args[7]);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityRecords.java
@@ -29,7 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-class InputClassFanOutComplexityRecords { // violation
+// violation below 'Class Fan-Out Complexity is 4 (max allowed is 2).'
+class InputClassFanOutComplexityRecords {
     private class InnerClass {
         public List _list = new ArrayList();
     }
@@ -50,7 +51,8 @@ class InputClassFanOutComplexityRecords { // violation
     }
 }
 
-record MyRecord1(boolean a, boolean b) { // violation
+// violation below 'Class Fan-Out Complexity is 4 (max allowed is 2).'
+record MyRecord1(boolean a, boolean b) {
     private class InnerClass {
         public List _list = new ArrayList();
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexitySealedClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexitySealedClasses.java
@@ -21,14 +21,14 @@ excludedPackages = (default)
 
 package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 
-// violation below, 'Class Fan-Out Complexity is 2 (max allowed is 0)'
+// violation below 'Class Fan-Out Complexity is 2 (max allowed is 0)'
 public class InputClassFanOutComplexitySealedClasses implements I, J {
 }
 
 // ok below, sealed classes don't rely on the permitted subclasses
 sealed class A permits B { }
 
-// violation below, 'Class Fan-Out Complexity is 1 (max allowed is 0)'
+// violation below 'Class Fan-Out Complexity is 1 (max allowed is 0)'
 final class B extends A { }
 
 interface I {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierOnClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierOnClass.java
@@ -48,38 +48,44 @@ public class InputClassMemberImpliedModifierOnClass {
             RED, GREEN, BLUE;
         }
 
-        enum SimpleInnerEnum {  // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        enum SimpleInnerEnum {
             RED, GREEN, BLUE;
         }
 
         static interface StaticInnerInterface {
         }
 
-        interface SimpleInnerInterface {  // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        interface SimpleInnerInterface {
         }
     }
 
-    enum SimpleEnum {  // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    enum SimpleEnum {
         RED, GREEN, BLUE;
 
         static enum StaticInnerEnum {
             RED, GREEN, BLUE;
         }
 
-        enum SimpleInnerEnum {  // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        enum SimpleInnerEnum {
             RED, GREEN, BLUE;
         }
 
         static interface StaticInnerInterface {
         }
 
-        interface SimpleInnerInterface {  // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        interface SimpleInnerInterface {
         }
     }
 
     static interface StaticInterface {
     }
 
-    interface SimpleInterface {  // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    interface SimpleInterface {
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierOnClassSetEnumFalse.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierOnClassSetEnumFalse.java
@@ -56,7 +56,8 @@ public class InputClassMemberImpliedModifierOnClassSetEnumFalse {
         static interface StaticInnerInterface {
         }
 
-        interface SimpleInnerInterface {  // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        interface SimpleInnerInterface {
         }
     }
 
@@ -74,13 +75,15 @@ public class InputClassMemberImpliedModifierOnClassSetEnumFalse {
         static interface StaticInnerInterface {
         }
 
-        interface SimpleInnerInterface {  // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        interface SimpleInnerInterface {
         }
     }
 
     static interface StaticInterface {
     }
 
-    interface SimpleInterface {  // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    interface SimpleInterface {
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierOnClassSetInterfaceFalse.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierOnClassSetInterfaceFalse.java
@@ -49,7 +49,8 @@ public class InputClassMemberImpliedModifierOnClassSetInterfaceFalse {
             RED, GREEN, BLUE;
         }
 
-        enum SimpleInnerEnum {  // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        enum SimpleInnerEnum {
             RED, GREEN, BLUE;
         }
 
@@ -60,14 +61,16 @@ public class InputClassMemberImpliedModifierOnClassSetInterfaceFalse {
         }
     }
 
-    enum SimpleEnum {  // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    enum SimpleEnum {
         RED, GREEN, BLUE;
 
         static enum StaticInnerEnum {
             RED, GREEN, BLUE;
         }
 
-        enum SimpleInnerEnum {  // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        enum SimpleInnerEnum {
             RED, GREEN, BLUE;
         }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierOnInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierOnInterface.java
@@ -57,39 +57,45 @@ public interface InputClassMemberImpliedModifierOnInterface {
                 RED, GREEN, BLUE;
             }
 
-            enum SimpleInnerEnum {  // violation
+            // violation below 'Implied modifier 'static' should be explicit.'
+            enum SimpleInnerEnum {
                 RED, GREEN, BLUE;
             }
 
             static interface StaticInnerInterface {
             }
 
-            interface SimpleInnerInterface {  // violation
+            // violation below 'Implied modifier 'static' should be explicit.'
+            interface SimpleInnerInterface {
             }
         }
 
-        enum SimpleEnum {  // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        enum SimpleEnum {
             RED, GREEN, BLUE;
 
             static enum StaticInnerEnum {
                 RED, GREEN, BLUE;
             }
 
-            enum SimpleInnerEnum {  // violation
+            // violation below 'Implied modifier 'static' should be explicit.'
+            enum SimpleInnerEnum {
                 RED, GREEN, BLUE;
             }
 
             static interface StaticInnerInterface {
             }
 
-            interface SimpleInnerInterface {  // violation
+            // violation below 'Implied modifier 'static' should be explicit.'
+            interface SimpleInnerInterface {
             }
         }
 
         static interface StaticInterface {
         }
 
-        interface SimpleInterface {  // violation
+        // violation below 'Implied modifier 'static' should be explicit.'
+        interface SimpleInterface {
         }
     }
 }


### PR DESCRIPTION
Issue #15456 
### Summary

- Removed ClassMemberImpliedModifierCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in ClassMemberImpliedModifierCheckTest
- Defined violation messages in InputClassMemberImpliedModifierCheck files