### PR TITLE
Issue #20624: Adding Example for missing property - missingjavadoctype

### DIFF
--- a/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
@@ -106,7 +106,7 @@
         <p id="Example1-code">Example1:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 /** Documented. */
-class Example1 {
+public class Example1 {
   /** Javadoc. */
   public class A {}
   /** Javadoc. */
@@ -123,6 +123,10 @@ class Example1 {
   private class Config {}
   /** Javadoc. */
   private class E {}
+  /** Javadoc. */
+  public interface F {}
+  /** Javadoc. */
+  public interface G {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -140,7 +144,7 @@ class Example1 {
 
         <p id="Example2-code">Example2:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example2 {        // violation, 'Missing a Javadoc comment'
+public class Example2 {        // violation, 'Missing a Javadoc comment'
   /** Javadoc. */
   public class A {}
 
@@ -157,6 +161,10 @@ class Example2 {        // violation, 'Missing a Javadoc comment'
   private class Config {}
   /** Javadoc. */
   private class E {}
+
+  public interface F {} // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  public interface G {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -174,7 +182,7 @@ class Example2 {        // violation, 'Missing a Javadoc comment'
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-code">Example3:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example3 {
+public class Example3 {
   /** Javadoc. */
   public class A {}
 
@@ -191,6 +199,10 @@ class Example3 {
   private class Config {}
   /** Javadoc. */
   private class E {}
+
+  public interface F {}
+  /** Javadoc. */
+  public interface G {}
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -211,7 +223,7 @@ class Example3 {
         <p id="Example4-code">Example4:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 /** Documented. */
-class Example4 {
+public class Example4 {
   /** Javadoc. */
   public class A {}
   /** Javadoc. */
@@ -227,7 +239,48 @@ class Example4 {
   @Configuration
   private class Config {}
 
-  private class E {} // violation, 'Missing a Javadoc comment'
+  private class E {}    // violation, 'Missing a Javadoc comment'
+
+  public interface F {} // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  public interface G {}
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check for <code>INTERFACE_DEF</code> tokens only:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MissingJavadocType"&gt;
+      &lt;property name="tokens" value="INTERFACE_DEF"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code">Example5:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example5 {
+  /** Javadoc. */
+  public class A {}
+
+  private class B {}
+
+  protected class C {}
+  /** Javadoc. */
+  class D {}
+  /** Javadoc. */
+  @SpringBootApplication
+  private class App {}
+  /** Javadoc. */
+  @Configuration
+  private class Config {}
+  /** Javadoc. */
+  private class E {}
+
+  public interface F {} // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  public interface G {}
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/javadoc/missingjavadoctype.xml.template
+++ b/src/site/xdoc/checks/javadoc/missingjavadoctype.xml.template
@@ -87,6 +87,20 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example4.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check for <code>INTERFACE_DEF</code> tokens only:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example5-code">Example5:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example5.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -201,7 +201,6 @@ public class XdocsExamplesAstConsistencyTest {
             // until https://github.com/checkstyle/checkstyle/issues/20624
             "checks/regexp/regexp",
             "checks/imports/illegalimport",
-            "checks/javadoc/missingjavadoctype",
             "checks/lineending",
             "checks/metrics/classdataabstractioncoupling",
             "checks/modifier/classmemberimpliedmodifier",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckExamplesTest.java
@@ -45,6 +45,7 @@ public class MissingJavadocTypeCheckExamplesTest extends AbstractExamplesModuleT
             "18:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "20:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "22:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "32:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -63,9 +64,19 @@ public class MissingJavadocTypeCheckExamplesTest extends AbstractExamplesModuleT
     public void testExample4() throws Exception {
         final String[] expected = {
             "37:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "39:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {
+            "32:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example1.java
@@ -9,7 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 // xdoc section -- start
 /** Documented. */
-class Example1 {
+public class Example1 {
   /** Javadoc. */
   public class A {}
   /** Javadoc. */
@@ -26,5 +26,9 @@ class Example1 {
   private class Config {}
   /** Javadoc. */
   private class E {}
+  /** Javadoc. */
+  public interface F {}
+  /** Javadoc. */
+  public interface G {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example3.java
@@ -12,7 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 // xdoc section -- start
 
-class Example3 {
+public class Example3 {
   /** Javadoc. */
   public class A {}
 
@@ -29,5 +29,9 @@ class Example3 {
   private class Config {}
   /** Javadoc. */
   private class E {}
+
+  public interface F {}
+  /** Javadoc. */
+  public interface G {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example4.java
@@ -18,7 +18,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 // xdoc section -- start
 /** Documented. */
-class Example4 {
+public class Example4 {
   /** Javadoc. */
   public class A {}
   /** Javadoc. */
@@ -34,6 +34,10 @@ class Example4 {
   @Configuration
   private class Config {}
 
-  private class E {} // violation, 'Missing a Javadoc comment'
+  private class E {}    // violation, 'Missing a Javadoc comment'
+
+  public interface F {} // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  public interface G {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example5.java
@@ -2,7 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="MissingJavadocType">
-      <property name="scope" value="private"/>
+      <property name="tokens" value="INTERFACE_DEF"/>
     </module>
   </module>
 </module>
@@ -11,15 +11,15 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 // xdoc section -- start
 
-public class Example2 {        // violation, 'Missing a Javadoc comment'
+public class Example5 {
   /** Javadoc. */
   public class A {}
 
-  private class B {}    // violation, 'Missing a Javadoc comment'
+  private class B {}
 
-  protected class C {}  // violation, 'Missing a Javadoc comment'
-
-  class D {}            // violation, 'Missing a Javadoc comment'
+  protected class C {}
+  /** Javadoc. */
+  class D {}
   /** Javadoc. */
   @SpringBootApplication
   private class App {}


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/20624

1. Adds Example5.java to checks `/javadoc/missingjavadoctype` covering the tokens property.
2. Updated xml.template
3. Removed suppressions