### PR TITLE
Issue #15456: specify violation messages for InterfaceMemberImpliedModifierCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -271,7 +271,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck",
-            "com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
@@ -41,12 +41,12 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testMethodsOnInterfaceNoImpliedPublicAbstract() throws Exception {
         final String[] expected = {
-            "21:5: " + getCheckMessage(MSG_KEY, "public"),
-            "27:5: " + getCheckMessage(MSG_KEY, "public"),
-            "34:5: " + getCheckMessage(MSG_KEY, "public"),
-            "36:5: " + getCheckMessage(MSG_KEY, "abstract"),
-            "38:5: " + getCheckMessage(MSG_KEY, "public"),
-            "38:5: " + getCheckMessage(MSG_KEY, "abstract"),
+            "22:5: " + getCheckMessage(MSG_KEY, "public"),
+            "29:5: " + getCheckMessage(MSG_KEY, "public"),
+            "37:5: " + getCheckMessage(MSG_KEY, "public"),
+            "40:5: " + getCheckMessage(MSG_KEY, "abstract"),
+            "42:5: " + getCheckMessage(MSG_KEY, "public"),
+            "42:5: " + getCheckMessage(MSG_KEY, "abstract"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierMethodsOnInterface.java"),
@@ -72,8 +72,8 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testMethodsOnInterfaceNoImpliedAbstractAllowImpliedPublic() throws Exception {
         final String[] expected = {
-            "36:5: " + getCheckMessage(MSG_KEY, "abstract"),
-            "38:5: " + getCheckMessage(MSG_KEY, "abstract"),
+            "37:5: " + getCheckMessage(MSG_KEY, "abstract"),
+            "40:5: " + getCheckMessage(MSG_KEY, "abstract"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierMethodsOnInterface2.java"),
@@ -83,10 +83,10 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testMethodsOnInterfaceNoImpliedPublicAllowImpliedAbstract() throws Exception {
         final String[] expected = {
-            "21:5: " + getCheckMessage(MSG_KEY, "public"),
-            "27:5: " + getCheckMessage(MSG_KEY, "public"),
-            "34:5: " + getCheckMessage(MSG_KEY, "public"),
-            "38:5: " + getCheckMessage(MSG_KEY, "public"),
+            "22:5: " + getCheckMessage(MSG_KEY, "public"),
+            "29:5: " + getCheckMessage(MSG_KEY, "public"),
+            "37:5: " + getCheckMessage(MSG_KEY, "public"),
+            "42:5: " + getCheckMessage(MSG_KEY, "public"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierMethodsOnInterface3.java"),
@@ -112,12 +112,12 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testMethodsOnInterfaceNestedNoImpliedPublicAbstract() throws Exception {
         final String[] expected = {
-            "23:9: " + getCheckMessage(MSG_KEY, "public"),
-            "29:9: " + getCheckMessage(MSG_KEY, "public"),
-            "34:9: " + getCheckMessage(MSG_KEY, "public"),
-            "36:9: " + getCheckMessage(MSG_KEY, "abstract"),
-            "38:9: " + getCheckMessage(MSG_KEY, "public"),
-            "38:9: " + getCheckMessage(MSG_KEY, "abstract"),
+            "24:9: " + getCheckMessage(MSG_KEY, "public"),
+            "31:9: " + getCheckMessage(MSG_KEY, "public"),
+            "37:9: " + getCheckMessage(MSG_KEY, "public"),
+            "40:9: " + getCheckMessage(MSG_KEY, "abstract"),
+            "42:9: " + getCheckMessage(MSG_KEY, "public"),
+            "42:9: " + getCheckMessage(MSG_KEY, "abstract"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierMethodsOnInterfaceNested.java"),
@@ -127,12 +127,12 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testMethodsOnClassNestedNoImpliedPublicAbstract() throws Exception {
         final String[] expected = {
-            "23:9: " + getCheckMessage(MSG_KEY, "public"),
-            "29:9: " + getCheckMessage(MSG_KEY, "public"),
-            "34:9: " + getCheckMessage(MSG_KEY, "public"),
-            "36:9: " + getCheckMessage(MSG_KEY, "abstract"),
-            "38:9: " + getCheckMessage(MSG_KEY, "public"),
-            "38:9: " + getCheckMessage(MSG_KEY, "abstract"),
+            "24:9: " + getCheckMessage(MSG_KEY, "public"),
+            "31:9: " + getCheckMessage(MSG_KEY, "public"),
+            "37:9: " + getCheckMessage(MSG_KEY, "public"),
+            "40:9: " + getCheckMessage(MSG_KEY, "abstract"),
+            "42:9: " + getCheckMessage(MSG_KEY, "public"),
+            "42:9: " + getCheckMessage(MSG_KEY, "abstract"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierMethodsOnClassNested.java"),
@@ -142,18 +142,18 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testFieldsOnInterfaceNoImpliedPublicStaticFinal() throws Exception {
         final String[] expected = {
-            "20:5: " + getCheckMessage(MSG_KEY, "final"),
-            "22:5: " + getCheckMessage(MSG_KEY, "static"),
+            "21:5: " + getCheckMessage(MSG_KEY, "final"),
             "24:5: " + getCheckMessage(MSG_KEY, "static"),
-            "24:5: " + getCheckMessage(MSG_KEY, "final"),
-            "26:5: " + getCheckMessage(MSG_KEY, "public"),
-            "28:5: " + getCheckMessage(MSG_KEY, "public"),
-            "28:5: " + getCheckMessage(MSG_KEY, "final"),
-            "30:5: " + getCheckMessage(MSG_KEY, "public"),
-            "30:5: " + getCheckMessage(MSG_KEY, "static"),
+            "26:5: " + getCheckMessage(MSG_KEY, "static"),
+            "26:5: " + getCheckMessage(MSG_KEY, "final"),
             "32:5: " + getCheckMessage(MSG_KEY, "public"),
-            "32:5: " + getCheckMessage(MSG_KEY, "static"),
-            "32:5: " + getCheckMessage(MSG_KEY, "final"),
+            "34:5: " + getCheckMessage(MSG_KEY, "public"),
+            "34:5: " + getCheckMessage(MSG_KEY, "final"),
+            "39:5: " + getCheckMessage(MSG_KEY, "public"),
+            "39:5: " + getCheckMessage(MSG_KEY, "static"),
+            "43:5: " + getCheckMessage(MSG_KEY, "public"),
+            "43:5: " + getCheckMessage(MSG_KEY, "static"),
+            "43:5: " + getCheckMessage(MSG_KEY, "final"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierFieldsOnInterface.java"),
@@ -163,14 +163,14 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testFieldsOnInterfaceNoImpliedPublicStaticAllowImpliedFinal() throws Exception {
         final String[] expected = {
-            "22:5: " + getCheckMessage(MSG_KEY, "static"),
-            "24:5: " + getCheckMessage(MSG_KEY, "static"),
-            "26:5: " + getCheckMessage(MSG_KEY, "public"),
-            "28:5: " + getCheckMessage(MSG_KEY, "public"),
-            "30:5: " + getCheckMessage(MSG_KEY, "public"),
-            "30:5: " + getCheckMessage(MSG_KEY, "static"),
+            "23:5: " + getCheckMessage(MSG_KEY, "static"),
+            "26:5: " + getCheckMessage(MSG_KEY, "static"),
+            "29:5: " + getCheckMessage(MSG_KEY, "public"),
             "32:5: " + getCheckMessage(MSG_KEY, "public"),
-            "32:5: " + getCheckMessage(MSG_KEY, "static"),
+            "34:5: " + getCheckMessage(MSG_KEY, "public"),
+            "34:5: " + getCheckMessage(MSG_KEY, "static"),
+            "39:5: " + getCheckMessage(MSG_KEY, "public"),
+            "39:5: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierFieldsOnInterface2.java"),
@@ -180,14 +180,14 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testFieldsOnInterfaceNoImpliedPublicFinalAllowImpliedStatic() throws Exception {
         final String[] expected = {
-            "20:5: " + getCheckMessage(MSG_KEY, "final"),
-            "24:5: " + getCheckMessage(MSG_KEY, "final"),
-            "26:5: " + getCheckMessage(MSG_KEY, "public"),
-            "28:5: " + getCheckMessage(MSG_KEY, "public"),
-            "28:5: " + getCheckMessage(MSG_KEY, "final"),
-            "30:5: " + getCheckMessage(MSG_KEY, "public"),
-            "32:5: " + getCheckMessage(MSG_KEY, "public"),
-            "32:5: " + getCheckMessage(MSG_KEY, "final"),
+            "21:5: " + getCheckMessage(MSG_KEY, "final"),
+            "26:5: " + getCheckMessage(MSG_KEY, "final"),
+            "29:5: " + getCheckMessage(MSG_KEY, "public"),
+            "31:5: " + getCheckMessage(MSG_KEY, "public"),
+            "31:5: " + getCheckMessage(MSG_KEY, "final"),
+            "37:5: " + getCheckMessage(MSG_KEY, "public"),
+            "39:5: " + getCheckMessage(MSG_KEY, "public"),
+            "39:5: " + getCheckMessage(MSG_KEY, "final"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierFieldsOnInterface3.java"),
@@ -197,14 +197,14 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testFieldsOnInterfaceNoImpliedStaticFinalAllowImpliedPublic() throws Exception {
         final String[] expected = {
-            "20:5: " + getCheckMessage(MSG_KEY, "final"),
-            "22:5: " + getCheckMessage(MSG_KEY, "static"),
+            "21:5: " + getCheckMessage(MSG_KEY, "final"),
             "24:5: " + getCheckMessage(MSG_KEY, "static"),
-            "24:5: " + getCheckMessage(MSG_KEY, "final"),
-            "28:5: " + getCheckMessage(MSG_KEY, "final"),
-            "30:5: " + getCheckMessage(MSG_KEY, "static"),
-            "32:5: " + getCheckMessage(MSG_KEY, "static"),
-            "32:5: " + getCheckMessage(MSG_KEY, "final"),
+            "26:5: " + getCheckMessage(MSG_KEY, "static"),
+            "26:5: " + getCheckMessage(MSG_KEY, "final"),
+            "34:5: " + getCheckMessage(MSG_KEY, "final"),
+            "37:5: " + getCheckMessage(MSG_KEY, "static"),
+            "39:5: " + getCheckMessage(MSG_KEY, "static"),
+            "39:5: " + getCheckMessage(MSG_KEY, "final"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierFieldsOnInterface4.java"),
@@ -230,18 +230,18 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testNestedOnInterfaceNoImpliedPublicStatic() throws Exception {
         final String[] expected = {
-            "21:5: " + getCheckMessage(MSG_KEY, "static"),
-            "24:5: " + getCheckMessage(MSG_KEY, "public"),
-            "27:5: " + getCheckMessage(MSG_KEY, "public"),
-            "27:5: " + getCheckMessage(MSG_KEY, "static"),
-            "35:5: " + getCheckMessage(MSG_KEY, "static"),
-            "40:5: " + getCheckMessage(MSG_KEY, "public"),
-            "45:5: " + getCheckMessage(MSG_KEY, "public"),
-            "45:5: " + getCheckMessage(MSG_KEY, "static"),
-            "53:5: " + getCheckMessage(MSG_KEY, "static"),
-            "56:5: " + getCheckMessage(MSG_KEY, "public"),
-            "59:5: " + getCheckMessage(MSG_KEY, "public"),
-            "59:5: " + getCheckMessage(MSG_KEY, "static"),
+            "22:5: " + getCheckMessage(MSG_KEY, "static"),
+            "26:5: " + getCheckMessage(MSG_KEY, "public"),
+            "29:5: " + getCheckMessage(MSG_KEY, "public"),
+            "29:5: " + getCheckMessage(MSG_KEY, "static"),
+            "40:5: " + getCheckMessage(MSG_KEY, "static"),
+            "46:5: " + getCheckMessage(MSG_KEY, "public"),
+            "51:5: " + getCheckMessage(MSG_KEY, "public"),
+            "51:5: " + getCheckMessage(MSG_KEY, "static"),
+            "63:5: " + getCheckMessage(MSG_KEY, "static"),
+            "67:5: " + getCheckMessage(MSG_KEY, "public"),
+            "69:5: " + getCheckMessage(MSG_KEY, "public"),
+            "69:5: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierNestedOnInterface.java"),
@@ -251,12 +251,12 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testNestedOnInterfaceNoImpliedStaticAllowImpliedPublic() throws Exception {
         final String[] expected = {
-            "21:5: " + getCheckMessage(MSG_KEY, "static"),
-            "27:5: " + getCheckMessage(MSG_KEY, "static"),
-            "35:5: " + getCheckMessage(MSG_KEY, "static"),
-            "45:5: " + getCheckMessage(MSG_KEY, "static"),
-            "53:5: " + getCheckMessage(MSG_KEY, "static"),
-            "59:5: " + getCheckMessage(MSG_KEY, "static"),
+            "22:5: " + getCheckMessage(MSG_KEY, "static"),
+            "29:5: " + getCheckMessage(MSG_KEY, "static"),
+            "38:5: " + getCheckMessage(MSG_KEY, "static"),
+            "49:5: " + getCheckMessage(MSG_KEY, "static"),
+            "58:5: " + getCheckMessage(MSG_KEY, "static"),
+            "65:5: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierNestedOnInterface2.java"),
@@ -266,12 +266,12 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testNestedOnInterfaceNoImpliedPublicAllowImpliedStatic() throws Exception {
         final String[] expected = {
-            "24:5: " + getCheckMessage(MSG_KEY, "public"),
-            "27:5: " + getCheckMessage(MSG_KEY, "public"),
-            "40:5: " + getCheckMessage(MSG_KEY, "public"),
+            "23:5: " + getCheckMessage(MSG_KEY, "public"),
+            "26:5: " + getCheckMessage(MSG_KEY, "public"),
+            "39:5: " + getCheckMessage(MSG_KEY, "public"),
             "45:5: " + getCheckMessage(MSG_KEY, "public"),
-            "56:5: " + getCheckMessage(MSG_KEY, "public"),
-            "59:5: " + getCheckMessage(MSG_KEY, "public"),
+            "55:5: " + getCheckMessage(MSG_KEY, "public"),
+            "58:5: " + getCheckMessage(MSG_KEY, "public"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierNestedOnInterface3.java"),
@@ -299,10 +299,10 @@ public class InterfaceMemberImpliedModifierCheckTest
         final String[] expected = {
             "20:9: " + getCheckMessage(MSG_KEY, "public"),
             "20:9: " + getCheckMessage(MSG_KEY, "static"),
-            "23:9: " + getCheckMessage(MSG_KEY, "public"),
-            "23:9: " + getCheckMessage(MSG_KEY, "static"),
-            "28:9: " + getCheckMessage(MSG_KEY, "public"),
-            "28:9: " + getCheckMessage(MSG_KEY, "static"),
+            "25:9: " + getCheckMessage(MSG_KEY, "public"),
+            "25:9: " + getCheckMessage(MSG_KEY, "static"),
+            "33:9: " + getCheckMessage(MSG_KEY, "public"),
+            "33:9: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierNestedOnInterfaceNested.java"),
@@ -314,10 +314,10 @@ public class InterfaceMemberImpliedModifierCheckTest
         final String[] expected = {
             "20:9: " + getCheckMessage(MSG_KEY, "public"),
             "20:9: " + getCheckMessage(MSG_KEY, "static"),
-            "23:9: " + getCheckMessage(MSG_KEY, "public"),
-            "23:9: " + getCheckMessage(MSG_KEY, "static"),
-            "28:9: " + getCheckMessage(MSG_KEY, "public"),
-            "28:9: " + getCheckMessage(MSG_KEY, "static"),
+            "25:9: " + getCheckMessage(MSG_KEY, "public"),
+            "25:9: " + getCheckMessage(MSG_KEY, "static"),
+            "33:9: " + getCheckMessage(MSG_KEY, "public"),
+            "33:9: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierNestedOnClassNested.java"),
@@ -327,28 +327,28 @@ public class InterfaceMemberImpliedModifierCheckTest
     @Test
     public void testPackageScopeInterface() throws Exception {
         final String[] expected = {
-            "20:5: " + getCheckMessage(MSG_KEY, "final"),
-            "22:5: " + getCheckMessage(MSG_KEY, "static"),
+            "21:5: " + getCheckMessage(MSG_KEY, "final"),
             "24:5: " + getCheckMessage(MSG_KEY, "static"),
-            "24:5: " + getCheckMessage(MSG_KEY, "final"),
-            "26:5: " + getCheckMessage(MSG_KEY, "public"),
-            "28:5: " + getCheckMessage(MSG_KEY, "public"),
-            "28:5: " + getCheckMessage(MSG_KEY, "final"),
-            "30:5: " + getCheckMessage(MSG_KEY, "public"),
-            "30:5: " + getCheckMessage(MSG_KEY, "static"),
+            "26:5: " + getCheckMessage(MSG_KEY, "static"),
+            "26:5: " + getCheckMessage(MSG_KEY, "final"),
             "32:5: " + getCheckMessage(MSG_KEY, "public"),
-            "32:5: " + getCheckMessage(MSG_KEY, "static"),
-            "32:5: " + getCheckMessage(MSG_KEY, "final"),
-            "37:5: " + getCheckMessage(MSG_KEY, "public"),
-            "43:5: " + getCheckMessage(MSG_KEY, "public"),
-            "48:5: " + getCheckMessage(MSG_KEY, "public"),
-            "50:5: " + getCheckMessage(MSG_KEY, "abstract"),
-            "52:5: " + getCheckMessage(MSG_KEY, "public"),
-            "52:5: " + getCheckMessage(MSG_KEY, "abstract"),
-            "57:5: " + getCheckMessage(MSG_KEY, "static"),
-            "60:5: " + getCheckMessage(MSG_KEY, "public"),
-            "63:5: " + getCheckMessage(MSG_KEY, "public"),
-            "63:5: " + getCheckMessage(MSG_KEY, "static"),
+            "34:5: " + getCheckMessage(MSG_KEY, "public"),
+            "34:5: " + getCheckMessage(MSG_KEY, "final"),
+            "39:5: " + getCheckMessage(MSG_KEY, "public"),
+            "39:5: " + getCheckMessage(MSG_KEY, "static"),
+            "44:5: " + getCheckMessage(MSG_KEY, "public"),
+            "44:5: " + getCheckMessage(MSG_KEY, "static"),
+            "44:5: " + getCheckMessage(MSG_KEY, "final"),
+            "54:5: " + getCheckMessage(MSG_KEY, "public"),
+            "59:5: " + getCheckMessage(MSG_KEY, "public"),
+            "64:5: " + getCheckMessage(MSG_KEY, "public"),
+            "67:5: " + getCheckMessage(MSG_KEY, "abstract"),
+            "69:5: " + getCheckMessage(MSG_KEY, "public"),
+            "69:5: " + getCheckMessage(MSG_KEY, "abstract"),
+            "77:5: " + getCheckMessage(MSG_KEY, "static"),
+            "80:5: " + getCheckMessage(MSG_KEY, "public"),
+            "82:5: " + getCheckMessage(MSG_KEY, "public"),
+            "82:5: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputInterfaceMemberImpliedModifierPackageScopeInterface.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierFieldsOnInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierFieldsOnInterface.java
@@ -17,18 +17,33 @@ public interface InputInterfaceMemberImpliedModifierFieldsOnInterface {
 
     public static final int fieldPublicStaticFinal = 1;
 
-    public static int fieldPublicStatic = 1; // violation
+    // violation below 'Implied modifier 'final' should be explicit.'
+    public static int fieldPublicStatic = 1;
 
-    public final int fieldPublicFinal = 1; // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public final int fieldPublicFinal = 1;
 
-    public int fieldPublic = 1; // 2 violations
+    public int fieldPublic = 1;
+    // 2 violations above:
+    //     'Implied modifier 'final' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
 
-    static final int fieldStaticFinal = 1; // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static final int fieldStaticFinal = 1;
 
-    static int fieldStatic = 1; // 2 violations
+    static int fieldStatic = 1;
+    // 2 violations above:
+    //     'Implied modifier 'final' should be explicit.'
+    //     'Implied modifier 'public' should be explicit.'
 
-    final int fieldFinal = 1; // 2 violations
-
-    int field = 1; // 3 violations
+    final int fieldFinal = 1;
+    // 2 violations above:
+    //     'Implied modifier 'public' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
+    int field = 1;
+    // 3 violations above:
+    //     'Implied modifier 'final' should be explicit.'
+    //     'Implied modifier 'public' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierFieldsOnInterface2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierFieldsOnInterface2.java
@@ -19,16 +19,25 @@ public interface InputInterfaceMemberImpliedModifierFieldsOnInterface2 {
 
     public static int fieldPublicStatic = 1;
 
-    public final int fieldPublicFinal = 1; // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public final int fieldPublicFinal = 1;
 
-    public int fieldPublic = 1; // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public int fieldPublic = 1;
 
-    static final int fieldStaticFinal = 1; // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static final int fieldStaticFinal = 1;
 
-    static int fieldStatic = 1; // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static int fieldStatic = 1;
 
-    final int fieldFinal = 1; // 2 violations
+    final int fieldFinal = 1;
+    // 2 violations above:
+    //        'Implied modifier 'public' should be explicit.'
+    //        'Implied modifier 'static' should be explicit.'
 
-    int field = 1; // 2 violations
-
+    int field = 1;
+    // 2 violations above:
+    //        'Implied modifier 'public' should be explicit.'
+    //        'Implied modifier 'static' should be explicit.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierFieldsOnInterface3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierFieldsOnInterface3.java
@@ -17,18 +17,28 @@ public interface InputInterfaceMemberImpliedModifierFieldsOnInterface3 {
 
     public static final int fieldPublicStaticFinal = 1;
 
-    public static int fieldPublicStatic = 1; // violation
+    // violation below 'Implied modifier 'final' should be explicit.'
+    public static int fieldPublicStatic = 1;
 
     public final int fieldPublicFinal = 1;
 
-    public int fieldPublic = 1; // violation
+    // violation below 'Implied modifier 'final' should be explicit.'
+    public int fieldPublic = 1;
 
-    static final int fieldStaticFinal = 1; // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static final int fieldStaticFinal = 1;
 
-    static int fieldStatic = 1; // 2 violations
+    static int fieldStatic = 1;
+    // 2 violations above:
+    //      'Implied modifier 'final' should be explicit.'
+    //      'Implied modifier 'public' should be explicit.'
 
-    final int fieldFinal = 1; // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    final int fieldFinal = 1;
 
-    int field = 1; // 2 violations
+    int field = 1;
+    // 2 violations above:
+    //      'Implied modifier 'final' should be explicit.'
+    //      'Implied modifier 'public' should be explicit.'
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierFieldsOnInterface4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierFieldsOnInterface4.java
@@ -17,18 +17,28 @@ public interface InputInterfaceMemberImpliedModifierFieldsOnInterface4 {
 
     public static final int fieldPublicStaticFinal = 1;
 
-    public static int fieldPublicStatic = 1; // violation
+    // violation below 'Implied modifier 'final' should be explicit.'
+    public static int fieldPublicStatic = 1;
 
-    public final int fieldPublicFinal = 1; // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public final int fieldPublicFinal = 1;
 
-    public int fieldPublic = 1; // 2 violations
+    public int fieldPublic = 1;
+    // 2 violations above:
+    //     'Implied modifier 'final' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
 
     static final int fieldStaticFinal = 1;
 
-    static int fieldStatic = 1; // violation
+    // violation below 'Implied modifier 'final' should be explicit.'
+    static int fieldStatic = 1;
 
-    final int fieldFinal = 1; // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    final int fieldFinal = 1;
 
-    int field = 1; // 2 violations
+    int field = 1;
+    // 2 violations above:
+    //     'Implied modifier 'final' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierMethodsOnClassNested.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierMethodsOnClassNested.java
@@ -20,22 +20,29 @@ public class InputInterfaceMemberImpliedModifierMethodsOnClassNested {
         public static void methodPublicStatic() {
         }
 
-        static void methodStatic() { // violation
+        // violation below 'Implied modifier 'public' should be explicit.'
+        static void methodStatic() {
         }
 
         public default void methodPublicDefault() {
         }
 
-        default void methodDefault() { // violation
+        // violation below 'Implied modifier 'public' should be explicit.'
+        default void methodDefault() {
         }
 
         public abstract void methodPublicAbstract();
 
-        abstract void methodAbstract(); // violation
+        // violation below 'Implied modifier 'public' should be explicit.'
+        abstract void methodAbstract();
 
-        public void methodPublic(); // violation
+        // violation below 'Implied modifier 'abstract' should be explicit.'
+        public void methodPublic();
 
-        void method(); // 2 violations
+        void method();
+        // 2 violations above:
+        //    'Implied modifier 'abstract' should be explicit.'
+        //    'Implied modifier 'public' should be explicit.'
 
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierMethodsOnInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierMethodsOnInterface.java
@@ -18,23 +18,30 @@ public interface InputInterfaceMemberImpliedModifierMethodsOnInterface {
     public static void methodPublicStatic() {
     }
 
-    static void methodStatic() { // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static void methodStatic() {
     }
 
     public default void methodPublicDefault() {
     }
 
-    default int methodDefault() { // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    default int methodDefault() {
         int foo = 6;
         return foo;
     }
 
     public abstract void methodPublicAbstract();
 
-    abstract void methodAbstract(); // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    abstract void methodAbstract();
 
-    public void methodPublic(); // violation
+    // violation below 'Implied modifier 'abstract' should be explicit.'
+    public void methodPublic();
 
-    void method(); // 2 violations
+    void method();
+    // 2 violations above:
+    //    'Implied modifier 'abstract' should be explicit.'
+    //    'Implied modifier 'public' should be explicit.'
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierMethodsOnInterface2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierMethodsOnInterface2.java
@@ -33,8 +33,10 @@ public interface InputInterfaceMemberImpliedModifierMethodsOnInterface2 {
 
     abstract void methodAbstract();
 
-    public void methodPublic(); // violation
+    // violation below 'Implied modifier 'abstract' should be explicit.'
+    public void methodPublic();
 
-    void method(); // violation
+    // violation below 'Implied modifier 'abstract' should be explicit.'
+    void method();
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierMethodsOnInterface3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierMethodsOnInterface3.java
@@ -18,23 +18,27 @@ public interface InputInterfaceMemberImpliedModifierMethodsOnInterface3 {
     public static void methodPublicStatic() {
     }
 
-    static void methodStatic() { // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static void methodStatic() {
     }
 
     public default void methodPublicDefault() {
     }
 
-    default int methodDefault() { // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    default int methodDefault() {
         int foo = 6;
         return foo;
     }
 
     public abstract void methodPublicAbstract();
 
-    abstract void methodAbstract(); // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    abstract void methodAbstract();
 
     public void methodPublic();
 
-    void method(); // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    void method();
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierMethodsOnInterfaceNested.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierMethodsOnInterfaceNested.java
@@ -20,22 +20,29 @@ public interface InputInterfaceMemberImpliedModifierMethodsOnInterfaceNested {
         public static void methodPublicStatic() {
         }
 
-        static void methodStatic() { // violation
+        // violation below 'Implied modifier 'public' should be explicit.'
+        static void methodStatic() {
         }
 
         public default void methodPublicDefault() {
         }
 
-        default void methodDefault() { // violation
+        // violation below 'Implied modifier 'public' should be explicit.'
+        default void methodDefault() {
         }
 
         public abstract void methodPublicAbstract();
 
-        abstract void methodAbstract(); // violation
+        // violation below 'Implied modifier 'public' should be explicit.'
+        abstract void methodAbstract();
 
-        public void methodPublic(); // violation
+        // violation below 'Implied modifier 'abstract' should be explicit.'
+        public void methodPublic();
 
-        void method(); // 2 violations
+        void method();
+        // 2 violations above:
+        //     'Implied modifier 'abstract' should be explicit.'
+        //     'Implied modifier 'public' should be explicit.'
 
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierNestedOnClassNested.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierNestedOnClassNested.java
@@ -17,16 +17,23 @@ public class InputInterfaceMemberImpliedModifierNestedOnClassNested {
 
     interface NestedInterface {
 
-        interface NestedNestedInterface { // 2 violations
-        }
+        interface NestedNestedInterface {}
+        // 2 violations above:
+        //     'Implied modifier 'public' should be explicit.'
+        //     'Implied modifier 'static' should be explicit.'
 
-        enum NestedNestedEnum { // 2 violations
+        enum NestedNestedEnum {
             TRUE,
             FALSE
         }
+        // 2 violations 4 lines above:
+        //     'Implied modifier 'public' should be explicit.'
+        //     'Implied modifier 'static' should be explicit.'
 
-        class NestedNestedClass { // 2 violations
-        }
+        class NestedNestedClass {}
+        // 2 violations above:
+        //     'Implied modifier 'public' should be explicit.'
+        //     'Implied modifier 'static' should be explicit.'
 
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierNestedOnInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierNestedOnInterface.java
@@ -18,46 +18,58 @@ public interface InputInterfaceMemberImpliedModifierNestedOnInterface {
     public static interface NestedInterfacePublicStatic {
     }
 
-    public interface NestedInterfacePublic { // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public interface NestedInterfacePublic {
     }
 
-    static interface NestedInterfaceStatic { // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static interface NestedInterfaceStatic {
     }
 
-    interface NestedInterface { // 2 violations
-    }
+    interface NestedInterface {}
+    // 2 violations above:
+    //     'Implied modifier 'public' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
 
     public static enum NestedEnumPublicStatic {
         TRUE,
         FALSE
     }
 
-    public enum NestedEnumPublic { // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public enum NestedEnumPublic {
         TRUE,
         FALSE
     }
 
-    static enum NestedEnumStatic { // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static enum NestedEnumStatic {
         TRUE,
         FALSE
     }
 
-    enum NestedEnum { // 2 violations
+    enum NestedEnum {
         TRUE,
         FALSE
     }
+    // 2 violations 4 lines above:
+    //     'Implied modifier 'public' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
 
     public static class NestedClassPublicStatic {
     }
 
-    public class NestedClassPublic { // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public class NestedClassPublic {
     }
 
-    static class NestedClassStatic { // violation
-    }
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static class NestedClassStatic {}
 
-    class NestedClass { // 2 violations
-    }
+    class NestedClass {}
+    // 2 violations above:
+    //     'Implied modifier 'public' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
 
     public default boolean methodWithLocalClass(String input) {
         class LocalClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierNestedOnInterface2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierNestedOnInterface2.java
@@ -18,13 +18,15 @@ public interface InputInterfaceMemberImpliedModifierNestedOnInterface2 {
     public static interface NestedInterfacePublicStatic {
     }
 
-    public interface NestedInterfacePublic { // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public interface NestedInterfacePublic {
     }
 
     static interface NestedInterfaceStatic {
     }
 
-    interface NestedInterface { // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    interface NestedInterface {
     }
 
     public static enum NestedEnumPublicStatic {
@@ -32,7 +34,8 @@ public interface InputInterfaceMemberImpliedModifierNestedOnInterface2 {
         FALSE
     }
 
-    public enum NestedEnumPublic { // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public enum NestedEnumPublic {
         TRUE,
         FALSE
     }
@@ -42,7 +45,8 @@ public interface InputInterfaceMemberImpliedModifierNestedOnInterface2 {
         FALSE
     }
 
-    enum NestedEnum { // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    enum NestedEnum {
         TRUE,
         FALSE
     }
@@ -50,13 +54,15 @@ public interface InputInterfaceMemberImpliedModifierNestedOnInterface2 {
     public static class NestedClassPublicStatic {
     }
 
-    public class NestedClassPublic { // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public class NestedClassPublic {
     }
 
     static class NestedClassStatic {
     }
 
-    class NestedClass { // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    class NestedClass {
     }
 
     public default boolean methodWithLocalClass(String input) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierNestedOnInterface3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierNestedOnInterface3.java
@@ -15,17 +15,15 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.interfacememberimpliedmo
 
 public interface InputInterfaceMemberImpliedModifierNestedOnInterface3 {
 
-    public static interface NestedInterfacePublicStatic {
-    }
+    public static interface NestedInterfacePublicStatic {}
 
-    public interface NestedInterfacePublic {
-    }
+    public interface NestedInterfacePublic {}
 
-    static interface NestedInterfaceStatic { // violation
-    }
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static interface NestedInterfaceStatic {}
 
-    interface NestedInterface { // violation
-    }
+    // violation below 'Implied modifier 'public' should be explicit.'
+    interface NestedInterface {}
 
     public static enum NestedEnumPublicStatic {
         TRUE,
@@ -37,27 +35,27 @@ public interface InputInterfaceMemberImpliedModifierNestedOnInterface3 {
         FALSE
     }
 
-    static enum NestedEnumStatic { // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static enum NestedEnumStatic {
         TRUE,
         FALSE
     }
 
-    enum NestedEnum { // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    enum NestedEnum {
         TRUE,
         FALSE
     }
 
-    public static class NestedClassPublicStatic {
-    }
+    public static class NestedClassPublicStatic {}
 
-    public class NestedClassPublic {
-    }
+    public class NestedClassPublic {}
 
-    static class NestedClassStatic { // violation
-    }
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static class NestedClassStatic {}
 
-    class NestedClass { // violation
-    }
+    // violation below 'Implied modifier 'public' should be explicit.'
+    class NestedClass {}
 
     public default boolean methodWithLocalClass(String input) {
         class LocalClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierNestedOnInterfaceNested.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierNestedOnInterfaceNested.java
@@ -17,16 +17,23 @@ public interface InputInterfaceMemberImpliedModifierNestedOnInterfaceNested {
 
     public static interface NestedInterface {
 
-        interface NestedNestedInterface { // 2 violations
-        }
+        interface NestedNestedInterface {}
+        // 2 violations above:
+        //     'Implied modifier 'public' should be explicit.'
+        //     'Implied modifier 'static' should be explicit.'
 
-        enum NestedNestedEnum { // 2 violations
+        enum NestedNestedEnum {
             TRUE,
             FALSE
         }
+        // 2 violations 4 lines above:
+        //     'Implied modifier 'public' should be explicit.'
+        //     'Implied modifier 'static' should be explicit.'
 
-        class NestedNestedClass { // 2 violations
-        }
+        class NestedNestedClass {}
+        // 2 violations above:
+        //     'Implied modifier 'public' should be explicit.'
+        //     'Implied modifier 'static' should be explicit.'
 
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierPackageScopeInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierPackageScopeInterface.java
@@ -17,50 +17,71 @@ interface InputInterfaceMemberImpliedModifierPackageScopeInterface {
 
     public static final int fieldPublicStaticFinal = 1;
 
-    public static int fieldPublicStatic = 1; // violation
+    // violation below 'Implied modifier 'final' should be explicit.'
+    public static int fieldPublicStatic = 1;
 
-    public final int fieldPublicFinal = 1; // violation
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public final int fieldPublicFinal = 1;
 
-    public int fieldPublic = 1; // 2 violations
+    public int fieldPublic = 1;
+    // 2 violations above:
+    //     'Implied modifier 'final' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
 
-    static final int fieldStaticFinal = 1; // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static final int fieldStaticFinal = 1;
 
-    static int fieldStatic = 1; // 2 violations
+    static int fieldStatic = 1;
+    // 2 violations above:
+    //     'Implied modifier 'final' should be explicit.'
+    //     'Implied modifier 'public' should be explicit.'
 
-    final int fieldFinal = 1; // 2 violations
+    final int fieldFinal = 1;
+    // 2 violations above:
+    //     'Implied modifier 'public' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
 
-    int field = 1; // 3 violations
+    int field = 1;
+    // 3 violations above:
+    //     'Implied modifier 'final' should be explicit.'
+    //     'Implied modifier 'public' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
 
     public static void methodPublicStatic() {
     }
 
-    static void methodStatic() { // violation
-    }
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static void methodStatic() {}
 
-    public default void methodPublicDefault() {
-    }
+    public default void methodPublicDefault() {}
 
-    default void methodDefault() { // violation
-    }
+    // violation below 'Implied modifier 'public' should be explicit.'
+    default void methodDefault() {}
 
     public abstract void methodPublicAbstract();
 
-    abstract void methodAbstract(); // violation
+    // violation below 'Implied modifier 'public' should be explicit.'
+    abstract void methodAbstract();
 
-    public void methodPublic(); // violation
+    // violation below 'Implied modifier 'abstract' should be explicit.'
+    public void methodPublic();
 
-    void method(); // 2 violations
+    void method();
+    // 2 violations above:
+    //     'Implied modifier 'abstract' should be explicit.'
+    //     'Implied modifier 'public' should be explicit.'
 
-    public static interface NestedInterfacePublicStatic {
-    }
+    public static interface NestedInterfacePublicStatic {}
 
-    public interface NestedInterfacePublic { // violation
-    }
+    // violation below 'Implied modifier 'static' should be explicit.'
+    public interface NestedInterfacePublic {}
 
-    static interface NestedInterfaceStatic { // violation
-    }
+    // violation below 'Implied modifier 'public' should be explicit.'
+    static interface NestedInterfaceStatic {}
 
-    interface NestedInterface { // 2 violations
-    }
+    interface NestedInterface {}
+    // 2 violations above:
+    //     'Implied modifier 'public' should be explicit.'
+    //     'Implied modifier 'static' should be explicit.'
 
 }


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed InterfaceMemberImpliedModifierCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in InterfaceMemberImpliedModifierCheckest
- Defined violation messages in InputInterfaceMemberImpliedModifierCheck files