### PR TITLE
Issue #15456: specify violation messages for TrailingCommentCheck

### DIFF
--- a/src/site/xdoc/checks/misc/trailingcomment.xml
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml
@@ -114,13 +114,13 @@ public class Example1 {
   int a;
   int b;
   int c;
-  int d; // violation, not suppressed
+  int d; // violation 'Don't use trailing comments.'
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK */ x &gt; 5) {}
-    int a = 5; // violation
+    int a = 5; // violation 'Don't use trailing comments.'
     doSomething(
             "param1"
     ); // ok, by default such trailing of method/code-block ending is allowed
@@ -150,19 +150,19 @@ public class Example1 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
-  int a; // violation, line content before comment should match pattern "^\s*$"
-  int b; // violation, line content before comment should match pattern "^\s*$"
-  int c; // violation, line content before comment should match pattern "^\s*$"
-  int d; // violation, line content before comment should match pattern "^\s*$"
+  int a; // violation 'Don't use trailing comments.'
+  int b; // violation 'Don't use trailing comments.'
+  int c; // violation 'Don't use trailing comments.'
+  int d; // violation 'Don't use trailing comments.'
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK, this comment does not end the line */ x &gt; 5) {}
-    int a = 5; // violation, line content before comment should match pattern "^\s*$"
+    int a = 5; // violation 'Don't use trailing comments.'
     doSomething(
             "param1"
-    ); // violation, line content before comment should match pattern "^\s*$"
+    ); // violation 'Don't use trailing comments.'
 
   }
 
@@ -194,13 +194,13 @@ public class Example3 {
   int a;
   int b;
   int c;
-  int d; // violation, not suppressed
+  int d; // violation 'Don't use trailing comments.'
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK */ x &gt; 5) {}
-    int a = 5; // violation
+    int a = 5; // violation 'Don't use trailing comments.'
     doSomething(
             "param1"
     ); // ok, by default such trailing of method/code-block ending is allowed
@@ -237,7 +237,7 @@ public class UseCase1 {
   int a; // SUPPRESS CHECKSTYLE - OK, comment starts with " SUPPRESS CHECKSTYLE"
   int b; // NOPMD - OK, comment starts with " NOPMD"
   int c; // NOSONAR - OK, comment starts with " NOSONAR"
-  int d; // violation, not suppressed
+  int d; // violation 'Don't use trailing comments.'
 }
 </code></pre></div><hr class="example-separator"/>
 
@@ -269,7 +269,7 @@ public class UseCase2 {
     ); // FIXME: handle edge cases - ok, matches legalComment pattern
 
     int b = 10; // trailingcomment - ok, matches legalComment pattern
