### PR TITLE
Issue #20675: isolate invalid javadoc snippets from abstractjavadoc

### DIFF
--- a/.ci/javadoc-tool-excluded-packages.sh
+++ b/.ci/javadoc-tool-excluded-packages.sh
@@ -8,7 +8,6 @@ checks_package=com.puppycrawl.tools.checkstyle.checks
 javadoc_package=$checks_package.javadoc
 
 JAVADOC_TOOL_EXCLUDED_PACKAGES=(
-  "$source_root $javadoc_package.abstractjavadoc"
   "$source_root $javadoc_package.javadocmethod"
   "$source_root $javadoc_package.javadocpackage.annotation"
   "$source_root $javadoc_package.javadoctype"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -74,9 +74,9 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "16: " + getCheckMessage(MSG_JAVADOC_PARSE_RULE_ERROR, 4,
                     "no viable alternative at input 'see'", "SEE_TAG"),
-            "65: " + getCheckMessage(MSG_JAVADOC_PARSE_RULE_ERROR, 13,
+            "50: " + getCheckMessage(MSG_JAVADOC_PARSE_RULE_ERROR, 13,
                     "no viable alternative at input '}'", "REFERENCE"),
-            "73: " + getCheckMessage(MSG_JAVADOC_PARSE_RULE_ERROR, 19,
+            "58: " + getCheckMessage(MSG_JAVADOC_PARSE_RULE_ERROR, 19,
                     "no viable alternative at input '}'", "REFERENCE"),
         };
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocJavadocTagsWithoutArgs.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocJavadocTagsWithoutArgs.java
@@ -26,24 +26,9 @@ public class InputAbstractJavadocJavadocTagsWithoutArgs implements Serializable{
     /**serialField*/
     private static Object field5;
 
-    /**@exception*/
-    public static void method1() {
-
-    }
-
-    /**@throws*/
-    public static void method2() {
-
-    }
-
     /**@return*/
     public static int method3() {
         return -1;
-    }
-
-    /**@param*/
-    public static void method4(int a) {
-
     }
 
     /**@customTag*/


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/20675

### Summary

- removed abstractjavadoc from javadoc-tool-excluded-packages.sh
- removed invalid javadoc snippet from InputAbstractJavadocJavadocTagsWithoutArgs
- changed line numbers of AbstractJavadocCheckTest