### PR TITLE
Issue #15456: specify violation messages for RecordComponentNumberCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -268,7 +268,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
-            "com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck",
             "com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck",
             "com.puppycrawl.tools.checkstyle.api.AbstractCheckTest$ViolationAstCheck",
             "com.puppycrawl.tools.checkstyle.CheckerTest$VerifyPositionAfterTabFileSet"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheckTest.java
@@ -70,11 +70,11 @@ public class RecordComponentNumberCheckTest extends AbstractModuleTestSupport {
         final int max = 8;
 
         final String[] expected = {
-            "57:5: " + getCheckMessage(MSG_KEY, 14, max),
-            "70:9: " + getCheckMessage(MSG_KEY, 14, max),
-            "76:13: " + getCheckMessage(MSG_KEY, 14, max),
-            "82:17: " + getCheckMessage(MSG_KEY, 11, max),
-            "101:5: " + getCheckMessage(MSG_KEY, 15, max),
+            "49:5: " + getCheckMessage(MSG_KEY, 14, max),
+            "61:9: " + getCheckMessage(MSG_KEY, 14, max),
+            "68:13: " + getCheckMessage(MSG_KEY, 14, max),
+            "75:17: " + getCheckMessage(MSG_KEY, 11, max),
+            "93:5: " + getCheckMessage(MSG_KEY, 15, max),
         };
 
         verifyWithInlineConfigParser(
@@ -87,8 +87,8 @@ public class RecordComponentNumberCheckTest extends AbstractModuleTestSupport {
         final int max = 8;
 
         final String[] expected = {
-            "38:3: " + getCheckMessage(MSG_KEY, 15, max),
-            "48:3: " + getCheckMessage(MSG_KEY, 15, max),
+            "39:3: " + getCheckMessage(MSG_KEY, 15, max),
+            "50:3: " + getCheckMessage(MSG_KEY, 15, max),
         };
 
         verifyWithInlineConfigParser(
@@ -101,7 +101,7 @@ public class RecordComponentNumberCheckTest extends AbstractModuleTestSupport {
         final int max = 8;
 
         final String[] expected = {
-            "12:1: " + getCheckMessage(MSG_KEY, 15, max),
+            "13:1: " + getCheckMessage(MSG_KEY, 15, max),
         };
 
         verifyWithInlineConfigParser(
@@ -125,20 +125,20 @@ public class RecordComponentNumberCheckTest extends AbstractModuleTestSupport {
         final int max = 1;
 
         final String[] expected = {
-            "28:5: " + getCheckMessage(MSG_KEY, 2, max),
-            "32:5: " + getCheckMessage(MSG_KEY, 3, max),
-            "36:5: " + getCheckMessage(MSG_KEY, 5, max),
-            "52:5: " + getCheckMessage(MSG_KEY, 7, max),
-            "57:5: " + getCheckMessage(MSG_KEY, 14, max),
-            "65:9: " + getCheckMessage(MSG_KEY, 3, max),
-            "69:9: " + getCheckMessage(MSG_KEY, 14, max),
-            "73:13: " + getCheckMessage(MSG_KEY, 14, max),
-            "77:17: " + getCheckMessage(MSG_KEY, 6, max),
-            "90:5: " + getCheckMessage(MSG_KEY, 4, max),
-            "92:5: " + getCheckMessage(MSG_KEY, 15, max),
+            "25:5: " + getCheckMessage(MSG_KEY, 2, max),
+            "28:5: " + getCheckMessage(MSG_KEY, 3, max),
+            "31:5: " + getCheckMessage(MSG_KEY, 5, max),
+            "46:5: " + getCheckMessage(MSG_KEY, 7, max),
+            "52:5: " + getCheckMessage(MSG_KEY, 14, max),
+            "60:9: " + getCheckMessage(MSG_KEY, 3, max),
+            "64:9: " + getCheckMessage(MSG_KEY, 14, max),
+            "69:13: " + getCheckMessage(MSG_KEY, 14, max),
+            "74:17: " + getCheckMessage(MSG_KEY, 6, max),
+            "88:5: " + getCheckMessage(MSG_KEY, 4, max),
+            "91:5: " + getCheckMessage(MSG_KEY, 15, max),
             "102:5: " + getCheckMessage(MSG_KEY, 3, max),
-            "106:5: " + getCheckMessage(MSG_KEY, 6, max),
-            "117:5: " + getCheckMessage(MSG_KEY, 2, max),
+            "107:5: " + getCheckMessage(MSG_KEY, 6, max),
+            "119:5: " + getCheckMessage(MSG_KEY, 2, max),
         };
 
         verifyWithInlineConfigParser(
@@ -159,8 +159,8 @@ public class RecordComponentNumberCheckTest extends AbstractModuleTestSupport {
         final int max = 8;
 
         final String[] expected = {
-            "70:9: " + getCheckMessage(MSG_KEY, 14, max),
-            "76:13: " + getCheckMessage(MSG_KEY, 14, max),
+            "71:9: " + getCheckMessage(MSG_KEY, 14, max),
+            "78:13: " + getCheckMessage(MSG_KEY, 14, max),
         };
 
         verifyWithInlineConfigParser(
@@ -173,12 +173,11 @@ public class RecordComponentNumberCheckTest extends AbstractModuleTestSupport {
         final int max = 8;
 
         final String[] expected = {
-            "70:9: " + getCheckMessage(MSG_KEY, 14, max),
-            "76:13: " + getCheckMessage(MSG_KEY, 14, max),
+            "49:5: " + getCheckMessage(MSG_KEY, 15, max),
         };
 
         verifyWithInlineConfigParser(
-                getPath("InputRecordComponentNumberPrivateModifierOne.java"), expected);
+                getPath("InputRecordComponentNumberPrivateModifierTwo.java"), expected);
     }
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberMax1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberMax1.java
@@ -6,7 +6,6 @@ accessModifiers = (default)public, protected, package, private
 
 */
 
-
 package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 
 import java.awt.Point;
@@ -18,22 +17,18 @@ import java.util.List;
 import org.w3c.dom.Node;
 
 public class InputRecordComponentNumberMax1 {
-
     public record TestRecord1(int x){
-        public TestRecord1{
-
-        }
+        public TestRecord1{}
     }
 
-    public record TestRecord2(int x, int y){ // violation
+    // violation below 'Number of record components is 2'
+    public record TestRecord2(int x, int y){}
 
-    }
+    // violation below 'Number of record components is 3'
+    public record TestRecord3(String str, int x, int y){}
 
-    public record TestRecord3(String str, int x, int y){ // violation
-
-    }
-
-    public record TestRecord4(Node node, // violation
+    // violation below 'Number of record components is 5'
+    public record TestRecord4(Node node,
                               Point x,
                               Point y,
                               int translation,
@@ -43,38 +38,40 @@ public class InputRecordComponentNumberMax1 {
             try {
                 myDeque.add(x.toString());
                 myDeque.add(y.toString());
-            } catch (Exception ignored) {
-
-            }
+            } catch (Exception ignored) {}
         }
     }
 
-    public record TestRecord5(int x, int y, int z, // violation
+    // violation below 'Number of record components is 7'
+    public record TestRecord5(int x, int y, int z,
                               int a, int b, int c, int d){
 
     }
 
-    public record TestRecord6(int x, int y, int z, // violation
-                              int a, int b, int c, int d, int e,
-                              int f, int g, int h, int i, int j,
+    // violation below 'Number of record components is 14'
+    public record TestRecord6(int x, int y, int z,
+                              int a, int b, int c, int d, int e, int f,
+                              int g, int h, int i, int j,
                               int k){
 
     }
     public record TestRecord7(int y){
-
-        record InnerRecordOk(int x, int y, int z){ // violation
-
+        // violation below 'Number of record components is 3'
+        record InnerRecordOk(int x, int y, int z){
         }
 
-        private record InnerRecordBad(int x, int y, int z, // violation
-                                      int a, int b, int c, int d, int e,
-                                      int f, int g, int h, int i, int j, int k){
+        // violation below 'Number of record components is 14'
+        private record InnerRecordBad(int x, int y, int z,
+                                      int a, int b, int c, int d, int e, int f,
+                                      int g, int h, int i, int j, int k){
 
-            private record InnerRecordCeptionBad(int x, int y, int z, // violation
-                                      int a, int b, int c, int d, int e,
-                                      int f, int g, int h, int i, int j, int k){
+            // violation below 'Number of record components is 14'
+            private record InnerRecordCeptionBad(int x, int y, int z,
+                                      int a, int b, int c, int d, int e, int f,
+                                      int g, int h, int i, int j, int k){
 
-                public record InnerPublicBad(int[] arr, // violation
+                // violation below 'Number of record components is 6'
+                public record InnerPublicBad(int[] arr,
                                              LinkedHashMap<String, Node> linkedHashMap,
                                              int x,
                                              ArrayDeque<Node> arrayDeque,
@@ -87,9 +84,11 @@ public class InputRecordComponentNumberMax1 {
         }
     }
 
-    public record TestRecord8(int x, int y, int z, String... myVarargs){} // violation
+    // violation below 'Number of record components is 4'
+    public record TestRecord8(int x, int y, int z, String... myVarargs){}
 
-    public record TestRecord9(int x, int y, int z, // violation
+    // violation below 'Number of record components is 15'
+    public record TestRecord9(int x, int y, int z,
                               int a, int b, int c,
                               int d, int e, int f,
                               int g, int h, int i,
@@ -99,11 +98,13 @@ public class InputRecordComponentNumberMax1 {
 
     public record TestRecord10(String... myVarargs){}
 
-    public record TestRecord11(int[] arr, // violation
+    // violation below 'Number of record components is 3'
+    public record TestRecord11(int[] arr,
                                LinkedHashMap<String, Node> linkedHashMap,
                                int x){}
 
-    public record TestRecord12(int[] arr, // violation
+    // violation below 'Number of record components is 6'
+    public record TestRecord12(int[] arr,
                                LinkedHashMap<String, Node> linkedHashMap,
                                int x,
                                ArrayDeque<Node> arrayDeque,
@@ -114,6 +115,6 @@ public class InputRecordComponentNumberMax1 {
 
     private static record MyPrivateRecord1() {}
 
-    private static record MyPrivateRecord2(int x, int y) {} // violation
-
+    // violation below 'Number of record components is 2'
+    private static record MyPrivateRecord2(int x, int y) {}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberOne.java
@@ -18,20 +18,13 @@ import java.util.List;
 import org.w3c.dom.Node;
 
 public class InputRecordComponentNumberOne {
-
     public record TestRecord1(int x){
-        public TestRecord1{
-
-        }
+        public TestRecord1{}
     }
 
-    public record TestRecord2(int x, int y){
+    public record TestRecord2(int x, int y){}
 
-    }
-
-    public record TestRecord3(String str, int x, int y){
-
-    }
+    public record TestRecord3(String str, int x, int y){}
 
     public record TestRecord4(Node node,
                               Point x,
@@ -50,11 +43,10 @@ public class InputRecordComponentNumberOne {
     }
 
     public record TestRecord5(int x, int y, int z,
-                              int a, int b, int c, int d){
+                              int a, int b, int c, int d){}
 
-    }
-
-    public record TestRecord6(int x, int y, int z, // violation
+    // violation below 'Number of record components is 14'
+    public record TestRecord6(int x, int y, int z,
                               int a, int b, int c,
                               int d, int e, int f,
                               int g, int h, int i,
@@ -62,24 +54,25 @@ public class InputRecordComponentNumberOne {
 
     }
     public record TestRecord7(int y){
-
         record InnerRecordOk(int x, int y, int z){
-
         }
 
-        private record InnerRecordBad(int x, int y, int z, // violation
+        // violation below 'Number of record components is 14'
+        private record InnerRecordBad(int x, int y, int z,
                                       int a, int b, int c,
                                       int d, int e, int f,
                                       int g, int h, int i,
                                       int j, int k){
 
-            private record InnerRecordCeptionBad(int x, int y, int z, // violation
+            // violation below 'Number of record components is 14'
+            private record InnerRecordCeptionBad(int x, int y, int z,
                                                  int a, int b, int c,
                                                  int d, int e, int f,
                                                  int g, int h, int i,
                                                  int j, int k) {
 
-                public record InnerPublicBad(int[] arr, // violation
+                // violation below 'Number of record components is 11'
+                public record InnerPublicBad(int[] arr,
                                              LinkedHashMap<String, Node> linkedHashMap,
                                              int x,
                                              ArrayDeque<Node> arrayDeque,
@@ -94,11 +87,10 @@ public class InputRecordComponentNumberOne {
         }
     }
 
-    public record TestRecord8(int x, int y, int z, String... myVarargs){
+    public record TestRecord8(int x, int y, int z, String... myVarargs){}
 
-    }
-
-    public record TestRecord9(int x, int y, int z, // violation
+    // violation below 'Number of record components is 15'
+    public record TestRecord9(int x, int y, int z,
                               int a, int b, int c,
                               int d, int e, int f,
                               int g, int h, int i,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberPrivateModifierOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberPrivateModifierOne.java
@@ -67,13 +67,15 @@ public class InputRecordComponentNumberPrivateModifierOne {
 
         }
 
-        private record InnerRecordBad(int x, int y, int z, // violation
+        // violation below 'Number of record components is 14'
+        private record InnerRecordBad(int x, int y, int z,
                                       int a, int b, int c,
                                       int d, int e, int f,
                                       int g, int h, int i,
                                       int j, int k){
 
-            private record InnerRecordCeptionBad(int x, int y, int z, // violation
+            // violation below 'Number of record components is 14'
+            private record InnerRecordCeptionBad(int x, int y, int z,
                                                  int a, int b, int c,
                                                  int d, int e, int f,
                                                  int g, int h, int i,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberPrivateModifierTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberPrivateModifierTwo.java
@@ -45,7 +45,8 @@ public class InputRecordComponentNumberPrivateModifierTwo {
 
     }
 
-    private static record MyPrivateRecord1(int x, int y, int z, // violation
+    // violation below 'Number of record components is 15'
+    private static record MyPrivateRecord1(int x, int y, int z,
                                            int a, int b, int c,
                                            int d, int e, int f,
                                            int g, int h, int i,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTopLevel1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTopLevel1.java
@@ -9,7 +9,8 @@ accessModifiers = (default)public, protected, package, private
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 
-public record InputRecordComponentNumberTopLevel1(int x, int y, int z, // violation
+// violation below 'Number of record components is 15'
+public record InputRecordComponentNumberTopLevel1(int x, int y, int z,
                                                 int a, int b, int c,
                                                 int d, int e, int f,
                                                 int g, int h, int i,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTwo.java
@@ -35,7 +35,8 @@ public class InputRecordComponentNumberTwo {
 
   }
 
-  private static record MyPrivateRecord1(int x, int y, int z, // violation
+  // violation below 'Number of record components is 15'
+  private static record MyPrivateRecord1(int x, int y, int z,
                                            int a, int b, int c,
                                            int d, int e, int f,
                                            int g, int h, int i,
@@ -45,7 +46,8 @@ public class InputRecordComponentNumberTwo {
 
   protected static record MyProtectedRecord1(int x, int y) {}
 
-  protected static record MyProtectedRecord2(int x, int y, int z, // violation
+  // violation below 'Number of record components is 15'
+  protected static record MyProtectedRecord2(int x, int y, int z,
                                                int a, int b, int c,
                                                int d, int e, int f,
                                                int g, int h, int i,


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed RecordComponentNumberCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in RecordComponentNumberCheckest
- Defined violation messages in InputRecordComponentNumberCheck
- Updated a duplicated test InputRecordComponentNumberPrivateModifierOne with InputRecordComponentNumberPrivateModifierTwo