### PR TITLE
Issue checkstyle#19803: move violation comment in missingoverride

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -747,8 +747,6 @@
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]missingdeprecated[\\/]InputMissingDeprecatedClass\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]missingoverride[\\/]InputMissingOverrideBadOverrideFromObject\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsSingle1\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]illegalthrows[\\/]InputIllegalThrowsNotIgnoreOverriddenMethod\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckTest.java
@@ -44,11 +44,11 @@ public class MissingOverrideCheckTest extends AbstractModuleTestSupport {
     public void testBadOverrideFromObject() throws Exception {
 
         final String[] expected = {
-            "15:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
-            "26:9: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
-            "36:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
-            "41:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
-            "64:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "16:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "28:9: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "39:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "45:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
+            "69:5: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_OVERRIDE),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/InputMissingOverrideBadOverrideFromObject.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingoverride/InputMissingOverrideBadOverrideFromObject.java
@@ -9,10 +9,11 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.missingoverride;
 
 public class InputMissingOverrideBadOverrideFromObject
 {
+    // violation 4 lines below 'include @java.lang.Override annotation when '@inheritDoc''
     /**
      * {@inheritDoc}
      */
-    public boolean // violation 'include @java.lang.Override annotation when '@inheritDoc''
+    public boolean
     equals(Object obj) {
         return false;
     }
@@ -20,25 +21,28 @@ public class InputMissingOverrideBadOverrideFromObject
 
     class Junk {
 
+        // violation 4 lines below 'include @java.lang.Override annotation when '@inheritDoc''
         /**
          * {@inheritDoc}
          */
-        protected void // violation 'include @java.lang.Override annotation when '@inheritDoc''
+        protected void
         finalize() throws Throwable {}
     }
 }
 
 interface HashEq2 {
 
+    // violation 4 lines below 'include @java.lang.Override annotation when '@inheritDoc''
     /**
      * {@inheritDoc}
      */
-    public int hashCode(); // violation 'include @java.lang.Override annotation when '@inheritDoc''
+    public int hashCode();
 
+    // violation 4 lines below 'include @java.lang.Override annotation when '@inheritDoc''
     /**
      * {@inheritDoc}
      */
-    @Deprecated // violation 'include @java.lang.Override annotation when '@inheritDoc''
+    @Deprecated
     public String toString();
 
     @SuppressWarnings("")
@@ -58,11 +62,11 @@ interface HashEq2 {
 enum enum3 {
     B;
 
+    // violation 4 lines below 'include @java.lang.Override annotation when '@inheritDoc''
     /**
      * {@inheritDoc}
      */
     public String toString(){
-        // violation above 'include @java.lang.Override annotation when '@inheritDoc''
         return "B";
     }
 


### PR DESCRIPTION
 part of https://github.com/checkstyle/checkstyle/issues/19803

Moved the violation comment in InputMissingOverrideBadOverrideFromObject.java out from between annotations and the annotation declaration.

Removed the matching suppression from checkstyle-input-suppressions.xml and updated the expected violation line in MissingOverrideCheckTest.java
