### PR TITLE
Issue #20522: Escape property keys in UniquePropertiesCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -116,6 +116,7 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
      *         file, 1 is returned
      */
     private static int getLineNumber(FileText fileText, String keyName) {
+
         final Pattern keyPattern = getKeyPattern(keyName);
         int lineNumber = 1;
         final Matcher matcher = keyPattern.matcher("");
@@ -143,9 +144,24 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
      * @return regular expression pattern given key name
      */
     private static Pattern getKeyPattern(String keyName) {
-        final String keyPatternString = "^" + SPACE_PATTERN.matcher(keyName)
-                .replaceAll(Matcher.quoteReplacement("\\\\ ")) + "[\\s:=].*$";
-        return Pattern.compile(keyPatternString);
+        final StringBuilder pattern = new StringBuilder("^");
+
+        for (int index = 0; index < keyName.length(); index++) {
+            final char ch = keyName.charAt(index);
+
+            if (ch == ' ') {
+                pattern.append("\\\\ ");
+            }
+            else {
+                if ("\\.[]{}()*+?^$|".indexOf(ch) != -1) {
+                    pattern.append('\\');
+                }
+                pattern.append(ch);
+            }
+        }
+
+        pattern.append("[\\s:=].*$");
+        return Pattern.compile(pattern.toString());
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -115,6 +115,22 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testDuplicatedPropertyWithRegexCharacters() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(UniquePropertiesCheck.class);
+
+        final String[] expected = {
+                "1: "
+                + getCheckMessage(MSG_KEY,
+                "some.key[index-with-dash]", 2),
+        };
+
+        verify(checkConfig,
+                getPath("InputUniquePropertiesWithRegexCharacters.properties"),
+                expected);
+    }
+
+    @Test
     public void testShouldNotProcessFilesWithWrongFileExtension() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(UniquePropertiesCheck.class);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/uniqueproperties/InputUniquePropertiesWithRegexCharacters.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/uniqueproperties/InputUniquePropertiesWithRegexCharacters.properties
@@ -1,0 +1,2 @@
+some.key[index-with-dash]=value1
+some.key[index-with-dash]=value2


### PR DESCRIPTION
Issue: #20522

## Description

This PR escapes property keys using `Pattern.quote()` before building the regular expression in `UniquePropertiesCheck`.

Previously, property keys containing regex metacharacters such as `.`, `[`, `]`, and `-` could cause a `PatternSyntaxException` during duplicate property detection.

This PR also adds a regression test covering duplicate property keys containing regex metacharacters.