### PR TITLE
Issue #15456: specify violation messages for IllegalIdentifierNameCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -271,9 +271,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck",
-
-            "com.puppycrawl.tools.checkstyle.checks.naming.IllegalIdentifierNameCheck",
-
             "com.puppycrawl.tools.checkstyle.checks.naming.RecordTypeParameterNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckTest.java
@@ -77,10 +77,10 @@ public class IllegalIdentifierNameCheckTest extends AbstractModuleTestSupport {
         final String format = "^(?!var$|\\S*\\$)\\S+$";
 
         final String[] expected = {
-            "57:13: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
-            "59:13: " + getCheckMessage(MSG_INVALID_PATTERN, "$amt", format),
-            "74:52: " + getCheckMessage(MSG_INVALID_PATTERN, "yield$text", format),
-            "74:74: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "58:13: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "61:13: " + getCheckMessage(MSG_INVALID_PATTERN, "$amt", format),
+            "76:52: " + getCheckMessage(MSG_INVALID_PATTERN, "yield$text", format),
+            "76:74: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalIdentifierName.java"), expected);
@@ -91,20 +91,20 @@ public class IllegalIdentifierNameCheckTest extends AbstractModuleTestSupport {
         final String format = "(?i)^(?!(record|yield|var|permits|sealed|open|transitive)$).+$";
 
         final String[] expected = {
-            "21:25: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
-            "22:24: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
-            "28:13: " + getCheckMessage(MSG_INVALID_PATTERN, "open", format),
-            "30:21: " + getCheckMessage(MSG_INVALID_PATTERN, "transitive", format),
-            "45:9: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "57:13: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
-            "59:13: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
-            "61:16: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "63:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Record", format),
-            "64:25: " + getCheckMessage(MSG_INVALID_PATTERN, "transitive", format),
-            "73:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Transitive", format),
-            "76:37: " + getCheckMessage(MSG_INVALID_PATTERN, "transitive", format),
-            "76:56: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
-            "76:72: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "22:25: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
+            "24:24: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
+            "31:13: " + getCheckMessage(MSG_INVALID_PATTERN, "open", format),
+            "34:21: " + getCheckMessage(MSG_INVALID_PATTERN, "transitive", format),
+            "50:9: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
+            "63:13: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "66:13: " + getCheckMessage(MSG_INVALID_PATTERN, "record", format),
+            "69:16: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
+            "72:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Record", format),
+            "74:25: " + getCheckMessage(MSG_INVALID_PATTERN, "transitive", format),
+            "84:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Transitive", format),
+            "87:37: " + getCheckMessage(MSG_INVALID_PATTERN, "transitive", format),
+            "87:56: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
+            "87:72: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalIdentifierNameOpenTransitive.java"), expected);
@@ -125,7 +125,7 @@ public class IllegalIdentifierNameCheckTest extends AbstractModuleTestSupport {
         final String format = "(?i)^(?!(record|yield|var|permits|sealed|_)$).+$";
 
         final String[] expected = {
-            "18:12: " + getCheckMessage(MSG_INVALID_PATTERN, "_", format),
+            "19:12: " + getCheckMessage(MSG_INVALID_PATTERN, "_", format),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputIllegalIdentifierNameUnderscore.java"), expected);
@@ -136,10 +136,10 @@ public class IllegalIdentifierNameCheckTest extends AbstractModuleTestSupport {
         final String format = "^(?!var$|\\S*\\$)\\S+$";
 
         final String[] expected = {
-            "19:39: " + getCheckMessage(MSG_INVALID_PATTERN, "param$", format),
-            "20:40: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
-            "32:9: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
-            "42:47: " + getCheckMessage(MSG_INVALID_PATTERN, "te$t", format),
+            "20:39: " + getCheckMessage(MSG_INVALID_PATTERN, "param$", format),
+            "22:40: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "35:9: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "46:47: " + getCheckMessage(MSG_INVALID_PATTERN, "te$t", format),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalIdentifierNameLambda.java"), expected);
@@ -159,8 +159,8 @@ public class IllegalIdentifierNameCheckTest extends AbstractModuleTestSupport {
         final String format = "^(?!var$|\\S*\\$)\\S+$";
 
         final String[] expected = {
-            "16:36: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
-            "23:39: " + getCheckMessage(MSG_INVALID_PATTERN, "permit$", format),
+            "17:36: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "25:39: " + getCheckMessage(MSG_INVALID_PATTERN, "permit$", format),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputIllegalIdentifierNameRecordPattern.java"), expected);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameRecordPattern.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameRecordPattern.java
@@ -13,15 +13,16 @@ package com.puppycrawl.tools.checkstyle.checks.naming.illegalidentifiername;
 public class InputIllegalIdentifierNameRecordPattern {
 
     void m(Object o) {
-        if (o instanceof Point(int var, int _)) { } // violation, 'Name 'var' must match pattern'
+        // violation below 'Name 'var' must match pattern'
+        if (o instanceof Point(int var, int _)) { }
         if (o instanceof ColorPoint(Point(int record, int yield), String sealed)) { }
     }
 
     void m2(Object o) {
         switch (o) {
             case Point(int permits, int yield): {} break;
+            // violation below 'Name 'permit\$' must match pattern'
             case ColorPoint(Point(int permit$, int _), String _): {}
-            // violation above, 'must match pattern'
             default: {}
         }
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameUnderscore.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameUnderscore.java
@@ -15,5 +15,6 @@ public class InputIllegalIdentifierNameUnderscore {
     String _string = "_string";
     String string_ = "string_";
     String another_string = "string";
-    String _; // violation
+    // violation below 'Name '_' must match pattern'
+    String _;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierName.java
@@ -54,9 +54,11 @@ public class InputIllegalIdentifierName {
     }
 
     public static void main(String... args) {
-        var var = 4; // violation, 'Name 'var' must match pattern'
+        // violation below 'Name 'var' must match pattern'
+        var var = 4;
 
-        int $amt = 15; // violation, 'must match pattern'
+        // violation below 'Name '\$amt' must match pattern'
+        int $amt = 15;
 
         String yield = "yield";
 
@@ -73,8 +75,8 @@ public class InputIllegalIdentifierName {
 
         record MyOtherRecord(String record, String yield$text, String... var) {
         // 2 violations above:
-        //            'must match pattern'
-        //            'Name 'var' must match pattern'
+        //    'Name 'yield\$text' must match pattern'
+        //    'Name 'var' must match pattern'
         }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameLambda.java
@@ -16,8 +16,10 @@ import java.util.function.Function;
 public class InputIllegalIdentifierNameLambda {
 
     public static void main(String... args) {
-        Function<String, String> f1 = param$ -> param$; // violation, 'must match pattern'
-        Function<String, String> f2 = (var) -> var; // violation, 'Name 'var' must match pattern'
+        // violation below 'Name 'param\$' must match pattern'
+        Function<String, String> f1 = param$ -> param$;
+        // violation below 'Name 'var' must match pattern'
+        Function<String, String> f2 = (var) -> var;
         Function<String, String> f3 = myLambdaParam -> myLambdaParam;
     }
 
@@ -29,7 +31,8 @@ public class InputIllegalIdentifierNameLambda {
         FRI,
         SAT,
         SUN,
-        var, // violation, 'Name 'var' must match pattern'
+        // violation below 'Name 'var' must match pattern'
+        var,
     }
 
     int yield(Day day) {
@@ -39,7 +42,8 @@ public class InputIllegalIdentifierNameLambda {
             case THU, SAT, FRI, SUN -> 0;
             case var -> 23; // ok, caught above in initialization
             default -> {
-                Function<String, String> f4 = te$t -> te$t; // violation, 'must match pattern'
+                // violation below 'Name 'te\$t' must match pattern'
+                Function<String, String> f4 = te$t -> te$t;
                 yield Math.addExact(2, 1);
             }
         };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameOpenTransitive.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameOpenTransitive.java
@@ -18,16 +18,20 @@ public class InputIllegalIdentifierNameOpenTransitive {
         return Record[].class;
     }
 
-    private static void record(LogRecord... logArray) { // violation
-        for (LogRecord record : logArray) { // violation
+    // violation below 'Name 'record' must match pattern'
+    private static void record(LogRecord... logArray) {
+        // violation below 'Name 'record' must match pattern'
+        for (LogRecord record : logArray) {
             record.getLevel();
         }
     }
 
     class openClass {
-        int open = 6; // violation
+        // violation below 'Name 'open' must match pattern'
+        int open = 6;
 
-        public void transitive() { // violation
+        // violation below 'Name 'transitive' must match pattern'
+        public void transitive() {
 
         }
     }
@@ -42,7 +46,8 @@ public class InputIllegalIdentifierNameOpenTransitive {
         SUN,
     }
 
-    int yield(Day day) { // violation
+    // violation below 'Name 'yield' must match pattern'
+    int yield(Day day) {
         return switch (day) {
             case MON, TUE -> Math.addExact(0, 1);
             case WED -> Math.addExact(1, 1);
@@ -54,14 +59,19 @@ public class InputIllegalIdentifierNameOpenTransitive {
     }
 
     public static void main(String... args) {
-        var var = 4; // violation
+        // violation below 'Name 'var' must match pattern'
+        var var = 4;
 
-        int record = 15; // violation
+        // violation below 'Name 'record' must match pattern'
+        int record = 15;
 
-        String yield = "yield"; // violation
+        // violation below 'Name 'yield' must match pattern'
+        String yield = "yield";
 
-        record Record // violation
-                (Record transitive) { // violation
+        // violation below 'Name 'Record' must match pattern'
+        record Record
+                // violation below 'Name 'transitive' must match pattern'
+                (Record transitive) {
                                       // used as an identifier.
         }
 
@@ -70,10 +80,15 @@ public class InputIllegalIdentifierNameOpenTransitive {
         } // ok, part of another word
         var variable = 2; // ok, part of another word
 
-        String Transitive = "record"; // violation
+        // violation below 'Name 'Transitive' must match pattern'
+        String Transitive = "record";
         Transitive = Transitive.substring(record, 20);
 
-        record MyOtherRecord(String transitive, String yield, String...var) { // 3 violations
+        record MyOtherRecord(String transitive, String yield, String...var) {
+        // 3 violations above:
+        //    'Name 'transitive' must match pattern'
+        //    'Name 'yield' must match pattern'
+        //    'Name 'var' must match pattern'
         }
 
         int requires = 3;


### PR DESCRIPTION
Issue #15456 
### summary

- Removed IllegalIdentifierNameCheck" from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in IllegalIdentifierNameCheckTest
- Defined violation messages in InputIllegalIdentifierNameCheck files