### PR TITLE
Issue #15456: specify violation messages for AbstractCheckTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -268,7 +268,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",
-            "com.puppycrawl.tools.checkstyle.api.AbstractCheckTest$ViolationAstCheck",
             "com.puppycrawl.tools.checkstyle.CheckerTest$VerifyPositionAfterTabFileSet"
     );
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/api/abstractcheck/InputAbstractCheckTestFileContents.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/api/abstractcheck/InputAbstractCheckTestFileContents.java
@@ -2,9 +2,9 @@
 com.puppycrawl.tools.checkstyle.api.AbstractCheckTest$ViolationAstCheck
 
 */
-
+// violation below 'Violation.'
 package com.puppycrawl.tools.checkstyle.api.abstractcheck;
-// violation above
+
 
 /**
  * I'm a javadoc


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed AbstractCheckTest$ViolationAstCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Defined violation messages in InputAbstractCheckTest file