### PR TITLE
Issue #19933: followup PR for review fixes

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -143,6 +143,7 @@ public class XdocsExamplesAstConsistencyTest {
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
         // until https://github.com/checkstyle/checkstyle/issues/20625
+        "checks/javadoc/atclauseorder",
         "checks/annotation/annotationlocation",
         "checks/annotation/suppresswarnings",
         "checks/blocks/leftcurly",
@@ -200,6 +201,7 @@ public class XdocsExamplesAstConsistencyTest {
      */
     private static final Set<String> EXAMPLE_PROPERTY_COVERAGE_SUPPRESSED_MODULES = Set.of(
             // until https://github.com/checkstyle/checkstyle/issues/20624
+            "checks/regexp/regexp",
             "checks/imports/illegalimport",
             "checks/javadoc/javadoctype",
             "checks/javadoc/javadocvariable",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -2886,11 +2886,11 @@ public class XdocsPagesTest {
     }
 
     private static boolean hasAnyUseCaseId(Document doc) {
-        final NodeList allElements = doc.getElementsByTagName("*");
+        final NodeList allParagraphElements = doc.getElementsByTagName("p");
         boolean found = false;
 
-        for (int index = 0; !found && index < allElements.getLength(); index++) {
-            final Element element = (Element) allElements.item(index);
+        for (int index = 0; !found && index < allParagraphElements.getLength(); index++) {
+            final Element element = (Element) allParagraphElements.item(index);
             final String id = element.getAttribute("id");
             if (id != null && id.startsWith("UseCase")) {
                 found = true;


### PR DESCRIPTION
#19933

Optimize `hasAnyUseCaseId `to scan only <p> elements instead of every element in the document, since `UseCase `ids only ever appear on `<p>` tags.

```
[INFO] Running com.puppycrawl.tools.checkstyle.internal.XdocsExamplesAstConsistencyTest
line 2:26 token recognition error at: ''Pr'
[ERROR] Tests run: 4, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 1.603 s <<< FAILURE! -- in com.puppycrawl.tools.checkstyle.internal.XdocsExamplesAstConsistencyTest
[ERROR] com.puppycrawl.tools.checkstyle.internal.XdocsExamplesAstConsistencyTest.testExampleCountMatchesPropertyCount -- Time elapsed: 0.300 s <<< FAILURE!
Found 1 module(s) whose example count does not match property count + 1.

Directory: checks/javadoc/atclauseorder
Properties: 3
Expected AST-matching examples (at least): 4
Actual largest AST-matching group: 3 (of 3 total example files)

If intentional, add to EXAMPLE_COUNT_SUPPRESSED_MODULES.

expected to be empty
but was:
    [Directory: checks/javadoc/atclauseorder
    Properties: 3
    Expected AST-matching examples (at least): 4
    Actual largest AST-matching group: 3 (of 3 total example files)]
	at com.puppycrawl.tools.checkstyle.internal.XdocsExamplesAstConsistencyTest.testExampleCountMatchesPropertyCount(XdocsExamplesAstConsistencyTest.java:386)

[ERROR] com.puppycrawl.tools.checkstyle.internal.XdocsExamplesAstConsistencyTest.testEveryPropertyHasAnExample -- Time elapsed: 0.083 s <<< FAILURE!
Found 1 module(s) with a documented property not covered by any example.

Directory: checks/regexp/regexp
Documented properties: [duplicateLimit, errorLimit, format, ignoreComments, illegalPattern, message]
Properties with no covering example: [errorLimit, message, duplicateLimit]

If intentional add to EXAMPLE_PROPERTY_COVERAGE_SUPPRESSED_MODULES.

expected to be empty
but was:
    [Directory: checks/regexp/regexp
    Documented properties: [duplicateLimit, errorLimit, format, ignoreComments, illegalPattern, message]
    Properties with no covering example: [errorLimit, message, duplicateLimit]]
	at com.puppycrawl.tools.checkstyle.internal.XdocsExamplesAstConsistencyTest.testEveryPropertyHasAnExample(XdocsExamplesAstConsistencyTest.java:414)


```

Also I see after merge , 2 more suppressions required as AST test was failing.
Updated the suppression list as other PRs will also get affected by this
<img width="1052" height="532" alt="image" src="https://github.com/user-attachments/assets/049b7e42-a542-4334-a2ee-d8b0dd1c867c" />
