### PR TITLE
Issue #20653: unexpected output to logs from XdocsExamplesAstConsiste…

### DIFF
--- a/src/site/xdoc/checks/misc/translation.xml
+++ b/src/site/xdoc/checks/misc/translation.xml
@@ -190,10 +190,10 @@ ok=OK
 </code></pre></div>
         <p id="Example3-code">Validation for Example3:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-messages_home.properties   // violation,
-                          'Properties file 'messages_home_fr.properties' missing.'
-messages_home.translations // violation,
-                          'Properties file 'messages_home_fr.translations' missing.'
+messages_home.properties
+// violation above 'Properties file 'messages_home_fr.properties' missing.'
+messages_home.translations
+// violation above 'Properties file 'messages_home_fr.translations' missing.'
 </code></pre></div>
       </subsection>
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/translation/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/translation/Example3.java
@@ -12,10 +12,10 @@ package com.puppycrawl.tools.checkstyle.checks.translation;
 
 /*
 // xdoc section -- start
-messages_home.properties   // violation,
-                          'Properties file 'messages_home_fr.properties' missing.'
-messages_home.translations // violation,
-                          'Properties file 'messages_home_fr.translations' missing.'
+messages_home.properties
+// violation above 'Properties file 'messages_home_fr.properties' missing.'
+messages_home.translations
+// violation above 'Properties file 'messages_home_fr.translations' missing.'
 // xdoc section -- end
 */
 public class Example3 {}


### PR DESCRIPTION
#20653 

Running `XdocsExamplesAstConsistencyTest` (specifically the AST-parsing path in `parseContent`) surfaced an ANTLR lexer error:

```
line 2:26 token recognition error at: ''Pr'
```

This traced back to `checks/translation/Example3.java`, where the xdoc section (extracted from inside a `/* ... */` documentation block) looked like:

```
messages_home.properties   // violation,
                          'Properties file 'messages_home_fr.properties' missing.'
messages_home.translations // violation,
                          'Properties file 'messages_home_fr.translations' missing.'
```

### Root cause

`extractXdocSection()` pulls the raw text between `// xdoc section -- start` and `// xdoc section -- end` markers and hands it directly to `parseContent()`, which runs it through the Java lexer/parser regardless of whether the content is real compilable code or, as here, plain-text documentation describing which files trigger a violation.

The problem line (`'Properties file 'messages_home_fr.properties' missing.'`) had no `//` prefix of its own it was a bare continuation line following a trailing `// violation,` comment on the line above. Since it wasn't recognized as a comment in isolation, the Java lexer tried to tokenize it as actual code. It hit the leading `'` and interpreted it as the start of a Java character literal, then failed to find a valid single-character literal before hitting more text (`Pr...`), producing the recognition error.

### Fix

Restructured the xdoc section so each line is its own complete single-line comment, using the existing `// violation above` convention (already recognized by `isIgnoredComment`) instead of a trailing comment on the filename line followed by an unmarked continuation:

```java
/*
// xdoc section -- start
messages_home.properties
// violation above 'Properties file 'messages_home_fr.properties' missing.'
messages_home.translations
// violation above 'Properties file 'messages_home_fr.translations' missing.'
// xdoc section -- end
*/
public class Example3 {}
```

Each line the lexer now encounters either has no comment marker at all (safe — it's a bare filename token) or starts with `//`, making the entire line a single-line comment. Since a Java lexer never tokenizes content after `//` on that line, the nested apostrophes inside the violation message are never inspected as potential char-literal delimiters, and the recognition error disappears.

### Testing

Ran `XdocsExamplesAstConsistencyTest` locally; confirmed the lexer recognition error no longer occurs and `Example3` parses and compares successfully against other examples in `checks/translation/`.

Earlier:
<img width="1107" height="466" alt="image" src="https://github.com/user-attachments/assets/9b318db2-0ded-4423-bc2f-44ccc74efef7" />


After fix:
<img width="1237" height="447" alt="image" src="https://github.com/user-attachments/assets/6d8aaf65-1604-4b49-9330-895bc562fd15" />


