### PR TITLE
Issue #20624: Adding Example for missing property - newlineatendoffile

### DIFF
--- a/src/site/xdoc/checks/misc/newlineatendoffile.xml
+++ b/src/site/xdoc/checks/misc/newlineatendoffile.xml
@@ -163,6 +163,23 @@ public class Example5 { // ⤶
         <p id="Example6-code">Text file <code>Example6.txt</code>:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 Sample txt file. // ok, this file is not specified in the config.
+</code></pre></div><hr class="example-separator"/>
+
+        <p id="Example7-config">
+          To configure the check to work only on Java files:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="NewlineAtEndOfFile"&gt;
+    &lt;property name="fileExtensions" value="java"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example7-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example7 { // ⤶
+// ⤶
+} // violation first line 'File does not end with a newline.'
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/misc/newlineatendoffile.xml.template
+++ b/src/site/xdoc/checks/misc/newlineatendoffile.xml.template
@@ -99,6 +99,21 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/Example6.txt"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+
+        <p id="Example7-config">
+          To configure the check to work only on Java files:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/Example7.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example7-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/Example7.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -205,7 +205,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling",
             "checks/modifier/classmemberimpliedmodifier",
             "checks/naming/illegalidentifiername",
-            "checks/newlineatendoffile",
             "checks/regexp/regexpmultiline",
             "checks/regexp/regexponfilename",
             "checks/sizes/methodcount",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckExamplesTest.java
@@ -82,4 +82,13 @@ public class NewlineAtEndOfFileCheckExamplesTest extends AbstractExamplesModuleT
 
         verifyWithInlineConfigParser(getPath("Example6.txt"), expected);
     }
+
+    @Test
+    public void testExample7() throws Exception {
+        final String[] expected = {
+            "1: " + getCheckMessage(MSG_KEY_NO_NEWLINE_EOF),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example7.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/Example7.java
@@ -1,0 +1,14 @@
+/*xml
+<module name="Checker">
+  <module name="NewlineAtEndOfFile">
+    <property name="fileExtensions" value="java"/>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.newlineatendoffile;
+// xdoc section -- start
+public class Example7 { // ⤶
+// ⤶
+} // violation first line 'File does not end with a newline.'
+// xdoc section -- end


### PR DESCRIPTION
#20624 

1. Adds Example7.java to checks `newlineatendoffile `covering the `fileextensions `property.
2. Updated xml.template
3. Removed suppressions