### PR TITLE
Issue #20641: Add checks for programming section

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -157,6 +157,7 @@ chainedpropertyutil
 chapterformatting
 chapterjavasourcefiles
 chapternaming
+chapterprogrammingpractices
 charset
 CHDBEFIF
 checkchmod
@@ -1207,6 +1208,7 @@ rulemodifiers
 ruleorderofconstructorsandoverloadedmethods
 rulepackagedeclaration
 rulepackagenames
+ruleprogrammingpractices
 ruleredundantparenthesis
 ruleset
 rulesetfiles

--- a/src/it/java/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/ProgrammingPracticesTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/ProgrammingPracticesTest.java
@@ -1,0 +1,62 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.openjdk.checkstyle.test.chapterprogrammingpractices.ruleprogrammingpractices;
+
+import org.junit.jupiter.api.Test;
+
+import com.openjdk.checkstyle.test.base.AbstractOpenJdkModuleTestSupport;
+
+public class ProgrammingPracticesTest extends AbstractOpenJdkModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices";
+    }
+
+    @Test
+    public void testFallThrough() throws Exception {
+        verifyWithWholeConfig(getPath("InputProgrammingPracticesFallThrough.java"));
+    }
+
+    @Test
+    public void testOverrideOne() throws Exception {
+        verifyWithWholeConfig(getPath("InputProgrammingPracticesOverrideOne.java"));
+    }
+
+    @Test
+    public void testOverrideTwo() throws Exception {
+        verifyWithWholeConfig(getPath("InputProgrammingPracticesOverrideTwo.java"));
+    }
+
+    @Test
+    public void testParameterMutation() throws Exception {
+        verifyWithWholeConfig(getPath("InputProgrammingPracticesParameterMutation.java"));
+    }
+
+    @Test
+    public void testTodoComments() throws Exception {
+        verifyWithWholeConfig(getPath("InputProgrammingPracticesTodoComments.java"));
+    }
+
+    @Test
+    public void testVariable() throws Exception {
+        verifyWithWholeConfig(getPath("InputProgrammingPracticesVariable.java"));
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleindentation/InputIndentationInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleindentation/InputIndentationInvalid.java
@@ -3,7 +3,9 @@ package com.openjdk.checkstyle.test.chapterformatting.ruleindentation;
 /** Invalid indentation examples for OpenJDK style section 3.7. */
 public class InputIndentationInvalid {
 
-    private void method(int value) {
+    private void method() {
+        int value = 0;
+
         switch (value) {
           case 1: // violation ''case' construct must use '{}'s.'
           // violation above '.* incorrect indentation level 10, expected .* 12.'

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleindentation/InputIndentationValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleindentation/InputIndentationValid.java
@@ -3,7 +3,8 @@ package com.openjdk.checkstyle.test.chapterformatting.ruleindentation;
 /** Valid indentation examples for OpenJDK style section 3.7. */
 public class InputIndentationValid {
 
-    private void method(int value) {
+    private void method() {
+        int value = 0;
         switch (value) {
             case 1: // violation ''case' construct must use '{}'s.'
                 value++;

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulewrappingexpressions/InputWrappingExpressionsInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulewrappingexpressions/InputWrappingExpressionsInvalid.java
@@ -26,7 +26,8 @@ public class InputWrappingExpressionsInvalid {
                     ::compareToIgnoreCase);
     }
 
-    String typeGuardAfterParenthesizedTrueIfStatement2(Object o) {
+    String typeGuardAfterParenthesizedTrueIfStatement2(Object p) {
+        Object o = p;
         if (o != null && // violation ''&&' should be on a new line.'
                 o instanceof Integer i && // violation ''&&' should be on a new line.'
                         i == 0) {

--- a/src/it/resources/com/openjdk/checkstyle/test/chapternaming/rulevariables/InputVariablesInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapternaming/rulevariables/InputVariablesInvalid.java
@@ -4,11 +4,11 @@ import java.util.stream.Stream;
 
 public class InputVariablesInvalid {
 
-    public static int ItStatic1 = 2; // violation, 'must match pattern'
+    static int ItStatic1 = 2; // violation, 'must match pattern'
     protected static int ItStatic2 = 2; // violation, 'must match pattern'
     private static int ItStatic = 2; // violation, 'must match pattern'
-    public static int it_static = 2; // violation, 'must match pattern'
-    public static int It_Static = 2; // violation, 'must match pattern'
+    static int it_static = 2; // violation, 'must match pattern'
+    static int It_Static = 2; // violation, 'must match pattern'
     private static int It_Static1 = 2; // violation, 'must match pattern'
 
     public int NUM1; // violation 'Name 'NUM1' must match pattern'

--- a/src/it/resources/com/openjdk/checkstyle/test/chapternaming/rulevariables/InputVariablesValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapternaming/rulevariables/InputVariablesValid.java
@@ -4,11 +4,11 @@ import java.util.stream.Stream;
 
 public class InputVariablesValid {
 
-    public static int itStatic1 = 2;
+    static int itStatic1 = 2;
     protected static int itStatic2 = 2;
     private static int itStatic3 = 2;
-    public static int itStatic4 = 2;
-    public static int itStatic5 = 2;
+    static int itStatic4 = 2;
+    static int itStatic5 = 2;
     private static int itStatic6 = 2;
 
     public int num1;

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesFallThrough.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesFallThrough.java
@@ -1,0 +1,40 @@
+package com.openjdk.checkstyle.test.chapterprogrammingpractices.ruleprogrammingpractices;
+
+public class InputProgrammingPracticesFallThrough {
+    public void foo() throws Exception {
+        int i = 0;
+        while (i >= 0) {
+            switch (i) {
+                case 1: {
+                    i++;
+                }
+                // fall through
+                case 2: {
+                    i++;
+                    break;
+                }
+                case 3: {
+                    i++;
+                    return;
+                }
+                case 4: {
+                    i++;
+                    throw new Exception();
+                }
+                case 5: {
+                    i++;
+                }
+                case 6: { // violation 'Fall\ through from previous branch of the switch'
+                    break;
+                }
+                case 7: {
+                    i++;
+                    continue;
+                }
+                case 11: {
+                    i++;
+                }
+            }
+        }
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesOverrideOne.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesOverrideOne.java
@@ -1,0 +1,45 @@
+package com.openjdk.checkstyle.test.chapterprogrammingpractices.ruleprogrammingpractices;
+
+public class InputProgrammingPracticesOverrideOne {
+
+    class Child extends Parent {
+        /** {@inheritDoc} */
+        @Override
+        public void test1() {}
+
+        /** {@inheritDoc} */
+        public void test2() {}
+        // violation above """Must include @java.lang.Override annotation when
+        //  '@inheritDoc' Javadoc tag exists."""
+
+        /** {@inheritDoc} */
+        private void test3() {}
+        // violation above '{@inheritDoc} tag is not valid at this location.'
+
+        /** {@inheritDoc} */
+        public void test4() {}
+        // violation above """Must include @java.lang.Override annotation when
+        //  '@inheritDoc' Javadoc tag exists."""
+
+        /** {@inheritDoc} */
+        public boolean equals(Object o) {
+            // violation above """Must include @java.lang.Override annotation when
+            //  '@inheritDoc' Javadoc tag exists."""
+            return o == this;
+        }
+    }
+
+    class Parent {
+        public void test1() {
+        }
+
+        public void test2() {
+        }
+
+        private void test3() {
+        }
+
+        public void test4() {
+        }
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesOverrideTwo.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesOverrideTwo.java
@@ -1,0 +1,25 @@
+package com.openjdk.checkstyle.test.chapterprogrammingpractices.ruleprogrammingpractices;
+
+public class InputProgrammingPracticesOverrideTwo {
+
+    record Person(String name, int age) {
+
+        // violation below, 'method must include @java.lang.Override annotation.'
+        public String name() {
+            return name.toUpperCase();
+        }
+
+        public String name(String value) {
+            return value;
+        }
+
+        @Override
+        public int age() {
+            return age;
+        }
+
+        public int age(int value) {
+            return value;
+        }
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesParameterMutation.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesParameterMutation.java
@@ -1,0 +1,38 @@
+package com.openjdk.checkstyle.test.chapterprogrammingpractices.ruleprogrammingpractices;
+
+import java.util.function.IntBinaryOperator;
+import java.util.function.IntPredicate;
+
+public class InputProgrammingPracticesParameterMutation {
+
+    // violation below 'Assignment of parameter 'a' is not allowed.'
+    IntPredicate obj = a -> ++a == 12;
+    IntBinaryOperator obj2 = (int a, int b) -> {
+        a++;     // violation 'Assignment of parameter 'a' is not allowed.'
+        b += 12; // violation 'Assignment of parameter 'b' is not allowed.'
+        return a + b;
+    };
+
+    IntPredicate obj3 = a -> {
+        int b = a;
+        return ++b == 12;
+    };
+
+    int methodOne(int parameter) {
+        if (parameter <= 0) {
+            throw new IllegalArgumentException("A positive value is expected");
+        }
+        // violation below 'Assignment of parameter 'parameter' is not allowed.'
+        parameter -= 2;
+        return parameter;
+    }
+
+    int methodTwo(int parameter) {
+        if (parameter <= 0) {
+            throw new IllegalArgumentException("A positive value is expected");
+        }
+        int local = parameter;
+        local -= 2;
+        return local;
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesTodoComments.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesTodoComments.java
@@ -1,0 +1,17 @@
+package com.openjdk.checkstyle.test.chapterprogrammingpractices.ruleprogrammingpractices;
+
+public class InputProgrammingPracticesTodoComments {
+    int i;
+    int x;
+
+    public void test() {
+        // violation below 'matches to-do format'
+        i++;   // TODO: do differently in future
+        i++;   // todo: do differently in future
+    }
+
+    // violation below 'matches to-do format'
+    // TODO: complete the method
+    public void test1() {
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesVariable.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices/InputProgrammingPracticesVariable.java
@@ -1,0 +1,15 @@
+package com.openjdk.checkstyle.test.chapterprogrammingpractices.ruleprogrammingpractices;
+
+public class InputProgrammingPracticesVariable {
+
+    public static final int CONSTANT = 0;
+
+    public static int a = 0; // violation 'Public static variable must be final.'
+
+    private static int c = 0;
+
+    class Temp {
+        public static int cons = 10; // violation 'Public static variable must be final.'
+    }
+}
+

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -263,6 +263,20 @@
     <module name="SummaryJavadoc"/>
     <module name="JavadocContentLocation"/>
 
+    <module name="MissingOverride"/>
+    <module name="MissingOverrideOnRecordAccessor"/>
+    <module name="TodoComment"/>
+    <module name="ParameterAssignment"/>
+    <module name="FallThrough"/>
+    <module name="MethodLength"/>
+    <module name="MatchXpath">
+      <property name="id" value="PublicStaticFinalVariable"/>
+      <property name="query"
+        value="//VARIABLE_DEF[MODIFIERS[LITERAL_PUBLIC and LITERAL_STATIC and not(FINAL)]]"/>
+      <message key="matchxpath.match"
+        value="Public static variable must be final."/>
+    </module>
+
     <module name="PackageName">
       <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
     </module>

--- a/src/site/xdoc/checks/annotation/missingoverride.xml
+++ b/src/site/xdoc/checks/annotation/missingoverride.xml
@@ -164,6 +164,10 @@ class Example2Impl implements InterfaceB {
       <subsection name="Example of Usage" id="MissingOverride_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingOverride">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingOverride">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/annotation/missingoverride.xml.template
+++ b/src/site/xdoc/checks/annotation/missingoverride.xml.template
@@ -60,6 +60,10 @@
       <subsection name="Example of Usage" id="MissingOverride_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingOverride">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingOverride">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml
+++ b/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml
@@ -95,6 +95,10 @@ record Document(String title) implements Printable {
             Google Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingOverrideOnRecordAccessor">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingOverrideOnRecordAccessor">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml.template
+++ b/src/site/xdoc/checks/annotation/missingoverrideonrecordaccessor.xml.template
@@ -53,6 +53,10 @@
             Google Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingOverrideOnRecordAccessor">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingOverrideOnRecordAccessor">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/coding/fallthrough.xml
+++ b/src/site/xdoc/checks/coding/fallthrough.xml
@@ -204,6 +204,10 @@ class Example3 {
             Google Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/coding/fallthrough.xml.template
+++ b/src/site/xdoc/checks/coding/fallthrough.xml.template
@@ -83,6 +83,10 @@
             Google Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/coding/parameterassignment.xml
+++ b/src/site/xdoc/checks/coding/parameterassignment.xml
@@ -74,6 +74,10 @@ class Example1 {
       <subsection name="Example of Usage" id="ParameterAssignment_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParameterAssignment">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParameterAssignment">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/coding/parameterassignment.xml.template
+++ b/src/site/xdoc/checks/coding/parameterassignment.xml.template
@@ -40,6 +40,10 @@
       <subsection name="Example of Usage" id="ParameterAssignment_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParameterAssignment">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParameterAssignment">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/misc/todocomment.xml
+++ b/src/site/xdoc/checks/misc/todocomment.xml
@@ -171,6 +171,10 @@ public class Example3 {
             Google Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TodoComment">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TodoComment">
             Sun Style</a>
           </li>

--- a/src/site/xdoc/checks/misc/todocomment.xml.template
+++ b/src/site/xdoc/checks/misc/todocomment.xml.template
@@ -94,6 +94,10 @@
             Google Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TodoComment">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TodoComment">
             Sun Style</a>
           </li>

--- a/src/site/xdoc/checks/sizes/methodlength.xml
+++ b/src/site/xdoc/checks/sizes/methodlength.xml
@@ -261,6 +261,10 @@ public class Example3 {
             Sun Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodLength">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodLength">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/sizes/methodlength.xml.template
+++ b/src/site/xdoc/checks/sizes/methodlength.xml.template
@@ -82,6 +82,10 @@
             Sun Style</a>
           </li>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodLength">
+            OpenJDK Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodLength">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -1432,8 +1432,93 @@
                     <strong>Programming Practices</strong>
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_blue.png" alt=""/>
+                  </span>
+                  <a href="checks/annotation/missingoverrideonrecordaccessor.html#MissingOverrideOnRecordAccessor">
+                    MissingOverrideOnRecordAccessor</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingOverrideOnRecordAccessor">
+                  config</a>)
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ban_red.png" alt="" />
+                  </span>
+                  Only checks missing override for explicitly declared record accessor methods.
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_blue.png" alt=""/>
+                  </span>
+                  <a href="checks/annotation/missingoverride.html#MissingOverride">
+                    MissingOverride</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingOverride">
+                  config</a>)
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ban_red.png" alt="" />
+                  </span>
+                  Only checks for missing override when @inheritDoc javadoc tag is present.
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/sizes/methodlength.html#MethodLength">
+                    MethodLength</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodLength">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/coding/fallthrough.html#FallThrough">
+                    FallThrough</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/coding/matchxpath.html#MatchXpath">
+                    MatchXpath</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/coding/parameterassignment.html#ParameterAssignment">
+                    ParameterAssignment</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParameterAssignment">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/misc/todocomment.html#TodoComment">
+                    TodoComment</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TodoComment">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ban_red.png" alt=""/>
+                  </span>
+                  Some rules cannot be covered due to limitations of checkstyle like checkstyle
+                  cannot determine whether code is dead or not or all non-obvious pre and post
+                  conditions are documented or not or a static field/method is called using
+                  class identifiers and not variable identifiers.
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapterprogrammingpractices/ruleprogrammingpractices">
+                    samples
+                  </a>
+                </td>
               </tr>
               <tr>
                 <td>
@@ -1449,7 +1534,7 @@
                     Commenting Code
                   </a>
                 </td>
-                <td>???</td>
+                <td>--</td>
                 <td/>
               </tr>
               <!-- 6 When to reformat code -->


### PR DESCRIPTION
Issue: #20641 

Add checks for programming section.

Change symbol for commenting-code section because it does not contains any strict rule they are general instructions only.