### PR TITLE
Issue #15456: specify  violation messages for DesignForExtensionCheck and RequireEmptyLineBeforeBlockTagGroupCheck

### DIFF
--- a/src/site/xdoc/checks/design/designforextension.xml
+++ b/src/site/xdoc/checks/design/designforextension.xml
@@ -180,9 +180,11 @@ public abstract class Plant {
 public abstract class Example1 {
   private int bar;
 
-  public int m1() {return 2;}  // violation
+  // violation below 'Class 'Example1' looks like designed for extension'
+  public int m1() {return 2;}
 
-  public int m2() {return 8;}  // violation
+  // violation below 'Class 'Example1' looks like designed for extension'
+  public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.
 
@@ -206,8 +208,8 @@ public abstract class Example1 {
    * implementation ...
    */
   public int m8() {return 2;}  // ok, Have javadoc on overridable method.
-
-  @Override                   // violation
+  // violation below 'Class 'Example1' looks like designed for extension'
+  @Override
   public String toString() {
     return "";
   }
@@ -231,9 +233,11 @@ public abstract class Example1 {
 public abstract class Example2 {
   private int bar;
 
-  public int m1() {return 2;}  // violation
+  // violation below 'Class 'Example2' looks like designed for extension'
+  public int m1() {return 2;}
 
-  public int m2() {return 8;}  // violation
+  // violation below 'Class 'Example2' looks like designed for extension'
+  public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.
 
@@ -282,9 +286,11 @@ public abstract class Example2 {
 public abstract class Example3 {
   private int bar;
 
-  public int m1() {return 2;}  // violation
+  // violation below 'Class 'Example3' looks like designed for extension'
+  public int m1() {return 2;}
 
-  public int m2() {return 8;}  // violation
+  // violation below 'Class 'Example3' looks like designed for extension'
+  public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.
 
@@ -300,16 +306,16 @@ public abstract class Example3 {
 
   /**
    * Some comments ...
-   */
-  public int m7() {return 1;}  // violation
+   */ // violation below 'Class 'Example3' looks like designed for extension'
+  public int m7() {return 1;}
 
   /**
    * This
    * implementation ...
-   */
-  public int m8() {return 2;}  // violation
-
-  @Override                    // violation
+   */ // violation below 'Class 'Example3' looks like designed for extension'
+  public int m8() {return 2;}
+  // violation below 'Class 'Example3' looks like designed for extension'
+  @Override
   public String toString() {
     return "";
   }
@@ -334,9 +340,11 @@ public abstract class Example3 {
 public abstract class Example4 {
   private int bar;
 
-  public int m1() {return 2;}  // violation
+  // violation below 'Class 'Example4' looks like designed for extension'
+  public int m1() {return 2;}
 
-  public int m2() {return 8;}  // violation
+  // violation below 'Class 'Example4' looks like designed for extension'
+  public int m2() {return 8;}
 
   private void m3() {m4();}
 
@@ -352,16 +360,16 @@ public abstract class Example4 {
 
   /**
    * Some comments ...
-   */
-  public int m7() {return 1;}  // violation
+   */ // violation below 'Class 'Example4' looks like designed for extension'
+  public int m7() {return 1;}
 
   /**
    * This
    * implementation ...
    */
   public int m8() {return 2;}  // ok, Have required javadoc.
-
-  @Override                    // violation
+  // violation below 'Class 'Example4' looks like designed for extension'
+  @Override
   public String toString() {
     return "";
   }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -259,16 +259,6 @@ public final class InlineConfigParser {
     );
 
     /**
-     *  Checks in which violation message is not specified in input files.
-     *  Until <a href="https://github.com/checkstyle/checkstyle/issues/15456">#15456</a>.
-     */
-    private static final Set<String> SUPPRESSED_CHECKS = Set.of(
-            "com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc"
-                    + ".RequireEmptyLineBeforeBlockTagGroupCheck"
-    );
-
-    /**
      * Input files where violation messages are intentionally not specified,
      * because they would be too big or impractical to maintain.
      */
@@ -1478,9 +1468,7 @@ public final class InlineConfigParser {
         if (moduleLists.size() == 1) {
             final String moduleName = moduleLists.getFirst().getModuleName();
 
-            if (!PERMANENT_SUPPRESSED_CHECKS.contains(moduleName)
-                    && !SUPPRESSED_CHECKS.contains(moduleName)) {
-
+            if (!PERMANENT_SUPPRESSED_CHECKS.contains(moduleName)) {
                 final String fileName = Path.of(inputFilePath).getFileName().toString();
                 if (!SUPPRESSED_FILES.contains(fileName)) {
                     result = true;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
@@ -48,8 +48,8 @@ public class DesignForExtensionCheckTest
     @Test
     public void testIt() throws Exception {
         final String[] expected = {
-            "50:5: " + getCheckMessage(MSG_KEY, "InputDesignForExtension", "doh"),
-            "104:9: " + getCheckMessage(MSG_KEY, "anotherNonFinalClass", "someMethod"),
+            "51:5: " + getCheckMessage(MSG_KEY, "InputDesignForExtension", "doh"),
+            "106:9: " + getCheckMessage(MSG_KEY, "anotherNonFinalClass", "someMethod"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputDesignForExtension.java"), expected);
@@ -67,25 +67,25 @@ public class DesignForExtensionCheckTest
     @Test
     public void testOverridableMethods() throws Exception {
         final String[] expected = {
-            "14:9: " + getCheckMessage(MSG_KEY, "A", "foo1"),
-            "38:9: " + getCheckMessage(MSG_KEY, "A", "foo8"),
-            "43:9: " + getCheckMessage(MSG_KEY, "A", "foo9"),
-            "50:9: " + getCheckMessage(MSG_KEY, "A", "foo10"),
-            "57:9: " + getCheckMessage(MSG_KEY, "A", "foo11"),
-            "62:9: " + getCheckMessage(MSG_KEY, "A", "foo12"),
-            "69:9: " + getCheckMessage(MSG_KEY, "A", "foo13"),
-            "76:9: " + getCheckMessage(MSG_KEY, "A", "foo14"),
-            "98:9: " + getCheckMessage(MSG_KEY, "A", "foo22"),
-            "104:9: " + getCheckMessage(MSG_KEY, "A", "foo23"),
-            "113:9: " + getCheckMessage(MSG_KEY, "A", "foo25"),
-            "118:9: " + getCheckMessage(MSG_KEY, "A", "foo26"),
-            "125:9: " + getCheckMessage(MSG_KEY, "A", "foo27"),
-            "137:9: " + getCheckMessage(MSG_KEY, "A", "foo29"),
-            "159:9: " + getCheckMessage(MSG_KEY, "A", "foo31"),
-            "170:9: " + getCheckMessage(MSG_KEY, "A", "foo33"),
-            "176:9: " + getCheckMessage(MSG_KEY, "A", "foo34"),
-            "198:9: " + getCheckMessage(MSG_KEY, "A", "foo39"),
-            "205:9: " + getCheckMessage(MSG_KEY, "A", "foo41"),
+            "15:9: " + getCheckMessage(MSG_KEY, "A", "foo1"),
+            "40:9: " + getCheckMessage(MSG_KEY, "A", "foo8"),
+            "46:9: " + getCheckMessage(MSG_KEY, "A", "foo9"),
+            "54:9: " + getCheckMessage(MSG_KEY, "A", "foo10"),
+            "62:9: " + getCheckMessage(MSG_KEY, "A", "foo11"),
+            "68:9: " + getCheckMessage(MSG_KEY, "A", "foo12"),
+            "76:9: " + getCheckMessage(MSG_KEY, "A", "foo13"),
+            "84:9: " + getCheckMessage(MSG_KEY, "A", "foo14"),
+            "107:9: " + getCheckMessage(MSG_KEY, "A", "foo22"),
+            "114:9: " + getCheckMessage(MSG_KEY, "A", "foo23"),
+            "124:9: " + getCheckMessage(MSG_KEY, "A", "foo25"),
+            "130:9: " + getCheckMessage(MSG_KEY, "A", "foo26"),
+            "138:9: " + getCheckMessage(MSG_KEY, "A", "foo27"),
+            "151:9: " + getCheckMessage(MSG_KEY, "A", "foo29"),
+            "174:9: " + getCheckMessage(MSG_KEY, "A", "foo31"),
+            "186:9: " + getCheckMessage(MSG_KEY, "A", "foo33"),
+            "193:9: " + getCheckMessage(MSG_KEY, "A", "foo34"),
+            "216:9: " + getCheckMessage(MSG_KEY, "A", "foo39"),
+            "224:9: " + getCheckMessage(MSG_KEY, "A", "foo41"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputDesignForExtensionOverridableMethods.java"), expected);
@@ -94,15 +94,15 @@ public class DesignForExtensionCheckTest
     @Test
     public void testIgnoredAnnotationsOption() throws Exception {
         final String[] expected = {
-            "39:5: "
+            "40:5: "
                 + getCheckMessage(MSG_KEY, "InputDesignForExtensionIgnoredAnnotations", "foo1"),
-            "149:5: "
+            "151:5: "
                 + getCheckMessage(MSG_KEY, "InputDesignForExtensionIgnoredAnnotations", "foo21"),
-            "154:5: "
+            "157:5: "
                 + getCheckMessage(MSG_KEY, "InputDesignForExtensionIgnoredAnnotations", "setAge"),
-            "169:5: "
+            "173:5: "
                 + getCheckMessage(MSG_KEY, "InputDesignForExtensionIgnoredAnnotations", "foo24"),
-            "176:5: "
+            "181:5: "
                 + getCheckMessage(MSG_KEY, "InputDesignForExtensionIgnoredAnnotations", "dontUse4"),
         };
         verifyWithInlineConfigParser(
@@ -119,8 +119,8 @@ public class DesignForExtensionCheckTest
     @Test
     public void testNativeMethods() throws Exception {
         final String[] expected = {
-            "16:5: " + getCheckMessage(MSG_KEY, "InputDesignForExtensionNativeMethods", "foo1"),
-            "32:5: " + getCheckMessage(MSG_KEY, "InputDesignForExtensionNativeMethods", "foo6"),
+            "14:5: " + getCheckMessage(MSG_KEY, "InputDesignForExtensionNativeMethods", "foo1"),
+            "31:5: " + getCheckMessage(MSG_KEY, "InputDesignForExtensionNativeMethods", "foo6"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputDesignForExtensionNativeMethods.java"), expected);
@@ -139,10 +139,10 @@ public class DesignForExtensionCheckTest
     public void testRequiredJavadocPhrase() throws Exception {
         final String className = "InputDesignForExtensionRequiredJavadocPhrase";
         final String[] expected = {
-            "41:5: " + getCheckMessage(MSG_KEY, className, "foo5"),
-            "48:5: " + getCheckMessage(MSG_KEY, className, "foo8"),
-            "51:5: " + getCheckMessage(MSG_KEY, className, "foo9"),
-            "67:5: " + getCheckMessage(MSG_KEY, className, "foo12"),
+            "42:5: " + getCheckMessage(MSG_KEY, className, "foo5"),
+            "50:5: " + getCheckMessage(MSG_KEY, className, "foo8"),
+            "54:5: " + getCheckMessage(MSG_KEY, className, "foo9"),
+            "71:5: " + getCheckMessage(MSG_KEY, className, "foo12"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputDesignForExtensionRequiredJavadocPhrase.java"), expected);
@@ -152,7 +152,7 @@ public class DesignForExtensionCheckTest
     public void testRequiredJavadocPhraseMultiLine() throws Exception {
         final String className = "InputDesignForExtensionRequiredJavadocPhraseMultiLine";
         final String[] expected = {
-            "23:5: " + getCheckMessage(MSG_KEY, className, "foo2"),
+            "24:5: " + getCheckMessage(MSG_KEY, className, "foo2"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputDesignForExtensionRequiredJavadocPhraseMultiLine.java"),
@@ -162,7 +162,7 @@ public class DesignForExtensionCheckTest
     @Test
     public void testInterfaceMemberScopeIsPublic() throws Exception {
         final String[] expected = {
-            "15:9: " + getCheckMessage(MSG_KEY, "Inner", "getProperty"),
+            "16:9: " + getCheckMessage(MSG_KEY, "Inner", "getProperty"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputDesignForExtensionInterfaceMemberScopeIsPublic.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheckTest.java
@@ -60,14 +60,14 @@ public class RequireEmptyLineBeforeBlockTagGroupCheckTest extends AbstractModule
     @Test
     public void testIncorrect() throws Exception {
         final String[] expected = {
-            "14: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@since"),
-            "20: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@param"),
-            "28: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@param"),
-            "35: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@return"),
-            "47: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@see"),
-            "63: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@see"),
-            "74: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@param"),
-            "87: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@serial"),
+            "15: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@since"),
+            "22: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@param"),
+            "31: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@param"),
+            "39: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@return"),
+            "52: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@see"),
+            "69: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@see"),
+            "81: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@param"),
+            "95: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@serial"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRequireEmptyLineBeforeBlockTagGroupIncorrect.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtension.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtension.java
@@ -47,7 +47,8 @@ public abstract class InputDesignForExtension
 
     // this one is bad: neither abstract, final, nor empty
 
-    protected void doh() // violation
+    // violation below 'Class 'InputDesignForExtension' looks like designed'
+    protected void doh()
     {
         System.identityHashCode("nonempty and overriding possible");
     }
@@ -101,7 +102,8 @@ public abstract class InputDesignForExtension
     {
     // nonPrivate ctor
     public anotherNonFinalClass(){}
-        public void someMethod() // violation
+        // violation below 'Class 'anotherNonFinalClass' looks like designed'
+        public void someMethod()
         {
         System.identityHashCode("nonempty and overriding is possible");
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionIgnoredAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionIgnoredAnnotations.java
@@ -36,7 +36,8 @@ public class InputDesignForExtensionIgnoredAnnotations {
         return super.toString();
     }
 
-    public int foo1() {return  1;} // violation
+    // violation below 'Class 'InputDesignForExtensionIgnoredAnnotations'
+    public int foo1() {return  1;}
 
     /**
      *
@@ -146,12 +147,14 @@ public class InputDesignForExtensionIgnoredAnnotations {
     @InputDesignForExtensionsLocalAnnotations.ClassRule
     public void foo20() { return; }
 
-    @InputDesignForExtensionsLocalAnnotations.ClassRule // violation
+    // violation below 'Class 'InputDesignForExtensionIgnoredAnnotations'
+    @InputDesignForExtensionsLocalAnnotations.ClassRule
     public void foo21() { return; }
 
     private int age;
 
-    @Inject // violation
+    // violation below 'Class 'InputDesignForExtensionIgnoredAnnotations'
+    @Inject
     public void setAge(int age) {
         this.age = age;
     }
@@ -166,14 +169,16 @@ public class InputDesignForExtensionIgnoredAnnotations {
         foo1();
     }
 
-    public void foo24(@MyAnnotation int a) { // violation
+    // violation below 'Class 'InputDesignForExtensionIgnoredAnnotations'
+    public void foo24(@MyAnnotation int a) {
         foo1();
     }
 
     /**
      * @deprecated
      */
-    <T> T dontUse4() { // violation 'method 'dontUse4' does not have javadoc'
+    // violation below 'Class 'InputDesignForExtensionIgnoredAnnotations'
+    <T> T dontUse4() {
         return null;
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionInterfaceMemberScopeIsPublic.java
@@ -12,7 +12,8 @@ public interface InputDesignForExtensionInterfaceMemberScopeIsPublic {
 
     class Inner {
 
-        public String getProperty() { // violation
+        // violation below 'Class 'Inner' looks like designed'
+        public String getProperty() {
             return null;
         }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionNativeMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionNativeMethods.java
@@ -10,10 +10,8 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 
 public class InputDesignForExtensionNativeMethods {
 
-    // has a potentially complex implementation in native code.
-    // We can't check that, so to be safe DesignForExtension requires
-    // native methods to also be final
-    public native void foo1(); // violation
+    // violation below 'Class 'InputDesignForExtensionNativeMethods'
+    public native void foo1();
 
     public static native void foo2();
 
@@ -29,7 +27,8 @@ public class InputDesignForExtensionNativeMethods {
     /*
      * Violation. Block-commend doc for native method.
      */
-    public native void foo6(); // violation
+    // violation below 'Class 'InputDesignForExtensionNativeMethods'
+    public native void foo6();
 
     @Deprecated
     public native void foo7();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionOverridableMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionOverridableMethods.java
@@ -11,7 +11,8 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 public class InputDesignForExtensionOverridableMethods {
 
     public class A {
-        public int foo1(int a, int b) {return a + b;} // violation
+        // violation below 'Class 'A' looks like designed'
+        public int foo1(int a, int b) {return a + b;}
 
         public void foo2() { }
 
@@ -35,45 +36,52 @@ public class InputDesignForExtensionOverridableMethods {
              */
         }
 
-        public int foo8(int a, int b) { // violation
+        // violation below 'Class 'A' looks like designed'
+        public int foo8(int a, int b) {
             // single-line comment before content
             return a + b;
         }
 
-        public int foo9(int a, int b) { // violation
+        // violation below 'Class 'A' looks like designed'
+        public int foo9(int a, int b) {
             /*
              * block comment before content
              */
             return a + b;
         }
 
-        public int foo10(int a, int b) { // violation
+        // violation below 'Class 'A' looks like designed'
+        public int foo10(int a, int b) {
             /**
              * javadoc block comment before content
              */
             return a + b;
         }
 
-        public int foo11(int a, int b) { // violation
+        // violation below 'Class 'A' looks like designed'
+        public int foo11(int a, int b) {
             return a + b;
             // single-line comment after content
         }
 
-        public int foo12(int a, int b) { // violation
+        // violation below 'Class 'A' looks like designed'
+        public int foo12(int a, int b) {
             return a + b;
             /*
              * block comment after content
              */
         }
 
-        public int foo13(int a, int b) { // violation
+        // violation below 'Class 'A' looks like designed'
+        public int foo13(int a, int b) {
             return a + b;
             /**
              * javadoc block comment after content
              */
         }
 
-        protected int foo14(int a) {return a -1;} // violation
+        // violation below 'Class 'A' looks like designed'
+        protected int foo14(int a) {return a -1;}
 
         public final int foo15(int a) {return a - 2;}
 
@@ -95,13 +103,15 @@ public class InputDesignForExtensionOverridableMethods {
         protected final int foo21(int a) {return a - 2;}
 
         // Single line comment
-        public void foo22() { // violation
+        // violation below 'Class 'A' looks like designed'
+        public void foo22() {
             return;
         }
 
         // Single line comments
         // organized in a block
-        public void foo23() { // violation
+        // violation below 'Class 'A' looks like designed'
+        public void foo23() {
             return;
         }
 
@@ -110,19 +120,22 @@ public class InputDesignForExtensionOverridableMethods {
         public void foo24() {}
 
         /* Block comment violation */
-        public void foo25() { // violation
+        // violation below 'Class 'A' looks like designed'
+        public void foo25() {
             return;
         }
 
         // Single line comment
-        @Deprecated // violation
+        // violation below 'Class 'A' looks like designed'
+        @Deprecated
         public void foo26() {
             return;
         }
 
         // Single line comments
         // organized in a block
-        @Deprecated // violation
+        // violation below 'Class 'A' looks like designed'
+        @Deprecated
         public void foo27() {
             return;
         }
@@ -134,7 +147,8 @@ public class InputDesignForExtensionOverridableMethods {
         }
 
         /* Block comment violation */
-        @Deprecated // violation
+        // violation below 'Class 'A' looks like designed'
+        @Deprecated
         public void foo29() {
             return;
         }
@@ -156,7 +170,8 @@ public class InputDesignForExtensionOverridableMethods {
         }
 
         /* */
-        public int foo31() { // violation
+        // violation below 'Class 'A' looks like designed'
+        public int foo31() {
             /** */
             return 1;
         }
@@ -167,13 +182,15 @@ public class InputDesignForExtensionOverridableMethods {
             return 1;
         }
 
-        @Deprecated // violation
+        // violation below 'Class 'A' looks like designed'
+        @Deprecated
         /** */
         public int foo33() {
             return 1;
         }
 
-        @Deprecated // violation
+        // violation below 'Class 'A' looks like designed'
+        @Deprecated
         /* */
         public int foo34() {
             return 1;
@@ -195,14 +212,16 @@ public class InputDesignForExtensionOverridableMethods {
         // comment
         public void foo38() { }
 
-        @Deprecated /** */ // violation
+        // violation below 'Class 'A' looks like designed'
+        @Deprecated /** */
         public void foo39() {return; }
 
         void foo40() { // no violation: empty body
             /** */
         }
 
-        void foo41() { // violation
+        // violation below 'Class 'A' looks like designed'
+        void foo41() {
             return;
         }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhrase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhrase.java
@@ -37,18 +37,21 @@ public class InputDesignForExtensionRequiredJavadocPhrase {
      */
     public int foo4(int a, int b) {return a + b;}  // ok, required comment pattern in javadoc
 
+    // violation 2 lines below 'Class 'InputDesignForExtensionRequiredJa'
     /** This method can safely be overridden. */
-    public int foo5(int a, int b) {return a + b;} // violation
+    public int foo5(int a, int b) {return a + b;}
 
     public final int foo6(int a) {return a - 2;} // ok, final
 
     protected final int foo7(int a) {return a - 2;} // ok, final
 
+    // violation 2 lines below 'Class 'InputDesignForExtensionRequiredJa'
     /** */
-    public int foo8(int a) {return a - 2;} // violation
+    public int foo8(int a) {return a - 2;}
 
     // This implementation
-    public int foo9(int a, int b) {return a + b;} // violation
+    // violation below 'Class 'InputDesignForExtensionRequiredJa'
+    public int foo9(int a, int b) {return a + b;}
 
     @Deprecated
     protected final int foo10(int a) {return a - 2;} // ok, deprecated
@@ -63,8 +66,9 @@ public class InputDesignForExtensionRequiredJavadocPhrase {
      */
     public int foo11(int a, int b) {return a + b;} // ok, required comment pattern in javadoc
 
+    // violation 2 lines below 'Class 'InputDesignForExtensionRequiredJa'
     /**This method can safely be overridden. */
-    public int foo12(int a, int b) {  // violation
+    public int foo12(int a, int b) {
         return a + b;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhraseMultiLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhraseMultiLine.java
@@ -17,10 +17,11 @@ public class InputDesignForExtensionRequiredJavadocPhraseMultiLine {
         return a * b;
     }
 
+    // violation 4 lines below 'Class 'InputDesignForExtensionRequiredJa'
     /**
      * This method can safely be overridden.
      */
-    public int foo2(int a, int b) {  // violation
+    public int foo2(int a, int b) {
         return a + b;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/requireemptylinebeforeblocktaggroup/InputRequireEmptyLineBeforeBlockTagGroupIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/requireemptylinebeforeblocktaggroup/InputRequireEmptyLineBeforeBlockTagGroupIncorrect.java
@@ -9,30 +9,34 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.requireemptylinebeforeblo
 
 import java.io.IOException;
 
+// violation 3 lines below 'Javadoc tag '@since' should be preceded'
 /**
  * Some Javadoc.
- * @since 8.36 // violation
+ * @since 8.36
  */
 class InputRequireEmptyLineBeforeBlockTagGroupIncorrect {
 
+    // violation 3 lines below 'Javadoc tag '@param' should be preceded'
     /**
      * This documents the private method.
-     * @param thisParamTagNeedsNewline this documents the parameter. // violation
+     * @param thisParamTagNeedsNewline this documents the parameter.
      */
     private boolean paramTagNeedsNewline(boolean thisParamTagNeedsNewline) {
         return false;
     }
 
+    // violation 3 lines below 'Javadoc tag '@param' should be preceded'
     /**
      * This documents the private method.
-     * @param thisParamTagNeedsNewline this documents the parameter. // violation
+     * @param thisParamTagNeedsNewline this documents the parameter.
      * @return this one does not need an empty line, but the tag before this one does.
      */
     private boolean paramMultiTagNeedsNewline(boolean thisParamTagNeedsNewline) {
         return false;
     }
 
-    /**@return clientPort return clientPort if there is another ZK backup can run // violation
+    // violation 1 lines below 'Javadoc tag '@return' should be preceded'
+    /**@return clientPort return clientPort if there is another ZK backup can run
      *         when killing the current active; return -1, if there is no backups.
      * @throws IOException
      * @throws InterruptedException
@@ -42,9 +46,10 @@ class InputRequireEmptyLineBeforeBlockTagGroupIncorrect {
         return 0;
     }
     
+    // violation 3 lines below 'Javadoc tag '@see' should be preceded'
     /**
       * Resolve the entity.
-      * @see org.xml.sax.EntityResolver#resolveEntity(String, String). // violation
+      * @see org.xml.sax.EntityResolver#resolveEntity(String, String).
       * @param publicId The public identifier, or <code>null</code>
       *                 if none is available.
       * @param systemId The system identifier provided in the XML
@@ -57,21 +62,23 @@ class InputRequireEmptyLineBeforeBlockTagGroupIncorrect {
         return 0;
     }
 
+    // violation 4 lines below 'Javadoc tag '@see' should be preceded'
     /**
     * This {@link Collections#shuffle} is a valid link
     * and the check counts this as a usage.
-    * @see Arrays#sort   // violation
+    * @see Arrays#sort
     * @throws IllegalAccessError::new
     */
     public static void n() {}
     
+    // violation 7 lines below 'Javadoc tag '@param' should be preceded'
     /**
      * Parse the expected and actual content strings as XML and assert that the
      * two are "similar" -- i.e. they contain the same elements and attributes
      * regardless of order.
      * <p>Use of this method assumes the
      * <a href="http://xmlunit.sourceforge.net/">XMLUnit<a/> library is available.
-     * @param expected the expected XML content   // violation
+     * @param expected the expected XML content
      * @param actual the actual XML content
      * @see org.springframework.test.web.servlet#xpath(String, Object...)
      * @see org.springframework.test.web.servlet#xpath(String, Map, Object...)
@@ -81,10 +88,11 @@ class InputRequireEmptyLineBeforeBlockTagGroupIncorrect {
     }
 }
 
+// violation 4 lines below 'Javadoc tag '@serial' should be preceded'
 /**
 * This class is used by the query-building mechanism to represent binary
 * operations.
-* @serial include      // violation
+* @serial include
 *
 * @since 1.5
 */

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckExamplesTest.java
@@ -34,9 +34,9 @@ public class DesignForExtensionCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "14:3: " + getCheckMessage(MSG_KEY, "Example1", "m1"),
-            "16:3: " + getCheckMessage(MSG_KEY, "Example1", "m2"),
-            "41:3: " + getCheckMessage(MSG_KEY, "Example1", "toString"),
+            "15:3: " + getCheckMessage(MSG_KEY, "Example1", "m1"),
+            "18:3: " + getCheckMessage(MSG_KEY, "Example1", "m2"),
+            "43:3: " + getCheckMessage(MSG_KEY, "Example1", "toString"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -45,8 +45,8 @@ public class DesignForExtensionCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "16:3: " + getCheckMessage(MSG_KEY, "Example2", "m1"),
-            "18:3: " + getCheckMessage(MSG_KEY, "Example2", "m2"),
+            "17:3: " + getCheckMessage(MSG_KEY, "Example2", "m1"),
+            "20:3: " + getCheckMessage(MSG_KEY, "Example2", "m2"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -55,11 +55,11 @@ public class DesignForExtensionCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "16:3: " + getCheckMessage(MSG_KEY, "Example3", "m1"),
-            "18:3: " + getCheckMessage(MSG_KEY, "Example3", "m2"),
-            "35:3: " + getCheckMessage(MSG_KEY, "Example3", "m7"),
-            "41:3: " + getCheckMessage(MSG_KEY, "Example3", "m8"),
-            "43:3: " + getCheckMessage(MSG_KEY, "Example3", "toString"),
+            "17:3: " + getCheckMessage(MSG_KEY, "Example3", "m1"),
+            "20:3: " + getCheckMessage(MSG_KEY, "Example3", "m2"),
+            "37:3: " + getCheckMessage(MSG_KEY, "Example3", "m7"),
+            "43:3: " + getCheckMessage(MSG_KEY, "Example3", "m8"),
+            "45:3: " + getCheckMessage(MSG_KEY, "Example3", "toString"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -68,10 +68,10 @@ public class DesignForExtensionCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "17:3: " + getCheckMessage(MSG_KEY, "Example4", "m1"),
-            "19:3: " + getCheckMessage(MSG_KEY, "Example4", "m2"),
-            "36:3: " + getCheckMessage(MSG_KEY, "Example4", "m7"),
-            "44:3: " + getCheckMessage(MSG_KEY, "Example4", "toString"),
+            "18:3: " + getCheckMessage(MSG_KEY, "Example4", "m1"),
+            "21:3: " + getCheckMessage(MSG_KEY, "Example4", "m2"),
+            "38:3: " + getCheckMessage(MSG_KEY, "Example4", "m7"),
+            "46:3: " + getCheckMessage(MSG_KEY, "Example4", "toString"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example1.java
@@ -11,9 +11,11 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 public abstract class Example1 {
   private int bar;
 
-  public int m1() {return 2;}  // violation
+  // violation below 'Class 'Example1' looks like designed for extension'
+  public int m1() {return 2;}
 
-  public int m2() {return 8;}  // violation
+  // violation below 'Class 'Example1' looks like designed for extension'
+  public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.
 
@@ -37,8 +39,8 @@ public abstract class Example1 {
    * implementation ...
    */
   public int m8() {return 2;}  // ok, Have javadoc on overridable method.
-
-  @Override                   // violation
+  // violation below 'Class 'Example1' looks like designed for extension'
+  @Override
   public String toString() {
     return "";
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example2.java
@@ -13,9 +13,11 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 public abstract class Example2 {
   private int bar;
 
-  public int m1() {return 2;}  // violation
+  // violation below 'Class 'Example2' looks like designed for extension'
+  public int m1() {return 2;}
 
-  public int m2() {return 8;}  // violation
+  // violation below 'Class 'Example2' looks like designed for extension'
+  public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example3.java
@@ -13,9 +13,11 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 public abstract class Example3 {
   private int bar;
 
-  public int m1() {return 2;}  // violation
+  // violation below 'Class 'Example3' looks like designed for extension'
+  public int m1() {return 2;}
 
-  public int m2() {return 8;}  // violation
+  // violation below 'Class 'Example3' looks like designed for extension'
+  public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.
 
@@ -31,16 +33,16 @@ public abstract class Example3 {
 
   /**
    * Some comments ...
-   */
-  public int m7() {return 1;}  // violation
+   */ // violation below 'Class 'Example3' looks like designed for extension'
+  public int m7() {return 1;}
 
   /**
    * This
    * implementation ...
-   */
-  public int m8() {return 2;}  // violation
-
-  @Override                    // violation
+   */ // violation below 'Class 'Example3' looks like designed for extension'
+  public int m8() {return 2;}
+  // violation below 'Class 'Example3' looks like designed for extension'
+  @Override
   public String toString() {
     return "";
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example4.java
@@ -14,9 +14,11 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 public abstract class Example4 {
   private int bar;
 
-  public int m1() {return 2;}  // violation
+  // violation below 'Class 'Example4' looks like designed for extension'
+  public int m1() {return 2;}
 
-  public int m2() {return 8;}  // violation
+  // violation below 'Class 'Example4' looks like designed for extension'
+  public int m2() {return 8;}
 
   private void m3() {m4();}
 
@@ -32,16 +34,16 @@ public abstract class Example4 {
 
   /**
    * Some comments ...
-   */
-  public int m7() {return 1;}  // violation
+   */ // violation below 'Class 'Example4' looks like designed for extension'
+  public int m7() {return 1;}
 
   /**
    * This
    * implementation ...
    */
   public int m8() {return 2;}  // ok, Have required javadoc.
-
-  @Override                    // violation
+  // violation below 'Class 'Example4' looks like designed for extension'
+  @Override
   public String toString() {
     return "";
   }


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed DesignForExtensionCheck  and RequireEmptyLineBeforeBlockTagGroupCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in DesignForExtensionCheckest and RequireEmptyLineBeforeBlockTagGroupCheckTest
- Defined violation messages in InputDesignForExtensionCheck  and InputRequireEmptyLineBeforeBlockTagGroupCheckTest files