### PR TITLE
Issue #15456: specify violation messages for ExecutableStatementCount…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -268,7 +268,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
-            "com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck",
             "com.puppycrawl.tools.checkstyle.api.AbstractCheckTest$ViolationAstCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -59,17 +59,17 @@ public class ExecutableStatementCountCheckTest
     public void testMaxZero() throws Exception {
 
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_KEY, 3, 0),
-            "15:17: " + getCheckMessage(MSG_KEY, 1, 0),
-            "25:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "35:5: " + getCheckMessage(MSG_KEY, 1, 0),
-            "42:5: " + getCheckMessage(MSG_KEY, 3, 0),
-            "56:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "66:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "75:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "84:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "87:13: " + getCheckMessage(MSG_KEY, 1, 0),
-            "98:29: " + getCheckMessage(MSG_KEY, 1, 0),
+            "13:5: " + getCheckMessage(MSG_KEY, 3, 0),
+            "17:17: " + getCheckMessage(MSG_KEY, 1, 0),
+            "28:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "39:5: " + getCheckMessage(MSG_KEY, 1, 0),
+            "47:5: " + getCheckMessage(MSG_KEY, 3, 0),
+            "62:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "73:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "83:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "93:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "97:13: " + getCheckMessage(MSG_KEY, 1, 0),
+            "109:29: " + getCheckMessage(MSG_KEY, 1, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -80,12 +80,12 @@ public class ExecutableStatementCountCheckTest
     public void testMethodDef() throws Exception {
 
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_KEY, 3, 0),
-            "15:17: " + getCheckMessage(MSG_KEY, 1, 0),
-            "25:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "35:5: " + getCheckMessage(MSG_KEY, 1, 0),
-            "42:5: " + getCheckMessage(MSG_KEY, 3, 0),
-            "60:13: " + getCheckMessage(MSG_KEY, 1, 0),
+            "13:5: " + getCheckMessage(MSG_KEY, 3, 0),
+            "17:17: " + getCheckMessage(MSG_KEY, 1, 0),
+            "28:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "39:5: " + getCheckMessage(MSG_KEY, 1, 0),
+            "47:5: " + getCheckMessage(MSG_KEY, 3, 0),
+            "66:13: " + getCheckMessage(MSG_KEY, 1, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -96,8 +96,8 @@ public class ExecutableStatementCountCheckTest
     public void testCtorDef() throws Exception {
 
         final String[] expected = {
-            "12:5: " + getCheckMessage(MSG_KEY, 2, 0),
-            "22:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "13:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "24:5: " + getCheckMessage(MSG_KEY, 2, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -108,7 +108,7 @@ public class ExecutableStatementCountCheckTest
     public void testStaticInit() throws Exception {
 
         final String[] expected = {
-            "13:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "14:5: " + getCheckMessage(MSG_KEY, 2, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -119,7 +119,7 @@ public class ExecutableStatementCountCheckTest
     public void testInstanceInit() throws Exception {
 
         final String[] expected = {
-            "13:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "14:5: " + getCheckMessage(MSG_KEY, 2, 0),
         };
 
         verifyWithInlineConfigParser(
@@ -170,12 +170,12 @@ public class ExecutableStatementCountCheckTest
         final int max = 1;
 
         final String[] expected = {
-            "15:9: " + getCheckMessage(MSG_KEY, 3, max),
-            "24:9: " + getCheckMessage(MSG_KEY, 3, max),
-            "33:9: " + getCheckMessage(MSG_KEY, 3, max),
-            "41:9: " + getCheckMessage(MSG_KEY, 4, max),
-            "51:9: " + getCheckMessage(MSG_KEY, 6, max),
-            "65:17: " + getCheckMessage(MSG_KEY, 6, max),
+            "16:9: " + getCheckMessage(MSG_KEY, 3, max),
+            "26:9: " + getCheckMessage(MSG_KEY, 3, max),
+            "36:9: " + getCheckMessage(MSG_KEY, 3, max),
+            "45:9: " + getCheckMessage(MSG_KEY, 4, max),
+            "56:9: " + getCheckMessage(MSG_KEY, 6, max),
+            "71:17: " + getCheckMessage(MSG_KEY, 6, max),
         };
 
         verifyWithInlineConfigParser(
@@ -189,10 +189,10 @@ public class ExecutableStatementCountCheckTest
         final int max = 1;
 
         final String[] expected = {
-            "16:22: " + getCheckMessage(MSG_KEY, 6, max),
-            "25:22: " + getCheckMessage(MSG_KEY, 2, max),
-            "26:26: " + getCheckMessage(MSG_KEY, 2, max),
-            "30:26: " + getCheckMessage(MSG_KEY, 4, max),
+            "17:22: " + getCheckMessage(MSG_KEY, 6, max),
+            "27:22: " + getCheckMessage(MSG_KEY, 2, max),
+            "29:26: " + getCheckMessage(MSG_KEY, 2, max),
+            "34:26: " + getCheckMessage(MSG_KEY, 4, max),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountCtorDef.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountCtorDef.java
@@ -9,7 +9,8 @@ tokens = CTOR_DEF
 package com.puppycrawl.tools.checkstyle.checks.sizes.executablestatementcount;
 
 public class InputExecutableStatementCountCtorDef {
-    public InputExecutableStatementCountCtorDef() // violation
+    // violation below 'Executable statement count is 2'
+    public InputExecutableStatementCountCtorDef()
     {
         int i = 1;
         if (System.currentTimeMillis() == 0) {
@@ -18,8 +19,9 @@ public class InputExecutableStatementCountCtorDef {
         }
     }
 
+    // violation 2 lines below 'Executable statement count is 2'
     /** Inner */
-    public InputExecutableStatementCountCtorDef(int aParam) // violation
+    public InputExecutableStatementCountCtorDef(int aParam)
     {
         Runnable runnable = new Runnable() {
             public void run() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountInstanceInit.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountInstanceInit.java
@@ -10,7 +10,8 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.executablestatementcount;
 
 public class InputExecutableStatementCountInstanceInit {
     // INSTANCE_INIT
-    { // violation
+    // violation below 'Executable statement count is 2'
+    {
         int i = 1;
         if (System.currentTimeMillis() == 0) {
         } else if (System.currentTimeMillis() == 0) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountLambdas.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountLambdas.java
@@ -13,7 +13,8 @@ import java.util.function.Function;
 
 public class InputExecutableStatementCountLambdas {
 
-    Consumer a = (o) -> { // violation
+    // violation below 'Executable statement count is 6'
+    Consumer a = (o) -> {
         o.toString(); // 1
         o.toString(); // 2
         o.toString(); // 3
@@ -22,12 +23,15 @@ public class InputExecutableStatementCountLambdas {
         o.toString(); // 6
     };
 
-    Consumer b = (x) -> { // violation
-        Consumer c = (s) -> { // violation
+    // violation below 'Executable statement count is 2'
+    Consumer b = (x) -> {
+        // violation below 'Executable statement count is 2'
+        Consumer c = (s) -> {
             String str = s.toString();
             str = str + "!";
         };
-        Consumer d = (s) -> { // violation
+        // violation below 'Executable statement count is 4'
+        Consumer d = (s) -> {
             String str = s.toString();
             Consumer t = a -> a.toString().trim();
             Function x1 = a -> a;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountMaxZero.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountMaxZero.java
@@ -9,10 +9,12 @@ tokens = (default)CTOR_DEF, METHOD_DEF, INSTANCE_INIT, STATIC_INIT, COMPACT_CTOR
 package com.puppycrawl.tools.checkstyle.checks.sizes.executablestatementcount;
 
 public class InputExecutableStatementCountMaxZero {
-    public void foo() { // violation
+    // violation below 'Executable statement count is 3'
+    public void foo() {
         while (true) {
             Runnable runnable = new Runnable() {
-                public void run() { // violation
+                // violation below 'Executable statement count is 1'
+                public void run() {
                     while (true) {
                     }
                 }
@@ -22,7 +24,8 @@ public class InputExecutableStatementCountMaxZero {
         }
     }
 
-    public void bar() { // violation
+    // violation below 'Executable statement count is 2'
+    public void bar() {
         if (System.currentTimeMillis() == 0) {
             if (System.currentTimeMillis() == 0 && System.currentTimeMillis() == 0) {
             }
@@ -32,14 +35,16 @@ public class InputExecutableStatementCountMaxZero {
         }
     }
 
-    public void simpleElseIf() { // violation
+    // violation below 'Executable statement count is 1'
+    public void simpleElseIf() {
         if (System.currentTimeMillis() == 0) {
         } else if (System.currentTimeMillis() == 0) {
         } else {
         }
     }
 
-    public void stupidElseIf() { // violation
+    // violation below 'Executable statement count is 3'
+    public void stupidElseIf() {
         if (System.currentTimeMillis() == 0) {
         } else {
             if (System.currentTimeMillis() == 0) {
@@ -53,7 +58,8 @@ public class InputExecutableStatementCountMaxZero {
         }
     }
 
-    public InputExecutableStatementCountMaxZero() // violation
+    // violation below 'Executable statement count is 2'
+    public InputExecutableStatementCountMaxZero()
     {
         int i = 1;
         if (System.currentTimeMillis() == 0) {
@@ -63,7 +69,8 @@ public class InputExecutableStatementCountMaxZero {
     }
 
     // STATIC_INIT
-    static { // violation
+    // violation below 'Executable statement count is 2'
+    static {
         int i = 1;
         if (System.currentTimeMillis() == 0) {
         } else if (System.currentTimeMillis() == 0) {
@@ -72,7 +79,8 @@ public class InputExecutableStatementCountMaxZero {
     }
 
     // INSTANCE_INIT
-    { // violation
+    // violation below 'Executable statement count is 2'
+    {
         int i = 1;
         if (System.currentTimeMillis() == 0) {
         } else if (System.currentTimeMillis() == 0) {
@@ -80,11 +88,13 @@ public class InputExecutableStatementCountMaxZero {
         }
     }
 
+    // violation 2 lines below 'Executable statement count is 2'
     /** Inner */
-    public InputExecutableStatementCountMaxZero(int aParam) // violation
+    public InputExecutableStatementCountMaxZero(int aParam)
     {
         Runnable runnable = new Runnable() {
-            public void run() { // violation
+            // violation below 'Executable statement count is 1'
+            public void run() {
                 while (true) {
                 }
             }
@@ -95,7 +105,8 @@ public class InputExecutableStatementCountMaxZero {
     /** Empty constructor */
     public InputExecutableStatementCountMaxZero(String someString) {}
 
-    static Runnable r1 = () -> { // violation
+    // violation below 'Executable statement count is 1'
+    static Runnable r1 = () -> {
         String.valueOf("Hello world one!");
     };
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountMethodDef.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountMethodDef.java
@@ -9,10 +9,12 @@ tokens = METHOD_DEF
 package com.puppycrawl.tools.checkstyle.checks.sizes.executablestatementcount;
 
 public class InputExecutableStatementCountMethodDef {
-    public void foo() { // violation
+    // violation below 'Executable statement count is 3'
+    public void foo() {
         while (true) {
             Runnable runnable = new Runnable() {
-                public void run() { // violation
+                // violation below 'Executable statement count is 1'
+                public void run() {
                     while (true) {
                     }
                 }
@@ -22,7 +24,8 @@ public class InputExecutableStatementCountMethodDef {
         }
     }
 
-    public void bar() { // violation
+    // violation below 'Executable statement count is 2'
+    public void bar() {
         if (System.currentTimeMillis() == 0) {
             if (System.currentTimeMillis() == 0 && System.currentTimeMillis() == 0) {
             }
@@ -32,14 +35,16 @@ public class InputExecutableStatementCountMethodDef {
         }
     }
 
-    public void simpleElseIf() { // violation
+    // violation below 'Executable statement count is 1'
+    public void simpleElseIf() {
         if (System.currentTimeMillis() == 0) {
         } else if (System.currentTimeMillis() == 0) {
         } else {
         }
     }
 
-    public void stupidElseIf() { // violation
+    // violation below 'Executable statement count is 3'
+    public void stupidElseIf() {
         if (System.currentTimeMillis() == 0) {
         } else {
             if (System.currentTimeMillis() == 0) {
@@ -57,7 +62,8 @@ public class InputExecutableStatementCountMethodDef {
     public InputExecutableStatementCountMethodDef(int aParam)
     {
         Runnable runnable = new Runnable() {
-            public void run() { // violation
+            // violation below 'Executable statement count is 1'
+            public void run() {
                 while (true) {
                 }
             }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountRecords.java
@@ -12,7 +12,8 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.executablestatementcount;
 public class InputExecutableStatementCountRecords {
 
     record MyTestRecord() {
-        static { // violation
+        // violation below 'Executable statement count is 3'
+        static {
             System.out.println("test");
             System.out.println("test");
             System.out.println("test");
@@ -21,7 +22,8 @@ public class InputExecutableStatementCountRecords {
 
     //compact ctor
     record MyTestRecord2() {
-        public MyTestRecord2 { // violation
+        // violation below 'Executable statement count is 3'
+        public MyTestRecord2 {
             System.out.println("test");
             System.out.println("test");
             System.out.println("test");
@@ -30,7 +32,8 @@ public class InputExecutableStatementCountRecords {
     }
 
     record MyTestRecord3(String str) {
-        void foo() { // violation
+        // violation below 'Executable statement count is 3'
+        void foo() {
             System.out.println("test");
             System.out.println("test");
             System.out.println("test");
@@ -38,7 +41,8 @@ public class InputExecutableStatementCountRecords {
     }
 
     record MyTestRecord4(int x, int y) {
-        public MyTestRecord4() { // violation
+        // violation below 'Executable statement count is 4'
+        public MyTestRecord4() {
             this(4, 5);
             System.out.println("test");
             System.out.println("test");
@@ -48,7 +52,8 @@ public class InputExecutableStatementCountRecords {
     }
 
     record MyTestRecord5() {
-        static { // violation
+        // violation below 'Executable statement count is 6'
+        static {
             int y = 5;
             int z = 10;
             String newString = String.valueOf(y);
@@ -62,7 +67,8 @@ public class InputExecutableStatementCountRecords {
         Class<?> m(int x) {
             record R76(int x) {
 
-                public R76 { // violation
+                // violation below 'Executable statement count is 6'
+                public R76 {
                     int y = 5;
                     int z = 10;
                     String newString = String.valueOf(y);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountStaticInit.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount/InputExecutableStatementCountStaticInit.java
@@ -10,7 +10,8 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.executablestatementcount;
 
 public class InputExecutableStatementCountStaticInit {
     // STATIC_INIT
-    static { // violation
+    // violation below 'Executable statement count is 2'
+    static {
         int i = 1;
         if (System.currentTimeMillis() == 0) {
         } else if (System.currentTimeMillis() == 0) {


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed ExecutableStatementCountCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in ExecutableStatementCountCheckTest
- Defined violation messages in InputExecutableStatementCountCheck