### PR TITLE
Issue #15456: specify violation messages for AbbreviationAsWordInName…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -270,7 +270,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.RecordTypeParameterNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -38,14 +38,14 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 4;
 
         final String[] expected = {
-            "24:16: " + getWarningMessage("FactoryWithHARDName", expectedCapitalCount),
-            "27:16: " + getWarningMessage("AbstractCLASSName1", expectedCapitalCount),
-            "47:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "52:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "53:21: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
-            "54:21: " + getWarningMessage("systematicVARIABLEName", expectedCapitalCount),
-            "55:21: " + getWarningMessage("SYSTEMATICVariableName", expectedCapitalCount),
-            "73:20: " + getWarningMessage("serialNUMBER", expectedCapitalCount),
+            "25:16: " + getWarningMessage("FactoryWithHARDName", expectedCapitalCount),
+            "29:16: " + getWarningMessage("AbstractCLASSName1", expectedCapitalCount),
+            "50:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "56:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "58:21: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
+            "60:21: " + getWarningMessage("systematicVARIABLEName", expectedCapitalCount),
+            "62:21: " + getWarningMessage("SYSTEMATICVariableName", expectedCapitalCount),
+            "81:20: " + getWarningMessage("serialNUMBER", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -57,10 +57,10 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 4;
 
         final String[] expected = {
-            "22:16: " + getWarningMessage("FactoryWithHARDName2", expectedCapitalCount),
-            "25:16: " + getWarningMessage("AbstractCLASSName2", expectedCapitalCount),
-            "45:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "50:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "23:16: " + getWarningMessage("FactoryWithHARDName2", expectedCapitalCount),
+            "27:16: " + getWarningMessage("AbstractCLASSName2", expectedCapitalCount),
+            "48:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "54:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -72,7 +72,7 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 5;
 
         final String[] expected = {
-            "45:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "46:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -83,8 +83,8 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
     public void testTypeNamesForFivePermittedCapitalLetters() throws Exception {
         final int expectedCapitalCount = 6;
         final String[] expected = {
-            "45:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "50:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "46:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "52:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -96,11 +96,11 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 6;
 
         final String[] expected = {
-            "46:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "51:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "52:21: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
-            "53:17: " + getWarningMessage("systematicVARIABLEName", expectedCapitalCount),
-            "54:17: " + getWarningMessage("SYSTEMATICVariableName", expectedCapitalCount),
+            "47:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "53:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "55:21: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
+            "57:17: " + getWarningMessage("systematicVARIABLEName", expectedCapitalCount),
+            "59:17: " + getWarningMessage("SYSTEMATICVariableName", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -112,13 +112,13 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 6;
 
         final String[] expected = {
-            "48:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "53:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "54:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
-            "82:16: " + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "88:23: " + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "94:22: " + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "100:29: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "49:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "55:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "57:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
+            "86:16: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "93:23: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "100:22: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "107:29: " + getWarningMessage("VALUELONG", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -130,9 +130,9 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 6;
 
         final String[] expected = {
-            "43:17: " + getWarningMessage("InnerClassOneVIOLATION", expectedCapitalCount),
-            "47:18: " + getWarningMessage("InnerClassTwoVIOLATION", expectedCapitalCount),
-            "51:24: " + getWarningMessage("InnerClassThreeVIOLATION", expectedCapitalCount),
+            "44:17: " + getWarningMessage("InnerClassOneVIOLATION", expectedCapitalCount),
+            "49:18: " + getWarningMessage("InnerClassTwoVIOLATION", expectedCapitalCount),
+            "54:24: " + getWarningMessage("InnerClassThreeVIOLATION", expectedCapitalCount),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAbbreviationAsWordInNameNoIgnorePart2.java"), expected);
@@ -143,9 +143,9 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 6;
 
         final String[] expected = {
-            "48:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "53:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "54:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
+            "49:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "55:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "57:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -157,9 +157,9 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 6;
 
         final String[] expected = {
-            "44:17: " + getWarningMessage("InnerClassOneVIOLATION", expectedCapitalCount),
-            "48:18: " + getWarningMessage("InnerClassTwoVIOLATION", expectedCapitalCount),
-            "52:24: " + getWarningMessage("InnerClassThreeVIOLATION", expectedCapitalCount),
+            "45:17: " + getWarningMessage("InnerClassOneVIOLATION", expectedCapitalCount),
+            "50:18: " + getWarningMessage("InnerClassTwoVIOLATION", expectedCapitalCount),
+            "55:24: " + getWarningMessage("InnerClassThreeVIOLATION", expectedCapitalCount),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAbbreviationAsWordInNameIgnorePart2.java"), expected);
@@ -170,13 +170,13 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 5;
 
         final String[] expected = {
-            "28:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
-            "48:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "53:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "54:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
-            "74:20: "
+            "29:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "50:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "56:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "58:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
+            "79:20: "
                     + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
-            "76:28: " + getWarningMessage("s2erialNUMBER",
+            "82:28: " + getWarningMessage("s2erialNUMBER",
                     expectedCapitalCount), // no ignore for static
         };
 
@@ -190,13 +190,13 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 5;
 
         final String[] expected = {
-            "28:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
-            "48:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "53:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "54:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
-            "74:20: "
+            "29:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "50:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "56:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "58:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
+            "79:20: "
                 + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
-            "75:26: "
+            "81:26: "
                 + getWarningMessage("s1erialNUMBER", expectedCapitalCount), // no ignore for final
         };
 
@@ -210,15 +210,15 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 5;
 
         final String[] expected = {
-            "28:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
-            "48:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "53:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "54:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
-            "74:20: "
+            "29:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "50:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "56:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "58:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
+            "79:20: "
                     + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
-            "75:26: " + getWarningMessage("s1erialNUMBER",
+            "81:26: " + getWarningMessage("s1erialNUMBER",
                     expectedCapitalCount), // no ignore for final
-            "76:28: " + getWarningMessage("s2erialNUMBER",
+            "83:28: " + getWarningMessage("s2erialNUMBER",
                     expectedCapitalCount), // no ignore for static
         };
 
@@ -232,21 +232,21 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 5;
 
         final String[] expected = {
-            "28:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
-            "48:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "53:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "54:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
-            "74:20: "
+            "26:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "44:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "50:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "52:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
+            "72:20: "
                     + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
-            "77:34: " // no ignore for static final
+            "76:34: " // no ignore for static final
                     + getWarningMessage("s3erialNUMBER", expectedCapitalCount),
-            "82:16: "
+            "81:16: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "88:23: "
+            "86:23: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "94:22: "
+            "91:22: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "100:29: "
+            "96:29: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
         };
 
@@ -261,13 +261,13 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 5;
 
         final String[] expected = {
-            "28:16: " + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "32:23: " + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "36:22: " + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "40:29: " + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "43:17: " + getWarningMessage("InnerClassOneVIOLATION", expectedCapitalCount),
-            "47:18: " + getWarningMessage("InnerClassTwoVIOLATION", expectedCapitalCount),
-            "51:24: " + getWarningMessage("InnerClassThreeVIOLATION", expectedCapitalCount),
+            "29:16: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "34:23: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "39:22: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "44:29: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "48:17: " + getWarningMessage("InnerClassOneVIOLATION", expectedCapitalCount),
+            "53:18: " + getWarningMessage("InnerClassTwoVIOLATION", expectedCapitalCount),
+            "58:24: " + getWarningMessage("InnerClassThreeVIOLATION", expectedCapitalCount),
         };
         verifyWithInlineConfigParser(
                 getPath(
@@ -280,23 +280,23 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 5;
 
         final String[] expected = {
-            "28:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
-            "48:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "53:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "54:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
-            "74:20: "
+            "26:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "44:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "50:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "52:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
+            "72:20: "
                     + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
-            "76:28: " + getWarningMessage("s2erialNUMBER",
+            "75:28: " + getWarningMessage("s2erialNUMBER",
                     expectedCapitalCount), // no ignore for static
             "77:34: " // no ignore for static final
                     + getWarningMessage("s3erialNUMBER", expectedCapitalCount),
             "82:16: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "88:23: "
+            "87:23: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "94:22: "
+            "92:22: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "100:29: "
+            "98:29: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
         };
 
@@ -311,23 +311,23 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 5;
 
         final String[] expected = {
-            "28:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
-            "48:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
-            "53:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "54:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
-            "74:20: "
+            "26:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "45:15: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "51:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "53:25: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
+            "73:20: "
                     + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
             "75:26: " + getWarningMessage("s1erialNUMBER",
                     expectedCapitalCount), // no ignore for final
-            "77:34: " // no ignore for static final
+            "78:34: " // no ignore for static final
                     + getWarningMessage("s3erialNUMBER", expectedCapitalCount),
-            "82:16: "
+            "83:16: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
             "88:23: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "94:22: "
+            "93:22: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "100:29: "
+            "98:29: "
                     + getWarningMessage("VALUELONG", expectedCapitalCount),
         };
 
@@ -342,7 +342,7 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 4;
 
         final String[] expected = {
-            "35:20: " + getWarningMessage("overRIDDENMethod", expectedCapitalCount),
+            "36:20: " + getWarningMessage("overRIDDENMethod", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -355,10 +355,10 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 4;
 
         final String[] expected = {
-            "21:16: " + getWarningMessage("serialNUMBER", expectedCapitalCount),
-            "29:20: " + getWarningMessage("overRIDDENMethod", expectedCapitalCount),
-            "37:20: " + getWarningMessage("overRIDDENMethod", expectedCapitalCount),
-            "49:20: " + getWarningMessage("overRIDDENMethod", expectedCapitalCount),
+            "22:16: " + getWarningMessage("serialNUMBER", expectedCapitalCount),
+            "31:20: " + getWarningMessage("overRIDDENMethod", expectedCapitalCount),
+            "40:20: " + getWarningMessage("overRIDDENMethod", expectedCapitalCount),
+            "53:20: " + getWarningMessage("overRIDDENMethod", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -369,29 +369,29 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
     public void testTypeNamesForZeroPermittedCapitalLetter() throws Exception {
         final int expectedCapitalCount = 1;
         final String[] expected = {
-            "20:16: " + getWarningMessage("NonAAAAbstractClassName6", expectedCapitalCount),
-            "23:16: " + getWarningMessage("FactoryWithHARDName66", expectedCapitalCount),
-            "26:16: " + getWarningMessage("AbstractCLASSName6", expectedCapitalCount),
-            "46:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
+            "21:16: " + getWarningMessage("NonAAAAbstractClassName6", expectedCapitalCount),
+            "24:16: " + getWarningMessage("FactoryWithHARDName66", expectedCapitalCount),
+            "27:16: " + getWarningMessage("AbstractCLASSName6", expectedCapitalCount),
+            "45:11: " + getWarningMessage("AbstractINNERSClass", expectedCapitalCount),
             "51:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "52:21: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
-            "53:17: " + getWarningMessage("systematicVARIABLEName", expectedCapitalCount),
-            "54:17: " + getWarningMessage("SYSTEMATICVariableName", expectedCapitalCount),
-            "60:7: " + getWarningMessage("RIGHT", expectedCapitalCount),
-            "61:7: " + getWarningMessage("LEFT", expectedCapitalCount),
-            "62:7: " + getWarningMessage("UP", expectedCapitalCount),
-            "63:7: " + getWarningMessage("DOWN", expectedCapitalCount),
-            "71:16: " + getWarningMessage("NonAAAAbstractClassName26", expectedCapitalCount),
-            "72:16: " + getWarningMessage("serialNUMBER", expectedCapitalCount),
-            "73:22: " + getWarningMessage("s1erialNUMBER", expectedCapitalCount),
-            "74:24: " + getWarningMessage("s2erialNUMBER", expectedCapitalCount),
-            "75:30: " + getWarningMessage("s3erialNUMBER", expectedCapitalCount),
-            "80:12: " + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "86:19: " + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "92:18: " + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "98:25: " + getWarningMessage("VALUELONG", expectedCapitalCount),
-            "102:7: " + getWarningMessage("FIleNameFormatException6", expectedCapitalCount),
-            "104:31: " + getWarningMessage("serialVersionUID", expectedCapitalCount),
+            "53:21: " + getWarningMessage("systematicMETHODName", expectedCapitalCount),
+            "55:17: " + getWarningMessage("systematicVARIABLEName", expectedCapitalCount),
+            "57:17: " + getWarningMessage("SYSTEMATICVariableName", expectedCapitalCount),
+            "64:7: " + getWarningMessage("RIGHT", expectedCapitalCount),
+            "66:7: " + getWarningMessage("LEFT", expectedCapitalCount),
+            "68:7: " + getWarningMessage("UP", expectedCapitalCount),
+            "70:7: " + getWarningMessage("DOWN", expectedCapitalCount),
+            "78:16: " + getWarningMessage("NonAAAAbstractClassName26", expectedCapitalCount),
+            "80:16: " + getWarningMessage("serialNUMBER", expectedCapitalCount),
+            "82:22: " + getWarningMessage("s1erialNUMBER", expectedCapitalCount),
+            "84:24: " + getWarningMessage("s2erialNUMBER", expectedCapitalCount),
+            "86:30: " + getWarningMessage("s3erialNUMBER", expectedCapitalCount),
+            "91:12: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "96:19: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "101:18: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "106:25: " + getWarningMessage("VALUELONG", expectedCapitalCount),
+            "110:7: " + getWarningMessage("FIleNameFormatException6", expectedCapitalCount),
+            "112:31: " + getWarningMessage("serialVersionUID", expectedCapitalCount),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAbbreviationAsWordInNameType6.java"), expected);
@@ -403,11 +403,11 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 1;
 
         final String[] expected = {
-            "20:9: " + getWarningMessage("userID", expectedCapitalCount),
-            "29:12: " + getWarningMessage("VALUE", expectedCapitalCount),
-            "33:19: " + getWarningMessage("VALUE", expectedCapitalCount),
-            "37:18: " + getWarningMessage("VALUE", expectedCapitalCount),
-            "41:25: " + getWarningMessage("VALUE", expectedCapitalCount),
+            "21:9: " + getWarningMessage("userID", expectedCapitalCount),
+            "31:12: " + getWarningMessage("VALUE", expectedCapitalCount),
+            "36:19: " + getWarningMessage("VALUE", expectedCapitalCount),
+            "41:18: " + getWarningMessage("VALUE", expectedCapitalCount),
+            "46:25: " + getWarningMessage("VALUE", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -432,10 +432,10 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 4;
 
         final String[] expected = {
-            "25:36: " + getWarningMessage("STRING", expectedCapitalCount),
-            "26:43: " + getWarningMessage("INTEGER", expectedCapitalCount),
-            "35:41: " + getWarningMessage("ssSTRING", expectedCapitalCount),
-            "38:35: " + getWarningMessage("XMLHTTP", expectedCapitalCount),
+            "26:36: " + getWarningMessage("STRING", expectedCapitalCount),
+            "28:43: " + getWarningMessage("INTEGER", expectedCapitalCount),
+            "38:41: " + getWarningMessage("ssSTRING", expectedCapitalCount),
+            "42:35: " + getWarningMessage("XMLHTTP", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -451,11 +451,11 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 2;
 
         final String[] expected = {
-            "25:36: " + getWarningMessage("STRING", expectedCapitalCount),
-            "26:43: " + getWarningMessage("INTEGER", expectedCapitalCount),
-            "34:39: " + getWarningMessage("aTXT", expectedCapitalCount),
-            "35:41: " + getWarningMessage("ssSTRING", expectedCapitalCount),
-            "38:35: " + getWarningMessage("XMLHTTP", expectedCapitalCount),
+            "26:36: " + getWarningMessage("STRING", expectedCapitalCount),
+            "28:43: " + getWarningMessage("INTEGER", expectedCapitalCount),
+            "37:39: " + getWarningMessage("aTXT", expectedCapitalCount),
+            "39:41: " + getWarningMessage("ssSTRING", expectedCapitalCount),
+            "43:35: " + getWarningMessage("XMLHTTP", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -472,21 +472,21 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 4;
 
         final String[] expected = {
-            "22:11: " + getWarningMessage("myCLASS", expectedCapitalCount),
-            "23:13: " + getWarningMessage("INTEGER", expectedCapitalCount),
-            "24:14: " + getWarningMessage("METHOD", expectedCapitalCount),
-            "26:31: " + getWarningMessage("STRING", expectedCapitalCount),
-            "27:17: " + getWarningMessage("INTEGER", expectedCapitalCount),
-            "33:12: " + getWarningMessage("myRECORD1", expectedCapitalCount),
-            "33:29: " + getWarningMessage("STRING", expectedCapitalCount),
-            "35:14: " + getWarningMessage("METHOD", expectedCapitalCount),
-            "40:17: " + getWarningMessage("INTEGER", expectedCapitalCount),
-            "45:12: " + getWarningMessage("myRECORD2", expectedCapitalCount),
+            "23:11: " + getWarningMessage("myCLASS", expectedCapitalCount),
+            "25:13: " + getWarningMessage("INTEGER", expectedCapitalCount),
+            "27:14: " + getWarningMessage("METHOD", expectedCapitalCount),
+            "30:31: " + getWarningMessage("STRING", expectedCapitalCount),
+            "32:17: " + getWarningMessage("INTEGER", expectedCapitalCount),
+            "38:12: " + getWarningMessage("myRECORD1", expectedCapitalCount),
+            "38:29: " + getWarningMessage("STRING", expectedCapitalCount),
+            "44:14: " + getWarningMessage("METHOD", expectedCapitalCount),
             "50:17: " + getWarningMessage("INTEGER", expectedCapitalCount),
-            "54:12: " + getWarningMessage("myRECORD3", expectedCapitalCount),
-            "54:29: " + getWarningMessage("STRING", expectedCapitalCount),
-            "54:41: " + getWarningMessage("INTEGER", expectedCapitalCount),
-            "54:57: " + getWarningMessage("NODES", expectedCapitalCount),
+            "56:12: " + getWarningMessage("myRECORD2", expectedCapitalCount),
+            "62:17: " + getWarningMessage("INTEGER", expectedCapitalCount),
+            "66:12: " + getWarningMessage("myRECORD3", expectedCapitalCount),
+            "66:29: " + getWarningMessage("STRING", expectedCapitalCount),
+            "66:41: " + getWarningMessage("INTEGER", expectedCapitalCount),
+            "66:57: " + getWarningMessage("NODES", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(
@@ -551,7 +551,7 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
     @Test
     public void testAnnotation() throws Exception {
         final String[] expected = {
-            "25:12: " + getWarningMessage("readMETHOD", 4),
+            "26:12: " + getWarningMessage("readMETHOD", 4),
         };
 
         verifyWithInlineConfigParser(
@@ -563,8 +563,8 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 4;
 
         final String[] expected = {
-            "18:5: " + getWarningMessage("useHTTPSConnection", expectedCapitalCount),
-            "24:9: " + getWarningMessage("localHTTPSConnection", expectedCapitalCount),
+            "19:5: " + getWarningMessage("useHTTPSConnection", expectedCapitalCount),
+            "25:9: " + getWarningMessage("localHTTPSConnection", expectedCapitalCount),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckRecordPatterns.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckRecordPatterns.java
@@ -19,28 +19,28 @@ package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 public class InputAbbreviationAsWordInNameCheckRecordPatterns {
 
     void m(Object o) {
-        // violation below, 'Abbreviation in name 'POINT'*.'
+        // violation below 'Abbreviation in name 'POINT''
         if (o instanceof ColoredPoint POINT) {
 
         }
-        // violation below,  'Abbreviation in name 'COLOR'*.'
+        // violation below 'Abbreviation in name 'COLOR''
         if (o instanceof ColoredPoint(int x, int y, String COLOR)) {
 
         }
 
         if (o instanceof Rectangle(ColoredPoint(int INTEGER,_, String STRING),ColoredPoint _)) {}
         // 2 violations above:
-        //                'Abbreviation in name 'INTEGER'*.'
-        //               'Abbreviation in name 'STRING'*.'
+        //    'Abbreviation in name 'INTEGER''
+        //    'Abbreviation in name 'STRING''
     }
     void m2(Object o) {
         switch (o) {
-            // violation below, 'Abbreviation in name 'COLOR'*.'
+            // violation below 'Abbreviation in name 'COLOR''
             case ColoredPoint(int x, int y, String COLOR)  -> {}
             case Rectangle(ColoredPoint(int x, int INTEGER, String COLOR), _)  -> {}
             // 2 violations above:
-            //                  'Abbreviation in name 'INTEGER'*.'
-            //                 'Abbreviation in name 'COLOR'*.'
+            //    'Abbreviation in name 'INTEGER''
+            //    'Abbreviation in name 'COLOR''
             default -> {}
         }
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCompactSourceFile.java
@@ -15,12 +15,12 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION
 
 // non-compiled with javac: Compilable with Java25
 
+// violation below 'Abbreviation in name 'useHTTPSConnection''
 int useHTTPSConnection = 1;
-// violation above, ''useHTTPSConnection' must contain no more than '4' consecutive capital letters'
 
 static final int anotherHTTPSConnection = 2;
 
 void main() {
+    // violation below 'Abbreviation in name 'localHTTPSConnection''
     int localHTTPSConnection = 3;
-    // violation above, 'must contain no more than '4' consecutive capital letters'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameAnnotation.java
@@ -22,5 +22,6 @@ public interface InputAbbreviationAsWordInNameAnnotation extends BaseClass {
     String readMETHOD();
 }
 abstract interface BaseClass {
-    String readMETHOD(); // violation 'name 'readMETHOD' must contain no more than '4' .* cap.*.'
+    // violation below 'Abbreviation in name 'readMETHOD''
+    String readMETHOD();
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckEnhancedInstanceof.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckEnhancedInstanceof.java
@@ -22,8 +22,10 @@ import java.util.Locale;
 public class InputAbbreviationAsWordInNameCheckEnhancedInstanceof {
 
     public void t(Object o1, Object o2) {
-        if (!(o1 instanceof String STRING) // violation
-                && (o2 instanceof Integer INTEGER)) {} // violation
+        // violation below 'Abbreviation in name 'STRING''
+        if (!(o1 instanceof String STRING)
+                // violation below 'Abbreviation in name 'INTEGER''
+                && (o2 instanceof Integer INTEGER)) {}
 
         List<Integer> arrayList = new ArrayList<Integer>();
         if (arrayList instanceof ArrayList<Integer> aXML) {
@@ -32,10 +34,12 @@ public class InputAbbreviationAsWordInNameCheckEnhancedInstanceof {
 
         boolean result = (o1 instanceof String a1) ?
                 (o1 instanceof String aTXT) :
-                (!(o1 instanceof String ssSTRING)); // violation
+                // violation below 'Abbreviation in name 'ssSTRING''
+                (!(o1 instanceof String ssSTRING));
 
         String formatted;
-        if (o1 instanceof Integer XMLHTTP) formatted = // violation
+        // violation below 'Abbreviation in name 'XMLHTTP''
+        if (o1 instanceof Integer XMLHTTP) formatted =
                 String.format("int %d", XMLHTTP);
         else if (o1 instanceof Byte bYT) formatted = String.format("byte %d", bYT);
         else formatted = String.format("Something else "+ o1.toString());

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckEnhancedInstanceofAllowXmlLength1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckEnhancedInstanceofAllowXmlLength1.java
@@ -22,8 +22,10 @@ import java.util.Locale;
 public class InputAbbreviationAsWordInNameCheckEnhancedInstanceofAllowXmlLength1 {
 
     public void t(Object o1, Object o2) {
-        if (!(o1 instanceof String STRING) // violation
-                && (o2 instanceof Integer INTEGER)) {} // violation
+        // violation below 'Abbreviation in name 'STRING''
+        if (!(o1 instanceof String STRING)
+                // violation below 'Abbreviation in name 'INTEGER''
+                && (o2 instanceof Integer INTEGER)) {}
 
         List<Integer> arrayList = new ArrayList<Integer>();
         if (arrayList instanceof ArrayList<Integer> aXML) { // ok, allowed XML
@@ -31,11 +33,14 @@ public class InputAbbreviationAsWordInNameCheckEnhancedInstanceofAllowXmlLength1
         }
 
         boolean result = (o1 instanceof String a1) ?
-                (o1 instanceof String aTXT) :   // violation
-                (!(o1 instanceof String ssSTRING)); // violation
+                // violation below 'Abbreviation in name 'aTXT''
+                (o1 instanceof String aTXT) :
+                // violation below 'Abbreviation in name 'ssSTRING''
+                (!(o1 instanceof String ssSTRING));
 
         String formatted;
-        if (o1 instanceof Integer XMLHTTP) formatted = // violation
+        // violation below 'Abbreviation in name 'XMLHTTP''
+        if (o1 instanceof Integer XMLHTTP) formatted =
                 String.format("int %d", XMLHTTP);
         else if (o1 instanceof Byte bYT) formatted = String.format("byte %d", bYT);
         else formatted = String.format("Something else "+ o1.toString());

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckRecords.java
@@ -19,39 +19,56 @@ package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 import org.w3c.dom.Node;
 
 public class InputAbbreviationAsWordInNameCheckRecords {
-    class myCLASS { // violation
-        int INTEGER = 2; // violation
-        void METHOD(){} // violation
+    // violation below 'Abbreviation in name 'myCLASS''
+    class myCLASS {
+        // violation below 'Abbreviation in name 'INTEGER''
+        int INTEGER = 2;
+        // violation below 'Abbreviation in name 'METHOD''
+        void METHOD(){}
 
-        public myCLASS(String STRING) { // violation
-            int INTEGER = 6; // violation
+        // violation below 'Abbreviation in name 'STRING''
+        public myCLASS(String STRING) {
+            // violation below 'Abbreviation in name 'INTEGER''
+            int INTEGER = 6;
 
         }
 
     }
 
-    record myRECORD1(String STRING) { // 2 violations
+    record myRECORD1(String STRING) {
+        // 2 violations above:
+        //    'Abbreviation in name 'myRECORD1''
+        //    'Abbreviation in name 'STRING''
 
-        void METHOD(){} // violation
+        // violation below 'Abbreviation in name 'METHOD''
+        void METHOD(){}
 
         //ctor
         public myRECORD1(){
             this("string");
-            int INTEGER = 6; // violation
+            // violation below 'Abbreviation in name 'INTEGER''
+            int INTEGER = 6;
         }
 
     }
 
-    record myRECORD2() { // violation
+    // violation below 'Abbreviation in name 'myRECORD2''
+    record myRECORD2() {
         static int INTEGER = 6; // static ignored, all fields in record must be static
 
         //compact ctor
         public myRECORD2{
-            int INTEGER = 2; // violation
+            // violation below 'Abbreviation in name 'INTEGER''
+            int INTEGER = 2;
         }
     }
 
-    record myRECORD3(String STRING, int INTEGER, Node[] NODES) { // 4 violations
+    record myRECORD3(String STRING, int INTEGER, Node[] NODES) {
+        // 4 violations above:
+        //    'Abbreviation in name 'myRECORD3''
+        //    'Abbreviation in name 'STRING''
+        //    'Abbreviation in name 'INTEGER''
+        //    'Abbreviation in name 'NODES''
 
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnore.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnore.java
@@ -45,13 +45,16 @@ public class InputAbbreviationAsWordInNameIgnore {
     }
 
     abstract class AbstractClassName3 {
-        class AbstractINNERSClass { // violation
+        // violation below 'Abbreviation in name 'AbstractINNERSClass''
+        class AbstractINNERSClass {
         }
     }
 
     abstract class Class3Factory {
-        class WellNamedFACTORY { // violation
-            public void systematicMETHODName() { // violation
+        // violation below 'Abbreviation in name 'WellNamedFACTORY''
+        class WellNamedFACTORY {
+            // violation below 'Abbreviation in name 'systematicMETHODName''
+            public void systematicMETHODName() {
                 int systematicVARIABLEName = 2;
                 int SYSTEMATICVariableName = 1;
             }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreFinal.java
@@ -25,7 +25,8 @@ public class InputAbbreviationAsWordInNameIgnoreFinal {
     abstract class FactoryWithHARDName {
     }
 
-    abstract class AbstractCLASSName { // violation
+    // violation below 'Abbreviation in name 'AbstractCLASSName''
+    abstract class AbstractCLASSName {
         abstract class NonAbstractInnerClass {
         }
     }
@@ -45,13 +46,16 @@ public class InputAbbreviationAsWordInNameIgnoreFinal {
     }
 
     abstract class AbstractClassName3 {
-        class AbstractINNERSClass { // violation
+        // violation below 'Abbreviation in name 'AbstractINNERSClass''
+        class AbstractINNERSClass {
         }
     }
 
     abstract class Class3Factory {
-        class WellNamedFACTORY { // violation
-            public void systematicMETHODName() { // violation
+        // violation below 'Abbreviation in name 'WellNamedFACTORY''
+        class WellNamedFACTORY {
+            // violation below 'Abbreviation in name 'systematicMETHODName''
+            public void systematicMETHODName() {
                 int systematicVARIABLEName = 2;
                 int SYSTEMATICVariableName = 1;
             }
@@ -71,9 +75,11 @@ public class InputAbbreviationAsWordInNameIgnoreFinal {
     }
 
     abstract static class NonAAAAbstractClassName2 {
-        public int serialNUMBER = 6; // violation
+        // violation below 'Abbreviation in name 'serialNUMBER''
+        public int serialNUMBER = 6;
         public final int s1erialNUMBER = 6;
-        private static int s2erialNUMBER = 6; // violation
+        // violation below 'Abbreviation in name 's2erialNUMBER''
+        private static int s2erialNUMBER = 6;
         private static final int s3erialNUMBER = 6;
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreFinalKeepStaticFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreFinalKeepStaticFinal.java
@@ -16,16 +16,14 @@ package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
 public class InputAbbreviationAsWordInNameIgnoreFinalKeepStaticFinal {
 
-    abstract class InputAbbreviationAsWordInNameType {
-    }
+    abstract class InputAbbreviationAsWordInNameType {}
 
-    abstract class NonAAAAbstractClassName {
-    }
+    abstract class NonAAAAbstractClassName {}
 
-    abstract class FactoryWithHARDName {
-    }
+    abstract class FactoryWithHARDName {}
 
-    abstract class AbstractCLASSName { // violation
+    // violation below 'Abbreviation in name 'AbstractCLASSName''
+    abstract class AbstractCLASSName {
         abstract class NonAbstractInnerClass {
         }
     }
@@ -35,23 +33,23 @@ public class InputAbbreviationAsWordInNameIgnoreFinalKeepStaticFinal {
         }
     }
 
-    class NonAbstractClass1 {
-    }
+    class NonAbstractClass1 {}
 
-    class AbstractClass1 {
-    }
+    class AbstractClass1 {}
 
-    class Class1Factory1 {
-    }
+    class Class1Factory1 {}
 
     abstract class AbstractClassName3 {
-        class AbstractINNERSClass { // violation
+        // violation below 'Abbreviation in name 'AbstractINNERSClass''
+        class AbstractINNERSClass {
         }
     }
 
     abstract class Class3Factory {
-        class WellNamedFACTORY { // violation
-            public void systematicMETHODName() { // violation
+        // violation below 'Abbreviation in name 'WellNamedFACTORY''
+        class WellNamedFACTORY {
+            // violation below 'Abbreviation in name 'systematicMETHODName''
+            public void systematicMETHODName() {
                 int systematicVARIABLEName = 2;
                 int SYSTEMATICVariableName = 1;
             }
@@ -65,44 +63,42 @@ public class InputAbbreviationAsWordInNameIgnoreFinalKeepStaticFinal {
       int DOWN=4;
     }
 
-    interface BadNameForInterface
-    {
+    interface BadNameForInterface {
        void interfaceMethod();
     }
 
     abstract static class NonAAAAbstractClassName2 {
-        public int serialNUMBER = 6; // violation
+        // violation below 'Abbreviation in name 'serialNUMBER''
+        public int serialNUMBER = 6;
         public final int s1erialNUMBER = 6;
-        private static int s2erialNUMBER = 6; // violation
-        private static final int s3erialNUMBER = 6; // violation
+        // violation below 'Abbreviation in name 's2erialNUMBER''
+        private static int s2erialNUMBER = 6;
+        // violation below 'Abbreviation in name 's3erialNUMBER''
+        private static final int s3erialNUMBER = 6;
     }
 
     interface Interface1 {
-
-        String VALUELONG = "value"; // violation
-
+        // violation below 'Abbreviation in name 'VALUELONG''
+        String VALUELONG = "value";
     }
 
     interface Interface2 {
-
-        static String VALUELONG = "value"; // violation
-
+        // violation below 'Abbreviation in name 'VALUELONG''
+        static String VALUELONG = "value";
     }
 
     interface Interface3 {
-
-        final String VALUELONG = "value"; // violation
+        // violation below 'Abbreviation in name 'VALUELONG''
+        final String VALUELONG = "value";
 
     }
 
     interface Interface4 {
-
-        final static String VALUELONG = "value"; // violation
-
+        // violation below 'Abbreviation in name 'VALUELONG''
+        final static String VALUELONG = "value";
     }
 
     class FIleNameFormatException extends Exception {
-
         private static final long serialVersionUID = 1L;
 
         public FIleNameFormatException(Exception e) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreNonStaticFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreNonStaticFinal.java
@@ -16,16 +16,14 @@ package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
 public class InputAbbreviationAsWordInNameIgnoreNonStaticFinal {
 
-    abstract class InputAbbreviationAsWordInNameType {
-    }
+    abstract class InputAbbreviationAsWordInNameType {}
 
-    abstract class NonAAAAbstractClassName {
-    }
+    abstract class NonAAAAbstractClassName {}
 
-    abstract class FactoryWithHARDName {
-    }
+    abstract class FactoryWithHARDName {}
 
-    abstract class AbstractCLASSName { // violation
+    // violation below 'Abbreviation in name 'AbstractCLASSName''
+    abstract class AbstractCLASSName {
         abstract class NonAbstractInnerClass {
         }
     }
@@ -35,23 +33,23 @@ public class InputAbbreviationAsWordInNameIgnoreNonStaticFinal {
         }
     }
 
-    class NonAbstractClass1 {
-    }
+    class NonAbstractClass1 {}
 
-    class AbstractClass1 {
-    }
+    class AbstractClass1 {}
 
-    class Class1Factory1 {
-    }
+    class Class1Factory1 {}
 
     abstract class AbstractClassName3 {
-        class AbstractINNERSClass { // violation
+        // violation below 'Abbreviation in name 'AbstractINNERSClass''
+        class AbstractINNERSClass {
         }
     }
 
     abstract class Class3Factory {
-        class WellNamedFACTORY { // violation
-            public void systematicMETHODName() { // violation
+        // violation below 'Abbreviation in name 'WellNamedFACTORY''
+        class WellNamedFACTORY {
+            // violation below 'Abbreviation in name 'systematicMETHODName''
+            public void systematicMETHODName() {
                 int systematicVARIABLEName = 2;
                 int SYSTEMATICVariableName = 1;
             }
@@ -65,40 +63,37 @@ public class InputAbbreviationAsWordInNameIgnoreNonStaticFinal {
       int DOWN=4;
     }
 
-    interface BadNameForInterface
-    {
+    interface BadNameForInterface {
        void interfaceMethod();
     }
 
     abstract static class NonAAAAbstractClassName2 {
-        public int serialNUMBER = 6; // violation
+        // violation below 'Abbreviation in name 'serialNUMBER''
+        public int serialNUMBER = 6;
         public final int s1erialNUMBER = 6;
         private static int s2erialNUMBER = 6;
-        private static final int s3erialNUMBER = 6; // violation
+        // violation below 'Abbreviation in name 's3erialNUMBER''
+        private static final int s3erialNUMBER = 6;
     }
 
     interface Interface1 {
-
-        String VALUELONG = "value"; // violation
-
+        // violation below 'Abbreviation in name 'VALUELONG''
+        String VALUELONG = "value";
     }
 
     interface Interface2 {
-
-        static String VALUELONG = "value"; // violation
-
+        // violation below 'Abbreviation in name 'VALUELONG''
+        static String VALUELONG = "value";
     }
 
     interface Interface3 {
-
-        final String VALUELONG = "value"; // violation
-
+        // violation below 'Abbreviation in name 'VALUELONG''
+        final String VALUELONG = "value";
     }
 
     interface Interface4 {
-
-        final static String VALUELONG = "value"; // violation
-
+        // violation below 'Abbreviation in name 'VALUELONG''
+        final static String VALUELONG = "value";
     }
 
     class FIleNameFormatException extends Exception {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreNonStaticFinalPart2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreNonStaticFinalPart2.java
@@ -25,30 +25,37 @@ public class InputAbbreviationAsWordInNameIgnoreNonStaticFinalPart2 {
     }
 
     @interface Annotation1 {
-        String VALUELONG = "value"; // violation
+        // violation below 'Abbreviation in name 'VALUELONG''
+        String VALUELONG = "value";
     }
 
     @interface Annotation2 {
-        static String VALUELONG = "value"; // violation
+        // violation below 'Abbreviation in name 'VALUELONG''
+        static String VALUELONG = "value";
     }
 
     @interface Annotation3 {
-        final String VALUELONG = "value"; // violation
+        // violation below 'Abbreviation in name 'VALUELONG''
+        final String VALUELONG = "value";
     }
 
     @interface Annotation4 {
-        final static String VALUELONG = "value"; // violation
+        // violation below 'Abbreviation in name 'VALUELONG''
+        final static String VALUELONG = "value";
     }
 
-    final class InnerClassOneVIOLATION { // violation
+    // violation below 'Abbreviation in name 'InnerClassOneVIOLATION''
+    final class InnerClassOneVIOLATION {
         // only variable definitions are affected by ignore static/final properties
     }
 
-    static class InnerClassTwoVIOLATION { // violation
+    // violation below 'Abbreviation in name 'InnerClassTwoVIOLATION''
+    static class InnerClassTwoVIOLATION {
         // only variable definitions are affected by ignore static/final properties
     }
 
-    static final class InnerClassThreeVIOLATION { // violation
+    // violation below 'Abbreviation in name 'InnerClassThreeVIOLATION''
+    static final class InnerClassThreeVIOLATION {
         // only variable definitions are affected by ignore static/final properties
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnorePart2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnorePart2.java
@@ -41,15 +41,18 @@ public class InputAbbreviationAsWordInNameIgnorePart2{
         final static String VALUE = "value"; // in @interface this is final/static
     }
 
-    final class InnerClassOneVIOLATION { // violation
+    // violation below 'Abbreviation in name 'InnerClassOneVIOLATION''
+    final class InnerClassOneVIOLATION {
         // only variable definitions are affected by ignore static/final properties
     }
 
-    static class InnerClassTwoVIOLATION { // violation
+    // violation below 'Abbreviation in name 'InnerClassTwoVIOLATION''
+    static class InnerClassTwoVIOLATION {
         // only variable definitions are affected by ignore static/final properties
     }
 
-    static final class InnerClassThreeVIOLATION { // violation
+    // violation below 'Abbreviation in name 'InnerClassThreeVIOLATION''
+    static final class InnerClassThreeVIOLATION {
         // only variable definitions are affected by ignore static/final properties
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStatic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStatic.java
@@ -25,7 +25,8 @@ public class InputAbbreviationAsWordInNameIgnoreStatic {
     abstract class FactoryWithHARDName {
     }
 
-    abstract class AbstractCLASSName { // violation
+    // violation below 'Abbreviation in name 'AbstractCLASSName''
+    abstract class AbstractCLASSName {
         abstract class NonAbstractInnerClass {
         }
     }
@@ -45,13 +46,16 @@ public class InputAbbreviationAsWordInNameIgnoreStatic {
     }
 
     abstract class AbstractClassName3 {
-        class AbstractINNERSClass { // violation
+        // violation below 'Abbreviation in name 'AbstractINNERSClass''
+        class AbstractINNERSClass {
         }
     }
 
     abstract class Class3Factory {
-        class WellNamedFACTORY { // violation
-            public void systematicMETHODName() { // violation
+        // violation below 'Abbreviation in name 'WellNamedFACTORY''
+        class WellNamedFACTORY {
+            // violation below 'Abbreviation in name 'systematicMETHODName''
+            public void systematicMETHODName() {
                 int systematicVARIABLEName = 2;
                 int SYSTEMATICVariableName = 1;
             }
@@ -71,8 +75,10 @@ public class InputAbbreviationAsWordInNameIgnoreStatic {
     }
 
     abstract static class NonAAAAbstractClassName2 {
-        public int serialNUMBER = 6; // violation
-        public final int s1erialNUMBER = 6; // violation
+        // violation below 'Abbreviation in name 'serialNUMBER''
+        public int serialNUMBER = 6;
+        // violation below 'Abbreviation in name 's1erialNUMBER''
+        public final int s1erialNUMBER = 6;
         private static int s2erialNUMBER = 6;
         private static final int s3erialNUMBER = 6;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStaticFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStaticFinal.java
@@ -25,7 +25,8 @@ public class InputAbbreviationAsWordInNameIgnoreStaticFinal {
     abstract class FactoryWithHARDName {
     }
 
-    abstract class AbstractCLASSName { // violation
+    // violation below 'Abbreviation in name 'AbstractCLASSName''
+    abstract class AbstractCLASSName {
         abstract class NonAbstractInnerClass {
         }
     }
@@ -45,13 +46,16 @@ public class InputAbbreviationAsWordInNameIgnoreStaticFinal {
     }
 
     abstract class AbstractClassName3 {
-        class AbstractINNERSClass { // violation
+        // violation below 'Abbreviation in name 'AbstractINNERSClass''
+        class AbstractINNERSClass {
         }
     }
 
     abstract class Class3Factory {
-        class WellNamedFACTORY { // violation
-            public void systematicMETHODName() { // violation
+        // violation below 'Abbreviation in name 'WellNamedFACTORY''
+        class WellNamedFACTORY {
+            // violation below 'Abbreviation in name 'systematicMETHODName''
+            public void systematicMETHODName() {
                 int systematicVARIABLEName = 2;
                 int SYSTEMATICVariableName = 1;
             }
@@ -71,9 +75,12 @@ public class InputAbbreviationAsWordInNameIgnoreStaticFinal {
     }
 
     abstract static class NonAAAAbstractClassName2 {
-        public int serialNUMBER = 6; // violation
-        public final int s1erialNUMBER = 6; // violation
-        private static int s2erialNUMBER = 6; // violation
+        // violation below 'Abbreviation in name 'serialNUMBER''
+        public int serialNUMBER = 6;
+        // violation below 'Abbreviation in name 's1erialNUMBER''
+        public final int s1erialNUMBER = 6;
+        // violation below 'Abbreviation in name 's2erialNUMBER''
+        private static int s2erialNUMBER = 6;
         private static final int s3erialNUMBER = 6;
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStaticKeepStaticFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStaticKeepStaticFinal.java
@@ -16,16 +16,14 @@ package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
 public class InputAbbreviationAsWordInNameIgnoreStaticKeepStaticFinal {
 
-    abstract class InputAbbreviationAsWordInNameType {
-    }
+    abstract class InputAbbreviationAsWordInNameType {}
 
-    abstract class NonAAAAbstractClassName {
-    }
+    abstract class NonAAAAbstractClassName {}
 
-    abstract class FactoryWithHARDName {
-    }
+    abstract class FactoryWithHARDName {}
 
-    abstract class AbstractCLASSName { // violation
+    // violation below 'Abbreviation in name 'AbstractCLASSName''
+    abstract class AbstractCLASSName {
         abstract class NonAbstractInnerClass {
         }
     }
@@ -35,23 +33,24 @@ public class InputAbbreviationAsWordInNameIgnoreStaticKeepStaticFinal {
         }
     }
 
-    class NonAbstractClass1 {
-    }
+    class NonAbstractClass1 {}
 
     class AbstractClass1 {
     }
 
-    class Class1Factory1 {
-    }
+    class Class1Factory1 {}
 
     abstract class AbstractClassName3 {
-        class AbstractINNERSClass { // violation
+        // violation below 'Abbreviation in name 'AbstractINNERSClass''
+        class AbstractINNERSClass {
         }
     }
 
     abstract class Class3Factory {
-        class WellNamedFACTORY { // violation
-            public void systematicMETHODName() { // violation
+        // violation below 'Abbreviation in name 'WellNamedFACTORY''
+        class WellNamedFACTORY {
+            // violation below 'Abbreviation in name 'systematicMETHODName''
+            public void systematicMETHODName() {
                 int systematicVARIABLEName = 2;
                 int SYSTEMATICVariableName = 1;
             }
@@ -65,46 +64,42 @@ public class InputAbbreviationAsWordInNameIgnoreStaticKeepStaticFinal {
       int DOWN=4;
     }
 
-    interface BadNameForInterface
-    {
+    interface BadNameForInterface {
        void interfaceMethod();
     }
 
     abstract static class NonAAAAbstractClassName2 {
-        public int serialNUMBER = 6; // violation
-        public final int s1erialNUMBER = 6; // violation
+        // violation below 'Abbreviation in name 'serialNUMBER''
+        public int serialNUMBER = 6;
+        // violation below 'Abbreviation in name 's1erialNUMBER''
+        public final int s1erialNUMBER = 6;
         private static int s2erialNUMBER = 6;
-        private static final int s3erialNUMBER = 6; // violation
+        // violation below 'Abbreviation in name 's3erialNUMBER''
+        private static final int s3erialNUMBER = 6;
     }
 
     interface Interface1 {
-
-        String VALUELONG = "value"; // violation
-
+        // violation below 'Abbreviation in name 'VALUELONG''
+        String VALUELONG = "value";
     }
 
     interface Interface2 {
-
-        static String VALUELONG = "value"; // violation
-
+        // violation below 'Abbreviation in name 'VALUELONG''
+        static String VALUELONG = "value";
     }
 
     interface Interface3 {
-
-        final String VALUELONG = "value"; // violation
-
+        // violation below 'Abbreviation in name 'VALUELONG''
+        final String VALUELONG = "value";
     }
 
     interface Interface4 {
-
-        final static String VALUELONG = "value"; // violation
-
+        // violation below 'Abbreviation in name 'VALUELONG''
+        final static String VALUELONG = "value";
     }
 
     class FIleNameFormatException extends Exception {
-
         private static final long serialVersionUID = 1L;
-
         public FIleNameFormatException(Exception e) {
             super(e);
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameNoIgnore.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameNoIgnore.java
@@ -45,13 +45,16 @@ public class InputAbbreviationAsWordInNameNoIgnore {
     }
 
     abstract class AbstractClassName3 {
-        class AbstractINNERSClass { // violation
+        // violation below 'Abbreviation in name 'AbstractINNERSClass''
+        class AbstractINNERSClass {
         }
     }
 
     abstract class Class3Factory {
-        class WellNamedFACTORY { // violation
-            public void systematicMETHODName() { // violation
+        // violation below 'Abbreviation in name 'WellNamedFACTORY''
+        class WellNamedFACTORY {
+            // violation below 'Abbreviation in name 'systematicMETHODName''
+            public void systematicMETHODName() {
                 int systematicVARIABLEName = 2;
                 int SYSTEMATICVariableName = 1;
             }
@@ -79,25 +82,29 @@ public class InputAbbreviationAsWordInNameNoIgnore {
 
     interface Interface1 {
 
-        String VALUELONG = "value"; // violation
+        // violation below 'Abbreviation in name 'VALUELONG''
+        String VALUELONG = "value";
 
     }
 
     interface Interface2 {
 
-        static String VALUELONG = "value"; // violation
+        // violation below 'Abbreviation in name 'VALUELONG''
+        static String VALUELONG = "value";
 
     }
 
     interface Interface3 {
 
-        final String VALUELONG = "value"; // violation
+        // violation below 'Abbreviation in name 'VALUELONG''
+        final String VALUELONG = "value";
 
     }
 
     interface Interface4 {
 
-        final static String VALUELONG = "value"; // violation
+        // violation below 'Abbreviation in name 'VALUELONG''
+        final static String VALUELONG = "value";
 
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameNoIgnorePart2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameNoIgnorePart2.java
@@ -40,15 +40,18 @@ public class InputAbbreviationAsWordInNameNoIgnorePart2 {
         final static String VALUE = "value"; // in @interface this is final/static
     }
 
-    final class InnerClassOneVIOLATION { // violation
+    // violation below 'Abbreviation in name 'InnerClassOneVIOLATION''
+    final class InnerClassOneVIOLATION {
         // only variable definitions are affected by ignore static/final properties
     }
 
-    static class InnerClassTwoVIOLATION { // violation
+    // violation below 'Abbreviation in name 'InnerClassTwoVIOLATION''
+    static class InnerClassTwoVIOLATION {
         // only variable definitions are affected by ignore static/final properties
     }
 
-    static final class InnerClassThreeVIOLATION { // violation
+    // violation below 'Abbreviation in name 'InnerClassThreeVIOLATION''
+    static final class InnerClassThreeVIOLATION {
         // only variable definitions are affected by ignore static/final properties
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameOverridableMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameOverridableMethod.java
@@ -31,8 +31,9 @@ abstract class InputAbbreviationAsWordInNameOverridableMethod extends Class1 {
 }
 
 class Class1 {
+    // violation 2 lines below 'Abbreviation in name 'overRIDDENMethod''
     @SuppressWarnings(value = { "" })
-    protected void overRIDDENMethod(){ // violation
+    protected void overRIDDENMethod(){
         int a = 0;
         // blah-blah
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameOverridableMethod2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameOverridableMethod2.java
@@ -18,23 +18,26 @@ package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 import org.junit.Before;
 
 abstract class InputAbbreviationAsWordInNameOverridableMethod2 extends Class1 {
-    public int serialNUMBER = 6; // violation
+    // violation below 'Abbreviation in name 'serialNUMBER''
+    public int serialNUMBER = 6;
     public final int s1erialNUMBER = 6;
     private static int s2erialNUMBER = 6;
     private static final int s3erialNUMBER = 6;
 
+    // violation 4 lines below 'Abbreviation in name 'overRIDDENMethod''
     @Override
     @SuppressWarnings(value = { "" })
     @Before
-    protected void overRIDDENMethod(){ // violation
+    protected void overRIDDENMethod(){
         int a = 0;
         // blah-blah
     }
 }
 
 class Class12 {
+    // violation 2 lines below 'Abbreviation in name 'overRIDDENMethod''
     @SuppressWarnings(value = { "" })
-    protected void overRIDDENMethod(){ // violation
+    protected void overRIDDENMethod(){
         int a = 0;
         // blah-blah
     }
@@ -43,10 +46,11 @@ class Class12 {
 
 class Class22 extends Class1 {
 
+    // violation 4 lines below 'Abbreviation in name 'overRIDDENMethod''
     @Override
     @SuppressWarnings(value = { "" })
     @Before
-    protected void overRIDDENMethod(){ // violation
+    protected void overRIDDENMethod(){
         int a = 0;
         // blah-blah
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType.java
@@ -21,10 +21,12 @@ abstract class InputAbbreviationAsWordInNameType {
 abstract class NonAAAAbstractClassName {
 }
 
-abstract class FactoryWithHARDName { // violation
+// violation below 'Abbreviation in name 'FactoryWithHARDName''
+abstract class FactoryWithHARDName {
 }
 
-abstract class AbstractCLASSName1 { // violation
+// violation below 'Abbreviation in name 'AbstractCLASSName1''
+abstract class AbstractCLASSName1 {
     abstract class NonAbstractInnerClass {
     }
 }
@@ -44,15 +46,20 @@ class Class1Factory1 {
 }
 
 abstract class AbstractClassName31 {
-    class AbstractINNERSClass { // violation
+    // violation below 'Abbreviation in name 'AbstractINNERSClass''
+    class AbstractINNERSClass {
     }
 }
 
 abstract class Class3Factory {
-    class WellNamedFACTORY { // violation
-    	public void systematicMETHODName() { // violation
-    		int systematicVARIABLEName = 2; // violation
-    		int SYSTEMATICVariableName = 1; // violation
+    // violation below 'Abbreviation in name 'WellNamedFACTORY''
+    class WellNamedFACTORY {
+    	// violation below 'Abbreviation in name 'systematicMETHODName''
+    	public void systematicMETHODName() {
+    		// violation below 'Abbreviation in name 'systematicVARIABLEName''
+    		int systematicVARIABLEName = 2;
+    		// violation below 'Abbreviation in name 'SYSTEMATICVariableName''
+    		int SYSTEMATICVariableName = 1;
     	}
     }
 }
@@ -70,7 +77,8 @@ interface BadNameForInterface
 }
 
 abstract class NonAAAAbstractClassName21 {
-	public int serialNUMBER = 6; // violation
+	// violation below 'Abbreviation in name 'serialNUMBER''
+	public int serialNUMBER = 6;
 	public final int s1erialNUMBER = 6;
 	private static int s2erialNUMBER = 6;
 	private static final int s3erialNUMBER = 6;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType2.java
@@ -19,10 +19,12 @@ abstract class InputAbbreviationAsWordInNameType2 {
 abstract class NonAAAAbstractClassName2 {
 }
 
-abstract class FactoryWithHARDName2 { // violation
+// violation below 'Abbreviation in name 'FactoryWithHARDName2''
+abstract class FactoryWithHARDName2 {
 }
 
-abstract class AbstractCLASSName2 { // violation
+// violation below 'Abbreviation in name 'AbstractCLASSName2''
+abstract class AbstractCLASSName2 {
     abstract class NonAbstractInnerClass {
     }
 }
@@ -42,12 +44,14 @@ class Class1Factory12 {
 }
 
 abstract class AbstractClassName32 {
-    class AbstractINNERSClass { // violation
+    // violation below 'Abbreviation in name 'AbstractINNERSClass''
+    class AbstractINNERSClass {
     }
 }
 
 abstract class Class3Factory2 {
-    class WellNamedFACTORY { // violation
+    // violation below 'Abbreviation in name 'WellNamedFACTORY''
+    class WellNamedFACTORY {
         public void systematicMETHODName() {
             int systematicVARIABLEName = 2;
             int SYSTEMATICVariableName = 1;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType3.java
@@ -42,7 +42,8 @@ class Class1Factory13 {
 }
 
 abstract class AbstractClassName33 {
-    class AbstractINNERSClass { // violation
+    // violation below 'Abbreviation in name 'AbstractINNERSClass''
+    class AbstractINNERSClass {
     }
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType4.java
@@ -42,12 +42,14 @@ class Class1Factory14 {
 }
 
 abstract class AbstractClassName34 {
-    class AbstractINNERSClass { // violation
+    // violation below 'Abbreviation in name 'AbstractINNERSClass''
+    class AbstractINNERSClass {
     }
 }
 
 abstract class Class3Factory4 {
-    class WellNamedFACTORY { // violation
+    // violation below 'Abbreviation in name 'WellNamedFACTORY''
+    class WellNamedFACTORY {
         public void systematicMETHODName() {
             int systematicVARIABLEName = 2;
             int SYSTEMATICVariableName = 1;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType5.java
@@ -43,15 +43,20 @@ class Class1Factory15 {
 }
 
 abstract class AbstractClassName35 {
-    class AbstractINNERSClass { // violation
+    // violation below 'Abbreviation in name 'AbstractINNERSClass''
+    class AbstractINNERSClass {
     }
 }
 
 abstract class Class3Factory5 {
-    class WellNamedFACTORY { // violation
-        public void systematicMETHODName() { // violation
-            int systematicVARIABLEName = 2; // violation
-            int SYSTEMATICVariableName = 1; // violation
+    // violation below 'Abbreviation in name 'WellNamedFACTORY''
+    class WellNamedFACTORY {
+        // violation below 'Abbreviation in name 'systematicMETHODName''
+        public void systematicMETHODName() {
+            // violation below 'Abbreviation in name 'systematicVARIABLEName''
+            int systematicVARIABLEName = 2;
+            // violation below 'Abbreviation in name 'SYSTEMATICVariableName''
+            int SYSTEMATICVariableName = 1;
         }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType6.java
@@ -17,13 +17,14 @@ package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 abstract class InputAbbreviationAsWordInNameType6 {
 }
 
-abstract class NonAAAAbstractClassName6 { // violation
-}
+// violation below 'Abbreviation in name 'NonAAAAbstractClassName6''
+abstract class NonAAAAbstractClassName6 {}
 
-abstract class FactoryWithHARDName66 { // violation
-}
+// violation below 'Abbreviation in name 'FactoryWithHARDName66''
+abstract class FactoryWithHARDName66 {}
 
-abstract class AbstractCLASSName6 { // violation
+// violation below 'Abbreviation in name 'AbstractCLASSName6''
+abstract class AbstractCLASSName6 {
     abstract class NonAbstractInnerClass {
     }
 }
@@ -33,76 +34,82 @@ abstract class ClassFactory16 {
     }
 }
 
-class NonAbstractClass16 {
-}
+class NonAbstractClass16 {}
 
-class AbstractClass16 {
-}
+class AbstractClass16 {}
 
-class Class1Factory16 {
-}
+class Class1Factory16 {}
 
 abstract class AbstractClassName36 {
-    class AbstractINNERSClass { // violation
+    // violation below 'Abbreviation in name 'AbstractINNERSClass''
+    class AbstractINNERSClass {
     }
 }
 
 abstract class Class3Factory6 {
-    class WellNamedFACTORY { // violation
-        public void systematicMETHODName() { // violation
-            int systematicVARIABLEName = 2; // violation
-            int SYSTEMATICVariableName = 1; // violation
+    // violation below 'Abbreviation in name 'WellNamedFACTORY''
+    class WellNamedFACTORY {
+        // violation below 'Abbreviation in name 'systematicMETHODName''
+        public void systematicMETHODName() {
+            // violation below 'Abbreviation in name 'systematicVARIABLEName''
+            int systematicVARIABLEName = 2;
+            // violation below 'Abbreviation in name 'SYSTEMATICVariableName''
+            int SYSTEMATICVariableName = 1;
         }
     }
 }
 
 interface Directions6 {
-  int RIGHT=1; // violation
-  int LEFT=2; // violation
-  int UP=3; // violation
-  int DOWN=4; // violation
+  // violation below 'Abbreviation in name 'RIGHT''
+  int RIGHT=1;
+  // violation below 'Abbreviation in name 'LEFT''
+  int LEFT=2;
+  // violation below 'Abbreviation in name 'UP''
+  int UP=3;
+  // violation below 'Abbreviation in name 'DOWN''
+  int DOWN=4;
 }
 
-interface BadNameForInterface6
-{
+interface BadNameForInterface6 {
    void interfaceMethod();
 }
 
-abstract class NonAAAAbstractClassName26 { // violation
-    public int serialNUMBER = 6; // violation
-    public final int s1erialNUMBER = 6; // violation
-    private static int s2erialNUMBER = 6; // violation
-    private static final int s3erialNUMBER = 6; // violation
+// violation below 'Abbreviation in name 'NonAAAAbstractClassName26''
+abstract class NonAAAAbstractClassName26 {
+    // violation below 'Abbreviation in name 'serialNUMBER''
+    public int serialNUMBER = 6;
+    // violation below 'Abbreviation in name 's1erialNUMBER''
+    public final int s1erialNUMBER = 6;
+    // violation below 'Abbreviation in name 's2erialNUMBER''
+    private static int s2erialNUMBER = 6;
+    // violation below 'Abbreviation in name 's3erialNUMBER''
+    private static final int s3erialNUMBER = 6;
 }
 
 interface Interface16 {
-
-    String VALUELONG = "value"; // violation
-
+    // violation below 'Abbreviation in name 'VALUELONG''
+    String VALUELONG = "value";
 }
 
 interface Interface26 {
-
-    static String VALUELONG = "value"; // violation
-
+    // violation below 'Abbreviation in name 'VALUELONG''
+    static String VALUELONG = "value";
 }
 
 interface Interface36 {
-
-    final String VALUELONG = "value"; // violation
-
+    // violation below 'Abbreviation in name 'VALUELONG''
+    final String VALUELONG = "value";
 }
 
 interface Interface46 {
-
-    final static String VALUELONG = "value"; // violation
-
+    // violation below 'Abbreviation in name 'VALUELONG''
+    final static String VALUELONG = "value";
 }
 
-class FIleNameFormatException6 extends Exception { // violation
-
-    private static final long serialVersionUID = 1L; // violation
-
+// violation below 'Abbreviation in name 'FIleNameFormatException6''
+class FIleNameFormatException6 extends Exception {
+    // violation below 'Abbreviation in name 'serialVersionUID''
+    private static final long serialVersionUID = 1L;
     public FIleNameFormatException6(Exception e) {
         super(e);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType6Part2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameType6Part2.java
@@ -17,7 +17,8 @@ package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 abstract class InputAbbreviationAsWordInNameType6Part2{}
 
 class StateX6 {
-    int userID; // violation
+    // violation below 'Abbreviation in name 'userID''
+    int userID;
     int scaleX, scaleY, scaleZ;
 
     int getScaleX() {
@@ -26,17 +27,21 @@ class StateX6 {
 }
 
 @interface Annotation16 {
-    String VALUE = "value"; // violation
+    // violation below 'Abbreviation in name 'VALUE''
+    String VALUE = "value";
 }
 
 @interface Annotation26 {
-    static String VALUE = "value"; // violation
+    // violation below 'Abbreviation in name 'VALUE''
+    static String VALUE = "value";
 }
 
 @interface Annotation36 {
-    final String VALUE = "value"; // violation
+    // violation below 'Abbreviation in name 'VALUE''
+    final String VALUE = "value";
 }
 
 @interface Annotation46 {
-    final static String VALUE = "value"; // violation
+    // violation below 'Abbreviation in name 'VALUE''
+    final static String VALUE = "value";
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameTypeSnakeStyle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameTypeSnakeStyle.java
@@ -17,35 +17,35 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION
 package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
 
 public class InputAbbreviationAsWordInNameTypeSnakeStyle {
-    // violation below 'name 'FLAG_IS_FIRST_RUN' must contain no more than '4' .* cap.*.'
+    // violation below 'Abbreviation in name 'FLAG_IS_FIRST_RUN''
     public boolean FLAG_IS_FIRST_RUN = false;
 
-    // violation below 'name 'HYBRID_LOCK_PATH' must contain no more than '4' .* cap.*.'
+    // violation below 'Abbreviation in name 'HYBRID_LOCK_PATH''
     private int HYBRID_LOCK_PATH;
 
     Boolean[] BOOL_VALS = { false, true };
 
-     // violation below 'name '__DEMOS__TESTS_VAR' must contain no more than '4' .* cap.*.'
+     // violation below 'Abbreviation in name '__DEMOS__TESTS_VAR''
     private int __DEMOS__TESTS_VAR = 5;
 
     private int __DEMO__TEST_VAR = 6;
 
     private int TEST_FAM_23456 = 5;
 
-    // violation below 'name 'TESTING_FAM_23456' must contain no more than '4' .* cap.*.'
+    // violation below 'Abbreviation in name 'TESTING_FAM_23456''
     public int TESTING_FAM_23456 = 10;
 
     private int TEST_23456_FAM = 15;
 
-    // violation below 'name 'TESTING_23456_FAM' must contain no more than '4' .* cap.*.'
+    // violation below 'Abbreviation in name 'TESTING_23456_FAM''
     public int TESTING_23456_FAM = 20;
 
     public int TEST23456 = 30;
 
-    // violation below 'name '_234VIOLATION' must contain no more than '4' .* cap.*.'
+    // violation below 'Abbreviation in name '_234VIOLATION''
     public int _234VIOLATION = 40;
 
-    // violation below 'name 'VIOLATION23456' must contain no more than '4' .* cap.*.'
+    // violation below 'Abbreviation in name 'VIOLATION23456''
     public int VIOLATION23456 = 50;
 
     void getTEST() {
@@ -76,12 +76,12 @@ public class InputAbbreviationAsWordInNameTypeSnakeStyle {
 
     void getNON_ETest() {}
 
-    // violation below 'name 'getIsFIRST_Run' must contain no more than '4' .* cap.*.'
+    // violation below 'Abbreviation in name 'getIsFIRST_Run''
     private boolean getIsFIRST_Run() {
         return false;
     }
 
-    // violation below 'name 'getBoolean_VALUES' must contain no more than '4' .* cap.*.'
+    // violation below 'Abbreviation in name 'getBoolean_VALUES''
     private boolean getBoolean_VALUES() {
         return BOOL_VALS[0];
     }


### PR DESCRIPTION
Issue #15456 
### summary

- Removed AbbreviationAsWordInNameCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in AbbreviationAsWordInNameCheckTest
- Defined violation messages in InputAbbreviationAsWordInNameCheck files