### PR TITLE
Issue #20675: isolate invalid java docs of MissingOverrideCheck

### DIFF
--- a/.ci/javadoc-tool-excluded-packages.sh
+++ b/.ci/javadoc-tool-excluded-packages.sh
@@ -9,7 +9,6 @@ javadoc_package=$checks_package.javadoc
 
 JAVADOC_TOOL_EXCLUDED_PACKAGES=(
   "$source_root $checks_package.annotation.missingdeprecated"
-  "$source_root $checks_package.annotation.missingoverride"
   "$source_root $javadoc_package.abstractjavadoc"
   "$source_root $javadoc_package.javadocmethod"
   "$source_root $javadoc_package.javadocpackage.annotation"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckTest.java
@@ -45,10 +45,10 @@ public class MissingOverrideCheckTest extends AbstractModuleTestSupport {
 
         final String[] expected = {
             "15:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
-            "36:9: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
-            "46:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
-            "51:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
-            "74:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "26:9: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "36:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "41:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "64:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
         };
 
         verifyWithInlineConfigParser(
@@ -64,9 +64,9 @@ public class MissingOverrideCheckTest extends AbstractModuleTestSupport {
 
         final String[] expected = {
             "15:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
-            "36:9: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
-            "46:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
-            "55:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "26:9: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "36:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "45:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/InputMissingOverrideBadOverrideFromObject.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/InputMissingOverrideBadOverrideFromObject.java
@@ -17,16 +17,6 @@ public class InputMissingOverrideBadOverrideFromObject
         return false;
     }
 
-    /**
-     * {@inheritDoc no violation}
-     *
-     * @inheritDocs}
-     *
-     * {@inheritDoc
-     */
-    public int hashCode() {
-        return 1;
-    }
 
     class Junk {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/InputMissingOverrideBadOverrideFromObjectJava5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/InputMissingOverrideBadOverrideFromObjectJava5.java
@@ -17,16 +17,6 @@ public class InputMissingOverrideBadOverrideFromObjectJava5
         return false;
     }
 
-    /**
-     * {@inheritDoc no violation}
-     *
-     * @inheritDocs}
-     *
-     * {@inheritDoc
-     */
-    public int hashCode() {
-        return 1;
-    }
 
     class Junk {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/InputMissingOverrideGoodOverrideFromObject.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/InputMissingOverrideGoodOverrideFromObject.java
@@ -17,18 +17,6 @@ public class InputMissingOverrideGoodOverrideFromObject
         return false;
     }
 
-    /**
-     * {@inheritDoc no violation}
-     *
-     * @inheritDocs}
-     *
-     * {@inheritDoc
-     */
-    @Override
-    public int hashCode() {
-        return 1;
-    }
-
     class Junk {
 
         /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/InputMissingOverrideGoodOverrideFromObjectJava5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/InputMissingOverrideGoodOverrideFromObjectJava5.java
@@ -17,18 +17,6 @@ public class InputMissingOverrideGoodOverrideFromObjectJava5
         return false;
     }
 
-    /**
-     * {@inheritDoc no violation}
-     *
-     * @inheritDocs}
-     *
-     * {@inheritDoc
-     */
-    @Override
-    public int hashCode() {
-        return 1;
-    }
-
     class Junk {
 
         /**


### PR DESCRIPTION
Issue #20675 
### Summary 

- Removed invalid javadoc comments from MissingOverrideCheck input files
- Modified line numbers of in MissingOverrideCheckTest
- removed missingoverride from javadoc-tool-excluded-packages.sh
