### PR TITLE
Issue #20624: Adding Example for missing property - javadocvariable

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml
@@ -132,6 +132,42 @@ public class Example2 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check for <code>VARIABLE_DEF</code> tokens only:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocVariable"&gt;
+      &lt;property name="tokens" value="VARIABLE_DEF"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">
+          Example3:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example3 {
+  private int a;     // violation, 'Missing a Javadoc comment'
+
+  /**
+   * Some description here
+   */
+  private int b;
+  protected int c;   // violation, 'Missing a Javadoc comment'
+  public int d;      // violation, 'Missing a Javadoc comment'
+  /*package*/ int e; // violation, 'Missing a Javadoc comment'
+
+  public enum PublicEnum {
+    CONSTANT
+  }
+
+  private enum PrivateEnum {
+    CONSTANT
+  }
+}
+</code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
           To ignore absence of Javadoc comments for fields with names <code>log</code> or
           <code>logger</code>:

--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml.template
@@ -64,6 +64,22 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example2.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check for <code>VARIABLE_DEF</code> tokens only:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">
+          Example3:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
         <p id="Example4-config">
           To ignore absence of Javadoc comments for fields with names <code>log</code> or
           <code>logger</code>:

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -155,7 +155,6 @@ public class XdocsExamplesAstConsistencyTest {
         "checks/javadoc/javadocblocktaglocation",
         "checks/javadoc/javadocmethod",
         "checks/javadoc/javadocparagraph",
-        "checks/javadoc/javadocvariable",
         "checks/javadoc/missingjavadocmethod",
         "checks/javadoc/missingjavadoctype",
         "checks/javadoc/nonemptyatclausedescription",
@@ -202,7 +201,12 @@ public class XdocsExamplesAstConsistencyTest {
             // until https://github.com/checkstyle/checkstyle/issues/20624
             "checks/regexp/regexp",
             "checks/imports/illegalimport",
+<<<<<<< HEAD
             "checks/javadoc/javadocvariable",
+=======
+            "checks/javadoc/javadoctype",
+            "checks/javadoc/missingjavadocmethod",
+>>>>>>> 33a2a12015 (Issue #20624: Adding Example for missing property - javadocvariable)
             "checks/javadoc/missingjavadoctype",
             "checks/lineending",
             "checks/metrics/classdataabstractioncoupling",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckExamplesTest.java
@@ -55,14 +55,15 @@ public class JavadocVariableCheckExamplesTest extends AbstractExamplesModuleTest
     }
 
     @Test
-    public void testUseCase1() throws Exception {
+    public void testExample3() throws Exception {
         final String[] expected = {
             "14:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "22:15: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "29:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
-        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
+        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
 
     @Test
@@ -77,6 +78,17 @@ public class JavadocVariableCheckExamplesTest extends AbstractExamplesModuleTest
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
+    @Test
+    public void testUseCase1() throws Exception {
+        final String[] expected = {
+            "14:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:15: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "29:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example3.java
@@ -1,0 +1,32 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocVariable">
+      <property name="tokens" value="VARIABLE_DEF"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+// xdoc section -- start
+public class Example3 {
+  private int a;     // violation, 'Missing a Javadoc comment'
+
+  /**
+   * Some description here
+   */
+  private int b;
+  protected int c;   // violation, 'Missing a Javadoc comment'
+  public int d;      // violation, 'Missing a Javadoc comment'
+  /*package*/ int e; // violation, 'Missing a Javadoc comment'
+
+  public enum PublicEnum {
+    CONSTANT
+  }
+
+  private enum PrivateEnum {
+    CONSTANT
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
#20624 

Add example for tokens property in `JavadocVariableCheck`
1. Adds Example3.java to checks `/javadoc/javadocvariable ` covering the tokens property. 
2. Updated xml.template
3. Removed suppressions