### PR TITLE
Issue #15456: specify violation messages for MissingJavadocTypeCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -264,7 +264,6 @@ public final class InlineConfigParser {
      */
     private static final Set<String> SUPPRESSED_CHECKS = Set.of(
             "com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc"
                     + ".RequireEmptyLineBeforeBlockTagGroupCheck"
     );

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
@@ -70,9 +70,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTagsOne() throws Exception {
         final String[] expected = {
-            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "45:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "70:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "47:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "73:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeTagsOne.java"), expected);
@@ -81,7 +81,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTagsTwo() throws Exception {
         final String[] expected = {
-            "21:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeTagsTwo.java"), expected);
@@ -90,7 +90,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTagsThree() throws Exception {
         final String[] expected = {
-            "21:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeTagsThree.java"), expected);
@@ -99,7 +99,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTagsFour() throws Exception {
         final String[] expected = {
-            "21:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeTagsFour.java"), expected);
@@ -108,9 +108,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testInner() throws Exception {
         final String[] expected = {
-            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "27:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "33:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "29:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "36:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeInner.java"), expected);
@@ -119,10 +119,10 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypePublicOnly1One() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "21:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "41:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "45:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypePublicOnly1One.java"), expected);
@@ -131,7 +131,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypePublicOnly1Two() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypePublicOnly1Two.java"), expected);
@@ -140,7 +140,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypePublicOnly2One() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypePublicOnly2One.java"), expected);
@@ -149,7 +149,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypePublicOnly2Two() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypePublicOnly2Two.java"), expected);
@@ -158,8 +158,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPublic() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "45:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "47:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeScopeInnerInterfaces1.java"),
@@ -169,10 +169,10 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testProtest() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "36:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "45:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "72:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "48:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "76:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeScopeInnerInterfaces2.java"),
@@ -182,9 +182,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPkg() throws Exception {
         final String[] expected = {
-            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "25:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "27:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "30:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeScopeInnerClasses1.java"), expected);
@@ -193,7 +193,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testEclipse() throws Exception {
         final String[] expected = {
-            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeScopeInnerClasses2.java"), expected);
@@ -202,10 +202,10 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testScopesOne() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "26:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "50:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "28:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "41:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "54:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc1One.java"),
@@ -215,13 +215,13 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testScopesTwo() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "16:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "27:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "39:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "51:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "63:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "75:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "30:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "43:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "56:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "69:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "82:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc1Two.java"),
@@ -231,7 +231,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testLimitViolationsBySpecifyingTokens() throws Exception {
         final String[] expected = {
-            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadocOnInterface.java"),
@@ -241,8 +241,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypeNoJavadoc2One() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "26:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "28:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc2One.java"),
@@ -252,7 +252,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypeNoJavadoc2Two() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc2Two.java"),
@@ -262,8 +262,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypeNoJavadoc3One() throws Exception {
         final String[] expected = {
-            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "50:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "52:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc3One.java"),
@@ -273,12 +273,12 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypeNoJavadoc3Two() throws Exception {
         final String[] expected = {
-            "16:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "27:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "39:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "51:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "63:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "75:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "17:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "29:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "42:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "55:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "68:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "81:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNoJavadoc3Two.java"),
@@ -297,9 +297,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testSkipAnnotationsDefault() throws Exception {
 
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "18:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "22:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeSkipAnnotations1.java"),
@@ -309,9 +309,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testSkipAnnotationsWithFullyQualifiedName() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "18:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "22:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeSkipAnnotations2.java"),
@@ -331,9 +331,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testSkipAnnotationsNotAllowed() throws Exception {
 
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "18:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "22:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeSkipAnnotations4.java"),
@@ -344,13 +344,13 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testMissingJavadocTypeCheckRecords() throws Exception {
 
         final String[] expected = {
-            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "32:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "33:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "42:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "28:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "37:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "49:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeRecords.java"),
@@ -361,9 +361,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testInterfaceMemberScopeIsPublic() throws Exception {
 
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeInterfaceMemberScopeIsPublic.java"),
@@ -385,7 +385,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testQualifiedAnnotation2() throws Exception {
         final String[] expected = {
             "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeQualifiedAnnotation2.java"), expected);
@@ -421,8 +421,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMultipleQualifiedAnnotation() throws Exception {
         final String[] expected = {
-            "30:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "39:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "31:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "41:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeMultipleQualifiedAnnotation.java"), expected);
@@ -444,8 +444,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypeAboveComments() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "28:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "15:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "30:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeAboveComments.java"),
@@ -455,10 +455,10 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testNonJavadocBlockCommentDoesNotSatisfyJavadoc() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "25:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "29:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocTypeNonJavadocOnly.java"),
@@ -468,8 +468,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testMissingJavadocTypeEnum() throws Exception {
         final String[] expected = {
-            "36:6: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "49:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "37:6: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "51:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
         verifyWithInlineConfigParser(
             getPath("InputMissingJavadocTypeEnum.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeAboveComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeAboveComments.java
@@ -11,7 +11,8 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypeAboveComments { // violation, 'Missing a Javadoc comment.'
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypeAboveComments {
 
     /**
      *
@@ -25,7 +26,8 @@ public class InputMissingJavadocTypeAboveComments { // violation, 'Missing a Jav
      */
     public class Myclass { } /* My class */
 
-    public class Myclass2 { } // violation, 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    public class Myclass2 { }
 
     /**
      *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeEnum.java
@@ -33,7 +33,8 @@ public class InputMissingJavadocTypeEnum {
                 T value);
     }
 
-     enum Test2 { // violation 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+     enum Test2 {
         TEST_2 {
             @Override
             <T> void method(
@@ -46,7 +47,8 @@ public class InputMissingJavadocTypeEnum {
 
     ; /** @deprecated */ ;
 
-    static class A { // violation 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    static class A {
 
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInner.java
@@ -17,20 +17,23 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 class InputMissingJavadocTypeInner
 {
     // Ignore - two violations
-    class InnerInner2 // violation
+    // violation below 'Missing a Javadoc comment.'
+    class InnerInner2
     {
         // Ignore
         public int fData;
     }
 
     // Ignore - 2 violations
-    interface InnerInterface2 // violation
+    // violation below 'Missing a Javadoc comment.'
+    interface InnerInterface2
     {
         // Ignore - should be all upper case
         String data = "zxzc";
 
         // Ignore
-        class InnerInterfaceInnerClass // violation
+        // violation below 'Missing a Javadoc comment.'
+        class InnerInterfaceInnerClass
         {
             // Ignore - need Javadoc and made private
             public int rData;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInterfaceMemberScopeIsPublic.java
@@ -11,13 +11,16 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public interface InputMissingJavadocTypeInterfaceMemberScopeIsPublic { // violation
+// violation below 'Missing a Javadoc comment.'
+public interface InputMissingJavadocTypeInterfaceMemberScopeIsPublic {
 
-    enum Enum { // violation
+    // violation below 'Missing a Javadoc comment.'
+    enum Enum {
 
     }
 
-    class Class { // violation
+    // violation below 'Missing a Javadoc comment.'
+    class Class {
 
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeMultipleQualifiedAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeMultipleQualifiedAnnotation.java
@@ -27,7 +27,8 @@ public class InputMissingJavadocTypeMultipleQualifiedAnnotation {
     @Ann3
     public interface A { }
 
-    @Ann2 // violation 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    @Ann2
     @Ann3
     public interface B { }
 
@@ -36,7 +37,8 @@ public class InputMissingJavadocTypeMultipleQualifiedAnnotation {
     @Ann1
     public interface C { }
 
-    @AnnClass.Ann1 // violation 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    @AnnClass.Ann1
     @Ann2
     @Ann3
     public interface D { }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc1One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc1One.java
@@ -11,7 +11,8 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypeNoJavadoc1One // violation
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypeNoJavadoc1One
 {
     public int i1;
     protected int i2;
@@ -23,7 +24,8 @@ public class InputMissingJavadocTypeNoJavadoc1One // violation
     void foo3() {}
     private void foo4() {}
 
-    protected class ProtectedInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    protected class ProtectedInner {
         public int i1;
         protected int i2;
         int i3;
@@ -35,7 +37,8 @@ public class InputMissingJavadocTypeNoJavadoc1One // violation
         private void foo4() {}
     }
 
-    class PackageInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    class PackageInner {
         public int i1;
         protected int i2;
         int i3;
@@ -47,7 +50,8 @@ public class InputMissingJavadocTypeNoJavadoc1One // violation
         private void foo4() {}
     }
 
-    private class PrivateInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    private class PrivateInner {
         public int i1;
         protected int i2;
         int i3;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc1Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc1Two.java
@@ -11,9 +11,11 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypeNoJavadoc1Two {} // violation
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypeNoJavadoc1Two {}
 
-class PackageClass1 { // violation
+// violation below 'Missing a Javadoc comment.'
+class PackageClass1 {
     public int i1;
     protected int i2;
     int i3;
@@ -24,7 +26,8 @@ class PackageClass1 { // violation
     void foo3() {}
     private void foo4() {}
 
-    public class PublicInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    public class PublicInner {
         public int i1;
         protected int i2;
         int i3;
@@ -36,7 +39,8 @@ class PackageClass1 { // violation
         private void foo4() {}
     }
 
-    protected class ProtectedInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    protected class ProtectedInner {
         public int i1;
         protected int i2;
         int i3;
@@ -48,7 +52,8 @@ class PackageClass1 { // violation
         private void foo4() {}
     }
 
-    class PackageInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    class PackageInner {
         public int i1;
         protected int i2;
         int i3;
@@ -60,7 +65,8 @@ class PackageClass1 { // violation
         private void foo4() {}
     }
 
-    private class PrivateInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    private class PrivateInner {
         public int i1;
         protected int i2;
         int i3;
@@ -72,7 +78,8 @@ class PackageClass1 { // violation
         private void foo4() {}
     }
 
-    class IgnoredName { // violation
+    // violation below 'Missing a Javadoc comment.'
+    class IgnoredName {
         // ignore by name
         private int logger;
         // no warning, 'serialVersionUID' fields do not require Javadoc

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2One.java
@@ -11,7 +11,8 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypeNoJavadoc2One // violation
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypeNoJavadoc2One
 {
     public int i1;
     protected int i2;
@@ -23,7 +24,8 @@ public class InputMissingJavadocTypeNoJavadoc2One // violation
     void foo3() {}
     private void foo4() {}
 
-    protected class ProtectedInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    protected class ProtectedInner {
         public int i1;
         protected int i2;
         int i3;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc2Two.java
@@ -11,7 +11,8 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypeNoJavadoc2Two {} // violation
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypeNoJavadoc2Two {}
 
 class PackageClass2 {
     public int i1;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3One.java
@@ -35,7 +35,8 @@ public class InputMissingJavadocTypeNoJavadoc3One
         private void foo4() {}
     }
 
-    class PackageInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    class PackageInner {
         public int i1;
         protected int i2;
         int i3;
@@ -47,7 +48,8 @@ public class InputMissingJavadocTypeNoJavadoc3One
         private void foo4() {}
     }
 
-    private class PrivateInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    private class PrivateInner {
         public int i1;
         protected int i2;
         int i3;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadoc3Two.java
@@ -13,7 +13,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 public class InputMissingJavadocTypeNoJavadoc3Two {}
 
-class PackageClass3 { // violation
+// violation below 'Missing a Javadoc comment.'
+class PackageClass3 {
     public int i1;
     protected int i2;
     int i3;
@@ -24,7 +25,8 @@ class PackageClass3 { // violation
     void foo3() {}
     private void foo4() {}
 
-    public class PublicInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    public class PublicInner {
         public int i1;
         protected int i2;
         int i3;
@@ -36,7 +38,8 @@ class PackageClass3 { // violation
         private void foo4() {}
     }
 
-    protected class ProtectedInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    protected class ProtectedInner {
         public int i1;
         protected int i2;
         int i3;
@@ -48,7 +51,8 @@ class PackageClass3 { // violation
         private void foo4() {}
     }
 
-    class PackageInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    class PackageInner {
         public int i1;
         protected int i2;
         int i3;
@@ -60,7 +64,8 @@ class PackageClass3 { // violation
         private void foo4() {}
     }
 
-    private class PrivateInner { // violation
+    // violation below 'Missing a Javadoc comment.'
+    private class PrivateInner {
         public int i1;
         protected int i2;
         int i3;
@@ -72,7 +77,8 @@ class PackageClass3 { // violation
         private void foo4() {}
     }
 
-    class IgnoredName { // violation
+    // violation below 'Missing a Javadoc comment.'
+    class IgnoredName {
         // ignore by name
         private int logger;
         // no warning, 'serialVersionUID' fields do not require Javadoc

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadocOnInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadocOnInterface.java
@@ -13,5 +13,6 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 class InputMissingJavadocTypeNoJavadocOnInterface { // no violation,
     // CLASS_DEF not in the list of tokens
-    interface NoJavadoc {} // violation
+    // violation below 'Missing a Javadoc comment.'
+    interface NoJavadoc {}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNonJavadocOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNonJavadocOnly.java
@@ -10,19 +10,23 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 */
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypeNonJavadocOnly { // violation, 'Missing a Javadoc comment.'
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypeNonJavadocOnly {
     /* This is NOT a Javadoc comment */
-    public class InnerClass { // violation, 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    public class InnerClass {
     }
 
     /*
      This is NOT a Javadoc comment
     */
-    public class InnerClass2 { // violation, 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    public class InnerClass2 {
     }
 
     // This is NOT a Javadoc comment
-    public class InnerClass3 { // violation, 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    public class InnerClass3 {
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1One.java
@@ -11,14 +11,17 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypePublicOnly1One { // violation
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypePublicOnly1One {
 
-    private interface InnerInterface // violation
+    // violation below 'Missing a Javadoc comment.'
+    private interface InnerInterface
     {
         String CONST = "InnerInterface"; // ignore - w.n.r.a.j
         void method(); // ignore - when not relaxed about Javadoc
 
-        class InnerInnerClass // violation
+        // violation below 'Missing a Javadoc comment.'
+        class InnerInnerClass
         {
             private int mData; // ignore - when not relaxed about Javadoc
 
@@ -38,7 +41,8 @@ public class InputMissingJavadocTypePublicOnly1One { // violation
         }
     }
 
-    private class InnerClass // violation
+    // violation below 'Missing a Javadoc comment.'
+    private class InnerClass
     {
         private int mDiff; // ignore - when not relaxed about Javadoc
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly1Two.java
@@ -11,7 +11,8 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypePublicOnly1Two // violation
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypePublicOnly1Two
 {
     private int mSize; // ignore - when not relaxed about Javadoc
     int mLen; // ignore - when not relaxed about Javadoc

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2One.java
@@ -11,7 +11,8 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypePublicOnly2One // violation
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypePublicOnly2One
 {
     private interface InnerInterface
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypePublicOnly2Two.java
@@ -11,7 +11,8 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypePublicOnly2Two // violation
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypePublicOnly2Two
 {
     private int mSize; // ignore - when not relaxed about Javadoc
     int mLen; // ignore - when not relaxed about Javadoc

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation2.java
@@ -21,7 +21,8 @@ public class InputMissingJavadocTypeQualifiedAnnotation2 {
     @InputMissingJavadocTypeQualifiedAnnotation2.SomeAnnotation
     public interface B { }
 
-    @com.puppycrawl.tools.checkstyle.checks.javadoc // violation 'Missing a Javadoc comment.'
+    // violation below 'Missing a Javadoc comment.'
+    @com.puppycrawl.tools.checkstyle.checks.javadoc
         .missingjavadoctype.InputMissingJavadocTypeQualifiedAnnotation2.SomeAnnotation
     public interface C { }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeRecords.java
@@ -12,16 +12,20 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public record InputMissingJavadocTypeRecords() { // violation
-    class TestClass { // violation
+// violation below 'Missing a Javadoc comment.'
+public record InputMissingJavadocTypeRecords() {
+    // violation below 'Missing a Javadoc comment.'
+    class TestClass {
     }
 
     //no javadoc here
-    record MyRecord1() { // violation
+    // violation below 'Missing a Javadoc comment.'
+    record MyRecord1() {
 
     }
 
-    record MyRecord2(String myString) { // violation
+    // violation below 'Missing a Javadoc comment.'
+    record MyRecord2(String myString) {
 
         public MyRecord2 {
         }
@@ -29,8 +33,10 @@ public record InputMissingJavadocTypeRecords() { // violation
 
     @NonNull1
     record MyRecord3(int x) { // ok due to annotation
-        protected record MyRecord4(int y) { // violation
-            private record MyRecord5(int z) { // violation
+        // violation below 'Missing a Javadoc comment.'
+        protected record MyRecord4(int y) {
+            // violation below 'Missing a Javadoc comment.'
+            private record MyRecord5(int z) {
 
             }
 
@@ -39,4 +45,5 @@ public record InputMissingJavadocTypeRecords() { // violation
     }
 }
 
-@interface NonNull1{} // violation
+// violation below 'Missing a Javadoc comment.'
+@interface NonNull1{}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerClasses1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerClasses1.java
@@ -20,11 +20,14 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
  */
 public class InputMissingJavadocTypeScopeInnerClasses1
 {
-    public class InnerPublic // violation
+    // violation below 'Missing a Javadoc comment.'
+    public class InnerPublic
     {
-        protected class InnerProtected // violation
+        // violation below 'Missing a Javadoc comment.'
+        protected class InnerProtected
         {
-            class InnerPackage // violation
+            // violation below 'Missing a Javadoc comment.'
+            class InnerPackage
             {
                 private class InnerPrivate
                 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerClasses2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerClasses2.java
@@ -20,7 +20,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
  */
 public class InputMissingJavadocTypeScopeInnerClasses2
 {
-    public class InnerPublic // violation
+    // violation below 'Missing a Javadoc comment.'
+    public class InnerPublic
     {
         protected class InnerProtected
         {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerInterfaces1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerInterfaces1.java
@@ -11,7 +11,8 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypeScopeInnerInterfaces1 // violation
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypeScopeInnerInterfaces1
 {
     // inner interfaces with different scopes
 
@@ -42,7 +43,8 @@ public class InputMissingJavadocTypeScopeInnerInterfaces1 // violation
         void mb();
     }
 
-    public interface PublicInnerInterface // violation
+    // violation below 'Missing a Javadoc comment.'
+    public interface PublicInnerInterface
     {
         public String CA = "CONST A";
         String CB = "CONST b";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerInterfaces2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeScopeInnerInterfaces2.java
@@ -11,7 +11,8 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-public class InputMissingJavadocTypeScopeInnerInterfaces2 // violation
+// violation below 'Missing a Javadoc comment.'
+public class InputMissingJavadocTypeScopeInnerInterfaces2
 {
     // inner interfaces with different scopes
 
@@ -33,7 +34,8 @@ public class InputMissingJavadocTypeScopeInnerInterfaces2 // violation
         void mb();
     }
 
-    protected interface ProtectedInnerInterface // violation
+    // violation below 'Missing a Javadoc comment.'
+    protected interface ProtectedInnerInterface
     {
         public String CA = "CONST A";
         String CB = "CONST b";
@@ -42,7 +44,8 @@ public class InputMissingJavadocTypeScopeInnerInterfaces2 // violation
         void mb();
     }
 
-    public interface PublicInnerInterface // violation
+    // violation below 'Missing a Javadoc comment.'
+    public interface PublicInnerInterface
     {
         public String CA = "CONST A";
         String CB = "CONST b";
@@ -69,7 +72,8 @@ public class InputMissingJavadocTypeScopeInnerInterfaces2 // violation
     MyInterface2 {
     }
 
-    protected // violation
+    // violation below 'Missing a Javadoc comment.'
+    protected
     enum
     MyEnum {
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations1.java
@@ -11,15 +11,18 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-@ThisIsOk1 // violation
+// violation below 'Missing a Javadoc comment.'
+@ThisIsOk1
 class InputMissingJavadocTypeSkipAnnotations1 {
 }
 
-@com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype.ThisIsOk1 // violation
+// violation below 'Missing a Javadoc comment.'
+@com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype.ThisIsOk1
 class InputJavadocTypeSkipAnnotationsFQN1 {
 }
 
-@Generated1(value = "some code generator") // violation
+// violation below 'Missing a Javadoc comment.'
+@Generated1(value = "some code generator")
 class InputJavadocTypeAllowedAnnotationByDefault1 {
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations2.java
@@ -11,15 +11,18 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-@ThisIsOk2 // violation
+// violation below 'Missing a Javadoc comment.'
+@ThisIsOk2
 class InputMissingJavadocTypeSkipAnnotations2 {
 }
 
-@com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype.ThisIsOk2 // violation
+// violation below 'Missing a Javadoc comment.'
+@com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype.ThisIsOk2
 class InputJavadocTypeSkipAnnotationsFQN2 {
 }
 
-@Generated2(value = "some code generator") // violation
+// violation below 'Missing a Javadoc comment.'
+@Generated2(value = "some code generator")
 class InputJavadocTypeAllowedAnnotationByDefault2 {
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeSkipAnnotations4.java
@@ -11,15 +11,18 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-@ThisIsOk4 // violation
+// violation below 'Missing a Javadoc comment.'
+@ThisIsOk4
 class InputMissingJavadocTypeSkipAnnotations4 {
 }
 
-@com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype.ThisIsOk4 // violation
+// violation below 'Missing a Javadoc comment.'
+@com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype.ThisIsOk4
 class InputJavadocTypeSkipAnnotationsFQN4 {
 }
 
-@Generated4(value = "some code generator") // violation
+// violation below 'Missing a Javadoc comment.'
+@Generated4(value = "some code generator")
 class InputJavadocTypeAllowedAnnotationByDefault4 {
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsFour.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsFour.java
@@ -18,7 +18,8 @@ import java.io.IOException;
 public class InputMissingJavadocTypeTagsFour {}
 
 // Tests for Javadoc tags.
-class InputMissingJavadocTypeTags1Four // violation
+// violation below 'Missing a Javadoc comment.'
+class InputMissingJavadocTypeTags1Four
 {
     /**
      * Documenting different causes for the same exception

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsOne.java
@@ -12,7 +12,8 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 import java.io.IOException;
 // Tests for Javadoc tags.
-class InputMissingJavadocTypeTags1One // violation
+// violation below 'Missing a Javadoc comment.'
+class InputMissingJavadocTypeTags1One
 {
      /**
      * @exception WrongException exception w/o class info but matched by name
@@ -42,7 +43,8 @@ class InputMissingJavadocTypeTags1One // violation
         }
 }
 
-enum InputJavadocTypeTagsEnum // violation
+// violation below 'Missing a Javadoc comment.'
+enum InputJavadocTypeTagsEnum
 {
     CONSTANT_A,
 
@@ -67,7 +69,8 @@ enum InputJavadocTypeTagsEnum // violation
     }
 }
 
-@interface InputJavadocTypeTagsAnnotation // violation
+// violation below 'Missing a Javadoc comment.'
+@interface InputJavadocTypeTagsAnnotation
 {
     String someField();
     int A_CONSTANT = 0;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsThree.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsThree.java
@@ -18,7 +18,8 @@ import java.io.IOException;
 public class InputMissingJavadocTypeTagsThree {}
 
 // Tests for Javadoc tags.
-class InputMissingJavadocTypeTags1Three // violation
+// violation below 'Missing a Javadoc comment.'
+class InputMissingJavadocTypeTags1Three
 {
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeTagsTwo.java
@@ -18,7 +18,8 @@ import java.io.IOException;
 public class InputMissingJavadocTypeTagsTwo {}
 
 // Tests for Javadoc tags.
-class InputMissingJavadocTypeTags1Two // violation
+// violation below 'Missing a Javadoc comment.'
+class InputMissingJavadocTypeTags1Two
 {
     // Invalid - should be Javadoc
     private int mMissingJavadoc;


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/15456

### summary

- Removed MissingJavadocTypeCheck from SUPPRESSED_CHECKS of InlineConfigParser.Java
- Modified line numbers of violation messages in MissingJavadocTypeCheckTest
- Defined violation messages in InputMissingJavadocTypeCheck files