### PR TITLE
Issue #20624: Adding Example for missing property - javadoctype

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/javadoctype.xml
@@ -522,6 +522,57 @@ public class Example8 {
   @Generated("tool") // violation, 'Type Javadoc comment is missing @param &lt;T&gt; tag'
   public class ClassG&lt;T&gt; {}
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example9-config">
+          To configure the check for <code>CLASS_DEF</code> tokens only:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocType"&gt;
+      &lt;property name="tokens" value="CLASS_DEF"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example9-code">
+          Example9:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/**
+ * @author a
+ * @version $Revision1$
+ */
+public class Example9 {
+  /**
+   * @author a
+   * @version $Revision1$
+   */
+  public class ClassA {
+    /** */
+    private class ClassB {}
+  }
+
+  /**
+   * @author
+   * @version abc
+   * @unknownTag value
+   */
+  public class ClassC {}
+  // violation 3 lines above 'Unknown tag 'unknownTag''
+  /** */
+  public class ClassD {}
+
+  /** */
+  public class ClassE&lt;T&gt; {}  // violation, as param tag for &lt;T&gt; is missing
+
+  /** */
+  private class ClassF&lt;T&gt; {} // violation, as param tag for &lt;T&gt; is missing
+
+  /** */
+  @Generated("tool")
+  public class ClassG&lt;T&gt; {}
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadoctype.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadoctype.xml.template
@@ -142,6 +142,22 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example8.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example9-config">
+          To configure the check for <code>CLASS_DEF</code> tokens only:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example9.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example9-code">
+          Example9:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example9.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -155,7 +155,6 @@ public class XdocsExamplesAstConsistencyTest {
         "checks/javadoc/javadocblocktaglocation",
         "checks/javadoc/javadocmethod",
         "checks/javadoc/javadocparagraph",
-        "checks/javadoc/javadoctype",
         "checks/javadoc/javadocvariable",
         "checks/javadoc/missingjavadocmethod",
         "checks/javadoc/missingjavadoctype",
@@ -203,7 +202,6 @@ public class XdocsExamplesAstConsistencyTest {
             // until https://github.com/checkstyle/checkstyle/issues/20624
             "checks/regexp/regexp",
             "checks/imports/illegalimport",
-            "checks/javadoc/javadoctype",
             "checks/javadoc/javadocvariable",
             "checks/javadoc/missingjavadocmethod",
             "checks/javadoc/missingjavadoctype",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckExamplesTest.java
@@ -115,4 +115,15 @@ public class JavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example8.java"), expected);
     }
+
+    @Test
+    public void testExample9() throws Exception {
+        final String[] expected = {
+            "31:6: " + getCheckMessage(MSG_UNKNOWN_TAG, "unknownTag"),
+            "39:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "42:3: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example9.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/Example9.java
@@ -1,0 +1,48 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocType">
+      <property name="tokens" value="CLASS_DEF"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+import javax.annotation.processing.Generated;
+// xdoc section -- start
+/**
+ * @author a
+ * @version $Revision1$
+ */
+public class Example9 {
+  /**
+   * @author a
+   * @version $Revision1$
+   */
+  public class ClassA {
+    /** */
+    private class ClassB {}
+  }
+
+  /**
+   * @author
+   * @version abc
+   * @unknownTag value
+   */
+  public class ClassC {}
+  // violation 3 lines above 'Unknown tag 'unknownTag''
+  /** */
+  public class ClassD {}
+
+  /** */
+  public class ClassE<T> {}  // violation, as param tag for <T> is missing
+
+  /** */
+  private class ClassF<T> {} // violation, as param tag for <T> is missing
+
+  /** */
+  @Generated("tool")
+  public class ClassG<T> {}
+}
+// xdoc section -- end


### PR DESCRIPTION
#20624 

Add example for tokens property in `JavadocTypeCheck`
1. Adds Example9.java to checks`/javadoc/javadoctype` covering the tokens property of `JavadocTypeCheck`.
2. Updated xml.template
3. Removed suppressions