### PR TITLE
Issue #15456: specify violation messages for RedundantModifierCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -271,7 +271,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
             "com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheck",
-            "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
 
             "com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
@@ -54,15 +54,15 @@ public class RedundantModifierCheckTest
     @Test
     public void testItOne() throws Exception {
         final String[] expected = {
-            "58:12: " + getCheckMessage(MSG_KEY, "static"),
-            "61:9: " + getCheckMessage(MSG_KEY, "public"),
-            "67:9: " + getCheckMessage(MSG_KEY, "abstract"),
-            "70:9: " + getCheckMessage(MSG_KEY, "public"),
-            // "72:9: Redundant 'abstract' modifier.",
-            "76:9: " + getCheckMessage(MSG_KEY, "final"),
-            "83:13: " + getCheckMessage(MSG_KEY, "final"),
-            "92:12: " + getCheckMessage(MSG_KEY, "final"),
-            "103:1: " + getCheckMessage(MSG_KEY, "abstract"),
+            "59:12: " + getCheckMessage(MSG_KEY, "static"),
+            "62:9: " + getCheckMessage(MSG_KEY, "public"),
+            "68:9: " + getCheckMessage(MSG_KEY, "abstract"),
+            "72:9: " + getCheckMessage(MSG_KEY, "public"),
+            // "75:9: Redundant 'abstract' modifier.",
+            "79:9: " + getCheckMessage(MSG_KEY, "final"),
+            "86:13: " + getCheckMessage(MSG_KEY, "final"),
+            "95:12: " + getCheckMessage(MSG_KEY, "final"),
+            "105:1: " + getCheckMessage(MSG_KEY, "abstract"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRedundantModifierItOne.java"), expected);
@@ -103,7 +103,7 @@ public class RedundantModifierCheckTest
     @Test
     public void testEnumConstructorIsImplicitlyPrivate() throws Exception {
         final String[] expected = {
-            "16:5: " + getCheckMessage(MSG_KEY, "private"),
+            "17:5: " + getCheckMessage(MSG_KEY, "private"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRedundantModifierConstructorModifier.java"), expected);
@@ -135,11 +135,11 @@ public class RedundantModifierCheckTest
     public void testNestedClassConsInPublicInterfaceHasValidPublicModifier() throws Exception {
 
         final String[] expected = {
-            "24:17: " + getCheckMessage(MSG_KEY, "public"),
-            "26:13: " + getCheckMessage(MSG_KEY, "public"),
-            "28:21: " + getCheckMessage(MSG_KEY, "public"),
-            "39:12: " + getCheckMessage(MSG_KEY, "public"),
-            "47:17: " + getCheckMessage(MSG_KEY, "public"),
+            "25:17: " + getCheckMessage(MSG_KEY, "public"),
+            "28:13: " + getCheckMessage(MSG_KEY, "public"),
+            "31:21: " + getCheckMessage(MSG_KEY, "public"),
+            "43:12: " + getCheckMessage(MSG_KEY, "public"),
+            "52:17: " + getCheckMessage(MSG_KEY, "public"),
         };
 
         verifyWithInlineConfigParser(
@@ -200,8 +200,8 @@ public class RedundantModifierCheckTest
     public void testNestedStaticEnum() throws Exception {
         final String[] expected = {
             "14:5: " + getCheckMessage(MSG_KEY, "static"),
-            "18:9: " + getCheckMessage(MSG_KEY, "static"),
-            "22:9: " + getCheckMessage(MSG_KEY, "static"),
+            "19:9: " + getCheckMessage(MSG_KEY, "static"),
+            "24:9: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRedundantModifierStaticModifierInNestedEnum.java"),
@@ -212,7 +212,7 @@ public class RedundantModifierCheckTest
     public void testFinalInAnonymousClass()
             throws Exception {
         final String[] expected = {
-            "24:20: " + getCheckMessage(MSG_KEY, "final"),
+            "25:20: " + getCheckMessage(MSG_KEY, "final"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRedundantModifierFinalInAnonymousClass.java"),
@@ -223,8 +223,8 @@ public class RedundantModifierCheckTest
     public void testFinalInTryWithResource() throws Exception {
         final String[] expected = {
             "40:14: " + getCheckMessage(MSG_KEY, "final"),
-            "45:14: " + getCheckMessage(MSG_KEY, "final"),
-            "46:17: " + getCheckMessage(MSG_KEY, "final"),
+            "46:14: " + getCheckMessage(MSG_KEY, "final"),
+            "48:17: " + getCheckMessage(MSG_KEY, "final"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRedundantModifierFinalInTryWithResource.java"),
@@ -235,10 +235,10 @@ public class RedundantModifierCheckTest
     public void testFinalInAbstractMethods() throws Exception {
         final String[] expected = {
             "14:33: " + getCheckMessage(MSG_KEY, "final"),
-            "18:49: " + getCheckMessage(MSG_KEY, "final"),
-            "21:17: " + getCheckMessage(MSG_KEY, "final"),
-            "26:24: " + getCheckMessage(MSG_KEY, "final"),
-            "35:33: " + getCheckMessage(MSG_KEY, "final"),
+            "19:49: " + getCheckMessage(MSG_KEY, "final"),
+            "23:17: " + getCheckMessage(MSG_KEY, "final"),
+            "29:24: " + getCheckMessage(MSG_KEY, "final"),
+            "39:33: " + getCheckMessage(MSG_KEY, "final"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRedundantModifierFinalInAbstractMethods.java"),
@@ -258,7 +258,7 @@ public class RedundantModifierCheckTest
     @Test
     public void testEnumStaticMethodsInPublicClass() throws Exception {
         final String[] expected = {
-            "22:23: " + getCheckMessage(MSG_KEY, "final"),
+            "23:23: " + getCheckMessage(MSG_KEY, "final"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRedundantModifierFinalInEnumStaticMethods.java"), expected);
@@ -267,7 +267,7 @@ public class RedundantModifierCheckTest
     @Test
     public void testAnnotationOnEnumConstructor() throws Exception {
         final String[] expected = {
-            "24:5: " + getCheckMessage(MSG_KEY, "private"),
+            "26:5: " + getCheckMessage(MSG_KEY, "private"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRedundantModifierAnnotationOnEnumConstructor.java"),
@@ -277,7 +277,7 @@ public class RedundantModifierCheckTest
     @Test
     public void testPrivateMethodInPrivateClass() throws Exception {
         final String[] expected = {
-            "15:17: " + getCheckMessage(MSG_KEY, "final"),
+            "16:17: " + getCheckMessage(MSG_KEY, "final"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRedundantModifierPrivateMethodInPrivateClass.java"),
@@ -287,7 +287,7 @@ public class RedundantModifierCheckTest
     @Test
     public void testTryWithResourcesBlock() throws Exception {
         final String[] expected = {
-            "20:19: " + getCheckMessage(MSG_KEY, "final"),
+            "21:19: " + getCheckMessage(MSG_KEY, "final"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRedundantModifierTryWithResources.java"),
@@ -301,25 +301,25 @@ public class RedundantModifierCheckTest
             "14:5: " + getCheckMessage(MSG_KEY, "static"),
             "15:5: " + getCheckMessage(MSG_KEY, "public"),
             "15:12: " + getCheckMessage(MSG_KEY, "static"),
-            "16:5: " + getCheckMessage(MSG_KEY, "static"),
-            "16:12: " + getCheckMessage(MSG_KEY, "public"),
-            "19:9: " + getCheckMessage(MSG_KEY, "public"),
-            "22:5: " + getCheckMessage(MSG_KEY, "public"),
-            "22:12: " + getCheckMessage(MSG_KEY, "static"),
-            "25:5: " + getCheckMessage(MSG_KEY, "public"),
-            "25:12: " + getCheckMessage(MSG_KEY, "abstract"),
-            "25:21: " + getCheckMessage(MSG_KEY, "static"),
-            "29:1: " + getCheckMessage(MSG_KEY, "abstract"),
-            "31:5: " + getCheckMessage(MSG_KEY, "public"),
-            "31:12: " + getCheckMessage(MSG_KEY, "static"),
-            "35:9: " + getCheckMessage(MSG_KEY, "public"),
-            "35:16: " + getCheckMessage(MSG_KEY, "static"),
-            "37:13: " + getCheckMessage(MSG_KEY, "public"),
-            "37:20: " + getCheckMessage(MSG_KEY, "static"),
-            "40:13: " + getCheckMessage(MSG_KEY, "public"),
-            "40:20: " + getCheckMessage(MSG_KEY, "static"),
-            "43:13: " + getCheckMessage(MSG_KEY, "public"),
-            "43:20: " + getCheckMessage(MSG_KEY, "static"),
+            "19:5: " + getCheckMessage(MSG_KEY, "static"),
+            "19:12: " + getCheckMessage(MSG_KEY, "public"),
+            "25:9: " + getCheckMessage(MSG_KEY, "public"),
+            "28:5: " + getCheckMessage(MSG_KEY, "public"),
+            "28:12: " + getCheckMessage(MSG_KEY, "static"),
+            "34:5: " + getCheckMessage(MSG_KEY, "public"),
+            "34:12: " + getCheckMessage(MSG_KEY, "abstract"),
+            "34:21: " + getCheckMessage(MSG_KEY, "static"),
+            "42:1: " + getCheckMessage(MSG_KEY, "abstract"),
+            "44:5: " + getCheckMessage(MSG_KEY, "public"),
+            "44:12: " + getCheckMessage(MSG_KEY, "static"),
+            "51:9: " + getCheckMessage(MSG_KEY, "public"),
+            "51:16: " + getCheckMessage(MSG_KEY, "static"),
+            "56:13: " + getCheckMessage(MSG_KEY, "public"),
+            "56:20: " + getCheckMessage(MSG_KEY, "static"),
+            "62:13: " + getCheckMessage(MSG_KEY, "public"),
+            "62:20: " + getCheckMessage(MSG_KEY, "static"),
+            "68:13: " + getCheckMessage(MSG_KEY, "public"),
+            "68:20: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(getPath(
                 "InputRedundantModifierNestedDef.java"), expected);
@@ -331,15 +331,15 @@ public class RedundantModifierCheckTest
             "16:5: " + getCheckMessage(MSG_KEY, "static"),
             "20:9: " + getCheckMessage(MSG_KEY, "final"),
             "20:15: " + getCheckMessage(MSG_KEY, "static"),
-            "25:9: " + getCheckMessage(MSG_KEY, "static"),
-            "31:9: " + getCheckMessage(MSG_KEY, "final"),
-            "31:15: " + getCheckMessage(MSG_KEY, "static"),
-            "36:13: " + getCheckMessage(MSG_KEY, "static"),
-            "42:1: " + getCheckMessage(MSG_KEY, "final"),
-            "44:5: " + getCheckMessage(MSG_KEY, "final"),
-            "47:5: " + getCheckMessage(MSG_KEY, "static"),
-            "51:9: " + getCheckMessage(MSG_KEY, "final"),
-            "51:15: " + getCheckMessage(MSG_KEY, "static"),
+            "28:9: " + getCheckMessage(MSG_KEY, "static"),
+            "34:9: " + getCheckMessage(MSG_KEY, "final"),
+            "34:15: " + getCheckMessage(MSG_KEY, "static"),
+            "42:13: " + getCheckMessage(MSG_KEY, "static"),
+            "48:1: " + getCheckMessage(MSG_KEY, "final"),
+            "50:5: " + getCheckMessage(MSG_KEY, "final"),
+            "53:5: " + getCheckMessage(MSG_KEY, "static"),
+            "57:9: " + getCheckMessage(MSG_KEY, "final"),
+            "57:15: " + getCheckMessage(MSG_KEY, "static"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRedundantModifierRecords.java"), expected);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierCompactSourceFile.java
@@ -10,7 +10,7 @@ tokens = (default)METHOD_DEF, VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF,
 
 // non-compiled with javac: Compilable with Java25
 class Helper {
-    public Helper() { } // violation, 'Redundant .public. modifier'
+    public Helper() { } // violation 'Redundant 'public' modifier.'
 }
 
 void main() { }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalUnnamedVariables.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalUnnamedVariables.java
@@ -15,13 +15,13 @@ import java.util.function.BiFunction;
 
 public class InputRedundantModifierFinalUnnamedVariables {
     void m(Object o) {
-        // violation below, 'Redundant 'final' modifier'
+        // violation below 'Redundant 'final' modifier.'
         if (o instanceof final String _) { }
         if (o instanceof final String __) { }
         if (o instanceof final String s)
         if (o instanceof final String _s) { }
 
-        // violation below, 'Redundant 'final' modifier'
+        // violation below 'Redundant 'final' modifier.'
         final int _ = sideEffect();
         final int __ = sideEffect();
         final int x = sideEffect();
@@ -31,7 +31,7 @@ public class InputRedundantModifierFinalUnnamedVariables {
 
     void m2(Object o) {
         switch (o) {
-            // violation below, 'Redundant 'final' modifier'
+            // violation below 'Redundant 'final' modifier.'
             case final String _ -> { }
             case Float _ -> { }
             case final Integer __ -> { }
@@ -41,17 +41,17 @@ public class InputRedundantModifierFinalUnnamedVariables {
     }
 
     void m3() {
-        // violation below, 'Redundant 'final' modifier'
+        // violation below 'Redundant 'final' modifier.'
         try (final var a = lock();) {
 
         } catch (final Exception e) {
 
         }
 
-        // violation below, 'Redundant 'final' modifier'
+        // violation below 'Redundant 'final' modifier.'
         try (final var _ = lock();) {
 
-        // violation below, 'Redundant 'final' modifier'
+        // violation below 'Redundant 'final' modifier.'
         } catch (final Exception _) {
 
         }
@@ -62,15 +62,15 @@ public class InputRedundantModifierFinalUnnamedVariables {
             return 5;
         };
 
-        // violation below, 'Redundant 'final' modifier'
+        // violation below 'Redundant 'final' modifier.'
         BiFunction<Integer, Integer, Integer> f2 = (final Integer _, final Integer b) -> {
             return 5;
         };
 
         BiFunction<Integer, Integer, Integer> f3 = (final Integer _, final Integer _) -> {
         // 2 violations above:
-        //                   'Redundant 'final' modifier'
-        //                   'Redundant 'final' modifier'
+        //                   'Redundant 'final' modifier.'
+        //                   'Redundant 'final' modifier.'
             return 5;
         };
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalUnnamedVariablesWithOldVersion.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalUnnamedVariablesWithOldVersion.java
@@ -37,14 +37,14 @@ public class InputRedundantModifierFinalUnnamedVariablesWithOldVersion {
     }
 
     void m3() {
-        // violation below, 'Redundant 'final' modifier'
+        // violation below 'Redundant 'final' modifier.'
         try (final var a = lock();) {
 
         } catch (final Exception e) {
 
         }
 
-        // violation below, 'Redundant 'final' modifier'
+        // violation below 'Redundant 'final' modifier.'
         try (final var _ = lock();) {
 
         } catch (final Exception _) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierAnnotationOnEnumConstructor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierAnnotationOnEnumConstructor.java
@@ -20,7 +20,9 @@ public enum InputRedundantModifierAnnotationOnEnumConstructor {
 enum InputRedundantModifierAnnotationOnEnumConstructor2 {
     ;
 
+
+    // violation 2 lines below 'Redundant 'private' modifier.'
     @SuppressWarnings("checkstyle:name")
-    private InputRedundantModifierAnnotationOnEnumConstructor2() { // violation
+    private InputRedundantModifierAnnotationOnEnumConstructor2() {
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierClassesInsideOfInterfaces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierClassesInsideOfInterfaces.java
@@ -18,22 +18,22 @@ public interface InputRedundantModifierClassesInsideOfInterfaces {
     class B {}
 
     // All classes inside interfaces are public static classes, and static modifier is redundant.
-    static class C { // violation
+    static class C { // violation 'Redundant 'static' modifier.'
         public static boolean verifyState( A a ) {
             return true;
         }
     }
 
-    public class E {} // violation
+    public class E {} // violation 'Redundant 'public' modifier.'
 
     // Enums are static implicit subclasses of Enum class.
-    public enum Role1 { // violation
+    public enum Role1 { // violation 'Redundant 'public' modifier.'
         ADMIN,
         EDITOR,
         VANILLA;
     }
 
-    static enum Role2 { // violation
+    static enum Role2 { // violation 'Redundant 'static' modifier.'
         ADMIN,
         EDITOR,
         VANILLA;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierConstructorModifier.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierConstructorModifier.java
@@ -13,7 +13,8 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 public enum InputRedundantModifierConstructorModifier {
     VAL1, VAL2;
 
-    private InputRedundantModifierConstructorModifier() { } // violation
+    // violation below 'Redundant 'private' modifier.'
+    private InputRedundantModifierConstructorModifier() { }
 
     InputRedundantModifierConstructorModifier(int i) { }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInAbstractMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInAbstractMethods.java
@@ -5,25 +5,28 @@ tokens = (default)METHOD_DEF, VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF,
          CTOR_DEF, CLASS_DEF, ENUM_DEF, RESOURCE, ANNOTATION_DEF, RECORD_DEF, \
          PATTERN_VARIABLE_DEF, LITERAL_CATCH, LAMBDA
 
-
 */
 
 package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 
 public abstract class InputRedundantModifierFinalInAbstractMethods {
-    public abstract void method(final String param); // violation
+    // violation below 'Redundant 'final' modifier.'
+    public abstract void method(final String param);
 
     public abstract void method2(String param);
 
-    public abstract void method3(String param1, final String param2); // violation
+    // violation below 'Redundant 'final' modifier.'
+    public abstract void method3(String param1, final String param2);
 }
 interface IWhatever {
-    void method(final String param); // violation
+    // violation below 'Redundant 'final' modifier.'
+    void method(final String param);
 
     void method2(String param);
 }
 class CWhatever {
-    native void method(final String param); // violation
+    // violation below 'Redundant 'final' modifier.'
+    native void method(final String param);
 
     native void method2(String param);
 }
@@ -32,5 +35,6 @@ enum EWhatever {
         public void method(String s) {};
     };
 
-    public abstract void method(final String s); // violation
+    // violation below 'Redundant 'final' modifier.'
+    public abstract void method(final String s);
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInAnonymousClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInAnonymousClass.java
@@ -20,8 +20,9 @@ public class InputRedundantModifierFinalInAnonymousClass {
 
     public static void test() {
         new Example() {
+            // violation 2 lines below 'Redundant 'final' modifier.'
             @Override
-            public final void innerTest() { // violation
+            public final void innerTest() {
             }
         };
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInEnumMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInEnumMethods.java
@@ -14,7 +14,7 @@ public enum InputRedundantModifierFinalInEnumMethods {
     E1,
     E2 {
         @Override
-        public final void v() { // violation
+        public final void v() { // violation 'Redundant 'final' modifier.'
         }
     };
 
@@ -29,7 +29,7 @@ public enum InputRedundantModifierFinalInEnumMethods {
 enum InputRedundantModifierFinalInEnumMethods2 {
     E1 {
         @Override
-        public final void v() { // violation
+        public final void v() { // violation 'Redundant 'final' modifier.'
         }
     },
     E2 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInEnumStaticMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInEnumStaticMethods.java
@@ -19,7 +19,8 @@ public class InputRedundantModifierFinalInEnumStaticMethods {
          };
 
         public void someMethodToOverride() { }
-        public static final void someStaticMethod() { }    // violation
+        // violation below 'Redundant 'final' modifier.'
+        public static final void someStaticMethod() { }
         public static void someMethod() { }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInInterface.java
@@ -12,7 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 
 
 public interface InputRedundantModifierFinalInInterface {
-        final int k = 5; // violation
+        final int k = 5; // violation 'Redundant 'final' modifier.'
 
     default int defaultMethod(final int x) {
             if (k == 5) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInTryWithResource.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInTryWithResource.java
@@ -5,7 +5,6 @@ tokens = (default)METHOD_DEF, VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF,
          CTOR_DEF, CLASS_DEF, ENUM_DEF, RESOURCE, ANNOTATION_DEF, RECORD_DEF, \
          PATTERN_VARIABLE_DEF, LITERAL_CATCH, LAMBDA
 
-
 */
 
 package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
@@ -37,13 +36,16 @@ public class InputRedundantModifierFinalInTryWithResource {
         catch (IOException e) {
         }
 
-        try (final BufferedReader br =  new BufferedReader(streamm)) { // violation
+        // violation below 'Redundant 'final' modifier.'
+        try (final BufferedReader br =  new BufferedReader(streamm)) {
         }
         catch (IOException e) {
         }
 
-        try (final BufferedReader br =  new BufferedReader(streamm); // violation
-                final BufferedReader br2 = new BufferedReader(streamm)) { // violation
+        // violation below 'Redundant 'final' modifier.'
+        try (final BufferedReader br =  new BufferedReader(streamm);
+                // violation below 'Redundant 'final' modifier.'
+                final BufferedReader br2 = new BufferedReader(streamm)) {
         }
         catch (IOException e) {
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierItOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierItOne.java
@@ -54,33 +54,36 @@ strictfp final class InputRedundantModifierItOne // illegal order of modifiers f
     {
     }
 
+    // violation 2 lines below 'Redundant 'static' modifier.'
     /** holder for redundant 'public' modifier check. */
-    public static interface InputRedundantPublicModifier // violation
+    public static interface InputRedundantPublicModifier
     {
         /** redundant 'public' modifier */
-        public void a(); // violation
+        public void a(); // violation 'Redundant 'public' modifier.'
 
         /** all OK */
         void b();
 
         /** redundant abstract modifier */
-        abstract void c(); // violation
+        abstract void c(); // violation 'Redundant 'abstract' modifier.'
 
+        // violation 2 lines below 'Redundant 'public' modifier.'
         /** redundant 'public' modifier */
-        public float PI_PUBLIC = (float) 3.14; // violation
+        public float PI_PUBLIC = (float) 3.14;
 
-        /** redundant 'abstract' modifier (field can not be abstract) */
+        // redundant 'abstract' modifier (field can not be abstract)
 //        abstract float PI_ABSTRACT = (float) 3.14;
 
+        // violation 2 lines below 'Redundant 'final' modifier.'
         /** redundant 'final' modifier */
-        final float PI_FINAL = (float) 3.14; // violation
+        final float PI_FINAL = (float) 3.14;
 
         /** all OK */
         float PI_OK = (float) 3.14;
     }
 
     /** redundant 'final' modifier */
-    private final void method() // violation
+    private final void method() // violation 'Redundant 'final' modifier.'
     {
     }
 }
@@ -89,19 +92,17 @@ strictfp final class InputRedundantModifierItOne // illegal order of modifiers f
 final class RedundantFinalClass
 {
     /** redundant 'final' modifier */
-    public final void finalMethod() // violation
+    public final void finalMethod() // violation 'Redundant 'final' modifier.'
     {
     }
 
     /** OK */
-    public void method()
-    {
-    }
+    public void method() {}
 }
 
+// violation 2 lines below 'Redundant 'abstract' modifier.'
 /** Holder for redundant modifiers of inner implementation */
-abstract interface InnerImplementation // violation
-{
+abstract interface InnerImplementation {
     InnerImplementation inner =
             new InnerImplementation()
             {
@@ -113,8 +114,6 @@ abstract interface InnerImplementation // violation
 
     void method();
 }
-@interface MyAnnotation2 {
-}
+@interface MyAnnotation2 {}
 
-@interface MyAnnotation4 {
-}
+@interface MyAnnotation4 {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierItTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierItTwo.java
@@ -20,12 +20,12 @@ strictfp final class InputRedundantModifierItTwo {
 /** Holder for redundant modifiers of annotation fields/variables */
 @interface Annotation
 {
-    public String s1 = ""; // violation
-    final String s2 = ""; // violation
-    static String s3 = ""; // violation
+    public String s1 = ""; // violation 'Redundant 'public' modifier.'
+    final String s2 = ""; // violation 'Redundant 'final' modifier.'
+    static String s3 = ""; // violation 'Redundant 'static' modifier.'
     String s4 = "";
-    public String blah(); // violation
-    abstract String blah2(); // violation
+    public String blah(); // violation 'Redundant 'public' modifier.'
+    abstract String blah2(); // violation 'Redundant 'abstract' modifier.'
 }
 
 class SafeVarargsUsage {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierNestedClassInInt.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierNestedClassInInt.java
@@ -21,11 +21,14 @@ public interface InputRedundantModifierNestedClassInInt {
     class PublicClassInsideInt {
         private interface PrivateNestedInt {
             class ClassInPrivateNestedInt {
-                public ClassInPrivateNestedInt() { } // violation
+                // violation below 'Redundant 'public' modifier.'
+                public ClassInPrivateNestedInt() { }
             }
-            public interface PrivateNestedIntWithPublicModifier { // violation
+            // violation below 'Redundant 'public' modifier.'
+            public interface PrivateNestedIntWithPublicModifier {
                 class ClassInPrivateNestedInt {
-                    public ClassInPrivateNestedInt() { } // violation
+                    // violation below 'Redundant 'public' modifier.'
+                    public ClassInPrivateNestedInt() { }
                 }
             }
         }
@@ -36,7 +39,8 @@ public interface InputRedundantModifierNestedClassInInt {
         }
         protected interface PublicInnerInnerProtectedInterface {
           class PublicInnerClassInNestedProtectedInt {
-           public PublicInnerClassInNestedProtectedInt() { } // violation
+           // violation below 'Redundant 'public' modifier.'
+           public PublicInnerClassInNestedProtectedInt() { }
           }
         }
     }
@@ -44,7 +48,8 @@ public interface InputRedundantModifierNestedClassInInt {
         public PublicNestedClassInInterfaceWithPublicConst() { } // ok in public class
         private class PrivateClassInPublicNestedClass {
             public class PublicInPrivateClass {
-                public PublicInPrivateClass() { } // violation
+                // violation below 'Redundant 'public' modifier.'
+                public PublicInPrivateClass() { }
             }
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierNestedDef.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierNestedDef.java
@@ -10,37 +10,65 @@ tokens = (default)METHOD_DEF, VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF,
 package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 
 public interface InputRedundantModifierNestedDef {
-    public enum MyInnerEnum1 {} // violation
-    static enum MyInnerEnum2 {} // violation
-    public static enum MyInnerEnum3 {} // 2 violations
-    static public enum MyInnerEnum4 {} // 2 violations
+    public enum MyInnerEnum1 {} // violation 'Redundant 'public' modifier.'
+    static enum MyInnerEnum2 {} // violation 'Redundant 'static' modifier.'
+    public static enum MyInnerEnum3 {}
+    // 2 violations above:
+    // 'Redundant 'public' modifier.'
+    // 'Redundant 'static' modifier.'
+    static public enum MyInnerEnum4 {}
+    // 2 violations above:
+    // 'Redundant 'static' modifier.'
+    // 'Redundant 'public' modifier.'
 
     interface MyInnerInterface {
-        public strictfp class MyInnerClass {} // violation
+        public strictfp class MyInnerClass {} // violation 'Redundant 'public' modifier.'
     }
 
-    public static class testClass { // 2 violations
+    public static class testClass {
+    // 2 violations above:
+    // 'Redundant 'public' modifier.'
+    // 'Redundant 'static' modifier.'
     }
 
-    public abstract static @interface testAnnotatedInterface { // 3 violations
+    public abstract static @interface testAnnotatedInterface {
+    // 3 violations above:
+    // 'Redundant 'public' modifier.'
+    // 'Redundant 'abstract' modifier.'
+    // 'Redundant 'static' modifier.'
     }
 }
 
-abstract @interface testAnnotatedInterface { // violation
+abstract @interface testAnnotatedInterface { // violation 'Redundant 'abstract' modifier.'
 
-    public static enum testEnum { // 2 violations
+    public static enum testEnum {
+    // 2 violations above:
+    // 'Redundant 'public' modifier.'
+    // 'Redundant 'static' modifier.'
     }
 
     interface testInterface {
-        public static interface nestedInterface { // 2 violations
+        public static interface nestedInterface {
+        // 2 violations above:
+        // 'Redundant 'public' modifier.'
+        // 'Redundant 'static' modifier.'
 
-            public static class nestedClass { // 2 violations
+            public static class nestedClass {
+            // 2 violations above:
+            // 'Redundant 'public' modifier.'
+            // 'Redundant 'static' modifier.'
             }
 
-            public static @interface nestedAnnInterface { // 2 violations
+            public static @interface nestedAnnInterface {
+            // 2 violations above:
+            // 'Redundant 'public' modifier.'
+            // 'Redundant 'static' modifier.'
             }
 
-            public static enum nestedEnum { // 2 violations
+            public static enum nestedEnum {
+            // 2 violations above:
+            // 'Redundant 'public' modifier.'
+            // 'Redundant 'static' modifier.'
             }
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierPrivateMethodInPrivateClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierPrivateMethodInPrivateClass.java
@@ -12,6 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 
 public class InputRedundantModifierPrivateMethodInPrivateClass {
     private class Inner {
-        private final void example() {} // violation
+        // violation below 'Redundant 'final' modifier.'
+        private final void example() {}
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierPublicModifierInNotPublicClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierPublicModifierInNotPublicClass.java
@@ -21,7 +21,7 @@ public class InputRedundantModifierPublicModifierInNotPublicClass {
 }
 
 class PackagePrivateClass {
-    public PackagePrivateClass() {} // violation
+    public PackagePrivateClass() {} // violation 'Redundant 'public' modifier.'
 }
 
 class PackagePrivateClassWithNotRedundantConstructor {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierRecords.java
@@ -13,42 +13,51 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 // Java17
 public class InputRedundantModifierRecords {
 
-    static record testRecord(int a) { // violation 'Redundant 'static' modifier'
+    static record testRecord(int a) { // violation 'Redundant 'static' modifier.'
     }
 
     interface foo {
-        final static record testRecords(int a) { // 2 violations
+        final static record testRecords(int a) {
+        // 2 violations above:
+        // 'Redundant 'final' modifier.'
+        // 'Redundant 'static' modifier.'
         }
     }
 
     class b {
-        static record testRecord(int a) { // violation 'Redundant 'static' modifier'
+        static record testRecord(int a) { // violation 'Redundant 'static' modifier.'
         }
     }
 
     enum testEnum {
         ONE;
-        final static record testRecord() { // 2 violations
+        final static record testRecord() {
+        // 2 violations above:
+        // 'Redundant 'final' modifier.'
+        // 'Redundant 'static' modifier.'
 
         }
 
         class b {
-            static record testRecord() { // violation 'Redundant 'static' modifier'
+            static record testRecord() { // violation 'Redundant 'static' modifier.'
             }
         }
     }
 }
 
-final record testRecord(int a) { // violation 'Redundant 'final' modifier'
+final record testRecord(int a) { // violation 'Redundant 'final' modifier.'
 
-    final record anotherRecord(int b) { // violation 'Redundant 'final' modifier'
+    final record anotherRecord(int b) { // violation 'Redundant 'final' modifier.'
     }
 
-    static record anotherTestRecord(int c) { // violation 'Redundant 'static' modifier'
+    static record anotherTestRecord(int c) { // violation 'Redundant 'static' modifier.'
     }
 
     @interface hoo {
-        final static record someRecord() { // 2 violations
+        final static record someRecord() {
+        // 2 violations above:
+        // 'Redundant 'final' modifier.'
+        // 'Redundant 'static' modifier.'
         }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStaticInInnerTypeOfInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStaticInInnerTypeOfInterface.java
@@ -11,11 +11,11 @@ tokens = (default)METHOD_DEF, VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF,
 package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 
 public interface InputRedundantModifierStaticInInnerTypeOfInterface {
-    static class MyInnerClass { } // violation
+    static class MyInnerClass { } // violation 'Redundant 'static' modifier.'
 
     class MyInnerClass2 { }
 
-    static enum MyInnerEnum { } // violation
+    static enum MyInnerEnum { } // violation 'Redundant 'static' modifier.'
 
     enum MyInnerEnum2 { }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStaticModifierInNestedEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStaticModifierInNestedEnum.java
@@ -5,20 +5,22 @@ tokens = (default)METHOD_DEF, VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF,
          CTOR_DEF, CLASS_DEF, ENUM_DEF, RESOURCE, ANNOTATION_DEF, RECORD_DEF, \
          PATTERN_VARIABLE_DEF, LITERAL_CATCH, LAMBDA
 
-
 */
 
 package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 
 public class InputRedundantModifierStaticModifierInNestedEnum {
-    static enum NestedEnumWithRedundantStatic {} // violation
+    // violation below 'Redundant 'static' modifier.'
+    static enum NestedEnumWithRedundantStatic {}
 
     enum CorrectNestedEnum {
         VAL;
-        static enum NestedEnumWithRedundantStatic {} // violation
+        // violation below 'Redundant 'static' modifier.'
+        static enum NestedEnumWithRedundantStatic {}
     }
 
     interface NestedInterface {
-        static enum NestedEnumWithRedundantStatic {} // violation
+        // violation below 'Redundant 'static' modifier.'
+        static enum NestedEnumWithRedundantStatic {}
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStrictfpWithDefaultVersion.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStrictfpWithDefaultVersion.java
@@ -14,35 +14,35 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 public class InputRedundantModifierStrictfpWithDefaultVersion {
 
     public static strictfp class Test { }
-    // violation above, 'Redundant 'strictfp' modifier'
+    // violation above 'Redundant 'strictfp' modifier.'
 
     strictfp interface MyInterface { }
-    // violation above, 'Redundant 'strictfp' modifier'
+    // violation above 'Redundant 'strictfp' modifier.'
 
     strictfp enum MyEnum {}
-    // violation above, 'Redundant 'strictfp' modifier'
+    // violation above 'Redundant 'strictfp' modifier.'
 
     strictfp record MyRecord(int x) {}
-    // violation above, 'Redundant 'strictfp' modifier'
+    // violation above 'Redundant 'strictfp' modifier.'
 
     abstract strictfp class MyAbstractClass { }
-    // violation above, 'Redundant 'strictfp' modifier'
+    // violation above 'Redundant 'strictfp' modifier.'
 
     abstract strictfp interface MyStrictFPInterface {
         // 2 violations above:
-        //                  'Redundant 'abstract' modifier'
-        //                  'Redundant 'strictfp' modifier'
+        //                  'Redundant 'abstract' modifier.'
+        //                  'Redundant 'strictfp' modifier.'
         public static strictfp enum MyInnerEnum { }
         // 3 violations above:
-        //                   'Redundant 'public' modifier'
-        //                   'Redundant 'static' modifier'
-        //                   'Redundant 'strictfp' modifier'
+        //                   'Redundant 'public' modifier.'
+        //                   'Redundant 'static' modifier.'
+        //                   'Redundant 'strictfp' modifier.'
     }
 
     final class OtherClass {
         final strictfp void m1() {}
         // 2 violations above:
-        //                  'Redundant 'final' modifier'
-        //                  'Redundant 'strictfp' modifier'
+        //                  'Redundant 'final' modifier.'
+        //                  'Redundant 'strictfp' modifier.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStrictfpWithJava17.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStrictfpWithJava17.java
@@ -14,35 +14,35 @@ package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 public class InputRedundantModifierStrictfpWithJava17 {
 
     public static strictfp class Test { }
-    // violation above, 'Redundant 'strictfp' modifier'
+    // violation above 'Redundant 'strictfp' modifier.'
 
     strictfp interface MyInterface { }
-    // violation above, 'Redundant 'strictfp' modifier'
+    // violation above 'Redundant 'strictfp' modifier.'
 
     strictfp enum MyEnum {}
-    // violation above, 'Redundant 'strictfp' modifier'
+    // violation above 'Redundant 'strictfp' modifier.'
 
     strictfp record MyRecord(int x) {}
-    // violation above, 'Redundant 'strictfp' modifier'
+    // violation above 'Redundant 'strictfp' modifier.'
 
     abstract strictfp class MyAbstractClass { }
-    // violation above, 'Redundant 'strictfp' modifier'
+    // violation above 'Redundant 'strictfp' modifier.'
 
     abstract strictfp interface MyStrictFPInterface {
         // 2 violations above:
-        //                  'Redundant 'abstract' modifier'
-        //                  'Redundant 'strictfp' modifier'
+        //                  'Redundant 'abstract' modifier.'
+        //                  'Redundant 'strictfp' modifier.'
         public static strictfp enum MyInnerEnum { }
         // 3 violations above:
-        //                   'Redundant 'public' modifier'
-        //                   'Redundant 'static' modifier'
-        //                   'Redundant 'strictfp' modifier'
+        //                   'Redundant 'public' modifier.'
+        //                   'Redundant 'static' modifier.'
+        //                   'Redundant 'strictfp' modifier.'
     }
 
     final class OtherClass {
         final strictfp void m1() {}
         // 2 violations above:
-        //                  'Redundant 'final' modifier'
-        //                  'Redundant 'strictfp' modifier'
+        //                  'Redundant 'final' modifier.'
+        //                  'Redundant 'strictfp' modifier.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStrictfpWithOldVersion.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStrictfpWithOldVersion.java
@@ -24,15 +24,15 @@ public class InputRedundantModifierStrictfpWithOldVersion {
     abstract strictfp class MyAbstractClass { }
 
     abstract strictfp interface MyStrictFPInterface {
-        // violation above, 'Redundant 'abstract' modifier'
+        // violation above 'Redundant 'abstract' modifier.'
         public static strictfp enum MyInnerEnum { }
         // 2 violations above:
-        //                   'Redundant 'public' modifier'
-        //                   'Redundant 'static' modifier'
+        //                   'Redundant 'public' modifier.'
+        //                   'Redundant 'static' modifier.'
     }
 
     final class OtherClass {
         final strictfp void m1() {}
-        // violation above, 'Redundant 'final' modifier'
+        // violation above 'Redundant 'final' modifier.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStrictfpWithVersionBeforeJava9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierStrictfpWithVersionBeforeJava9.java
@@ -24,15 +24,15 @@ public class InputRedundantModifierStrictfpWithVersionBeforeJava9 {
     abstract strictfp class MyAbstractClass { }
 
     abstract strictfp interface MyStrictFPInterface {
-        // violation above, 'Redundant 'abstract' modifier'
+        // violation above 'Redundant 'abstract' modifier.'
         public static strictfp enum MyInnerEnum { }
         // 2 violations above:
-        //                   'Redundant 'public' modifier'
-        //                   'Redundant 'static' modifier'
+        //                   'Redundant 'public' modifier.'
+        //                   'Redundant 'static' modifier.'
     }
 
     final class OtherClass {
         final strictfp void m1() {}
-        // violation above, 'Redundant 'final' modifier'
+        // violation above 'Redundant 'final' modifier.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierTryWithResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierTryWithResources.java
@@ -17,7 +17,8 @@ import java.io.OutputStreamWriter;
 public class InputRedundantModifierTryWithResources {
     public static void main(String[] args) {
         OutputStreamWriter out = null;
-        try (out; final OutputStreamWriter out2 = null;) { // violation
+        // violation below 'Redundant 'final' modifier.'
+        try (out; final OutputStreamWriter out2 = null;) {
             out.write(1);
         } catch (IOException ex) {
             System.err.println(ex);


### PR DESCRIPTION
Issue #15456 
### summary

- Removed RedundantModifierCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in RedundantModifierCheckest
- Defined violation messages in InputRedundantModifierCheck files