### PR TITLE
Issue #15456: specify violation messages for JavadocBlockTagLocationC…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -264,7 +264,6 @@ public final class InlineConfigParser {
      */
     private static final Set<String> SUPPRESSED_CHECKS = Set.of(
             "com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
@@ -74,13 +74,13 @@ public class JavadocBlockTagLocationCheckTest extends AbstractModuleTestSupport 
     @Test
     public void testIncorrect() throws Exception {
         final String[] expected = {
-            "22: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "author"),
-            "23: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "since"),
-            "24: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "param"),
-            "26: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "throws"),
-            "27: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "see"),
-            "28: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "return"),
-            "28: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "throws"),
+            "23: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "author"),
+            "24: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "since"),
+            "25: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "param"),
+            "27: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "throws"),
+            "28: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "see"),
+            "29: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "return"),
+            "29: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "throws"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocBlockTagLocationIncorrect.java"), expected);
@@ -89,12 +89,12 @@ public class JavadocBlockTagLocationCheckTest extends AbstractModuleTestSupport 
     @Test
     public void testCustomTags() throws Exception {
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
-            "20: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
-            "20: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
-            "22: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
-            "23: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
-            "24: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
+            "21: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
+            "21: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
+            "21: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
+            "23: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
+            "24: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implNote"),
+            "25: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "implSpec"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocBlockTagLocationCustomTags.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCustomTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationCustomTags.java
@@ -10,12 +10,13 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
 public class InputJavadocBlockTagLocationCustomTags {
 
-    // violation 7 lines below ''@apiNote' should be placed at the beginning'
-    // violation 6 lines below ''@implNote' should be placed at the beginning'
-    // violation 5 lines below ''@implSpec' should be placed at the beginning'
-    // violation 6 lines below ''@apiNote' should be placed at the beginning'
-    // violation 6 lines below ''@implNote' should be placed at the beginning'
-    // violation 6 lines below ''@implSpec' should be placed at the beginning'
+    // 3 violations 8 lines below:
+    //     'The Javadoc block tag '@apiNote' should be placed'
+    //     'The Javadoc block tag '@implNote' should be placed'
+    //     'The Javadoc block tag '@implSpec' should be placed'
+    // violation 6 lines below 'The Javadoc block tag '@apiNote' should be placed'
+    // violation 6 lines below 'The Javadoc block tag '@implNote' should be placed'
+    // violation 6 lines below 'The Javadoc block tag '@implSpec' should be placed'
     /**
      * Text. @apiNote note @implNote note @implSpec spec
      * {@code @apiNote}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/InputJavadocBlockTagLocationIncorrect.java
@@ -11,13 +11,14 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
 public class InputJavadocBlockTagLocationIncorrect {
 
-    // violation 8 lines below ''@author' should be placed at the beginning'
-    // violation 8 lines below ''@since' should be placed at the beginning'
-    // violation 8 lines below ''@param' should be placed at the beginning'
-    // violation 9 lines below ''@throws' should be placed at the beginning'
-    // violation 9 lines below ''@see' should be placed at the beginning'
-    // violation 9 lines below ''@return' should be placed at the beginning'
-    // violation 8 lines below ''@throws' should be placed at the beginning'
+    // violation 9 lines below 'The Javadoc block tag '@author' should be placed'
+    // violation 9 lines below 'The Javadoc block tag '@since' should be placed'
+    // violation 9 lines below 'The Javadoc block tag '@param' should be placed'
+    // violation 10 lines below 'The Javadoc block tag '@throws' should be placed'
+    // violation 10 lines below 'The Javadoc block tag '@see' should be placed'
+    // 2 violations 10 lines below:
+    //     'The Javadoc block tag '@return' should be placed'
+    //     'The Javadoc block tag '@throws' should be placed'
     /**
      * Summary. @author me
      * <p>Text</p> @since 1.0


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed JavadocBlockTagLocationCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in JavadocBlockTagLocationCheckTest
- Defined violation messages in InputJavadocBlockTagLocationCheck files