### PR TITLE
Issue #15456: specify violation messgaes for AbstractJavadocCheckTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -264,8 +264,6 @@ public final class InlineConfigParser {
      */
     private static final Set<String> SUPPRESSED_CHECKS = Set.of(
             "com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc."
-                    + "AbstractJavadocCheckTest$TokenIsNotInAcceptablesCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocTokensFail.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocTokensFail.java
@@ -6,6 +6,7 @@ javadocTokens: RETURN_BLOCK_TAG
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.abstractjavadoc;
 
+// violation 2 lines below 'Javadoc Token "RETURN_BLOCK_TAG" was not found'
 /** Javadoc */
-public class InputAbstractJavadocTokensFail { // violation
+public class InputAbstractJavadocTokensFail {
 }


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed AbstractJavadocCheckTest$TokenIsNotInAcceptablesCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Defined violation messages in InputAbstractJavadocTokensFail.java