### PR TITLE
Issue #20675: Isolate invalid javadoc comments of missingdeprecated

### DIFF
--- a/.ci/javadoc-tool-excluded-packages.sh
+++ b/.ci/javadoc-tool-excluded-packages.sh
@@ -8,7 +8,6 @@ checks_package=com.puppycrawl.tools.checkstyle.checks
 javadoc_package=$checks_package.javadoc
 
 JAVADOC_TOOL_EXCLUDED_PACKAGES=(
-  "$source_root $checks_package.annotation.missingdeprecated"
   "$source_root $javadoc_package.abstractjavadoc"
   "$source_root $javadoc_package.javadocmethod"
   "$source_root $javadoc_package.javadocpackage.annotation"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckTest.java
@@ -89,11 +89,10 @@ public class MissingDeprecatedCheckTest extends AbstractModuleTestSupport {
     public void testBadDeprecatedJavadoc() throws Exception {
 
         final String[] expected = {
-            "18: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
-            "36: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
-            "45: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
+            "29: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
+            "38: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
+            "48: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
             "55: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
-            "62: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadJavadoc.java
@@ -12,13 +12,6 @@ import java.lang.annotation.Inherited;
 @Deprecated
 public class InputMissingDeprecatedBadJavadoc
 {
-    /**
-     * @Deprecated this is not the same
-     */
-    @Deprecated // violation '.*@java.lang.Deprecated annotation and @deprecated.*description.'
-    protected InputMissingDeprecatedBadJavadoc() {
-
-    }
 
     @Deprecated
     @Override


### PR DESCRIPTION
Issue #20675 
### Summary

- removed missingdeprecated from javadoc-tool-excluded-packages.sh
- removed invalid javadoc snippet from InputMissingDeprecatedBadJavadoc
- removed the one violation that was part of invalid javadoc in the test file and changed line numbers respectively.