### PR TITLE
Issue #15456: specify violation messages for AnonInnerLengthCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -270,7 +270,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
-            "com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheckTest.java
@@ -61,7 +61,7 @@ public class AnonInnerLengthCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDefaultOne() throws Exception {
         final String[] expected = {
-            "52:35: " + getCheckMessage(MSG_KEY, 21, 20),
+            "53:35: " + getCheckMessage(MSG_KEY, 21, 20),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnonInnerLengthPartOne.java"), expected);
@@ -70,7 +70,7 @@ public class AnonInnerLengthCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDefaultTwo() throws Exception {
         final String[] expected = {
-            "21:35: " + getCheckMessage(MSG_KEY, 21, 20),
+            "22:35: " + getCheckMessage(MSG_KEY, 21, 20),
         };
 
         verifyWithInlineConfigParser(
@@ -80,7 +80,7 @@ public class AnonInnerLengthCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testNonDefaultOne() throws Exception {
         final String[] expected = {
-            "52:35: " + getCheckMessage(MSG_KEY, 21, 6),
+            "53:35: " + getCheckMessage(MSG_KEY, 21, 6),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnonInnerLength2PartOne.java"), expected);
@@ -89,7 +89,7 @@ public class AnonInnerLengthCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testNonDefaultTwo() throws Exception {
         final String[] expected = {
-            "22:35: " + getCheckMessage(MSG_KEY, 20, 6),
+            "23:35: " + getCheckMessage(MSG_KEY, 20, 6),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnonInnerLength2PartTwo.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/anoninnerlength/InputAnonInnerLength2PartOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/anoninnerlength/InputAnonInnerLength2PartOne.java
@@ -46,10 +46,11 @@ public class InputAnonInnerLength2PartOne {
     }
     );
 
+    // violation 4 lines below 'Anonymous inner class length is 21 lines'
     /**
      anon inner in member variable initialization which is 21 lines long
      */
-    private Runnable mRunnable1 = new Runnable() { // violation
+    private Runnable mRunnable1 = new Runnable() {
         public void run() // should not have to be documented, class is anon.
         {
             System.identityHashCode("running");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/anoninnerlength/InputAnonInnerLength2PartTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/anoninnerlength/InputAnonInnerLength2PartTwo.java
@@ -16,10 +16,11 @@ public class InputAnonInnerLength2PartTwo {
 
     private JButton mButton = new JButton();
 
+    // violation 4 lines below 'Anonymous inner class length is 20 lines'
     /**
      anon inner in member variable initialization which is 20 lines long
      */
-    private Runnable mRunnable2 = new Runnable() { // violation
+    private Runnable mRunnable2 = new Runnable() {
         public void run() // should not have to be documented, class is anon.
         {
             System.identityHashCode("running");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/anoninnerlength/InputAnonInnerLengthPartOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/anoninnerlength/InputAnonInnerLengthPartOne.java
@@ -46,10 +46,11 @@ public class InputAnonInnerLengthPartOne {
     }
     );
 
+    // violation 4 lines below 'Anonymous inner class length is 21 lines'
     /**
      anon inner in member variable initialization which is 21 lines long
      */
-    private Runnable mRunnable1 = new Runnable() { // violation
+    private Runnable mRunnable1 = new Runnable() {
         public void run() // should not have to be documented, class is anon.
         {
             System.identityHashCode("running");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/anoninnerlength/InputAnonInnerLengthPartTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/anoninnerlength/InputAnonInnerLengthPartTwo.java
@@ -15,10 +15,11 @@ public class InputAnonInnerLengthPartTwo {
 
     private JButton mButton = new JButton();
 
+    // violation 4 lines below 'Anonymous inner class length is 21 lines'
     /**
      anon inner in member variable initialization which is 21 lines long
      */
-    private Runnable mRunnable1 = new Runnable() { // violation
+    private Runnable mRunnable1 = new Runnable() {
         public void run()
         {
             System.identityHashCode("running");


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed AnonInnerLengthCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in AnonInnerLengthCheckTest
- Defined violation messages in InputAnonInnerLengthCheck files