### PR TITLE
Issue #20624: Adding Example for missing property - missingjavadoc

### DIFF
--- a/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml
@@ -398,6 +398,44 @@ public class Example7 {
     System.out.println("line 3");
   }
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example8-config">
+          To configure the check for <code>METHOD_DEF</code> tokens only:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MissingJavadocMethod"&gt;
+      &lt;property name="tokens" value="METHOD_DEF"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example8-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example8 {
+  public Example8() {}
+  public void testMethod1() {}   // violation, 'Missing a Javadoc comment'
+  /**
+   * Some description here.
+   */
+  public void testMethod2() {}
+
+  @Override
+  public String toString() {
+    return "Some string";
+  }
+
+  private void testMethod3() {}
+  protected void testMethod4() {}
+  void testMethod5() {}
+
+  public void testMethod6() {    // violation, 'Missing a Javadoc comment'
+    System.out.println("line 1");
+    System.out.println("line 2");
+    System.out.println("line 3");
+  }
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml.template
+++ b/src/site/xdoc/checks/javadoc/missingjavadocmethod.xml.template
@@ -130,6 +130,20 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/Example7.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example8-config">
+          To configure the check for <code>METHOD_DEF</code> tokens only:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/Example8.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example8-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/Example8.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -205,7 +205,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/imports/illegalimport",
             "checks/javadoc/javadoctype",
             "checks/javadoc/javadocvariable",
-            "checks/javadoc/missingjavadocmethod",
             "checks/javadoc/missingjavadoctype",
             "checks/lineending",
             "checks/metrics/classdataabstractioncoupling",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckExamplesTest.java
@@ -108,4 +108,14 @@ public class MissingJavadocMethodCheckExamplesTest extends AbstractExamplesModul
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
     }
+
+    @Test
+    public void testExample8() throws Exception {
+        final String[] expected = {
+            "15:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "30:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/Example8.java
@@ -1,0 +1,36 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MissingJavadocMethod">
+      <property name="tokens" value="METHOD_DEF"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
+
+// xdoc section -- start
+public class Example8 {
+  public Example8() {}
+  public void testMethod1() {}   // violation, 'Missing a Javadoc comment'
+  /**
+   * Some description here.
+   */
+  public void testMethod2() {}
+
+  @Override
+  public String toString() {
+    return "Some string";
+  }
+
+  private void testMethod3() {}
+  protected void testMethod4() {}
+  void testMethod5() {}
+
+  public void testMethod6() {    // violation, 'Missing a Javadoc comment'
+    System.out.println("line 1");
+    System.out.println("line 2");
+    System.out.println("line 3");
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
#20624 

1. Adds Example8.java to checks /javadoc/missingjavadoc covering the tokens property.
2. Updated xml.template
3. Removed suppressions