### PR TITLE
Issue #20590: add EmptyStatement compact source input coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheckTest.java
@@ -74,4 +74,17 @@ public class EmptyStatementCheckTest
                 .isNotNull();
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "12:5: " + getCheckMessage(MSG_KEY),
+            "15:18: " + getCheckMessage(MSG_KEY),
+            "17:14: " + getCheckMessage(MSG_KEY),
+            "21:9: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("compact/InputEmptyStatementCompactSourceFile.java"),
+                expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -123,7 +123,6 @@ public class AllChecksCompactSourceCoverageTest {
         "EmptyForInitializerPadCheck",
         "EmptyForIteratorPadCheck",
         "EmptyLineSeparatorCheck",
-        "EmptyStatementCheck",
         "EqualsAvoidNullCheck",
         "EqualsHashCodeCheck",
         "ExecutableStatementCountCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/emptystatement/compact/InputEmptyStatementCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/emptystatement/compact/InputEmptyStatementCompactSourceFile.java
@@ -1,0 +1,23 @@
+/*
+EmptyStatement
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+; // ok until https://github.com/checkstyle/checkstyle/issues/20749
+
+void main() {
+    ; // violation 'Empty statement'
+
+    boolean cond = true;
+    for (; cond;); // violation 'Empty statement'
+
+    if (cond); // violation 'Empty statement'
+
+    while (cond) {
+        cond = false;
+        ; // violation 'Empty statement'
+    }
+}


### PR DESCRIPTION
Issue: #20590

Added compact source input coverage for EmptyStatementCheck.
Verified via CLI that violations on the compact input match the
equivalent ordinary source (same 4 violations, offset only by the
class wrapper).
