### PR TITLE
Issue #20562: Adding LocalFinalVariableName to google_checks.xml

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNamesTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNamesTest.java
@@ -62,4 +62,14 @@ public class LocalVariableNamesTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getNonCompilablePath("InputPatternVariableNameUnnamed.java"));
     }
 
+    @Test
+    public void testLocalFinalVariableNames() throws Exception {
+        verifyWithWholeConfig(getPath("InputLocalFinalVariableName.java"));
+    }
+
+    @Test
+    public void testLocalFinalVariableUnnamed() throws Exception {
+        verifyWithWholeConfig(getNonCompilablePath("InputUnnamedFinalVariables.java"));
+    }
+
 }

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputUnnamedFinalVariables.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputUnnamedFinalVariables.java
@@ -1,0 +1,31 @@
+// non-compiled with javac: Compilable with Java22
+
+package com.google.checkstyle.test.chapter5naming.rule527localvariablenames;
+
+/** Some javadoc. */
+public class InputUnnamedFinalVariables {
+
+  /** Some javadoc. */
+  void foo() {
+    final var _ = 1;
+    final int[] arr = {1, 2, 3};
+
+    int count = 0;
+    for (final int _ : arr) {
+      count++;
+    }
+
+    try {
+      // something
+    } catch (final Error _) {
+      // error handling
+    }
+
+    // violation below 'Local final variable name '_name' must match pattern'
+    final var _name = "test";
+    // violation below 'Local final variable name 'na_me' must match pattern'
+    final var na_me = "test";
+    // violation below 'Local final variable name 'name_' must match pattern'
+    final var name_ = "test";
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalFinalVariableName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalFinalVariableName.java
@@ -1,0 +1,82 @@
+package com.google.checkstyle.test.chapter5naming.rule527localvariablenames;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+/** Some javadoc. */
+public class InputLocalFinalVariableName {
+
+  /** Some javadoc. */
+  void methodWrongNaming() {
+    final int BadName = 1;
+    // violation above 'Local final variable name 'BadName' must match pattern'
+    final int VARIABLE2 = 2;
+    // 2 violations above
+    // 'VARIABLE2' must contain no more than '1' consecutive capital letters.
+    // 'Local final variable name 'VARIABLE2' must match pattern'
+    final String FOO_2 = "foo";
+    // 2 violations above
+    // 'FOO2' must contain no more than '1' consecutive capital letters.
+    // 'Local final variable name 'FOO_2' must match pattern'
+    final String A = "a";
+    // violation above 'Local final variable name 'A' must match pattern'
+    final boolean _wrong = true;
+    // violation above 'Local final variable name '_wrong' must match pattern'
+    final boolean badCharacter$ = true;
+    // violation above 'Local final variable name '.*' must match pattern'
+    final boolean a_a = true;
+    // violation above 'Local final variable name 'a_a' must match pattern'
+    final boolean aA = false;
+    // violation above 'Local final variable name 'aA' must match pattern'
+    final boolean SOLVE6X6 = true;
+    // 2 violations above
+    // 'SOLVE6X6' must contain no more than '1' consecutive capital letters.
+    // 'Local final variable name 'SOLVE6X6' must match pattern'
+  }
+
+  /** Some javadoc. */
+  void methodCorrectNaming() {
+    final int badName = 1;
+
+    final int variable = 2;
+
+    final String foo2 = "foo";
+
+    final String a = "a";
+
+    final boolean wrong = true;
+
+    final boolean badCharacter = true;
+
+    final boolean aa = true;
+
+    final boolean aaA = false;
+
+    final boolean solve6x6 = true;
+  }
+
+  /** Some javadoc. */
+  void foo(final String Name, final int Age) {
+    // 2 violations above
+    // 'Local final variable name 'Name' must match pattern'
+    // 'Local final variable name 'Age' must match pattern'
+    try (final InputStreamReader In = new InputStreamReader(System.in);
+        final OutputStreamWriter Out = new OutputStreamWriter(System.out)) {
+      // violation 2 lines above 'Local final variable name 'In' must match pattern'
+      // violation 2 lines above 'Local final variable name 'Out' must match pattern'
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  /** Some javadoc. */
+  void fooCorrect(final String name, final String age) {
+
+    try (final InputStreamReader in = new InputStreamReader(System.in);
+        final OutputStreamWriter out = new OutputStreamWriter(System.out)) {
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -278,6 +278,12 @@
       <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>
     </module>
+    <module name="LocalFinalVariableName">
+      <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
+      <property name="tokens" value="VARIABLE_DEF, PARAMETER_DEF, RESOURCE"/>
+      <message key="name.invalidPattern"
+               value="Local final variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
     <module name="PatternVariableName">
       <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"

--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml
@@ -165,6 +165,10 @@ class UseCase1 {
       <subsection name="Example of Usage" id="LocalFinalVariableName_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LocalFinalVariableName">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LocalFinalVariableName">
             Sun Style</a>
           </li>

--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml.template
@@ -80,6 +80,10 @@
       <subsection name="Example of Usage" id="LocalFinalVariableName_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LocalFinalVariableName">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LocalFinalVariableName">
             Sun Style</a>
           </li>

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -2046,6 +2046,14 @@
                   <span class="wrapper inline">
                     <img src="images/ok_green.png" alt="" />
                   </span>
+                  <a href="checks/naming/localfinalvariablename.html#LocalFinalVariableName">LocalFinalVariableName</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LocalFinalVariableName">
+                  config</a>)
+                  <br/>
+                  <br/>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
                   <a href="checks/naming/patternvariablename.html#PatternVariableName">PatternVariableName</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PatternVariableName">
                   config</a>)


### PR DESCRIPTION
Issue: #20562

Adding [LocalFinalVariableName](https://checkstyle.sourceforge.io/checks/naming/localfinalvariablename.html) to google_checks.xml

Covers:

[5.2.7-local-variable-names](https://google.github.io/styleguide/javaguide.html#s5.2.7-local-variable-names)
Local variable names are written in [lowerCamelCase](https://google.github.io/styleguide/javaguide.html#s5.3-camel-case).
Even when final and immutable, local variables are not considered to be constants, and should not be styled as constants.

```java
atharv@atharv-IdeaPad-3-15IIL05:~/test$ cat -n Test.java
     1  /** Some javadoc. */
     2  public class Test {
     3
     4    /** Some javadoc. */
     5    void methodLocalVariable() {
     6      int LocalVariable = 1;              // violation reported
     7      String Variable2 = "";              // violation reported
     8      int VARIABLE = 1;                   // violation reported
     9    }
    10   
    11    /** Some javadoc. */
    12    void methodLocalVariableFinal() {
    13      final int LocalVariable = 1;        // violation reported        
    14      final String Variable2 = "";        // violation reported
    15      final int VARIABLE = 1;             // violation reported
    16    }
    17  }
```

```
atharv@atharv-IdeaPad-3-15IIL05:~/test$ java -jar checkstyle-13.8.0-SNAPSHOT-all.jar -c /google_checks.xml Test.java
Starting audit...
[WARN] /home/atharv/test/Test.java:6:9: Local variable name 'LocalVariable' must match pattern '^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$'. [LocalVariableName]
[WARN] /home/atharv/test/Test.java:7:12: Local variable name 'Variable2' must match pattern '^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$'. [LocalVariableName]
[WARN] /home/atharv/test/Test.java:8:9: Abbreviation in name 'VARIABLE' must contain no more than '1' consecutive capital letters. [AbbreviationAsWordInName]
[WARN] /home/atharv/test/Test.java:8:9: Local variable name 'VARIABLE' must match pattern '^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$'. [LocalVariableName]
[WARN] /home/atharv/test/Test.java:13:15: Local final variable name 'LocalVariable' must match pattern '^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$'. [LocalFinalVariableName]
[WARN] /home/atharv/test/Test.java:14:18: Local final variable name 'Variable2' must match pattern '^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$'. [LocalFinalVariableName]
[WARN] /home/atharv/test/Test.java:15:15: Abbreviation in name 'VARIABLE' must contain no more than '1' consecutive capital letters. [AbbreviationAsWordInName]
[WARN] /home/atharv/test/Test.java:15:15: Local final variable name 'VARIABLE' must match pattern '^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$'. [LocalFinalVariableName]
Audit done.
```