### PR TITLE
Issue #19803: move MissingNullCase violation comments

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -134,10 +134,6 @@
   <suppress id="presenceOfCompilationComment"
             files="[\\/]checks[\\/]coding[\\/]magicnumber[\\/]InputMagicNumberMagicNumberWithUnnamedVariables.java"/>
   <suppress id="presenceOfCompilationComment"
-            files="[\\/]checks[\\/]coding[\\/]missingnullcaseinswitch[\\/]InputMissingNullCaseInSwitchWithPattern.java"/>
-  <suppress id="presenceOfCompilationComment"
-            files="[\\/]checks[\\/]coding[\\/]missingnullcaseinswitch[\\/]InputMissingNullCaseInSwitchWithRecordPattern.java"/>
-  <suppress id="presenceOfCompilationComment"
             files="[\\/]checks[\\/]coding[\\/]missingswitchdefault[\\/]InputMissingSwitchDefaultRecordPattern.java"/>
   <suppress id="presenceOfCompilationComment"
             files="[\\/]checks[\\/]coding[\\/]modifiedcontrolvariable[\\/]InputModifiedControlVariableRecordDecomposition.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingNullCaseInSwitchCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingNullCaseInSwitchCheckTest.java
@@ -55,11 +55,11 @@ public class MissingNullCaseInSwitchCheckTest extends
     @Test
     public void testMissingNullCaseInSwitchWithPattern() throws Exception {
         final String[] expected = {
-            "12:9: " + getCheckMessage(MSG_KEY),
-            "31:9: " + getCheckMessage(MSG_KEY),
-            "51:20: " + getCheckMessage(MSG_KEY),
-            "68:20: " + getCheckMessage(MSG_KEY),
-            "88:17: " + getCheckMessage(MSG_KEY),
+            "13:9: " + getCheckMessage(MSG_KEY),
+            "33:9: " + getCheckMessage(MSG_KEY),
+            "53:20: " + getCheckMessage(MSG_KEY),
+            "70:20: " + getCheckMessage(MSG_KEY),
+            "90:17: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputMissingNullCaseInSwitchWithPattern.java"),
@@ -80,11 +80,11 @@ public class MissingNullCaseInSwitchCheckTest extends
     @Test
     public void testMissingNullCaseInSwitchWithRecordPattern() throws Exception {
         final String[] expected = {
-            "12:9: " + getCheckMessage(MSG_KEY),
-            "32:9: " + getCheckMessage(MSG_KEY),
-            "52:20: " + getCheckMessage(MSG_KEY),
-            "69:20: " + getCheckMessage(MSG_KEY),
-            "90:17: " + getCheckMessage(MSG_KEY),
+            "13:9: " + getCheckMessage(MSG_KEY),
+            "34:9: " + getCheckMessage(MSG_KEY),
+            "54:20: " + getCheckMessage(MSG_KEY),
+            "71:20: " + getCheckMessage(MSG_KEY),
+            "92:17: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputMissingNullCaseInSwitchWithRecordPattern.java"),

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingnullcaseinswitch/InputMissingNullCaseInSwitchWithPattern.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingnullcaseinswitch/InputMissingNullCaseInSwitchWithPattern.java
@@ -3,13 +3,14 @@ MissingNullCaseInSwitch
 
 */
 
-// Java21
+// non-compiled with javac: Compilable with Java22
 package com.puppycrawl.tools.checkstyle.checks.coding.missingnullcaseinswitch;
 
 public class InputMissingNullCaseInSwitchWithPattern {
 
     void testSwitchRule(Object obj) {
-        switch (obj) { // violation, 'Switch using reference types should have a null case.'
+        // violation below, 'Switch using reference types should have a null case.'
+        switch (obj) {
             case Integer i when i > 0 -> {}
             case String s when s.length() > 0 -> {}
             default -> {}
@@ -28,7 +29,8 @@ public class InputMissingNullCaseInSwitchWithPattern {
 
     }
     void testSwitchStatments(Object obj) {
-        switch (obj) {  // violation, 'Switch using reference types should have a null case.'
+        // violation below, 'Switch using reference types should have a null case.'
+        switch (obj) {
             case Integer i when i > 10 : {}break;
             case String s: {}break;
             default: {}
@@ -100,7 +102,6 @@ public class InputMissingNullCaseInSwitchWithPattern {
             case null, default : {}
         }
     }
-
     public void testCaseNullInCaseGroup(Object obj) {
          switch (obj) {
             case Integer _:

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingnullcaseinswitch/InputMissingNullCaseInSwitchWithRecordPattern.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingnullcaseinswitch/InputMissingNullCaseInSwitchWithRecordPattern.java
@@ -3,13 +3,14 @@ MissingNullCaseInSwitch
 
 */
 
-// Java21
+// non-compiled with javac: Compilable with Java22
 package com.puppycrawl.tools.checkstyle.checks.coding.missingnullcaseinswitch;
 
 public class InputMissingNullCaseInSwitchWithRecordPattern {
 
     void testSwitchRule(Object obj) {
-        switch (obj) {   // violation, 'Switch using reference types should have a null case.'
+        // violation below, 'Switch using reference types should have a null case.'
+        switch (obj) {
             case Rectangle(ColoredPoint _, ColoredPoint _) -> {}
             case ColoredPoint(int x, int _ ,String _) when x > 0 -> {}
             default -> {}
@@ -29,7 +30,8 @@ public class InputMissingNullCaseInSwitchWithRecordPattern {
     }
 
     void testSwitchStatments(Object obj) {
-        switch (obj) {  // violation, 'Switch using reference types should have a null case.'
+        // violation below, 'Switch using reference types should have a null case.'
+        switch (obj) {
             case Rectangle(ColoredPoint(int _, int _, String _), ColoredPoint lc): {}break;
             default: {}
         }


### PR DESCRIPTION
Issue: #19803

Moves the violation comments out of the Java statements in the two
`coding/missingnullcaseinswitch` non-compilable inputs, updates the expected
violation line numbers, adds the required Java 21 compilation metadata, and
removes the corresponding temporary suppressions.

Scope claimed in #19803:

- `InputMissingNullCaseInSwitchWithPattern.java`
- `InputMissingNullCaseInSwitchWithRecordPattern.java`

Validation:

- `mvnw.cmd -q clean -Dtest=MissingNullCaseInSwitchCheckTest test`
- `mvnw.cmd clean verify`
- `git diff --check`

AI assistance was used to locate and edit the repetitive test fixtures. I
reviewed the complete diff and ran the focused and full builds locally with
Temurin JDK 21.