### PR TITLE
Issue #15456: specify violation messages for OuterTypeNumberCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -272,7 +272,6 @@ public final class InlineConfigParser {
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck",
-            "com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckTest.java
@@ -77,7 +77,7 @@ public class OuterTypeNumberCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDefault() throws Exception {
         final String[] expected = {
-            "8:1: " + getCheckMessage(MSG_KEY, 3, 1),
+            "9:1: " + getCheckMessage(MSG_KEY, 3, 1),
         };
         verifyWithInlineConfigParser(
                 getPath("InputOuterTypeNumberSimple.java"), expected);
@@ -103,7 +103,7 @@ public class OuterTypeNumberCheckTest extends AbstractModuleTestSupport {
         final int max = 1;
 
         final String[] expected = {
-            "9:1: " + getCheckMessage(MSG_KEY, 2, max),
+            "10:1: " + getCheckMessage(MSG_KEY, 2, max),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberRecords.java
@@ -6,7 +6,8 @@ max = (default)1
 */
 
 
-package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber; // violation
+// violation below 'Outer types defined is 2 (max allowed is 1).'
+package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber;
 
 class InputOuterTypeNumberRecords { }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberSimple.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/outertypenumber/InputOuterTypeNumberSimple.java
@@ -5,8 +5,8 @@ max = (default)1
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber; // violation
-                                                 // 'Outer type number is 3 (max allowed is 1).'
+// violation below 'Outer types defined is 3 (max allowed is 1).'
+package com.puppycrawl.tools.checkstyle.checks.sizes.outertypenumber;
 
 /**
  * Test input with 3 outer types to trigger OuterTypeNumber violation.


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed OuterTypeNumberCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in OuterTypeNumberCheckTest
- Defined violation messages in InputOuterTypeNumberCheck