### PR TITLE
Issue #19954: IllegalTokenText prevent matches from splitting escapesequences

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
@@ -35,28 +35,42 @@ public class InputSpecialEscapeSequences {
 
   /** Some javadoc. */
   public void specialCharsWithWarn() {
-    String r1 = "\\u0008"; // violation 'Consider using special escape sequence'
-    String r2 = "\\u0009"; // violation 'Consider using special escape sequence .*'
-    String r3 = "\\u000a"; // violation 'Consider using special escape sequence .*'
-    String r4 = "\\u000c"; // violation 'Consider using special escape sequence .*'
-    String r5 = "\\u000d"; // violation 'Consider using special escape sequence .*'
-    String r6 = "\\u0020"; // violation 'Consider using special escape sequence'
-    String r7 = "\\u0022"; // violation 'Consider using special escape sequence'
-    String r8 = "\\u0027"; // violation 'Consider using special escape sequence'
-    String r9 = "\\u005c"; // violation 'Consider using special escape sequence'
+    String r1 = "\u0008"; // violation 'Consider using special escape sequence'
+    String r2 = "\u0009"; // violation 'Consider using special escape sequence .*'
+    String r3 = "\u000c"; // violation 'Consider using special escape sequence .*'
+    String r4 = "\u0020"; // violation 'Consider using special escape sequence'
+    String r5 = "\u0027"; // violation 'Consider using special escape sequence'
+    String r6 = // violation below 'Consider using special escape sequence .*'
+        """
+        \u000a
+        """;
+    String r7 = // violation below 'Consider using special escape sequence .*'
+        """
+        \u000d
+        """;
+    // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
+    String r8 = // violation below 'Consider using special escape sequence'
+        """
+        \u0022
+        """;
+    // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
+    String r9 = // violation below 'Consider using special escape sequence'
+        """
+        \u005c
+        """;
   }
 
   /** Some javadoc. */
   public void specialCharsWithWarn2() {
-    String r1 = "\\010"; // violation 'Consider using special escape sequence .*'
-    String r2 = "\\011"; // violation 'Consider using special escape sequence .*'
-    String r3 = "\\012"; // violation 'Consider using special escape sequence .*'
-    String r4 = "\\014"; // violation 'Consider using special escape sequence .*'
-    String r5 = "\\015"; // violation 'Consider using special escape sequence .*'
-    String r6 = "\\040"; // violation 'Consider using special escape sequence'
-    String r7 = "\\042"; // violation 'Consider using special escape sequence .*'
-    String r8 = "\\047"; // violation 'Consider using special escape sequence .*'
-    String r9 = "\\134"; // violation 'Consider using special escape sequence .*'
+    String r1 = "\010"; // violation 'Consider using special escape sequence .*'
+    String r2 = "\011"; // violation 'Consider using special escape sequence .*'
+    String r3 = "\012"; // violation 'Consider using special escape sequence .*'
+    String r4 = "\014"; // violation 'Consider using special escape sequence .*'
+    String r5 = "\015"; // violation 'Consider using special escape sequence .*'
+    String r6 = "\040"; // violation 'Consider using special escape sequence'
+    String r7 = "\042"; // violation 'Consider using special escape sequence .*'
+    String r8 = "\047"; // violation 'Consider using special escape sequence .*'
+    String r9 = "\134"; // violation 'Consider using special escape sequence .*'
   }
 
   class Inner {
@@ -84,27 +98,41 @@ public class InputSpecialEscapeSequences {
     }
 
     public void specialCharsWithWarn() {
-      String r1 = "\\u0008"; // violation 'Consider using special escape sequence'
-      String r2 = "\\u0009"; // violation 'Consider using special escape sequence .*'
-      String r3 = "\\u000a"; // violation 'Consider using special escape sequence .*'
-      String r4 = "\\u000c"; // violation 'Consider using special escape sequence .*'
-      String r5 = "\\u000d"; // violation 'Consider using special escape sequence .*'
-      String r6 = "\\u0020"; // violation 'Consider using special escape sequence .*'
-      String r7 = "\\u0022"; // violation 'Consider using special escape sequence'
-      String r8 = "\\u0027"; // violation 'Consider using special escape sequence .*'
-      String r9 = "\\u005c"; // violation 'Consider using special escape sequence .*'
+      String r1 = "\u0008"; // violation 'Consider using special escape sequence'
+      String r2 = "\u0009"; // violation 'Consider using special escape sequence .*'
+      String r3 = "\u000c"; // violation 'Consider using special escape sequence .*'
+      String r4 = "\u0020"; // violation 'Consider using special escape sequence .*'
+      String r5 = "\u0027"; // violation 'Consider using special escape sequence .*'
+      String r6 = // violation below 'Consider using special escape sequence .*'
+          """
+          \u000a
+          """;
+      String r7 = // violation below 'Consider using special escape sequence .*'
+          """
+          \u000d
+          """;
+      // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
+      String r8 = // violation below 'Consider using special escape sequence'
+          """
+          \u0022
+          """;
+      // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
+      String r9 = // violation below 'Consider using special escape sequence .*'
+          """
+          \u005c
+          """;
     }
 
     public void specialCharsWithWarn2() {
-      String r1 = "\\010"; // violation 'Consider using special escape sequence .*'
-      String r2 = "\\011"; // violation 'Consider using special escape sequence .*'
-      String r3 = "\\012"; // violation 'Consider using special escape sequence .*'
-      String r4 = "\\014"; // violation 'Consider using special escape sequence .*'
-      String r5 = "\\015"; // violation 'Consider using special escape sequence .*'
-      String r6 = "\\040"; // violation 'Consider using special escape sequence'
-      String r7 = "\\042"; // violation 'Consider using special escape sequence .*'
-      String r8 = "\\047"; // violation 'Consider using special escape sequence .*'
-      String r9 = "\\134"; // violation 'Consider using special escape sequence .*'
+      String r1 = "\010"; // violation 'Consider using special escape sequence .*'
+      String r2 = "\011"; // violation 'Consider using special escape sequence .*'
+      String r3 = "\012"; // violation 'Consider using special escape sequence .*'
+      String r4 = "\014"; // violation 'Consider using special escape sequence .*'
+      String r5 = "\015"; // violation 'Consider using special escape sequence .*'
+      String r6 = "\040"; // violation 'Consider using special escape sequence'
+      String r7 = "\042"; // violation 'Consider using special escape sequence .*'
+      String r8 = "\047"; // violation 'Consider using special escape sequence .*'
+      String r9 = "\134"; // violation 'Consider using special escape sequence .*'
     }
 
     Inner anoInner =
@@ -133,27 +161,41 @@ public class InputSpecialEscapeSequences {
           }
 
           public void specialCharsWithWarn() {
-            String r1 = "\\u0008"; // violation 'Consider using special escape sequence'
-            String r2 = "\\u0009"; // violation 'Consider using special escape sequence .*'
-            String r3 = "\\u000a"; // violation 'Consider using special escape sequence .*'
-            String r4 = "\\u000c"; // violation 'Consider using special escape sequence .*'
-            String r5 = "\\u000d"; // violation 'Consider using special escape sequence .*'
-            String r6 = "\\u0020"; // violation 'Consider using special escape sequence'
-            String r7 = "\\u0022"; // violation 'Consider using special escape sequence .*'
-            String r8 = "\\u0027"; // violation 'Consider using special escape sequence .*'
-            String r9 = "\\u005c"; // violation 'Consider using special escape sequence .*'
+            String r1 = "\u0008"; // violation 'Consider using special escape sequence'
+            String r2 = "\u0009"; // violation 'Consider using special escape sequence .*'
+            String r3 = "\u000c"; // violation 'Consider using special escape sequence .*'
+            String r4 = "\u0020"; // violation 'Consider using special escape sequence'
+            String r5 = "\u0027"; // violation 'Consider using special escape sequence .*'
+            String r6 = // violation below 'Consider using special escape sequence .*'
+                """
+                \u000a
+                """;
+            String r7 = // violation below 'Consider using special escape sequence .*'
+                """
+                \u000d
+                """;
+            // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
+            String r8 = // violation below 'Consider using special escape sequence .*'
+                """
+                \u0022
+                """;
+            // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
+            String r9 = // violation below 'Consider using special escape sequence .*'
+                """
+                \u005c
+                """;
           }
 
           public void specialCharsWithWarn2() {
-            String r1 = "\\010"; // violation 'Consider using special escape sequence .*'
-            String r2 = "\\011"; // violation 'Consider using special escape sequence .*'
-            String r3 = "\\012"; // violation 'Consider using special escape sequence .*'
-            String r4 = "\\014"; // violation 'Consider using special escape sequence .*'
-            String r5 = "\\015"; // violation 'Consider using special escape sequence .*'
-            String r6 = "\\040"; // violation 'Consider using special escape sequence'
-            String r7 = "\\042"; // violation 'Consider using special escape sequence .*'
-            String r8 = "\\047"; // violation 'Consider using special escape sequence .*'
-            String r9 = "\\134"; // violation 'Consider using special escape sequence .*'
+            String r1 = "\010"; // violation 'Consider using special escape sequence .*'
+            String r2 = "\011"; // violation 'Consider using special escape sequence .*'
+            String r3 = "\012"; // violation 'Consider using special escape sequence .*'
+            String r4 = "\014"; // violation 'Consider using special escape sequence .*'
+            String r5 = "\015"; // violation 'Consider using special escape sequence .*'
+            String r6 = "\040"; // violation 'Consider using special escape sequence'
+            String r7 = "\042"; // violation 'Consider using special escape sequence .*'
+            String r8 = "\047"; // violation 'Consider using special escape sequence .*'
+            String r9 = "\134"; // violation 'Consider using special escape sequence .*'
           }
         };
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForOctalValues.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForOctalValues.java
@@ -95,78 +95,78 @@ public class InputSpecialEscapeSequencesInTextBlockForOctalValues {
   private void specialCharsWithWarn2() {
     String r1 = // violation below 'Consider using special escape sequence'
         """
-        \\010
+        \010
         """;
     String r2 = // violation below 'Consider using special escape sequence'
         """
-        \\011
+        \011
         """;
     String r3 = // violation below 'Consider using special escape sequence'
         """
-        \\012
+        \012
         """;
     String r4 = // violation below 'Consider using special escape sequence'
         """
-        \\014
+        \014
         """;
     String r5 = // violation below 'Consider using special escape sequence'
         """
-        \\015
+        \015
         """;
     String r6 = // violation below 'Consider using special escape sequence'
         """
-        \\042
+        \042
         """;
     String r7 = // violation below 'Consider using special escape sequence'
         """
-        \\047
+        \047
         """;
     String r8 = // violation below 'Consider using special escape sequence'
         """
-        \\134
+        \134
         """;
     String r9 = // violation below 'Consider using special escape sequence'
         """
-        \\040
+        \040
         """;
   }
 
   private static void specialCharsWithWarn3() {
     String r1 = // violation below 'Consider using special escape sequence'
         """
-        \\010
+        \010
         """;
     String r2 = // violation below 'Consider using special escape sequence'
         """
-        \\011
+        \011
         """;
     String r3 = // violation below 'Consider using special escape sequence'
         """
-        \\012
+        \012
         """;
     String r4 = // violation below 'Consider using special escape sequence'
         """
-        \\014
+        \014
         """;
     String r5 = // violation below 'Consider using special escape sequence'
         """
-        \\015
+        \015
         """;
     String r6 = // violation below 'Consider using special escape sequence'
         """
-        \\040
+        \040
         """;
     String r7 = // violation below 'Consider using special escape sequence'
         """
-        \\042
+        \042
         """;
     String r8 = // violation below 'Consider using special escape sequence'
         """
-        \\047
+        \047
         """;
     String r9 = // violation below 'Consider using special escape sequence'
         """
-        \\134
+        \134
         """;
   }
 
@@ -214,39 +214,39 @@ public class InputSpecialEscapeSequencesInTextBlockForOctalValues {
         public void specialCharsWithWarn2() {
           String r1 = // violation below 'Consider using special escape sequence'
               """
-              \\010
+              \010
               """;
           String r2 = // violation below 'Consider using special escape sequence'
               """
-              \\011
+              \011
               """;
           String r3 = // violation below 'Consider using special escape sequence'
               """
-              \\012
+              \012
               """;
           String r4 = // violation below 'Consider using special escape sequence'
               """
-              \\014
+              \014
               """;
           String r5 = // violation below 'Consider using special escape sequence'
               """
-              \\015
+              \015
               """;
           String r6 = // violation below 'Consider using special escape sequence'
               """
-              \\040
+              \040
               """;
           String r7 = // violation below 'Consider using special escape sequence'
               """
-              \\042
+              \042
               """;
           String r8 = // violation below 'Consider using special escape sequence'
               """
-              \\047
+              \047
               """;
           String r9 = // violation below 'Consider using special escape sequence'
               """
-              \\134
+              \134
               """;
         }
       };

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForUnicodeValues.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForUnicodeValues.java
@@ -19,76 +19,79 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
           """;
       final String r4 = // violation below 'Consider using special escape sequence'
           """
-          \\u000c
+          \u000c
           """;
       final String r5 = // violation below 'Consider using special escape sequence'
           """
-          \\u000d
+          \u000d
           """;
+      // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
       final String r6 = // violation below 'Consider using special escape sequence'
           """
-          \\u0022
+          \u0022
           """;
+      // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
       final String r7 = // violation below 'Consider using special escape sequence'
           """
-          \\u0027
+          \u0027
           """;
+      // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
       final String r8 = // violation below 'Consider using special escape sequence'
           """
-          \\u005c
+          \u005c
           """;
       // The following have no escape sequences, should not cause violations
       final String r9 =
           """
-          \\u000b
+          \u000b
           """;
       final String r10 =
           """
-          \\u001c
+          \u001c
           """;
       final String r11 =
           """
-          \\u001D
+          \u001D
           """;
       final String r12 =
           """
-          \\u001E
+          \u001E
           """;
       final String r13 =
           """
-          \\u001F
+          \u001F
           """;
       final String r14 =
           """
-          \\u1680
+          \u1680
           """;
       final String r15 =
           """
-          \\u2000
+          \u2000
           """;
       final String r16 =
           """
-          \\u200A
+          \u200A
           """;
       final String r17 =
           """
-          \\u2028
+          \u2028
           """;
       final String r18 =
           """
-          \\u2029
+          \u2029
           """;
       final String r19 =
           """
-          \\u202F
+          \u202F
           """;
       final String r20 =
           """
-          \\u205F
+          \u205F
           """;
       final String r21 =
           """
-          \\u3000
+          \u3000
           """;
     }
   }
@@ -97,44 +100,47 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
   public void specialCharsWithWarnUnicode() {
     String r1 = // violation below 'Consider using special escape sequence'
         """
-        \\u0008
+        \u0008
         """;
     String r2 = // violation below 'Consider using special escape sequence'
         """
-        \\u0009
+        \u0009
         """;
     String r3 = // violation below 'Consider using special escape sequence'
         """
-        \\u000a
+        \u000a
         """;
     String r4 = // violation below 'Consider using special escape sequence'
         """
-        \\u000c
+        \u000c
         """;
     String r5 = // violation below 'Consider using special escape sequence'
         """
-        \\u000d
+        \u000d
         """;
     String r6 = // violation below 'Consider using special escape sequence'
         """
-        \\u0020
+        \u0020
         """;
+    // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
     String r7 = // violation below 'Consider using special escape sequence'
         """
-        \\u0022
+        \u0022
         """;
+    // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
     String r8 = // violation below 'Consider using special escape sequence'
         """
-        \\u0027
+        \u0027
         """;
+    // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
     String r9 = // violation below 'Consider using special escape sequence'
         """
-        \\u005c
+        \u005c
         """;
     // The following have no escape sequences, should not cause violations
     String r10 =
         """
-        \\u000b
+        \u000b
         """;
     String r11 =
         """
@@ -142,15 +148,15 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
         """;
     String r12 =
         """
-        \\u1680
+        \u1680
         """;
     String r13 =
         """
-        \\u2000
+        \u2000
         """;
     String r14 =
         """
-        \\u3000
+        \u3000
         """;
   }
 
@@ -201,39 +207,42 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
   private static void specialCharsWithWarn() {
     String r1 = // violation below 'Consider using special escape sequence'
         """
-        \\u0008
+        \u0008
         """;
     String r2 = // violation below 'Consider using special escape sequence'
         """
-        \\u0009
+        \u0009
         """;
     String r3 = // violation below 'Consider using special escape sequence'
         """
-        \\u000a
+        \u000a
         """;
     String r4 = // violation below 'Consider using special escape sequence'
         """
-        \\u000c
+        \u000c
         """;
     String r5 = // violation below 'Consider using special escape sequence'
         """
-        \\u000d
+        \u000d
         """;
     String r6 = // violation below 'Consider using special escape sequence'
         """
-        \\u0020
+        \u0020
         """;
+    // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
     String r7 = // violation below 'Consider using special escape sequence'
         """
-        \\u0022
+        \u0022
         """;
+    // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
     String r8 = // violation below 'Consider using special escape sequence'
         """
-        \\u0027
+        \u0027
         """;
+    // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
     String r9 = // violation below 'Consider using special escape sequence'
         """
-        \\u005c
+        \u005c
         """;
   }
 
@@ -261,60 +270,66 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
         public void specialCharsWithWarn() {
           String r1 = // violation below 'Consider using special escape sequence'
               """
-              \\u0008
+              \u0008
               """;
           String r2 = // violation below 'Consider using special escape sequence'
               """
-              \\u0009
+              \u0009
               """;
           String r3 = // violation below 'Consider using special escape sequence'
               """
-              \\u000a
+              \u000a
               """;
           String r4 = // violation below 'Consider using special escape sequence'
               """
-              \\u000c
+              \u000c
               """;
           String r5 = // violation below 'Consider using special escape sequence'
               """
-              \\u000d
+              \u000d
               """;
           String r6 = // violation below 'Consider using special escape sequence'
               """
-              \\u0020
+              \u0020
               """;
+
+          // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
           String r7 = // violation below 'Consider using special escape sequence'
               """
-              \\u0022
+              \u0022
               """;
+
+          // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
           String r8 = // violation below 'Consider using special escape sequence'
               """
-              \\u0027
+              \u0027
               """;
+
+          // violation 2 lines below 'Unicode escape(s) usage should be avoided.'
           String r9 = // violation below 'Consider using special escape sequence'
               """
-              \\u005c
+              \u005c
               """;
           // The following have no escape sequences, should not cause violations
           String r10 =
               """
-              \\u000b
+              \u000b
               """;
           String r11 =
               """
-              \\u001c
+              \u001c
               """;
           String r12 =
               """
-              \\u1680
+              \u1680
               """;
           String r13 =
               """
-              \\u2000
+              \u2000
               """;
           String r14 =
               """
-              \\u3000
+              \u3000
               """;
         }
       };

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -19,7 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.BitSet;
 import java.util.Objects;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
@@ -45,6 +47,10 @@ public class IllegalTokenTextCheck
      * file.
      */
     public static final String MSG_KEY = "illegal.token.text";
+
+    /** Pattern for escape sequence. */
+    private static final Pattern ESCAPE_SEQUENCE =
+            Pattern.compile("\\\\(u+[0-9a-fA-F]{4}|[0-3][0-7]{2}|[0-7]{1,2}|[\\s\\S])");
 
     /**
      * Define the message which is used to notify about violations;
@@ -94,15 +100,18 @@ public class IllegalTokenTextCheck
     @Override
     public void visitToken(DetailAST ast) {
         final String text = ast.getText();
-        if (format.matcher(text).find()) {
+        final boolean matched = switch (ast.getType()) {
+            case TokenTypes.STRING_LITERAL,
+                 TokenTypes.CHAR_LITERAL,
+                 TokenTypes.TEXT_BLOCK_CONTENT -> matchesAnyEscapeSpan(text);
+            default -> format.matcher(text).find();
+        };
+        if (matched) {
             String customMessage = message;
             if (customMessage.isEmpty()) {
                 customMessage = MSG_KEY;
             }
-            log(
-                ast,
-                customMessage,
-                formatString);
+            log(ast, customMessage, formatString);
         }
     }
 
@@ -153,6 +162,51 @@ public class IllegalTokenTextCheck
             compileFlags = 0;
         }
         format = CommonUtil.createPattern(formatString, compileFlags);
+    }
+
+    /**
+     * Checks whether the format pattern matches without splitting the interior of
+     * an escape sequence. A match is valid only if it either avoids escape
+     * interiors entirely, covers an escape interior completely, or exactly matches
+     * the interior of a single escape sequence.
+     *
+     * @param text the text to inspect
+     * @return {@code true} if a valid match is found; {@code false} otherwise
+     */
+    private boolean matchesAnyEscapeSpan(String text) {
+        final BitSet escapeInterior = buildEscapeInteriorPositions(text);
+        final Matcher matcher = format.matcher(text);
+
+        boolean matched = false;
+        while (!matched && matcher.find()) {
+            final int start = matcher.start();
+            final int end = matcher.end();
+
+            if (!escapeInterior.get(start)) {
+                final int firstInterior = escapeInterior.nextSetBit(start);
+
+                matched = firstInterior == -1
+                        || firstInterior >= end
+                        || end >= escapeInterior.nextClearBit(firstInterior);
+            }
+        }
+        return matched;
+    }
+
+    /**
+     * Builds a bit set marking the interior characters of every escape sequence in
+     * the given text. The leading backslash is excluded from the marked range.
+     *
+     * @param text the text to analyze
+     * @return a bit set whose set bits correspond to escape sequence interiors
+     */
+    private static BitSet buildEscapeInteriorPositions(String text) {
+        final BitSet interior = new BitSet(text.length());
+        final Matcher matcher = ESCAPE_SEQUENCE.matcher(text);
+        while (matcher.find()) {
+            interior.set(matcher.start() + 1, matcher.end());
+        }
+        return interior;
     }
 
 }

--- a/src/site/xdoc/checks/coding/illegaltokentext.xml
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml
@@ -102,7 +102,9 @@ public class Example1 {
     String test2 = "A href"; // ok, case is sensitive
     String link = "href";
     final String quote = """
-            \"""";
+            " """;
+    final String escapedQuote = """
+            \" """;
     int num1 = 0;
     int num2 = 0x111;
     int num3 = 0X111;
@@ -137,7 +139,9 @@ public class Example2 {
     String test2 = "A href";
     String link = "href";
     final String quote = """
-            \"""";
+            " """;
+    final String escapedQuote = """
+            \" """;
     int num1 = 0;
     int num2 = 0x111;
     int num3 = 0X111;
@@ -172,7 +176,9 @@ public class Example5 {
     String test2 = "A href"; // violation 'Custom illegal text found'
     String link = "href";    // violation 'Custom illegal text found'
     final String quote = """
-            \"""";
+            " """;
+    final String escapedQuote = """
+            \" """;
     int num1 = 0;
     int num2 = 0x111;
     int num3 = 0X111;
@@ -206,7 +212,9 @@ public class Example3 {
     String test2 = "A href";
     String link = "href";
     final String quote = """
-            \""""; // violation above 'Token text matches the illegal pattern '"'.'
+            " """; // violation above 'Token text matches the illegal pattern '"'.'
+    final String escapedQuote = """
+            \" """;
     int num1 = 0;
     int num2 = 0x111;
     int num3 = 0X111;
@@ -241,7 +249,9 @@ public class Example4 {
     String test2 = "A href";
     String link = "href";
     final String quote = """
-            \"""";
+            " """;
+    final String escapedQuote = """
+            \" """;
     int num1 = 0;
     int num2 = 0x111;
     int num3 = 0X111; // ok, case is ignored

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
@@ -104,8 +104,6 @@ public class IllegalTokenTextCheckTest
         final String[] expected = {
             "16:28: " + getCheckMessage(MSG_KEY, "\""),
             "18:33: " + getCheckMessage(MSG_KEY, "\""),
-            "20:32: " + getCheckMessage(MSG_KEY, "\""),
-            "22:36: " + getCheckMessage(MSG_KEY, "\""),
             "32:37: " + getCheckMessage(MSG_KEY, "\""),
             "37:37: " + getCheckMessage(MSG_KEY, "\""),
             "44:42: " + getCheckMessage(MSG_KEY, "\""),
@@ -196,4 +194,33 @@ public class IllegalTokenTextCheckTest
         verifyWithInlineConfigParser(
                 getPath("InputIllegalTokenTextDefaultFormat.java"), expected);
     }
+
+    @Test
+    public void testIllegalTokenTextEscapeSequences() throws Exception {
+
+        final String[] expected = {
+            "16:22: " + getCheckMessage(MSG_KEY, "\\\\12"),
+            "17:20: " + getCheckMessage(MSG_KEY, "\\\\12"),
+            "18:20: " + getCheckMessage(MSG_KEY, "\\\\12"),
+            "20:20: " + getCheckMessage(MSG_KEY, "\\\\12"),
+            "23:22: " + getCheckMessage(MSG_KEY, "\\\\12"),
+            "26:24: " + getCheckMessage(MSG_KEY, "\\\\12"),
+            "29:21: " + getCheckMessage(MSG_KEY, "\\\\12"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputIllegalTokenTextEscapeSequences.java"), expected);
+    }
+
+    @Test
+    public void testIllegalTokenNoMatchInEscapeSequence() throws Exception {
+
+        final String[] expected = {
+            "16:22: " + getCheckMessage(MSG_KEY, 12),
+            "24:23: " + getCheckMessage(MSG_KEY, 12),
+            "25:24: " + getCheckMessage(MSG_KEY, 12),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputIllegalTokenTextEscapeSequences2.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextEscapeSequences.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextEscapeSequences.java
@@ -1,0 +1,34 @@
+/*
+IllegalTokenText
+format = \\\\12
+ignoreCase = (default)false
+message = (default)
+tokens = STRING_LITERAL, TEXT_BLOCK_CONTENT, CHAR_LITERAL
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
+
+public class InputIllegalTokenTextEscapeSequences {
+
+    public void method() {
+        String str = "\121\12";     // violation 'Token text matches the illegal pattern '\\\\12'.'
+        String a = "\12";           // violation 'Token text matches the illegal pattern '\\\\12'.'
+        String b = "\12abc";        // violation 'Token text matches the illegal pattern '\\\\12'.'
+        String c = "\121";
+        String i = "\128";          // violation 'Token text matches the illegal pattern '\\\\12'.'
+        String j = "\7";
+        String start = "\127";
+        String end = "\n\12";       // violation 'Token text matches the illegal pattern '\\\\12'.'
+        String left = "\\12";
+        String right = "\\121";
+        String above = "\u0041\12"; // violation 'Token text matches the illegal pattern '\\\\12'.'
+        String below = "\u0041";
+
+        char line = '\12';          // violation 'Token text matches the illegal pattern '\\\\12'.'
+        char lines = '\127';
+        char column = '\"';
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextEscapeSequences2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextEscapeSequences2.java
@@ -1,0 +1,36 @@
+/*
+IllegalTokenText
+format = 12
+ignoreCase = (default)false
+message = (default)
+tokens = STRING_LITERAL, TEXT_BLOCK_CONTENT, CHAR_LITERAL
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
+
+public class InputIllegalTokenTextEscapeSequences2 {
+
+    public void method() {
+        String str = "\121\1812";    // violation 'Token text matches the illegal pattern '12'.'
+        String a = "\12";
+        String b = "\12abc";
+        String c = "\121";
+        String i = "\128";
+        String j = "\7";
+        String start = "\127";
+        String end = "\n\12";
+        String left = "\\12";         // violation 'Token text matches the illegal pattern '12'.'
+        String right = "\\121";       // violation 'Token text matches the illegal pattern '12'.'
+        String above = "\u0041\12";
+        String below = "\u0041";
+        String multipleU = """
+                \uuuu0012
+                """;
+
+        char line = '\12';
+        char lines = '\127';
+        char column = '\"';
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocksQuotes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocksQuotes.java
@@ -18,9 +18,9 @@ public class InputIllegalTokenTextTextBlocksQuotes {
         final String refCase1 = "<A hReF=\"";
 
         final String ref2 = """
-                <a href=\""""; // violation above 'Token text matches the illegal pattern '"''
+                <a href=\"""";
         final String refCase2 = """
-                <A hReF=\""""; // violation above 'Token text matches the illegal pattern '"''
+                <A hReF=\"""";
 
         String escape = """
                 <html>\u000D\u000A\n

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
@@ -62,8 +62,8 @@ public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTes
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "28:16: " + getCheckMessage(MSG_KEY, "^0[^lx]"),
-            "30:17: " + getCheckMessage(MSG_KEY, "^0[^lx]"),
+            "30:16: " + getCheckMessage(MSG_KEY, "^0[^lx]"),
+            "32:17: " + getCheckMessage(MSG_KEY, "^0[^lx]"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.java
@@ -20,7 +20,9 @@ public class Example1 {
     String test2 = "A href"; // ok, case is sensitive
     String link = "href";
     final String quote = """
-            \"""";
+            " """;
+    final String escapedQuote = """
+            \" """;
     int num1 = 0;
     int num2 = 0x111;
     int num3 = 0X111;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.java
@@ -21,7 +21,9 @@ public class Example2 {
     String test2 = "A href";
     String link = "href";
     final String quote = """
-            \"""";
+            " """;
+    final String escapedQuote = """
+            \" """;
     int num1 = 0;
     int num2 = 0x111;
     int num3 = 0X111;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.java
@@ -21,7 +21,9 @@ public class Example3 {
     String test2 = "A href";
     String link = "href";
     final String quote = """
-            \""""; // violation above 'Token text matches the illegal pattern '"'.'
+            " """; // violation above 'Token text matches the illegal pattern '"'.'
+    final String escapedQuote = """
+            \" """;
     int num1 = 0;
     int num2 = 0x111;
     int num3 = 0X111;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.java
@@ -21,7 +21,9 @@ public class Example4 {
     String test2 = "A href";
     String link = "href";
     final String quote = """
-            \"""";
+            " """;
+    final String escapedQuote = """
+            \" """;
     int num1 = 0;
     int num2 = 0x111;
     int num3 = 0X111; // ok, case is ignored

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example5.java
@@ -21,7 +21,9 @@ public class Example5 {
     String test2 = "A href"; // violation 'Custom illegal text found'
     String link = "href";    // violation 'Custom illegal text found'
     final String quote = """
-            \"""";
+            " """;
+    final String escapedQuote = """
+            \" """;
     int num1 = 0;
     int num2 = 0x111;
     int num3 = 0X111;


### PR DESCRIPTION
Issue: #19954 

Prevent IllegalTokenTextCheck from matching partial Java escape sequences.

For example, a pattern like 12 no longer matches inside \12 or \121, while patterns that do not split escape sequences (e.g. \\12 or abc\\12) continue to match correctly. This avoids false positives caused by matching the interior of escape sequences.

```
atharv@atharv-IdeaPad-3-15IIL05:~/test$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="IllegalTokenText">
      <property name="tokens" value="STRING_LITERAL"/>
      <property name="format" value="\\11"/>
    </module>
  </module>
</module>
```

```
atharv@atharv-IdeaPad-3-15IIL05:~/test$ cat -n Test.java
     1  public class Test {
     2
     3      public void openjdkCase() {
     4          String a = "\117"; // no violation expected
     5
     6          String b = "\118"; // violation
     7      }
     8
     9      public void guavaCase() {
    10          String c = "\\11"; // no violation expected
    11
    12          String d = "\11"; // violation
    13      }
    14  }
```

```
atharv@atharv-IdeaPad-3-15IIL05:~/test$ java -jar checkstyle-13.8.0-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/atharv/test/Test.java:6:20: Token text matches the illegal pattern '\\11'. [IllegalTokenText]
[ERROR] /home/atharv/test/Test.java:12:20: Token text matches the illegal pattern '\\11'. [IllegalTokenText]
Audit done.
Checkstyle ends with 2 errors.
```