-    int c = 15; // violation, regular comment doesn't match pattern
+    int c = 15; // violation 'Don't use trailing comments.'
   }
 
   private static void doSomething(String param) {
@@ -305,7 +305,7 @@ public class UseCase3 {
   int b; /* NOPMD */
   int c; /* NOSONAR */
   int d; /* there is violation because of illegal content */
-  // violation above
+  // violation above 'Don't use trailing comments.'
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -268,7 +268,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
-            "com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck",
             "com.puppycrawl.tools.checkstyle.api.AbstractCheckTest$ViolationAstCheck",
             "com.puppycrawl.tools.checkstyle.CheckerTest$VerifyPositionAfterTabFileSet"
     );

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
@@ -90,23 +90,23 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
     public void testFormat() throws Exception {
         final String[] expected = {
             "1:1: " + getCheckMessage(MSG_KEY),
-            "12:12: " + getCheckMessage(MSG_KEY),
-            "13:5: " + getCheckMessage(MSG_KEY),
-            "14:33: " + getCheckMessage(MSG_KEY),
-            "15:39: " + getCheckMessage(MSG_KEY),
-            "16:22: " + getCheckMessage(MSG_KEY),
-            "21:44: " + getCheckMessage(MSG_KEY),
-            "22:7: " + getCheckMessage(MSG_KEY),
-            "23:5: " + getCheckMessage(MSG_KEY),
-            "26:19: " + getCheckMessage(MSG_KEY),
-            "27:36: " + getCheckMessage(MSG_KEY),
-            "34:5: " + getCheckMessage(MSG_KEY),
-            "37:50: " + getCheckMessage(MSG_KEY),
-            "38:62: " + getCheckMessage(MSG_KEY),
-            "39:31: " + getCheckMessage(MSG_KEY),
-            "42:33: " + getCheckMessage(MSG_KEY),
-            "43:9: " + getCheckMessage(MSG_KEY),
-            "51:5: " + getCheckMessage(MSG_KEY),
+            "14:12: " + getCheckMessage(MSG_KEY),
+            "16:5: " + getCheckMessage(MSG_KEY),
+            "18:5: " + getCheckMessage(MSG_KEY),
+            "20:12: " + getCheckMessage(MSG_KEY),
+            "22:22: " + getCheckMessage(MSG_KEY),
+            "28:17: " + getCheckMessage(MSG_KEY),
+            "30:7: " + getCheckMessage(MSG_KEY),
+            "32:5: " + getCheckMessage(MSG_KEY),
+            "36:19: " + getCheckMessage(MSG_KEY),
+            "38:21: " + getCheckMessage(MSG_KEY),
+            "47:5: " + getCheckMessage(MSG_KEY),
+            "50:50: " + getCheckMessage(MSG_KEY),
+            "52:51: " + getCheckMessage(MSG_KEY),
+            "54:31: " + getCheckMessage(MSG_KEY),
+            "58:9: " + getCheckMessage(MSG_KEY),
+            "60:9: " + getCheckMessage(MSG_KEY),
+            "69:5: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputTrailingComment3.java"), expected);
@@ -127,9 +127,7 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
             "15:27: " + getCheckMessage(MSG_KEY),
             "21:33: " + getCheckMessage(MSG_KEY),
             "25:13: " + getCheckMessage(MSG_KEY),
-            "27:16: " + getCheckMessage(MSG_KEY),
-            "28:24: " + getCheckMessage(MSG_KEY),
-            "33:37: " + getCheckMessage(MSG_KEY),
+            "28:16: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
             getPath("InputTrailingCommentWithEmoji.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment.java
@@ -9,13 +9,13 @@ legalComment = (default)(null)
 package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
 
 public class InputTrailingComment {
-    // violation below
+    // violation below 'Don't use trailing comments.'
     int i; // don't use trailing comments :)
     // it fine to have comment w/o any statement
     /* good c-style comment. */
-    // violation below
+    // violation below 'Don't use trailing comments.'
     int j; /* bad c-style comment. */
-    // violation below
+    // violation below 'Don't use trailing comments.'
     void method1() { /* some c-style multi-line
                         comment*/
         Runnable r = (new Runnable() {
@@ -26,23 +26,23 @@ public class InputTrailingComment {
     /*
       Let's check multi-line comments.
     */
-    // violation below
+    // violation below 'Don't use trailing comments.'
     /* c-style */ // cpp-style
     /* c-style 1 */ /*c-style 2 */
-     // violation above
+     // violation above 'Don't use trailing comments.'
     /* package */ void method2(long ms /* we should ignore this */) {
         /* comment before text */int z;
         /* int y */int y/**/;
     }
 
+    // violation 4 lines below 'Don't use trailing comments.'
     /**
      * comment with trailing space.
      */
-    // violation below
     final static public String NAME="Some Name"; // NOI18N
-     // violation below
+     // violation below 'Don't use trailing comments.'
     final static public String NAME2="Some Name"; /*NOI18N*/
-     // violation below
+     // violation below 'Don't use trailing comments.'
     String NAME3="Some Name"; /*NOI18N
 */
     /* package */ void method3() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment2.java
@@ -9,13 +9,13 @@ legalComment = ^NOI18N$
 package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
 
 public class InputTrailingComment2 {
-    // violation below
+    // violation below 'Don't use trailing comments.'
     int i; // don't use trailing comments :)
     // it fine to have comment w/o any statement
     /* good c-style comment. */
-    // violation below
+    // violation below 'Don't use trailing comments.'
     int j; /* bad c-style comment. */
-    // violation below
+    // violation below 'Don't use trailing comments.'
     void method1() { /* some c-style multi-line
                         comment*/
         Runnable r = (new Runnable() {
@@ -26,9 +26,9 @@ public class InputTrailingComment2 {
     /*
       Let's check multi-line comments.
     */
-    // violation below
+    // violation below 'Don't use trailing comments.'
     /* c-style */ // cpp-style
-    // violation below
+    // violation below 'Don't use trailing comments.'
     /* c-style 1 */ /*c-style 2 */
 
     /* package */ void method2(long ms /* we should ignore this */) {
@@ -36,12 +36,12 @@ public class InputTrailingComment2 {
         /* int y */int y/**/;
     }
 
+    // violation 3 lines below 'Don't use trailing comments.'
     /**
      * comment with trailing space.      */
-    // violation below
     final static public String NAME="Some Name"; // NOI18N
     final static public String NAME2="Some Name"; /*NOI18N*/
-    // violation below
+    // violation below 'Don't use trailing comments.'
     String NAME3="Some Name"; /*NOI18N
 */
     /* package */ void method3() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment3.java
@@ -1,46 +1,63 @@
-/* // violation
+/*
 TrailingComment
 format = NOT MATCH
-legalComment = (default)(null)
+legalComment = violation (above|below|[0-9]+ lines)
 
 
 */
+// violation 7 lines above 'Don't use trailing comments.'
 
 package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
 
 public class InputTrailingComment3 {
-    int i; // don't use trailing comments :) // violation
-    // it fine to have comment w/o any statement // violation
-    /* good c-style comment. */ // violation
-    int j; /* bad c-style comment. */ // violation
-    void method1() { /* some c-style multi-line // violation
+    // violation below 'Don't use trailing comments.'
+    int i; // don't use trailing comments :)
+    // violation below 'Don't use trailing comments.'
+    // it fine to have comment w/o any statement
+    // violation below 'Don't use trailing comments.'
+    /* good c-style comment. */
+    // violation below 'Don't use trailing comments.'
+    int j; /* bad c-style comment. */
+    // violation below 'Don't use trailing comments.'
+    void method1() { /* some c-style multi-line
                         comment*/
         Runnable r = (new Runnable() {
                 public void run() {
                 }
-            }); /* we should allow this */ // violation
-    } // we should allow this // violation
-    /* // violation
+            // violation below 'Don't use trailing comments.'
+            }); /* we should allow this */
+    // violation below 'Don't use trailing comments.'
+    } // we should allow this
+    // violation below 'Don't use trailing comments.'
+    /*
       Let's check multi-line comments.
     */
-    /* c-style */ // cpp-style // violation
-    /* c-style 1 */ /*c-style 2 */ // violation
+    // violation below 'Don't use trailing comments.'
+    /* c-style */ // cpp-style
+    // violation below 'Don't use trailing comments.'
+    /* c-style 1 */ /*c-style 2 */
 
     /* package */ void method2(long ms /* we should ignore this */) {
         /* comment before text */int z;
         /* int y */int y/**/;
     }
 
-    /** // violation
+    // violation 2 lines below 'Don't use trailing comments.'
+    // violation 4 lines below 'Don't use trailing comments.'
+    /**
      * comment with trailing space.
      */
-    final static public String NAME="Some Name"; // NOI18N // violation
-    final static public String NAME2="Some Name"; /*NOI18N*/ // violation
-    String NAME3="Some Name"; /*NOI18N // violation
+    final static public String NAME="Some Name"; // NOI18N
+    // violation below 'Don't use trailing comments.'
+    final static public String NAME2="Some Name"; /*NOI18N*/
+    // violation below 'Don't use trailing comments.'
+    String NAME3="Some Name"; /*NOI18N
 */
     /* package */ void method3() {
-        /* bla on this block */ // violation
-        // violation here for format NOT FOUND // violation
+        // violation below 'Don't use trailing comments.'
+        /* bla on this block */
+        // violation below 'Don't use trailing comments.'
+        // violation here for format NOT FOUND
     }
 
     private static class TimerEntry {
@@ -48,7 +65,8 @@ public class InputTrailingComment3 {
         /* ok */ final long start = 0L;
     }
 
-    /** // violation
+    // violation below 'Don't use trailing comments.'
+    /**
      * violation above this line.
      **/
     /* package */ void addError() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingCommentWithEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingCommentWithEmoji.java
@@ -9,26 +9,27 @@ legalComment = ^ this is ok
 package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
 
 public class InputTrailingCommentWithEmoji {
-    // violation below
+    // violation below 'Don't use trailing comments.'
     String a = "🧐🥳😠😨"; /*string with emoji */
-    // violation below
+    // violation below 'Don't use trailing comments.'
     String b = "👌🏻🤞🏻😂😂🎄"; // another string
 
     /* yet another */String c = "😂😂🎄👍"; /* this is ok */
     String d = "🧐🥳"; // this is ok
   /*
-  * 🎄a🎄b🎄c🎄 // violation below
+  * 🎄a🎄b🎄c🎄 // violation below 'Don't use trailing comments.'
   * 🎄 👌🏻 🤘🏻 🎄*/  void test1() { /* some
    🎄  adsad 🎄                  /*comments */
     }
-    // violation below
+    // violation below 'Don't use trailing comments.'
     /*😂 😂*/ // 🤛🏻🤛🏻
 
-    /* 🎃 ☠️ */ // 👿 asd😱 // violation
-    /* 😱 🎄 */ /*🎄 🥶 */ // violation
+    // violation below 'Don't use trailing comments.'
+    /* 🎃 ☠️ */ // 👿 asd😱
+    /* 😱 🎄 */ /*🎄 🥶 */
 
     /**  // comment
      * 🤛🏻q🥳w👆🏻e😠r👇🏻t😨y
      */
-    /* 👆🏻 👇🏻    */  void test2() {} // violation
+    /* 👆🏻 👇🏻    */  void test2() {}
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example1.java
@@ -13,13 +13,13 @@ public class Example1 {
   int a;
   int b;
   int c;
-  int d; // violation, not suppressed
+  int d; // violation 'Don't use trailing comments.'
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK */ x > 5) {}
-    int a = 5; // violation
+    int a = 5; // violation 'Don't use trailing comments.'
     doSomething(
             "param1"
     ); // ok, by default such trailing of method/code-block ending is allowed

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example2.java
@@ -12,19 +12,19 @@ package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
 
 // xdoc section -- start
 public class Example2 {
-  int a; // violation, line content before comment should match pattern "^\s*$"
-  int b; // violation, line content before comment should match pattern "^\s*$"
-  int c; // violation, line content before comment should match pattern "^\s*$"
-  int d; // violation, line content before comment should match pattern "^\s*$"
+  int a; // violation 'Don't use trailing comments.'
+  int b; // violation 'Don't use trailing comments.'
+  int c; // violation 'Don't use trailing comments.'
+  int d; // violation 'Don't use trailing comments.'
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK, this comment does not end the line */ x > 5) {}
-    int a = 5; // violation, line content before comment should match pattern "^\s*$"
+    int a = 5; // violation 'Don't use trailing comments.'
     doSomething(
             "param1"
-    ); // violation, line content before comment should match pattern "^\s*$"
+    ); // violation 'Don't use trailing comments.'
 
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
@@ -15,13 +15,13 @@ public class Example3 {
   int a;
   int b;
   int c;
-  int d; // violation, not suppressed
+  int d; // violation 'Don't use trailing comments.'
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK */ x > 5) {}
-    int a = 5; // violation
+    int a = 5; // violation 'Don't use trailing comments.'
     doSomething(
             "param1"
     ); // ok, by default such trailing of method/code-block ending is allowed

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase1.java
@@ -15,6 +15,6 @@ public class UseCase1 {
   int a; // SUPPRESS CHECKSTYLE - OK, comment starts with " SUPPRESS CHECKSTYLE"
   int b; // NOPMD - OK, comment starts with " NOPMD"
   int c; // NOSONAR - OK, comment starts with " NOSONAR"
-  int d; // violation, not suppressed
+  int d; // violation 'Don't use trailing comments.'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase2.java
@@ -22,7 +22,7 @@ public class UseCase2 {
     ); // FIXME: handle edge cases - ok, matches legalComment pattern
 
     int b = 10; // trailingcomment - ok, matches legalComment pattern
-    int c = 15; // violation, regular comment doesn't match pattern
+    int c = 15; // violation 'Don't use trailing comments.'
   }
 
   private static void doSomething(String param) {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase3.java
@@ -22,6 +22,6 @@ public class UseCase3 {
   int b; /* NOPMD */
   int c; /* NOSONAR */
   int d; /* there is violation because of illegal content */
-  // violation above
+  // violation above 'Don't use trailing comments.'
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed TrailingCommentCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in TrailingCommentCheckest
- Defined violation messages in InputTrailingCommentCheck