### PR TITLE
Issue #19764: Move violation comments out of Javadoc for JavadocTagContinuationIndentation

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -468,22 +468,7 @@
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignIncorrect.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignTabs.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationAnonymousClass.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationInnerClass.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationMethod456.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationOthers.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationBlockTag.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationDescription.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationOffset3.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadoctagcontinuationindentation[\\/]InputJavadocTagContinuationIndentationPreTag.java"/>
+
 
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]summaryjavadoc[\\/]InputSummaryJavadocInlineReturn.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -67,8 +67,8 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testCheckMethod456() throws Exception {
         final String[] expected = {
-            "38: " + getCheckMessage(MSG_KEY, 4),
-            "41: " + getCheckMessage(MSG_KEY, 4),
+            "40: " + getCheckMessage(MSG_KEY, 4),
+            "43: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationMethod456.java"),
@@ -78,8 +78,8 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testCheckInnerClass() throws Exception {
         final String[] expected = {
-            "93: " + getCheckMessage(MSG_KEY, 4),
-            "96: " + getCheckMessage(MSG_KEY, 4),
+            "95: " + getCheckMessage(MSG_KEY, 4),
+            "98: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationInnerClass.java"),
@@ -89,11 +89,11 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testCheckAnonymousClass() throws Exception {
         final String[] expected = {
-            "18: " + getCheckMessage(MSG_KEY, 4),
             "20: " + getCheckMessage(MSG_KEY, 4),
-            "82: " + getCheckMessage(MSG_KEY, 4),
-            "85: " + getCheckMessage(MSG_KEY, 4),
+            "22: " + getCheckMessage(MSG_KEY, 4),
             "87: " + getCheckMessage(MSG_KEY, 4),
+            "90: " + getCheckMessage(MSG_KEY, 4),
+            "92: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationAnonymousClass.java"),
@@ -103,10 +103,10 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testCheckOthers() throws Exception {
         final String[] expected = {
-            "20: " + getCheckMessage(MSG_KEY, 4),
-            "32: " + getCheckMessage(MSG_KEY, 4),
-            "34: " + getCheckMessage(MSG_KEY, 4),
-            "53: " + getCheckMessage(MSG_KEY, 4),
+            "21: " + getCheckMessage(MSG_KEY, 4),
+            "35: " + getCheckMessage(MSG_KEY, 4),
+            "37: " + getCheckMessage(MSG_KEY, 4),
+            "57: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationOthers.java"),
@@ -116,8 +116,8 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testCheckWithOffset3() throws Exception {
         final String[] expected = {
-            "15: " + getCheckMessage(MSG_KEY, 3),
-            "27: " + getCheckMessage(MSG_KEY, 3),
+            "16: " + getCheckMessage(MSG_KEY, 3),
+            "29: " + getCheckMessage(MSG_KEY, 3),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationOffset3.java"),
@@ -127,14 +127,14 @@ public class JavadocTagContinuationIndentationCheckTest
     @Test
     public void testCheckWithDescription() throws Exception {
         final String[] expected = {
-            "16: " + getCheckMessage(MSG_KEY, 4),
-            "17: " + getCheckMessage(MSG_KEY, 4),
-            "18: " + getCheckMessage(MSG_KEY, 4),
-            "47: " + getCheckMessage(MSG_KEY, 4),
-            "49: " + getCheckMessage(MSG_KEY, 4),
-            "50: " + getCheckMessage(MSG_KEY, 4),
-            "70: " + getCheckMessage(MSG_KEY, 4),
-            "71: " + getCheckMessage(MSG_KEY, 4),
+            "19: " + getCheckMessage(MSG_KEY, 4),
+            "20: " + getCheckMessage(MSG_KEY, 4),
+            "21: " + getCheckMessage(MSG_KEY, 4),
+            "53: " + getCheckMessage(MSG_KEY, 4),
+            "55: " + getCheckMessage(MSG_KEY, 4),
+            "56: " + getCheckMessage(MSG_KEY, 4),
+            "76: " + getCheckMessage(MSG_KEY, 4),
+            "77: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationDescription.java"),
@@ -145,17 +145,11 @@ public class JavadocTagContinuationIndentationCheckTest
     public void testBlockTag() throws Exception {
         final String[] expected = {
             "21: " + getCheckMessage(MSG_KEY, 4),
-            "32: " + getCheckMessage(MSG_KEY, 4),
-            "42: " + getCheckMessage(MSG_KEY, 4),
-            "62: " + getCheckMessage(MSG_KEY, 4),
-            "74: " + getCheckMessage(MSG_KEY, 4),
-            "75: " + getCheckMessage(MSG_KEY, 4),
-            "89: " + getCheckMessage(MSG_KEY, 4),
-            "90: " + getCheckMessage(MSG_KEY, 4),
-            "91: " + getCheckMessage(MSG_KEY, 4),
-            "92: " + getCheckMessage(MSG_KEY, 4),
-            "93: " + getCheckMessage(MSG_KEY, 4),
-            "94: " + getCheckMessage(MSG_KEY, 4),
+            "31: " + getCheckMessage(MSG_KEY, 4),
+            "40: " + getCheckMessage(MSG_KEY, 4),
+            "57: " + getCheckMessage(MSG_KEY, 4),
+            "67: " + getCheckMessage(MSG_KEY, 4),
+            "68: " + getCheckMessage(MSG_KEY, 4),
             "95: " + getCheckMessage(MSG_KEY, 4),
             "96: " + getCheckMessage(MSG_KEY, 4),
             "97: " + getCheckMessage(MSG_KEY, 4),
@@ -164,8 +158,14 @@ public class JavadocTagContinuationIndentationCheckTest
             "100: " + getCheckMessage(MSG_KEY, 4),
             "101: " + getCheckMessage(MSG_KEY, 4),
             "102: " + getCheckMessage(MSG_KEY, 4),
+            "103: " + getCheckMessage(MSG_KEY, 4),
+            "104: " + getCheckMessage(MSG_KEY, 4),
+            "105: " + getCheckMessage(MSG_KEY, 4),
+            "106: " + getCheckMessage(MSG_KEY, 4),
             "107: " + getCheckMessage(MSG_KEY, 4),
             "108: " + getCheckMessage(MSG_KEY, 4),
+            "113: " + getCheckMessage(MSG_KEY, 4),
+            "114: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTagContinuationIndentationBlockTag.java"),
@@ -223,9 +223,9 @@ public class JavadocTagContinuationIndentationCheckTest
     public void testJavadocTagContinuationIndentationCheckPreTag() throws Exception {
         final String[] expected = {
             "91: " + getCheckMessage(MSG_KEY, 4),
-            "100: " + getCheckMessage(MSG_KEY, 4),
             "101: " + getCheckMessage(MSG_KEY, 4),
             "102: " + getCheckMessage(MSG_KEY, 4),
+            "103: " + getCheckMessage(MSG_KEY, 4),
         };
         verifyWithInlineConfigParser(
             getPath("InputJavadocTagContinuationIndentationPreTag.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationAnonymousClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationAnonymousClass.java
@@ -11,13 +11,15 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationind
 class InputJavadocTagContinuationIndentationAnonymousClass {
     Object anon = new Object()
     {
+        // violation 6 lines below 'Line continuation .* expected level should be 4'
+        // violation 7 lines below 'Line continuation .* expected level should be 4'
         /**
          * Some text.
          * @throws Exception Some text.
          * @param aString Some text.
-         *   Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *   Some javadoc.
          * @serialData Some javadoc.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @see Some text.
          * @return Some text.
          */
@@ -75,16 +77,19 @@ class InputJavadocTagContinuationIndentationAnonymousClass {
             return "null";
         }
 
+        // violation 7 lines below 'Line continuation .* expected level should be 4'
+        // violation 9 lines below 'Line continuation .* expected level should be 4'
+        // violation 10 lines below 'Line continuation .* expected level should be 4'
         /**
          * Some text.
          *       Some javadoc.
          * @param aString Some text.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @return Some text.
          * @param aInt Some text.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @throws Exception Some text.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @param aBoolean Some text.
          * @see Some text.
          */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationBlockTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationBlockTag.java
@@ -11,65 +11,58 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationind
 import java.io.Serializable;
 
 public class InputJavadocTagContinuationIndentationBlockTag {
-
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
     /**
      * Example from issue 5711.
      * Returns the value represented by the specified string of the specified
      * type. Returns 0 for types other than float, double, int, and long.
      * @param text the string to be parsed.
      * @param type the token type of the text. Should be a constant of
-     * {@link TokenTypes}. // violation, 'Line continuation .* expected level should be 4'
+     * {@link TokenTypes}.
      * @return the double value represented by the string argument.
      */
     public static double parseDouble(String text, int type) {
         return 0;
     }
-
+    // violation 4 lines below 'Line continuation .* expected level should be 4'
     /**
      * Javadoc.
-     *
      * @param x this line is normal
      * {@code this} line is wrongly indented
-     */ // violation above 'Line continuation .* expected level should be 4'
+     */
     public void newlineThenBlockTag(int x) {
         // do stuff
     }
-
+    // violation 4 lines below 'Line continuation .* expected level should be 4'
     /**
      * Not enough indentation.
-     *
      * @param x this line is normal
      *   {@code this} line is wrongly indented
-     */ // violation above 'Line continuation .* expected level should be 4'
+     */
     public void partialIndent(int x) {
         // do stuff
     }
-
     /**
      * There can be a newline but nothing follows it.
-     *
      * @param x input
      * @return itself
      * */
     public int identity(int x) {
         return x;
     }
-
+    // violation 4 lines below 'Line continuation .* expected level should be 4'
     /**
      * Javadoc.
-     *
      * @param args
      * {@code this} line is not correctly indented
-     *     {@code this} // violation above 'Line continuation .* expected level should be 4'
+     *     {@code this}
      * <pre>pre tags are skipped</pre>
      */
     public void multipleLines1(String args) {
         // do stuff
     }
-
     /**
      * Javadoc.
-     *
      * @return false always
      * {@code this} line is not correctly indented
      * {@code this} line is not correctly indented
@@ -80,36 +73,48 @@ public class InputJavadocTagContinuationIndentationBlockTag {
     }
     // violation 7 lines above 'Line continuation .* expected level should be 4'
     // violation 7 lines above 'Line continuation .* expected level should be 4'
-    // violation 6 lines below 'Line continuation .* expected level should be 4'
-
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 19 lines below 'Line continuation .* expected level should be 4'
+    // violation 23 lines below 'Line continuation .* expected level should be 4'
+    // violation 23 lines below 'Line continuation .* expected level should be 4'
     /**
      * Javadoc from regression test case (apache-ant).
-     * // violation 3 lines below 'Line continuation .* expected level should be 4'
      * @param c the command line which will be configured
      * if the commandline is initially null, the function is a noop
      * otherwise the function append to the commandline arguments concerning
-     * <ul> // violation, 'Line continuation .* expected level should be 4'
-     * <li> // violation, 'Line continuation .* expected level should be 4'
-     * cvs package // violation, 'Line continuation .* expected level should be 4'
-     * </li> // violation, 'Line continuation .* expected level should be 4'
-     * <li> // violation, 'Line continuation .* expected level should be 4'
-     * compression // violation, 'Line continuation .* expected level should be 4'
-     * </li> // violation, 'Line continuation .* expected level should be 4'
-     * <li> // violation, 'Line continuation .* expected level should be 4'
-     * quiet or reallyquiet // violation, 'Line continuation .* expected level should be 4'
-     * </li> // violation, 'Line continuation .* expected level should be 4'
-     * <li>cvsroot</li> // violation, 'Line continuation .* expected level should be 4'
-     * <li>noexec</li> // violation, 'Line continuation .* expected level should be 4'
+     * <ul>
+     * <li>
+     * cvs package
+     * </li>
+     * <li>
+     * compression
+     * </li>
+     * <li>
+     * quiet or reallyquiet
+     * </li>
+     * <li>cvsroot</li>
+     * <li>noexec</li>
      *     <li>
      *     another item
      *     </li>
      *     <li> yet another item </li>
-     * </ul> // violation, 'Line continuation .* expected level should be 4'
+     * </ul>
      * some text <i>word</i> more text.
      *     some text <i>word</i> more text.
-     */ // violation 2 lines above 'Line continuation .* expected level should be 4'
+     */
     public String regressionNestedHtml(CharSequence c) {
         return "";
     }
-
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationDescription.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationDescription.java
@@ -9,13 +9,16 @@ offset = (default)4
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
 
 public class InputJavadocTagContinuationIndentationDescription {
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
+    // violation 7 lines below 'Line continuation .* expected level should be 4'
     /**
      * General Description here.
      *
      * @param s
-     * Description 1. // violation, 'Line continuation .* expected level should be 4'
-     * Description 2. // violation, 'Line continuation .* expected level should be 4'
-     * Description 3. // violation, 'Line continuation .* expected level should be 4'
+     * Description 1.
+     * Description 2.
+     * Description 3.
      *                         Description 4 with extra indentation.
      *
      *
@@ -42,13 +45,16 @@ public class InputJavadocTagContinuationIndentationDescription {
      */
     public void testWithMissingAsterisk(int x) {}
 
+    // violation 5 lines below 'Line continuation .* expected level should be 4'
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
     /**
-     * @param s // violation below 'Line continuation .* expected level should be 4'
+     * @param s
      *Description with missing space.
-     * @param s2 // violation below 'Line continuation .* expected level should be 4'
+     * @param s2
      *****Description with multiple asterisk and missing space
      ***** Description with multiple asterisk and missing space
-     */ // violation above 'Line continuation .* expected level should be 4'
+     */
     public void testOtherCases(String s, String s2) {}
     
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationInnerClass.java
@@ -85,15 +85,17 @@ class InputJavadocTagContinuationIndentationInnerClass {
             return "null";
         }
 
+        // violation 7 lines below 'Line continuation .* expected level should be 4'
+        // violation 9 lines below 'Line continuation .* expected level should be 4'
         /**
          * Some text.
          * @param aString Some text.
          * @return Some text.
          * @param aInt Some text.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @throws Exception Some text.
          * @param aBoolean Some text.
-         *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+         *    Some javadoc.
          * @see Some text.
          */
         String method6(String aString, int aInt, boolean aBoolean) throws Exception

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationMethod456.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationMethod456.java
@@ -31,14 +31,16 @@ class InputJavadocTagContinuationIndentationMethod456
         return "null";
     }
 
+    // violation 6 lines below 'Line continuation .* expected level should be 4'
+    // violation 8 lines below 'Line continuation .* expected level should be 4'
     /**
      * Some text.
      * @param aString Some text.
      * @return Some text.
-     *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+     *    Some javadoc.
      * @serialData Some javadoc.
      * @param aInt Some text.
-     *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+     *    Some javadoc.
      * @throws Exception Some text.
      * @param aBoolean Some text.
      * @see Some text.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationOffset3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationOffset3.java
@@ -8,11 +8,12 @@ offset = 3
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
 
-/**
- * Some javadoc.
- *
- * @since Some javadoc.
- *   Some javadoc. // violation, 'Line continuation .* expected level should be 3'
+    // violation 5 lines below 'Line continuation .* expected level should be 3'
+    /**
+     * Some javadoc.
+     *
+     * @since Some javadoc.
+     *   Some javadoc.
  * @version 1.0
  * @deprecated Some javadoc.
  *    Some javadoc.
@@ -21,10 +22,11 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationind
  *     Some javadoc.
  */
 class InputJavadocTagContinuationIndentationOffset3 {
+    // violation 4 lines below 'Line continuation .* expected level should be 3'
         /**
      * The client's first name.
      * @serial Some javadoc.
-        *   Some javadoc. // violation, 'Line continuation .* expected level should be 3'
+        *   Some javadoc.
      */
     private String fFirstName;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationOthers.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationOthers.java
@@ -8,6 +8,7 @@ offset = (default)4
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
 
+// violation 10 lines below 'Line continuation .* expected level should be 4'
 /**
  * Some javadoc.
  *
@@ -17,11 +18,13 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationind
  *     Some javadoc.
  *     Some javadoc.
  * @see Some javadoc.
- *    Some javadoc. // violation, 'Line continuation .* expected level should be 4'
+ *    Some javadoc.
  * @author max
  */
 enum InputJavadocTagContinuationIndentationOthers {}
 
+// violation 9 lines below 'Line continuation .* expected level should be 4'
+// violation 10 lines below 'Line continuation .* expected level should be 4'
 /**
  * Some javadoc.
  *
@@ -30,8 +33,8 @@ enum InputJavadocTagContinuationIndentationOthers {}
  *     Some javadoc.
  * @serialData Some javadoc.
  *   Line below is empty on purpose.
- * @see Some Text. // violation above 'Line continuation .* expected level should be 4'
- * L. // violation, 'Line continuation .* expected level should be 4'
+ * @see Some Text.
+ * L.
  *
  * @author max
  * @customTag {@link com.puppycrawl.tools.checkstyle.AllChecksPresentOnAvailableChecksPageTest
@@ -46,11 +49,12 @@ interface FooIn1 {}
 interface FooIn2 {}
 
 class ShortNextLine {
+    // violation 5 lines below 'Line continuation .* expected level should be 4'
     /**
      * Test.
      *
      * @return Test
-     * tt <code>null</code>. // violation, 'Line continuation .* expected level should be 4'
+     * tt <code>null</code>.
      */
     public void example() {
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationPreTag.java
@@ -93,10 +93,11 @@ public class InputJavadocTagContinuationIndentationPreTag {
     public void test4() {}
     // violation 3 lines above 'Line continuation have .* expected level should be 4'
 
+    // violation 5 lines below 'Line continuation .* expected level should be 4'
     /**
      * Writes the object using a
      * <a href="{@docRoot}/serialized-form.html#ja">deserialized form</a>.
-     * @serialData // violation below 'Line continuation .* expected level should be 4'
+     * @serialData
      * Refer to the serialized form of
      * <a href="{@docRoot}/serialized-formRules">ZoneRules.writeReplace</a>
      * for the encoding of epoch seconds and offsets.


### PR DESCRIPTION
Issue #19764

## Summary

- Moved inline `// violation` comments outside Javadocs for the `JavadocTagContinuationIndentation` input files.
- Updated expected violation line numbers in `JavadocTagContinuationIndentationCheckTest`.
- Removed obsolete `noViolationCommentsInJavadoc` suppressions from `checkstyle-input-suppressions.xml`.

## Testing

```bash
./mvnw clean verify