### PR TITLE
Issue #20624: Cover fileExtensions property in LineEnding examples

### DIFF
--- a/src/site/xdoc/checks/misc/lineending.xml
+++ b/src/site/xdoc/checks/misc/lineending.xml
@@ -93,12 +93,13 @@ public class Example2 { // ␍␊  // ok line ending is CRLF
 </code></pre></div><hr class="example-separator"/>
 
         <p id="Example3-config">
-          To configure the check to enforce CR line endings:
+          To configure the check to enforce CR line endings for Java files only:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="LineEnding"&gt;
     &lt;property name="lineEnding" value="cr"/&gt;
+    &lt;property name="fileExtensions" value="java"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -109,6 +110,28 @@ public class Example3 {  // ␊ // violation 'Expected line ending for file is C
     int x = 1; // ␊           // violation 'Expected line ending for file is CR, but LF is detected.'
   } // ␊                      // violation 'Expected line ending for file is CR, but LF is detected.'
 } // ␊                        // violation 'Expected line ending for file is CR, but LF is detected.'
+</code></pre></div><hr class="example-separator"/>
+
+        <p id="Example4-config">
+          To configure the check to enforce CR line endings for TXT files only:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="LineEnding"&gt;
+    &lt;property name="lineEnding" value="cr"/&gt;
+    &lt;property name="fileExtensions" value="txt"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code">
+          Example (Java file with LF line endings - no violations, as only TXT files are checked):
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example4 {  // ␊ // ok, only .txt files are checked
+  public void method() { // ␊ // ok, only .txt files are checked
+    int x = 1; // ␊           // ok, only .txt files are checked
+  } // ␊                      // ok, only .txt files are checked
+} // ␊                        // ok, only .txt files are checked
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/lineending.xml.template
+++ b/src/site/xdoc/checks/misc/lineending.xml.template
@@ -66,7 +66,7 @@
         </macro><hr class="example-separator"/>
 
         <p id="Example3-config">
-          To configure the check to enforce CR line endings:
+          To configure the check to enforce CR line endings for Java files only:
         </p>
         <macro name="example">
           <param name="path"
@@ -77,6 +77,23 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/lineending/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+
+        <p id="Example4-config">
+          To configure the check to enforce CR line endings for TXT files only:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/lineending/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">
+          Example (Java file with LF line endings - no violations, as only TXT files are checked):
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/lineending/Example4.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -201,7 +201,6 @@ public class XdocsExamplesAstConsistencyTest {
             // until https://github.com/checkstyle/checkstyle/issues/20624
             "checks/regexp/regexp",
             "checks/imports/illegalimport",
-            "checks/lineending",
             "checks/metrics/classdataabstractioncoupling",
             "checks/modifier/classmemberimpliedmodifier",
             "checks/naming/illegalidentifiername",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/LineEndingCheckExampleTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/LineEndingCheckExampleTest.java
@@ -71,6 +71,7 @@ public class LineEndingCheckExampleTest extends AbstractExamplesModuleTestSuppor
             "13: " + getCheckMessage(MSG_KEY_WRONG_ENDING, CR, LF),
             "14: " + getCheckMessage(MSG_KEY_WRONG_ENDING, CR, LF),
             "15: " + getCheckMessage(MSG_KEY_WRONG_ENDING, CR, LF),
+            "16: " + getCheckMessage(MSG_KEY_WRONG_ENDING, CR, LF),
         };
 
         final DefaultConfiguration checkConfig = createModuleConfig(LineEndingCheck.class);
@@ -79,6 +80,15 @@ public class LineEndingCheckExampleTest extends AbstractExamplesModuleTestSuppor
 
         verify(checkConfig,
                 getPath("Example3.java"), expected
+        );
+    }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("Example4.java"), expected
         );
     }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/lineending/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/lineending/Example3.java
@@ -2,6 +2,7 @@
 <module name="Checker">
   <module name="LineEnding">
     <property name="lineEnding" value="cr"/>
+    <property name="fileExtensions" value="java"/>
   </module>
 </module>
 */

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/lineending/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/lineending/Example4.java
@@ -1,0 +1,16 @@
+/*xml
+<module name="Checker">
+  <module name="LineEnding">
+    <property name="lineEnding" value="cr"/>
+    <property name="fileExtensions" value="txt"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.lineending;
+// xdoc section -- start
+public class Example4 {  // ␊ // ok, only .txt files are checked
+  public void method() { // ␊ // ok, only .txt files are checked
+    int x = 1; // ␊           // ok, only .txt files are checked
+  } // ␊                      // ok, only .txt files are checked
+} // ␊                        // ok, only .txt files are checked
+// xdoc section -- end


### PR DESCRIPTION
Issue: #20624

Covered the documented `fileExtensions` property in the `LineEnding` xdocs
examples.

Changes:

- added `fileExtensions="java"` to Example3 so it demonstrates CR line-ending
  violations for Java files;
- added Example4 with `fileExtensions="txt"` to demonstrate that a Java file is
  ignored and produces no violations when only TXT files are checked;
- updated the LineEnding example tests;
- updated the xdoc template and regenerated the LineEnding xdoc;
- removed `checks/lineending` from
  `EXAMPLE_PROPERTY_COVERAGE_SUPPRESSED_MODULES`.