### PR TITLE
Issue #15456: specify violation messages for RegexpSinglelineJavaCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -270,7 +270,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
-            "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckTest.java
@@ -55,7 +55,7 @@ public class RegexpSinglelineJavaCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIt() throws Exception {
         final String[] expected = {
-            "77: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "System\\.(out)|(err)\\.print(ln)?\\("),
+            "78: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "System\\.(out)|(err)\\.print(ln)?\\("),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRegexpSinglelineJavaSemantic.java"), expected);
@@ -65,7 +65,7 @@ public class RegexpSinglelineJavaCheckTest extends AbstractModuleTestSupport {
     public void testMessageProperty()
             throws Exception {
         final String[] expected = {
-            "78: " + "Bad line :(",
+            "79: " + "Bad line :(",
         };
         verifyWithInlineConfigParser(
                 getPath("InputRegexpSinglelineJavaSemantic2.java"), expected);
@@ -74,7 +74,7 @@ public class RegexpSinglelineJavaCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIgnoreCaseTrue() throws Exception {
         final String[] expected = {
-            "78: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "SYSTEM\\.(OUT)|(ERR)\\.PRINT(LN)?\\("),
+            "79: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "SYSTEM\\.(OUT)|(ERR)\\.PRINT(LN)?\\("),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRegexpSinglelineJavaSemantic3.java"), expected);
@@ -99,7 +99,7 @@ public class RegexpSinglelineJavaCheckTest extends AbstractModuleTestSupport {
     public void testIgnoreCommentsFalseCppStyle() throws Exception {
         // See if the comment is removed properly
         final String[] expected = {
-            "16: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "don't\\suse trailing comments"),
+            "17: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "don't\\suse trailing comments"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRegexpSinglelineJavaTrailingComment2.java"), expected);
@@ -116,7 +116,7 @@ public class RegexpSinglelineJavaCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIgnoreCommentsFalseBlockStyle() throws Exception {
         final String[] expected = {
-            "31: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "c-style\\s1"),
+            "32: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "c-style\\s1"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRegexpSinglelineJavaTrailingComment4.java"), expected);
@@ -147,7 +147,7 @@ public class RegexpSinglelineJavaCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIgnoreCommentsInlineEnd() throws Exception {
         final String[] expected = {
-            "34: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "int z"),
+            "35: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "int z"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRegexpSinglelineJavaTrailingComment8.java"), expected);
@@ -156,7 +156,7 @@ public class RegexpSinglelineJavaCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIgnoreCommentsInlineMiddle() throws Exception {
         final String[] expected = {
-            "35: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "int y"),
+            "36: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "int y"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRegexpSinglelineJavaTrailingComment9.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic.java
@@ -73,7 +73,8 @@ class InputRegexpSinglelineJavaSemantic
             }
             // can never happen, empty compound statement is another workaround
         }
-        catch (UnsupportedOperationException handledException) { // violation below
+        catch (UnsupportedOperationException handledException) {
+            // violation below 'Line matches the illegal pattern 'System'
             System.out.println(handledException.getMessage());
         }
         catch (SecurityException ex) { /* hello */ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic2.java
@@ -74,7 +74,8 @@ class InputRegexpSinglelineJavaSemantic2
             }
             // can never happen, empty compound statement is another workaround
         }
-        catch (UnsupportedOperationException handledException) { // violation below
+        catch (UnsupportedOperationException handledException) {
+            // violation below 'Bad line '
             System.out.println(handledException.getMessage());
         }
         catch (SecurityException ex) { /* hello */ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic3.java
@@ -74,7 +74,8 @@ class InputRegexpSinglelineJavaSemantic3
             }
             // can never happen, empty compound statement is another workaround
         }
-        catch (UnsupportedOperationException handledException) { // violation below
+        catch (UnsupportedOperationException handledException) {
+            // violation below 'Line matches the illegal pattern 'SYSTEM'
             System.out.println(handledException.getMessage());
         }
         catch (SecurityException ex) { /* hello */ }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaSemantic7.java
@@ -1,4 +1,4 @@
-/* // violation
+/* // violation 'File does not contain at least 1 matches for pattern '
 RegexpSinglelineJava
 format = This\\stext is not in the file
 message = (default)(null)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaTrailingComment2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaTrailingComment2.java
@@ -12,7 +12,8 @@ ignoreComments = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexpsinglelinejava;
 
-public class InputRegexpSinglelineJavaTrailingComment2 { // violation below
+public class InputRegexpSinglelineJavaTrailingComment2 {
+    // violation below "Line matches the illegal pattern 'don't"
     int i; // don't use trailing comments :)
     // it fine to have comment w/o any statement
     /* good c-style comment. */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaTrailingComment4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaTrailingComment4.java
@@ -27,7 +27,8 @@ public class InputRegexpSinglelineJavaTrailingComment4 {
     /*
       Let's check multi-line comments.
     */
-    /* c-style */ // cpp-style // violation below
+    /* c-style */ // cpp-style
+    // violation below 'Line matches the illegal pattern 'c-style'
     /* c-style 1 */ /*c-style 2 */
 
     void method2(long ms /* we should ignore this */) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaTrailingComment8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaTrailingComment8.java
@@ -30,7 +30,8 @@ public class InputRegexpSinglelineJavaTrailingComment8 {
     /* c-style */ // cpp-style
     /* c-style 1 */ /*c-style 2 */
 
-    void method2(long ms /* we should ignore this */) { // violation below
+    void method2(long ms /* we should ignore this */) {
+        // violation below 'Line matches the illegal pattern 'int'
         /* comment before text */int z;
         /* int y */int y/**/;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaTrailingComment9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava/InputRegexpSinglelineJavaTrailingComment9.java
@@ -31,7 +31,8 @@ public class InputRegexpSinglelineJavaTrailingComment9 {
     /* c-style 1 */ /*c-style 2 */
 
     void method2(long ms /* we should ignore this */) {
-        /* comment before text */int z; // violation below
+        /* comment before text */int z;
+        // violation below 'Line matches the illegal pattern 'int'
         /* int y */int y/**/;
     }
 


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed RegexpSinglelineJavaCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in RegexpSinglelineJavaCheckTest
- Defined violation messages in InputRegexpSinglelineJavaCheck