### PR TITLE
Issue #15456: specify violation messages for CheckerTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -1394,8 +1394,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testTabViolationDefault() throws Exception {
         final String[] expected = {
-            "17:17: violation",
-            "21:49: violation",
+            "18:17: violation",
+            "22:49: violation",
         };
         verifyWithInlineConfigParser(getPath("InputCheckerTabCharacter.java"),
             expected);
@@ -1404,8 +1404,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testTabViolationCustomWidth() throws Exception {
         final String[] expected = {
-            "18:17: violation",
-            "22:37: violation",
+            "19:17: violation",
+            "23:37: violation",
         };
 
         verifyWithInlineXmlConfig(getPath("InputCheckerTabCharacterCustomWidth.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -267,8 +267,7 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
-                    + ".RequireEmptyLineBeforeBlockTagGroupCheck",
-            "com.puppycrawl.tools.checkstyle.CheckerTest$VerifyPositionAfterTabFileSet"
+                    + ".RequireEmptyLineBeforeBlockTagGroupCheck"
     );
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
@@ -62,8 +62,7 @@ public final class TestInputConfiguration {
             "com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheckTest$ViolationFileSetCheck",
             "com.puppycrawl.tools.checkstyle.api.FileSetCheckTest$TestFileSetCheck",
             "com.puppycrawl.tools.checkstyle.internal.testmodules"
-                + ".VerifyPositionAfterLastTabFileSet",
-            "com.puppycrawl.tools.checkstyle.CheckerTest$VerifyPositionAfterTabFileSet"
+                + ".VerifyPositionAfterLastTabFileSet"
     ));
 
     private final List<ModuleInputConfiguration> childrenModules;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checker/InputCheckerTabCharacter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checker/InputCheckerTabCharacter.java
@@ -14,11 +14,12 @@ public class InputCheckerTabCharacter {
     int sum = numOne + numTwo;
 
     // has a tab after  ';'
-    numOne ++;	// violation 'violation'
+    // violation below 'violation'
+    numOne ++;	// has tab
 
-    // violation 2 lines below 'violation'
     // has 2 tabs after ';' and after 'comment'
-    numTwo ++;		// comment		violation
+    // violation below 'violation'
+    numTwo ++;		// comment		last tab
 
     return sum;
   }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checker/InputCheckerTabCharacterCustomWidth.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checker/InputCheckerTabCharacterCustomWidth.java
@@ -15,11 +15,12 @@ public class InputCheckerTabCharacterCustomWidth {
     int sum = numOne + numTwo;
 
     // has a tab after  ';'
-    numOne ++;	// violation 'violation'
+    // violation below 'violation'
+    numOne ++;	// has tab
 
-    // violation 2 lines below 'violation'
     // has 2 tabs after ';' and after 'comment'
-    numTwo ++;		// comment		violation
+    // violation below 'violation'
+    numTwo ++;		// comment		last tab
 
     return sum;
   }


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

**summary**

- Removed AbstractCheckTest$ViolationAstCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in CheckerTestTest
- Defined violation messages in InputCheckerTest files
-  removed VerifyPositionAfterLastTabFileSet  from CHECKER_CHILDREN in TestInputConfiguration