### PR TITLE
Issue #15456: specify violation messages for RecordTypeParameterNameC…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -270,7 +270,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.RecordTypeParameterNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/RecordTypeParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/RecordTypeParameterNameCheckTest.java
@@ -51,9 +51,9 @@ public class RecordTypeParameterNameCheckTest extends AbstractModuleTestSupport 
         final String pattern = "^[A-Z]$";
 
         final String[] expected = {
-            "16:44: " + getCheckMessage(MSG_INVALID_PATTERN, "t", pattern),
-            "23:18: " + getCheckMessage(MSG_INVALID_PATTERN, "foo", pattern),
-            "38:25: " + getCheckMessage(MSG_INVALID_PATTERN, "foo", pattern),
+            "17:44: " + getCheckMessage(MSG_INVALID_PATTERN, "t", pattern),
+            "25:18: " + getCheckMessage(MSG_INVALID_PATTERN, "foo", pattern),
+            "41:25: " + getCheckMessage(MSG_INVALID_PATTERN, "foo", pattern),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRecordTypeParameterName.java"), expected);
@@ -66,9 +66,9 @@ public class RecordTypeParameterNameCheckTest extends AbstractModuleTestSupport 
         final String pattern = "^foo$";
 
         final String[] expected = {
-            "16:47: " + getCheckMessage(MSG_INVALID_PATTERN, "T", pattern),
-            "23:15: " + getCheckMessage(MSG_INVALID_PATTERN, "T", pattern),
-            "44:19: " + getCheckMessage(MSG_INVALID_PATTERN, "T", pattern),
+            "17:47: " + getCheckMessage(MSG_INVALID_PATTERN, "T", pattern),
+            "25:15: " + getCheckMessage(MSG_INVALID_PATTERN, "T", pattern),
+            "47:19: " + getCheckMessage(MSG_INVALID_PATTERN, "T", pattern),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRecordTypeParameterNameFoo.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordtypeparametername/InputRecordTypeParameterName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordtypeparametername/InputRecordTypeParameterName.java
@@ -13,14 +13,16 @@ import java.util.LinkedHashMap;
 
 import org.w3c.dom.Node;
 
-public record InputRecordTypeParameterName<t>(Integer x, String str) { // violation
+// violation below 'Name 't' must match pattern'
+public record InputRecordTypeParameterName<t>(Integer x, String str) {
     public <TT> void foo() { }
 
     <e_e> void foo(int i) {
     }
 }
 
-record OtherOne <foo extends Serializable & Cloneable> // violation
+// violation below 'Name 'foo' must match pattern'
+record OtherOne <foo extends Serializable & Cloneable>
 (LinkedHashMap<String, Node> linkedHashMap) {
 
     foo getOne() {
@@ -35,7 +37,8 @@ record OtherOne <foo extends Serializable & Cloneable> // violation
         return null;
     }
 
-    static record Junk <foo>() { // violation
+    // violation below 'Name 'foo' must match pattern'
+    static record Junk <foo>() {
         <_fo extends foo> void getMoreFoo() {
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordtypeparametername/InputRecordTypeParameterNameFoo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordtypeparametername/InputRecordTypeParameterNameFoo.java
@@ -13,14 +13,16 @@ import java.util.LinkedHashMap;
 
 import org.w3c.dom.Node;
 
-public record InputRecordTypeParameterNameFoo<T>(Integer x, String str) { // violation
+// violation below 'Name 'T' must match pattern'
+public record InputRecordTypeParameterNameFoo<T>(Integer x, String str) {
     public <TT> void foo() { }
 
     <e_e> void foo(int i) {
     }
 }
 
-record Other <T extends Serializable & Cloneable> // violation
+// violation below 'Name 'T' must match pattern'
+record Other <T extends Serializable & Cloneable>
         (LinkedHashMap<String, Node> linkedHashMap) {
 
     foo getOne() {
@@ -41,7 +43,8 @@ record Other <T extends Serializable & Cloneable> // violation
     }
 }
 
-record MoreOther <T extends Cloneable>(char c, String string) { // violation
+// violation below 'Name 'T' must match pattern'
+record MoreOther <T extends Cloneable>(char c, String string) {
 
     interface Boo<Input> {
         Input boo();


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed RecordTypeParameterNameCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in RecordTypeParameterNameCheckTest
- Defined violation messages in InputRecordTypeParameterNameCheck files