### PR TITLE
Issue #15456: missed violation in examples

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -16,6 +16,9 @@
   <suppress checks="FileLength"
              files="TokenTypes.java|IndentationCheckTest.java|XdocsPagesTest|CheckerTest.java"
              lines="1"/>
+  <!-- Until reduce the suppression data blocks -->
+  <suppress checks="FileLength"
+            files="[\\/]bdd[\\/]InlineConfigParser\.java"/>
 
   <!-- illegal words are part of Javadoc -->
   <suppress checks="TodoComment" files=".*TodoCommentCheck\.java"/>

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesForEscapedS.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesForEscapedS.java
@@ -6,7 +6,7 @@ class InputSpecialEscapeSequencesForEscapedS {
     final String r0 = "\s";
     final String r1 = "\u0020"; // violation 'Consider using special escape sequence'
     final String r2 = "\u0008"; // violation 'Consider using special escape sequence'
-    // These have no escape sequences, should not cause violations
+    // ok, These have no escape sequences
     final String r3 = "\u000b";
     final String r4 = "\u001c";
     final String r5 = "\u001D";

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForUnicodeValues.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForUnicodeValues.java
@@ -37,7 +37,7 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
           """
           \\u005c
           """;
-      // The following have no escape sequences, should not cause violations
+      // ok,  The following have no escape sequences
       final String r9 =
           """
           \\u000b
@@ -131,7 +131,7 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
         """
         \\u005c
         """;
-    // The following have no escape sequences, should not cause violations
+    // ok, The following have no escape sequences
     String r10 =
         """
         \\u000b
@@ -167,15 +167,15 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
         """
         \u000csssdfsd
         """; // violation 2 lines above 'Consider using special escape sequence'
-    final String r4 = // violation below 'Consider using special escape sequence'
+    final String r4 =
         """
         \u0022
-        """; // violation 2 lines above, 'Unicode escape(s) usage should be avoided.
-    final String r5 = // violation below 'Consider using special escape sequence'
+        """; // violation 2 lines above 'Consider using special escape sequence'
+    final String r5 =
         """
         \u000csssdfsd
-        """; // violation 2 lines above, 'Unicode escape(s) usage should be avoided.
-    // The following have no escape sequences, should not cause violations
+        """; // violation 2 lines above 'Consider using special escape sequence'
+    // ok, The following have no escape sequences
     final String r6 =
         """
         \u000b
@@ -295,7 +295,7 @@ public class InputSpecialEscapeSequencesInTextBlockForUnicodeValues {
               """
               \\u005c
               """;
-          // The following have no escape sequences, should not cause violations
+          // ok, The following have no escape sequences
           String r10 =
               """
               \\u000b

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurly.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurly.java
@@ -8,8 +8,8 @@ public class InputRightCurly {
     try {
       /* foo */
     } finally { after = true; }
-    // 2 violations above
+    // 2 violations above:
     //  ''{' at column 15 should have line break after.'
-    //  ''}' at column 30 should be alone on a line.'
+    //  ''}' at column 31 should be alone on a line.'
   }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputBoxComments.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputBoxComments.java
@@ -27,21 +27,21 @@ public class InputBoxComments {
   // =========================================
   // violation above 'Comment uses box-like repetitive character pattern.'
 
-  // box with only 9 chars triggers violation
+  // box with only 9 chars
   void myFunc2() {
     // violation below 'Comment uses box-like repetitive character pattern.'
     // =========
     int y = 2;
   }
 
-  // box with only 9 chars triggers violation
+  // box with only 9 chars
   // violation below 'Comment uses box-like repetitive character pattern.'
   // *********
   void myFunc3() {
     int z = 3;
   }
 
-  // box with only 9 chars triggers violation
+  // box with only 9 chars
   void myFunc4() {
     // violation below 'Comment uses box-like repetitive character pattern.'
     // #########

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksIndentation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule489textblocks/InputTextBlocksIndentation.java
@@ -32,7 +32,7 @@ public class InputTextBlocksIndentation {
     getData(
             """
         Indentation of Text-block
-            """, // violation Above,'Each line of text in the text block must be indented'
+            """,
         5
     );
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalFinalVariableName.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputLocalFinalVariableName.java
@@ -12,12 +12,12 @@ public class InputLocalFinalVariableName {
     final int BadName = 1;
     // violation above 'Local final variable name 'BadName' must match pattern'
     final int VARIABLE2 = 2;
-    // 2 violations above
-    // 'VARIABLE2' must contain no more than '1' consecutive capital letters.
+    // 2 violations above:
+    // 'VARIABLE2' must contain no more than '1' consecutive capital letters.'
     // 'Local final variable name 'VARIABLE2' must match pattern'
     final String FOO_2 = "foo";
-    // 2 violations above
-    // 'FOO2' must contain no more than '1' consecutive capital letters.
+    // 2 violations above:
+    // 'FOO_2' must contain no more than '1' consecutive capital letters.'
     // 'Local final variable name 'FOO_2' must match pattern'
     final String A = "a";
     // violation above 'Local final variable name 'A' must match pattern'
@@ -30,8 +30,8 @@ public class InputLocalFinalVariableName {
     final boolean aA = false;
     // violation above 'Local final variable name 'aA' must match pattern'
     final boolean SOLVE6X6 = true;
-    // 2 violations above
-    // 'SOLVE6X6' must contain no more than '1' consecutive capital letters.
+    // 2 violations above:
+    // 'SOLVE6X6' must contain no more than '1' consecutive capital letters.'
     // 'Local final variable name 'SOLVE6X6' must match pattern'
   }
 
@@ -58,9 +58,9 @@ public class InputLocalFinalVariableName {
 
   /** Some javadoc. */
   void foo(final String Name, final int Age) {
-    // 2 violations above
-    // 'Local final variable name 'Name' must match pattern'
-    // 'Local final variable name 'Age' must match pattern'
+    // 2 violations above:
+    // 'Parameter name 'Name' must match pattern'
+    // 'Parameter name 'Age' must match pattern'
     try (final InputStreamReader In = new InputStreamReader(System.in);
         final OutputStreamWriter Out = new OutputStreamWriter(System.out)) {
       // violation 2 lines above 'Local final variable name 'In' must match pattern'

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleannotations/InputAnnotationsDoAndDonts.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleannotations/InputAnnotationsDoAndDonts.java
@@ -54,7 +54,7 @@ public class InputAnnotationsDoAndDonts {
         }
     }
 
-    // No violation until https://github.com/checkstyle/checkstyle/issues/20209
+    // ok until https://github.com/checkstyle/checkstyle/issues/20209
     class Donts extends Temp {
 
         @Override @Deprecated public void foo() {

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleclassstructure/InputClassStructureInvalidOrder.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleclassstructure/InputClassStructureInvalidOrder.java
@@ -9,13 +9,15 @@ public class InputClassStructureInvalidOrder {
     InputClassStructureInvalidOrder() {
     }
 
-    public int c; // violation, Field declaration is in wrong order
-    static Long s; // violation, Field declaration is in wrong order
+    public int c;  // violation, 'Field declaration is in wrong order'
+    static Long s; // violation, 'Field declaration is in wrong order'
 
     void foo() {}
 
-    InputClassStructureInvalidOrder(int z) { // 2 violations
-    } // 'Constructor definition in wrong order.'
+    InputClassStructureInvalidOrder(int z) {
+      // 2 violations above:
+    } // 'Constructors should be grouped together.'
+      // 'Constructor definition in wrong order.'
 
     void foo1() {}
 

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceDosAndDonts.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceDosAndDonts.java
@@ -31,7 +31,8 @@ public class InputHorizontalWhiteSpaceDosAndDonts {
         long   sixtyfourFlags;
         // violation above 'Use a single space to separate non-whitespace characters.'
 
-        if ( isFlagSet( "GO" ) ) { // 4 violations
+        if ( isFlagSet( "GO" ) ) {
+            // 4 violations above:
             // ''(' is followed by whitespace.'
             // ''(' is followed by whitespace.'
             // '')' is preceded with whitespace.'

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceInvalidFive.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceInvalidFive.java
@@ -12,12 +12,14 @@ public class InputHorizontalWhiteSpaceInvalidFive {
     void  fun2() {} // violation 'Use a single space'
 
     public void temp() {
-        if  (1 > 2)  { // 2 violations
+        if  (1 > 2)  {
+            // 2 violations above:
             // 'Use a single space'
             // 'Use a single space'
         }
 
-        for  (int i = 0; i < 10;  i++)  { // 3 violations
+        for  (int i = 0; i < 10;  i++)  {
+            // 3 violations above:
             // 'Use a single space'
             // 'Use a single space'
             // 'Use a single space'
@@ -25,7 +27,8 @@ public class InputHorizontalWhiteSpaceInvalidFive {
 
         int a = 0;
 
-        switch  (a)  { // 2 violations
+        switch  (a)  {
+            // 2 violations above:
             // 'Use a single space'
             // 'Use a single space'
             case 1:  { // violation 'Use a single space'

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceInvalidFour.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceInvalidFour.java
@@ -21,7 +21,8 @@ public class InputHorizontalWhiteSpaceInvalidFour {
     public void fun() {
 
         boolean a = true;
-        if ( a ) { // 2 violations
+        if ( a ) {
+        // 2 violations above:
         // ''(' is followed by whitespace'
         // '')' is preceded with whitespace'
         }
@@ -31,7 +32,8 @@ public class InputHorizontalWhiteSpaceInvalidFour {
         } catch ( IOException e) { // violation 'is followed by whitespace'
         } catch (Exception e ) {}  // violation 'is preceded with whitespace'
 
-        for ( int i = 0; i < x; i++ ) { // 2 violations
+        for ( int i = 0; i < x; i++ ) {
+        // 2 violations above:
         // ''(' is followed by whitespace'
         // '')' is preceded with whitespace'
         }
@@ -67,7 +69,8 @@ public class InputHorizontalWhiteSpaceInvalidFour {
          * Dummy input.
          */
         Bar(int k) {
-            super( k ); // 2 violations
+            super( k );
+            // 2 violations above:
             // ''(' is followed by whitespace'
             // '')' is preceded with whitespace'
             for ( int i = 0; i < k; i++) { // violation ''(' is followed by whitespace'

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceInvalidOne.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceInvalidOne.java
@@ -12,9 +12,10 @@ public class InputHorizontalWhiteSpaceInvalidOne {
      */
     void example() {
         int b = 0;
-        switch(b){ // 2 violations
-            // ''{' is not preceded with whitespace.'
+        switch(b){
+            // 2 violations above:
             // ''switch' is not followed by whitespace.'
+            // ''{' is not preceded with whitespace.'
             case 1: {
                 System.out.println("hello");
                 break;
@@ -38,9 +39,10 @@ public class InputHorizontalWhiteSpaceInvalidOne {
             System.out.println("True");
         }
 
-        int s=4; // 2 violations
-        // '=' is not followed by whitespace.
-        // '=' is not preceded with whitespace.
+        int s=4;
+        // 2 violations above:
+        // ''=' is not followed by whitespace.'
+        // ''=' is not preceded with whitespace.'
     }
 
     /**
@@ -49,10 +51,11 @@ public class InputHorizontalWhiteSpaceInvalidOne {
     record MyRecord3() {
         void method (){ // violation ''{' is not preceded with whitespace'
             final int a = 1;
-            int b= 1; // violation ''=' is not preceded with whitespace'
-            b=1; // 2 violations
-            // '=' is not followed by whitespace.
-            // '=' is not preceded with whitespace.
+            int b= 1;  // violation ''=' is not preceded with whitespace'
+            b=1;
+            // 2 violations above:
+            // ''=' is not followed by whitespace.'
+            // ''=' is not preceded with whitespace.'
         }
     }
 }

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceInvalidThree.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceInvalidThree.java
@@ -19,11 +19,13 @@ public class InputHorizontalWhiteSpaceInvalidThree {
     /**
      * Dummy Test method.
      */
-    public void method(int x,int y,int z) { // 2 violations
+    public void method(int x,int y,int z) {
+        // 2 violations above:
         // '',' is not followed by whitespace.'
         // '',' is not followed by whitespace.'
 
-        for (int i = 0;i <= 9;i++) { // 2 violations
+        for (int i = 0;i <= 9;i++) {
+        // 2 violations above:
         // '';' is not followed by whitespace.'
         // '';' is not followed by whitespace.'
         }
@@ -35,7 +37,8 @@ public class InputHorizontalWhiteSpaceInvalidThree {
     class Inner {
         Inner(int e,int f) {} // violation 'not followed by whitespace'
 
-        Inner(int e,int f,int g) {} // 2 violations
+        Inner(int e,int f,int g) {}
+        // 2 violations above:
         // '',' is not followed by whitespace.'
         // '',' is not followed by whitespace.'
     }

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceInvalidTwo.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulehorizontalwhitespace/InputHorizontalWhiteSpaceInvalidTwo.java
@@ -46,9 +46,10 @@ public class InputHorizontalWhiteSpaceInvalidTwo {
     }
 
     // violation below ''//' must be followed by a whitespace.'
-    //this comment cause violation
+    //this comment cause
     void testMethod(float f1) {
-        int n = ( int ) f1; // 2 violations
+        int n = ( int ) f1;
+        // 2 violations above:
         // ''(' is followed by whitespace.'
         // '')' is preceded with whitespace.'
 

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleindentation/InputIdentationDoAndDonts.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleindentation/InputIdentationDoAndDonts.java
@@ -26,19 +26,22 @@ public class InputIdentationDoAndDonts {
 
     public void styleGuideDont(Choice var) {
         switch (var) {
-        case TWO: // 2 violations
-        // '.* incorrect indentation level 8, expected .* 12.'
-        // ''case' construct must use '{}'s.'
+        case TWO:
+            // 2 violations above:
+            // ''case' construct must use '{}'s.'
+            // '.* incorrect indentation level 8, expected .* 12.'
             setChoice("two"); // violation '.* incorrect indentation level 12, expected .* 16.'
             break; // violation '.* incorrect indentation level 12, expected .* 16.'
-        case THREE: // 2 violations
-        // '.* incorrect indentation level 8, expected .* 12.'
-        // ''case' construct must use '{}'s.'
+        case THREE:
+            // 2 violations above:
+            // ''case' construct must use '{}'s.'
+            // '.* incorrect indentation level 8, expected .* 12.'
             setChoice("three"); // violation '.* incorrect indentation level 12, expected .* 16.'
             break; // violation '.* incorrect indentation level 12, expected .* 16.'
-        default: // 2 violations
-        // '.* incorrect indentation level 8, expected .* 12.'
-        // ''default' construct must use '{}'s.'
+        default:
+            // 2 violations above:
+            // ''default' construct must use '{}'s.'
+            // '.* incorrect indentation level 8, expected .* 12.'
             throw new IllegalArgumentException();
             // violation above '.* incorrect indentation level 12, expected .* 16.'
         }

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulejavadoc/InputJavadocDosAndDonts.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulejavadoc/InputJavadocDosAndDonts.java
@@ -22,7 +22,7 @@ public class InputJavadocDosAndDonts {
     public void styleGuideDonts1() {
     }
 
-    // no violation until https://github.com/checkstyle/checkstyle/issues/18570
+    // ok, until https://github.com/checkstyle/checkstyle/issues/18570
     /**
      * The String below may interfere with the HTML.
      *

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/InputLambdaExpressionsDosAndDonts.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulelambdaexpressions/InputLambdaExpressionsDosAndDonts.java
@@ -42,15 +42,15 @@ public class InputLambdaExpressionsDosAndDonts {
 
     public void styleGuideDonts(List<String> list) {
 
-        // no violation for block until https://github.com/checkstyle/checkstyle/issues/20692
+        // ok, for block until https://github.com/checkstyle/checkstyle/issues/20692
         Runnable r = () -> { System.out.println("Hello World"); };
         // violation above, ''{' at column 28 should have line break after.'
 
-        // no violation for block until https://github.com/checkstyle/checkstyle/issues/20692
+        // ok, for block until https://github.com/checkstyle/checkstyle/issues/20692
         Supplier<String> supp = () -> { return "Hello World"; };
         // violation above, ''{' at column 39 should have line break after.'
 
-        // no violation until https://github.com/checkstyle/checkstyle/issues/20693
+        // ok, until https://github.com/checkstyle/checkstyle/issues/20693
         appendFilter(s -> list.contains(s));
 
         // this can not be determined it is a subjective case
@@ -60,7 +60,7 @@ public class InputLambdaExpressionsDosAndDonts {
         Function<Person, String> nameFunc = (Person p) -> p.getFirstName() + " " + p.getLastName();
 
         class Util {
-            // no violation here because the current max allowed length of lambda is 10 or now
+            // ok, here because the current max allowed length of lambda is 10 or now
             static void printAllPersons(List<Person> persons) {
                 persons.stream()
                         .map(p -> {

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleliterals/InputLiteralsDoAndDonts.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleliterals/InputLiteralsDoAndDonts.java
@@ -14,8 +14,9 @@ public class InputLiteralsDoAndDonts {
 
     public void styleGuideDonts() {
         long l = 5432l; // violation 'Should use uppercase 'L'.'
-        int i = 0X123 + 0xabc; // 2 violations
-        // 'Numerical prefix should be in uppercase.'
+        int i = 0X123 + 0xabc;
+        // 2 violations above:
+        // 'Numerical prefix should be in lowercase.'
         // 'Should use uppercase hexadecimal letters.'
         byte b = 0B1010; // violation 'Numerical prefix should be in lowercase.'
         float f1 = 1 / 5432F; // violation 'Numerical suffix should be in lowercase.'

--- a/src/it/resources/com/openjdk/checkstyle/test/chapternaming/ruleconstants/InputConstantsDoAndDonts.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapternaming/ruleconstants/InputConstantsDoAndDonts.java
@@ -11,7 +11,8 @@ public class InputConstantsDoAndDonts {
     // violation below 'Name 'CURRENT_WORDS' must match pattern'
     public final List<String> CURRENT_WORDS = new ArrayList<>();
 
-    enum ApplicationModeOne { Running, Paused, Terminated } // 3 violations
+    enum ApplicationModeOne { Running, Paused, Terminated }
+    // 3 violations above:
     // 'must match pattern'
     // 'must match pattern'
     // 'must match pattern'

--- a/src/it/resources/com/openjdk/checkstyle/test/chapternaming/rulenaming/InputNamingOne.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapternaming/rulenaming/InputNamingOne.java
@@ -4,7 +4,7 @@ public class InputNamingOne {
     private String field;
     private String testField;
 
-    InputNamingOne(String testField) { // no violation constructor param is allowed
+    InputNamingOne(String testField) { // ok, constructor param is allowed
     }
 
     void method(String param) {
@@ -20,6 +20,6 @@ public class InputNamingOne {
     }
 
     abstract class Inner {
-        abstract int method(String field); // no violation abstract method parameter are allowed
+        abstract int method(String field); // ok, abstract method parameter are allowed
     }
 }

--- a/src/it/resources/com/openjdk/checkstyle/test/chapternaming/rulenaming/InputNamingTwo.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapternaming/rulenaming/InputNamingTwo.java
@@ -47,7 +47,8 @@ public class InputNamingTwo {
             }
         }
 
-        private void shadowParam(int innerHidden, int hidden) { // 2 violations
+        private void shadowParam(int innerHidden, int hidden) {
+            // 2 violations above:
             // ''innerHidden' hides a field'
             // ''hidden' hides a field'
         }

--- a/src/it/resources/com/openjdk/checkstyle/test/chapternaming/ruletypevariables/InputTypeVariablesDosAndDonts.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapternaming/ruletypevariables/InputTypeVariablesDosAndDonts.java
@@ -13,7 +13,8 @@ public class InputTypeVariablesDosAndDonts {
     }
 
     public void styleGuideDonts() {
-        interface SpecialMap<Key, Value> extends Map<Key, Value> { // 2 violations
+        interface SpecialMap<Key, Value> extends Map<Key, Value> {
+            // 2 violations above:
             // 'Name 'Key' must match pattern'
             // 'Name 'Value' must match pattern'
         }

--- a/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
+++ b/src/site/xdoc/checks/annotation/suppresswarningsholder.xml
@@ -63,16 +63,16 @@
 class Example1 {
   private int K; // violation, 'Name 'K' must match pattern'
   @SuppressWarnings({"membername"})
-  private int J; // violation suppressed
+  private int J;
 
   @SuppressWarnings("ParamListShouldBeShort")
-    public void needsLotsOfParameters1 (int a, // violation suppressed
+    public void needsLotsOfParameters1 (int a,
      int b, int c, int d, int e, int f, int g, int h) {}
 
   private int [] ARR; // violation ''int' is followed by whitespace'
   // violation above, 'Name 'ARR' must match pattern'
   @SuppressWarnings("all")
-  private int [] ARRAY; // violation suppressed
+  private int [] ARRAY;
   // violation 2 lines below 'More than 7 parameters (found 8)'
   @SuppressWarnings("paramcounter")
     public void needsLotsOfParameters2 (int a,
@@ -113,7 +113,7 @@ class Example1 {
 class Example2 {
   private int K; // violation, 'Name 'K' must match pattern'
   @SuppressWarnings({"membername"})
-  private int J; // violation suppressed
+  private int J;
 
   @SuppressWarnings("ParamListShouldBeShort")
   public void needsLotsOfParameters1 (int a,
@@ -122,10 +122,10 @@ class Example2 {
   private int [] ARR; // violation ''int' is followed by whitespace'
   // violation above, 'Name 'ARR' must match pattern'
   @SuppressWarnings("all")
-  private int [] ARRAY; // violation suppressed
+  private int [] ARRAY;
 
   @SuppressWarnings("paramcounter")
-  public void needsLotsOfParameters2 (int a, // violation suppressed
+  public void needsLotsOfParameters2 (int a,
     int b, int c, int d, int e, int f, int g, int h) {}
 }
 </code></pre></div>
@@ -175,7 +175,7 @@ public class UseCase1 {
   @SuppressWarnings("paramcounter")
   public void needsLotsOfParameters2(
           int a, int b, int c, int d,
-          int e, int f, int g, int h) {} // violation suppressed
+          int e, int f, int g, int h) {}
 
   private int [] ARR;
 
@@ -226,7 +226,7 @@ public class UseCase2 {
   @SuppressWarnings("paramcounter")
   public void needsLotsOfParameters2(
           int a, int b, int c, int d,
-          int e, int f, int g, int h) {} // violation suppressed
+          int e, int f, int g, int h) {}
 
   private int [] ARR;
 

--- a/src/site/xdoc/checks/coding/covariantequals.xml
+++ b/src/site/xdoc/checks/coding/covariantequals.xml
@@ -95,7 +95,7 @@ public class Example1 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
-  public boolean equals(Example2 same) {  // no violation
+  public boolean equals(Example2 same) {
     return false;
   }
 
@@ -104,7 +104,7 @@ public class Example2 {
   }
 
   record Test(String str) {
-    public boolean equals(Test same) {  // no violation
+    public boolean equals(Test same) {
       return false;
     }
 

--- a/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
+++ b/src/site/xdoc/checks/coding/variabledeclarationusagedistance.xml
@@ -303,7 +303,7 @@ public class Example6 {
 public class UseCase1 {
 
   public void case1(long timeNow, int hh, int min) {
-    int minutes = min + 5; // ok, No violation reported
+    int minutes = min + 5;
     Calendar cal = Calendar.getInstance();
     cal.setTimeInMillis(timeNow);
     cal.set(Calendar.SECOND, 0);

--- a/src/site/xdoc/checks/sizes/filelength.xml
+++ b/src/site/xdoc/checks/sizes/filelength.xml
@@ -102,7 +102,7 @@ public class Example2 {
 public class Example3 {
   public void myTest() {
     // small class with more than 5 lines less than 2000 lines
-    String test = "Some content"; // ok, no violation as only txt file validated
+    String test = "Some content"; // ok, as only txt file validated
   }
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/sizes/methodcount.xml
+++ b/src/site/xdoc/checks/sizes/methodcount.xml
@@ -331,7 +331,7 @@ class Example5 { // violation, 'Number of package methods is 1 (max allowed is 0
 </code></pre></div><hr class="example-separator"/>
         <p id="Example6-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example6 { // ok, no violation there are no protected methods in this class
+class Example6 { // ok, there are no protected methods in this class
 
   public void outerMethod1(int i) {}
   public void outerMethod2() {}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -222,7 +222,7 @@ public final class InlineConfigParser {
 
     /** A pattern that matches any comment by default. */
     private static final Pattern VIOLATION_DEFAULT = Pattern
-            .compile("//.*violation.*");
+            .compile(".*//.*violation.*");
 
     /** The String "(null)". */
     private static final String NULL_STRING = "(null)";
@@ -259,11 +259,168 @@ public final class InlineConfigParser {
     );
 
     /**
-     * Input files where violation messages are intentionally not specified,
-     * because they would be too big or impractical to maintain.
+     * Checks in which violation message is not yet fully specified in all input files.
+     * Temporary suppression until
+     * <a href="https://github.com/checkstyle/checkstyle/issues/15456">#15456</a>
      */
     private static final Set<String> SUPPRESSED_FILES = Set.of(
-            "InputAvoidEscapedUnicodeCharactersAllEscapedUnicodeCharacters.java"
+            "checks/avoidescapedunicodecharacters/"
+                    + "InputAvoidEscapedUnicodeCharactersAllEscapedUnicodeCharacters.java",
+            "sariflogger/InputSarifLoggerSingleException.java",
+            "sariflogger/InputSarifLoggerLineOnly.java",
+            "sariflogger/InputSarifLoggerMultipleMessages.java",
+            "checks/arraytypestyle/InputArrayTypeStyleOff.java",
+            "checks/arraytypestyle/InputArrayTypeStyle.java",
+            "checks/descendanttoken/InputDescendantTokenLastTokenType.java",
+            "checks/descendanttoken/InputDescendantTokenLastTokenType2.java",
+            "checks/descendanttoken/InputDescendantTokenReturnFromFinally3.java",
+            "checks/descendanttoken/InputDescendantTokenReturnFromFinally4.java",
+            "checks/descendanttoken/InputDescendantTokenReturnFromFinally5.java",
+            "checks/descendanttoken/InputDescendantTokenReturnFromFinally6.java",
+            "checks/trailingcomment/InputTrailingComment.java",
+            "checks/trailingcomment/InputTrailingComment3.java",
+            "checks/trailingcomment/InputTrailingComment2.java",
+            "annotation/annotationlocation/InputAnnotationLocationParameterized.java",
+            "annotation/annotationlocation/InputAnnotationLocationSingleParameterless.java",
+            "annotation/annotationlocation/InputAnnotationLocationIncorrect3One.java",
+            "annotation/annotationlocation/InputAnnotationLocationIncorrectOne.java",
+            "annotation/annotationlocation/"
+                    + "InputAnnotationLocationCustomAnnotationsDeclared.java",
+            "annotation/annotationusestyle/InputAnnotationUseStyleNoTrailingComma.java",
+            "annotation/annotationusestyle/InputAnnotationUseStyleWithTrailingCommaNever.java",
+            "annotation/annotationusestyle/InputAnnotationUseStyleWithParens.java",
+            "annotation/suppresswarnings/InputSuppressWarningsCompact2.java",
+            "annotation/suppresswarnings/InputSuppressWarningsCompactNonConstant2.java",
+            "annotation/suppresswarnings/InputSuppressWarningsCompactNonConstant1.java",
+            "annotation/suppresswarnings/InputSuppressWarningsCompact5.java",
+            "annotation/suppresswarnings/InputSuppressWarningsCompactNonConstant4.java",
+            "annotation/suppresswarnings/InputSuppressWarningsCompactNonConstant3.java",
+            "annotation/suppresswarnings/InputSuppressWarningsCompact6.java",
+            "annotation/suppresswarnings/InputSuppressWarningsCompact7.java",
+            "annotation/suppresswarnings/InputSuppressWarningsCompactNonConstant6.java",
+            "annotation/suppresswarnings/InputSuppressWarningsCompactNonConstant5.java",
+            "annotation/suppresswarnings/InputSuppressWarningsExpanded2.java",
+            "annotation/suppresswarnings/InputSuppressWarningsExpandedNonConstant2.java",
+            "annotation/suppresswarnings/InputSuppressWarningsExpandedNonConstant1.java",
+            "annotation/suppresswarnings/InputSuppressWarningsExpanded5.java",
+            "annotation/suppresswarnings/InputSuppressWarningsExpandedNonConstant5.java",
+            "annotation/suppresswarnings/InputSuppressWarningsExpanded6.java",
+            "annotation/suppresswarnings/InputSuppressWarningsExpanded7.java",
+            "annotation/suppresswarnings/InputSuppressWarningsExpandedNonConstant7.java",
+            "annotation/suppresswarnings/InputSuppressWarningsExpandedNonConstant6.java",
+            "annotation/suppresswarnings/InputSuppressWarningsSingle2.java",
+            "annotation/suppresswarnings/InputSuppressWarningsSingle1.java",
+            "annotation/suppresswarnings/InputSuppressWarningsSingle5.java",
+            "annotation/suppresswarnings/InputSuppressWarningsSingle6.java",
+            "annotation/suppresswarnings/InputSuppressWarningsSingle7.java",
+            "annotation/suppresswarnings/InputSuppressWarningsRecords.java",
+            "whitespace/parenpad/Example1.java",
+            "whitespace/singlespaceseparator/Example2.java",
+            "whitespace/typecastparenpad/InputTypecastParenPadWhitespace.java",
+            "whitespace/typecastparenpad/InputTypecastParenPadWhitespaceTestSpace.java",
+            "whitespace/typecastparenpad/Example1.java",
+            "whitespace/typecastparenpad/Example2.java",
+            "whitespace/whitespacearound/"
+                    + "InputWhitespaceAroundDoubleBraceInitialization.java",
+            "whitespace/whitespacearound/"
+                    + "InputWhitespaceAroundAllowEmptyLambdaExpressions2.java",
+            "whitespace/whitespacearound/"
+                    + "InputWhitespaceAroundAllowEmptyTypesAndNonEmptyClasses.java",
+            "whitespace/whitespacearound/"
+                    + "InputWhitespaceAroundAllowEmptyTypesAndNonEmptyClasses2.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundArrayInitialization.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundBraces2Part2.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundBracesPart2.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundEmptyTypesAndCycles2.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundEmptyTypesAndCycles.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundGenerics.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundKeywordsAndOperators.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyLambdaExpressions.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundAfterEmoji.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundAfterPermitsList.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundAllTokens.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyCompactCtors.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundLambda.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundRecords.java",
+            "whitespace/whitespacearound/InputWhitespaceAroundVarargs.java",
+            "whitespace/whitespacearound/Example1.java",
+            "whitespace/whitespacearound/Example10.java",
+            "whitespace/whitespacearound/Example11.java",
+            "whitespace/whitespacearound/Example4.java",
+            "whitespace/whitespacearound/Example5.java",
+            "whitespace/whitespacearound/Example6.java",
+            "whitespace/whitespacearound/Example7.java",
+            "whitespace/whitespacearound/Example8.java",
+            "whitespace/whitespacearound/Example9.java",
+            "whitespace/whitespacearound/UseCase1.java"
+    );
+
+    /**
+     * Checks in which violation message is not yet fully specified in all input files.
+     * Temporary suppression until
+     * <a href="https://github.com/checkstyle/checkstyle/issues/15456">#15456</a>
+     * is fully resolved for these checks. Remove entries here as their input files
+     * are updated with proper violation messages.
+     */
+    private static final Set<String> SUPPRESSED_CHECKS = Set.of(
+            "com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsHolder",
+            "com.puppycrawl.tools.checkstyle.checks.arraytypestyle.ArrayTypeStyleCheck",
+            "com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck",
+            "com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck",
+            "com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.CovariantEqualsCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanExpressionCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck",
+            "com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck",
+            "com.puppycrawl.tools.checkstyle.checks.descendanttoken.DescendantTokenCheck",
+            "com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck",
+            "com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassConstructorCheck",
+            "com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck",
+            "com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck",
+            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck",
+            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck",
+            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck",
+            "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck",
+            "com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck",
+            "com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck",
+            "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck",
+            "com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck",
+            "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",
+            "com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck",
+            "com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck",
+            "com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck",
+            "com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck",
+            "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck",
+            "com.puppycrawl.tools.checkstyle.checks.sizes.MethodCountCheck",
+            "com.puppycrawl.tools.checkstyle.checks.trailingcomment.TrailingCommentCheck",
+            "com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck",
+            "com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck",
+            "com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck",
+            "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck",
+            "com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck",
+            "com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck",
+            "com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPad",
+            "com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparator",
+            "com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPad",
+            "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck",
+            "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAround",
+            "com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyTextFilter",
+            "com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilter",
+            "com.puppycrawl.tools.checkstyle.filters.SuppressionFilter",
+            "com.puppycrawl.tools.checkstyle.sariflogger.SarifLogger"
     );
 
     /**
@@ -1466,9 +1623,15 @@ public final class InlineConfigParser {
         if (moduleLists.size() == 1) {
             final String moduleName = moduleLists.getFirst().getModuleName();
 
-            if (!PERMANENT_SUPPRESSED_CHECKS.contains(moduleName)) {
-                final String fileName = Path.of(inputFilePath).getFileName().toString();
-                if (!SUPPRESSED_FILES.contains(fileName)) {
+            if (!PERMANENT_SUPPRESSED_CHECKS.contains(moduleName)
+                    && !SUPPRESSED_CHECKS.contains(moduleName)) {
+
+                final String normalizedPath = inputFilePath.replace('\\', '/');
+
+                final boolean isSuppressed = SUPPRESSED_FILES.stream()
+                        .anyMatch(normalizedPath::endsWith);
+
+                if (!isSuppressed) {
                     result = true;
                 }
             }
@@ -1632,71 +1795,111 @@ public final class InlineConfigParser {
             int lineNo, boolean specifyViolationMessage)
             throws CheckstyleException {
         final String line = lines.get(lineNo);
-        final Matcher multipleViolationsMatcher =
-                MULTIPLE_VIOLATIONS_PATTERN.matcher(line);
-        final Matcher multipleViolationsAboveMatcher =
-                MULTIPLE_VIOLATIONS_ABOVE_PATTERN.matcher(line);
-        final Matcher multipleViolationsBelowMatcher =
-                MULTIPLE_VIOLATIONS_BELOW_PATTERN.matcher(line);
+
+        boolean matched = isRelativeLineViolationProcessed(inputConfigBuilder, lines, line, lineNo,
+                specifyViolationMessage);
+
+        if (!matched) {
+            matched = isMultipleViolationProcessed(inputConfigBuilder, line, lineNo,
+                    specifyViolationMessage);
+        }
+
+        if (!matched) {
+            if (useFilteredViolations) {
+                setFilteredViolation(inputConfigBuilder, lineNo + 1,
+                        lines, lineNo, specifyViolationMessage);
+            }
+            else if (!isFilteredViolationComment(line)) {
+                final Matcher violationsDefault = VIOLATION_DEFAULT.matcher(line);
+                if (violationsDefault.matches()) {
+                    final int violationLineNum = lineNo + 1;
+                    checkWhetherViolationSpecified(specifyViolationMessage, null, violationLineNum);
+                    inputConfigBuilder.addViolation(violationLineNum, null);
+                }
+            }
+        }
+    }
+
+    private static boolean isRelativeLineViolationProcessed(
+            TestInputConfiguration.Builder inputConfigBuilder, List<String> lines,
+            String line, int lineNo, boolean specifyViolationMessage) throws CheckstyleException {
         final Matcher violationsAboveMatcherWithMessages =
                 VIOLATIONS_ABOVE_PATTERN_WITH_MESSAGES.matcher(line);
         final Matcher violationsSomeLinesAboveMatcher =
                 VIOLATIONS_SOME_LINES_ABOVE_PATTERN.matcher(line);
         final Matcher violationsSomeLinesBelowMatcher =
                 VIOLATIONS_SOME_LINES_BELOW_PATTERN.matcher(line);
-        final Matcher violationsDefault =
-                VIOLATION_DEFAULT.matcher(line);
 
+        boolean processed = true;
         if (violationsAboveMatcherWithMessages.matches()) {
             inputConfigBuilder.addViolations(
-                getExpectedViolationsForSpecificLine(
-                    lines, lineNo, lineNo, violationsAboveMatcherWithMessages));
+                    getExpectedViolationsForSpecificLine(
+                            lines, lineNo, lineNo, violationsAboveMatcherWithMessages,
+                            specifyViolationMessage));
         }
         else if (violationsSomeLinesAboveMatcher.matches()) {
             inputConfigBuilder.addViolations(
-                getExpectedViolations(
-                    lines, lineNo, violationsSomeLinesAboveMatcher, true));
+                    getExpectedViolations(
+                            lines, lineNo, violationsSomeLinesAboveMatcher, true,
+                            specifyViolationMessage));
         }
         else if (violationsSomeLinesBelowMatcher.matches()) {
             inputConfigBuilder.addViolations(
                     getExpectedViolations(
-                            lines, lineNo, violationsSomeLinesBelowMatcher, false));
+                            lines, lineNo, violationsSomeLinesBelowMatcher, false,
+                            specifyViolationMessage));
         }
-        else if (multipleViolationsMatcher.matches()) {
-            Collections
-                    .nCopies(Integer.parseInt(multipleViolationsMatcher.group(1)), lineNo + 1)
+        else {
+            processed = false;
+        }
+        return processed;
+    }
+
+    private static boolean isMultipleViolationProcessed(
+            TestInputConfiguration.Builder inputConfigBuilder, String line,
+            int lineNo, boolean specifyViolationMessage) throws CheckstyleException {
+        final Matcher multipleViolationsMatcher = MULTIPLE_VIOLATIONS_PATTERN.matcher(line);
+        final Matcher multipleViolationsAboveMatcher =
+                MULTIPLE_VIOLATIONS_ABOVE_PATTERN.matcher(line);
+        final Matcher multipleViolationsBelowMatcher =
+                MULTIPLE_VIOLATIONS_BELOW_PATTERN.matcher(line);
+
+        boolean processed = true;
+        if (multipleViolationsMatcher.matches()) {
+            final int violationLineNum = lineNo + 1;
+            final int count = Integer.parseInt(multipleViolationsMatcher.group(1));
+            checkWhetherViolationSpecified(specifyViolationMessage, null, violationLineNum);
+            Collections.nCopies(count, violationLineNum)
                     .forEach(actualLineNumber -> {
                         inputConfigBuilder.addViolation(actualLineNumber, null);
                     });
         }
         else if (multipleViolationsAboveMatcher.matches()) {
-            Collections
-                    .nCopies(Integer.parseInt(multipleViolationsAboveMatcher.group(1)), lineNo)
+            final int count = Integer.parseInt(multipleViolationsAboveMatcher.group(1));
+            checkWhetherViolationSpecified(specifyViolationMessage, null, lineNo);
+            Collections.nCopies(count, lineNo)
                     .forEach(actualLineNumber -> {
                         inputConfigBuilder.addViolation(actualLineNumber, null);
                     });
         }
         else if (multipleViolationsBelowMatcher.matches()) {
-            Collections
-                    .nCopies(Integer.parseInt(multipleViolationsBelowMatcher.group(1)),
-                            lineNo + 2)
+            final int violationLineNum = lineNo + 2;
+            final int count = Integer.parseInt(multipleViolationsBelowMatcher.group(1));
+            checkWhetherViolationSpecified(specifyViolationMessage, null, violationLineNum);
+            Collections.nCopies(count, violationLineNum)
                     .forEach(actualLineNumber -> {
                         inputConfigBuilder.addViolation(actualLineNumber, null);
                     });
         }
-        else if (useFilteredViolations) {
-            setFilteredViolation(inputConfigBuilder, lineNo + 1,
-                    lines, lineNo, specifyViolationMessage);
+        else {
+            processed = false;
         }
-        else if (violationsDefault.matches()) {
-            final int violationLineNum = lineNo + 1;
-            inputConfigBuilder.addViolation(violationLineNum, null);
-        }
+        return processed;
     }
 
     private static List<TestInputViolation> getExpectedViolationsForSpecificLine(
-                                              List<String> lines, int lineNo, int violationLineNum,
-                                              Matcher matcher) {
+            List<String> lines, int lineNo, int violationLineNum,
+            Matcher matcher, boolean specifyViolationMessage) throws CheckstyleException {
         final List<TestInputViolation> results = new ArrayList<>();
 
         final int expectedMessageCount =
@@ -1706,6 +1909,8 @@ public final class InlineConfigParser {
             final Matcher messageMatcher = VIOLATION_MESSAGE_PATTERN.matcher(lineWithMessage);
             if (messageMatcher.find()) {
                 final String violationMessage = messageMatcher.group(1);
+                checkWhetherViolationSpecified(specifyViolationMessage, violationMessage,
+                        violationLineNum);
                 results.add(new TestInputViolation(violationLineNum, violationMessage));
             }
         }
@@ -1719,8 +1924,9 @@ public final class InlineConfigParser {
     }
 
     private static List<TestInputViolation> getExpectedViolations(
-                                              List<String> lines, int lineNo,
-                                              Matcher matcher, boolean isAbove) {
+            List<String> lines, int lineNo,
+            Matcher matcher, boolean isAbove, boolean specifyViolationMessage)
+                    throws CheckstyleException {
         final int violationLine =
             Integer.parseInt(matcher.group(2));
         final int violationLineNum;
@@ -1731,7 +1937,7 @@ public final class InlineConfigParser {
             violationLineNum = lineNo + violationLine + 1;
         }
         return getExpectedViolationsForSpecificLine(lines,
-            lineNo, violationLineNum, matcher);
+            lineNo, violationLineNum, matcher, specifyViolationMessage);
     }
 
     private static void setFilteredViolation(TestInputConfiguration.Builder inputConfigBuilder,
@@ -1800,7 +2006,22 @@ public final class InlineConfigParser {
                 || VIOLATION_SOME_LINES_BELOW_PATTERN.matcher(line).matches()
                 || VIOLATION_FIRST_LINE_PATTERN.matcher(line).matches()
                 || VIOLATION_LAST_LINE_PATTERN.matcher(line).matches()
-                || FILTERED_VIOLATION_PATTERN.matcher(line).matches();
+                || isFilteredViolationComment(line);
+    }
+
+    /**
+     * Checks whether the given line is a well-formed "filtered violation" comment,
+     * in any of its recognized forms (bare, above, below, N-lines-above, N-lines-below).
+     *
+     * @param line the line to check.
+     * @return true if the line matches any filtered-violation comment pattern.
+     */
+    private static boolean isFilteredViolationComment(String line) {
+        return FILTERED_VIOLATION_PATTERN.matcher(line).matches()
+                || FILTERED_VIOLATION_ABOVE_PATTERN.matcher(line).matches()
+                || FILTERED_VIOLATION_BELOW_PATTERN.matcher(line).matches()
+                || FILTERED_VIOLATION_SOME_LINES_ABOVE_PATTERN.matcher(line).matches()
+                || FILTERED_VIOLATION_SOME_LINES_BELOW_PATTERN.matcher(line).matches();
     }
 
     private static String assembleTripleQuoteMessage(String firstPart,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -528,8 +528,8 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             "23: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 80, 83),
             "33: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 96),
             "33: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 80, 96),
-            "63: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 76),
-            "70: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 87),
+            "62: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 76),
+            "69: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 87),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestAloneOrSingleline.java
@@ -115,7 +115,7 @@ public class InputRightCurlyTestAloneOrSingleline {
             put("first", "second");
             put("polygene", "lubricants");
             put("alpha", "betical");
-        }}; //NO violation
+        }};
         // violation below ''}' at column 75 should be alone on a line'
         Thread t = new Thread() {@Override public void run() {super.run();}};
         // 2 violations below

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestWithAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestWithAnnotations.java
@@ -156,7 +156,7 @@ class InputRightCurlyTestWithAnnotations
             put("first", "second");
             put("polygene", "lubricants");
             put("alpha", "betical");
-        }}; //NO violation
+        }};
         // violation below ''}' at col.* 75 should be alone on a line'
         Thread t = new Thread() {@Override public void run() {super.run();}};
         new Object() { public int hashCode() { return 1; }  { int a = 5; }}; // 2 violations

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastOne.java
@@ -24,7 +24,7 @@ public class InputDefaultComesLastOne
         case 2: break;
         }
 
-        // violation !!! default is not the last one.
+        // ok, default is not the last one.
         switch (i) {
         case 1:
             break;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSkipIfLastAndSharedWithCaseOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSkipIfLastAndSharedWithCaseOne.java
@@ -12,7 +12,7 @@ public class InputDefaultComesLastSkipIfLastAndSharedWithCaseOne
     void method(int i) {
         switch (i) {
             case 1:
-            default: // No violation with the new option is expected
+            default: // ok, new option
                 break;
             case 2:
                 break;
@@ -44,12 +44,12 @@ public class InputDefaultComesLastSkipIfLastAndSharedWithCaseOne
         }
 
         switch (i) {
-            case 1: default: break; case 2: break;  // No violation with the new option is expected
+            case 1: default: break; case 2: break;  // ok, new option
         }
 
         switch (i) {
             case 1:
-            default: // No violation with the new option is expected
+            default: // ok, new option
                 break;
             case 2:
                 break;
@@ -71,7 +71,7 @@ public class InputDefaultComesLastSkipIfLastAndSharedWithCaseOne
             case 1:
                 break;
             case 2:
-            default: // No violation with the new option is expected
+            default: // ok, new option
                 break;
             case 3:
                 break;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSkipIfLastAndSharedWithCaseTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSkipIfLastAndSharedWithCaseTwo.java
@@ -24,7 +24,7 @@ public class InputDefaultComesLastSkipIfLastAndSharedWithCaseTwo {
                 break;
             case 2:
                 break;
-            default: // No violation.
+            default:
                 break;
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSwitchExpressionsSkipIfLast.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastSwitchExpressionsSkipIfLast.java
@@ -23,7 +23,7 @@ public class InputDefaultComesLastSwitchExpressionsSkipIfLast {
         return x;
     }
 
-    // This should still be a violation, since switch rules are not subject to fall through
+    // switch rules are not subject to fall through
     public int method2(int i) {
         int x = 7;
         switch (i) {
@@ -41,7 +41,7 @@ public class InputDefaultComesLastSwitchExpressionsSkipIfLast {
         return x;
     }
 
-    // This should still be a violation, since switch rules are not subject to fall through
+    // switch rules are not subject to fall through
     public int method3(int i) {
         return switch (i) {
             case 1 -> 8;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Five.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Five.java
@@ -14,7 +14,7 @@ public class InputFinalLocalVariable2Five {
             int shouldBeFinal;
             class Bar {
                 void bar () {
-                    int shouldBeFinal;// violation Variable 'shouldBeFinal' should be declared final
+                    int shouldBeFinal;
                     final boolean b = false;
                     if (b) {
                         shouldBeFinal = 1;
@@ -29,7 +29,7 @@ public class InputFinalLocalVariable2Five {
     class class52 {
         public void test1(){
             final boolean b = false;
-            int shouldBeFinal;    // violation Variable 'shouldBeFinal' should be declared final
+            int shouldBeFinal;
             if(b){
                 if(b){
                     shouldBeFinal = 1;
@@ -40,7 +40,7 @@ public class InputFinalLocalVariable2Five {
         }
         public void test2() {
             final int b = 10;
-            int shouldBeFinal;        // violation Variable 'shouldBeFinal' should be declared final
+            int shouldBeFinal;
 
             switch (b) {
                 case 0:
@@ -59,7 +59,7 @@ public class InputFinalLocalVariable2Five {
             }
         }
         public void test3() {
-            int x;    //No Violation
+            int x;
             try {
                 x = 0;
                 try {
@@ -75,7 +75,7 @@ public class InputFinalLocalVariable2Five {
             int shouldBeFinal;
             class Bar {
                 void bar () {
-                    int shouldBeFinal;// violation Variable 'shouldBeFinal' should be declared final
+                    int shouldBeFinal;
                     final boolean b = false;
                     if (b) {
                         if (b) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Four.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Four.java
@@ -12,7 +12,7 @@ public class InputFinalLocalVariable2Four {
     class Class32 {
         public void test1() {
             final boolean b = true;
-            int shouldBeFinal;        // violation Variable 'shouldBeFinal' should be declared final
+            int shouldBeFinal;
 
             if (b) {
                 shouldBeFinal = 1;
@@ -24,7 +24,7 @@ public class InputFinalLocalVariable2Four {
 
         public void test2() {
             final int b = 10;
-            int shouldBeFinal;        // violation Variable 'shouldBeFinal' should be declared final
+            int shouldBeFinal;
 
             switch (b) {
                 case 0:
@@ -37,14 +37,14 @@ public class InputFinalLocalVariable2Four {
         }
 
         public void test3() {
-            int x;        // No Violation
+            int x;
             try {
                 x = 0;
             } catch (final Exception e) {
                 x = 1;
             }
 
-            int y;        // No Violation
+            int y;
             try {
                 y = 0;
             } finally {
@@ -54,7 +54,7 @@ public class InputFinalLocalVariable2Four {
 
         public void test4() {
             final boolean b = false;
-            int x;        // No Violation
+            int x;
             if (b) {
                 x = 1;
             } else {
@@ -68,7 +68,7 @@ public class InputFinalLocalVariable2Four {
 
         public void test5() {
             final boolean b = false;
-            int shouldBeFinal;    // violation Variable 'shouldBeFinal' should be declared final
+            int shouldBeFinal;
             if(b) {
             }
             if (b) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Three.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariable2Three.java
@@ -95,13 +95,13 @@ public class InputFinalLocalVariable2Three {
         public void method(final int i) {
             switch (i) {
                 case 1:
-                    int foo = 1;    // violation Variable 'foo' should be declared final
+                    int foo = 1;
                     break;
                 default:
             }
             switch (i) {
                 case 1:
-                    int foo = 1;    // No violation
+                    int foo = 1;
                     break;
                 case 2:
                     foo = 2;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField2Interface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField2Interface.java
@@ -16,6 +16,6 @@ interface InputHiddenField2Interface
 {
     public static int notHidden = 0;
 
-    // not a violation
+
     public void noShadow(int notHidden);
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField3Interface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField3Interface.java
@@ -16,6 +16,6 @@ interface InputHiddenField3Interface
 {
     public static int notHidden = 0;
 
-    // not a violation
+
     public void noShadow(int notHidden);
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField4Interface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField4Interface.java
@@ -16,6 +16,6 @@ interface InputHiddenField4Interface
 {
     public static int notHidden = 0;
 
-    // not a violation
+
     public void noShadow(int notHidden);
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField5Interface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField5Interface.java
@@ -16,6 +16,6 @@ interface InputHiddenField5Interface
 {
     public static int notHidden = 0;
 
-    // not a violation
+
     public void noShadow(int notHidden);
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField6.java
@@ -102,7 +102,7 @@ interface NothingHidden6
 {
     public static int notHidden = 0;
 
-    // not a violation
+
     public void noShadow(int notHidden);
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenField7.java
@@ -104,7 +104,7 @@ interface NothingHidden7
 {
     public static int notHidden = 0;
 
-    // not a violation
+
     public void noShadow(int notHidden);
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldInterface.java
@@ -16,6 +16,6 @@ interface InputHiddenFieldInterface
 {
     public static int notHidden = 0;
 
-    // not a violation
+
     public void noShadow(int notHidden);
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldRecordsImplicitlyStaticClassComparison.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldRecordsImplicitlyStaticClassComparison.java
@@ -41,7 +41,7 @@ class Test {
         public void m(int x) {}
     }
 
-    // non-static class, should have a violation
+    // non-static class
     public class C2 {
         public void m(int x) {} // violation ''x' hides a field'
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldReorder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldReorder.java
@@ -106,7 +106,7 @@ interface NothingHiddenReorder
 {
     public static int notHidden = 0;
 
-    // not a violation
+
     public void noShadow(int notHidden);
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclaration6.java
@@ -14,11 +14,11 @@ package com.puppycrawl.tools.checkstyle.checks.coding.magicnumber;
 public class InputMagicNumberIgnoreFieldDeclaration6 {
 
     @interface MyAnnotation {
-        int value() default 5; // no violation
+        int value() default 5;
 
         public static int CONSTANT = 10; // violation ''10' is a magic number'
         public static int ANOTHER_CONSTANT = 15; // violation ''15' is a magic number'
     }
 
-    static int regularField = 42; // no violation
+    static int regularField = 42;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclarationRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberIgnoreFieldDeclarationRecords.java
@@ -23,11 +23,11 @@ public class InputMagicNumberIgnoreFieldDeclarationRecords {
         private static int myInt = 7;
 
         public MyRecord{
-            int i = myInt + 1; // no violation, 1 is defined as non-magic
+            int i = myInt + 1; // ok, 1 is defined as non-magic
             int j = myInt + 8; // violation ''8' is a magic number'
         }
         void foo() {
-            int i = myInt + 1; // no violation, 1 is defined as non-magic
+            int i = myInt + 1; // ok, 1 is defined as non-magic
             int j = myInt + 8; // violation ''8' is a magic number'
         }
 
@@ -37,7 +37,7 @@ public class InputMagicNumberIgnoreFieldDeclarationRecords {
     }
 
     @interface anno {
-        int value() default 10; // no violation
+        int value() default 10;
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberRecordsDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberRecordsDefault.java
@@ -23,11 +23,11 @@ public class InputMagicNumberRecordsDefault {
         private static int myInt = 7; // violation ''7' is a magic number'
 
         public MyRecord{
-            int i = myInt + 1; // no violation, 1 is defined as non-magic
+            int i = myInt + 1; // ok, 1 is defined as non-magic
             int j = myInt + 8; // violation ''8' is a magic number'
         }
         void foo() {
-            int i = myInt + 1; // no violation, 1 is defined as non-magic
+            int i = myInt + 1; // ok, 1 is defined as non-magic
             int j = myInt + 8; // violation ''8' is a magic number'
         }
 
@@ -37,7 +37,7 @@ public class InputMagicNumberRecordsDefault {
     }
 
     @interface anno {
-        int value() default 10; // no violation
+        int value() default 10;
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableBothForLoops.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable/InputModifiedControlVariableBothForLoops.java
@@ -16,7 +16,7 @@ class InputModifiedControlVariableBothForLoops
     int k;
     void method1()
     {
-        // violation :
+
         for (int i = 0; i < 1; i++) {
             i++; // violation 'Control variable 'i' is modified.'
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks1.java
@@ -13,22 +13,22 @@ package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
 public class InputMultipleStringLiteralsTextBlocks1 {
     // violation below 'The String "string" appears 3 times in the file.'
     String string1 = "string"; // occurrence #1
-    String string2a = "string"; // violation #1
+    String string2a = "string";
     String string2b = """
-            string"""; // violation #2
+            string""";
 
     // violation below 'The String "other string" appears 2 times in the file.'
     String string3 = """
             other string"""; // occurrence #1
     String string4 = """
-            other string"""; // violation #1
+            other string""";
     // violation below 'The String "other string\\n" appears 2 times.*'
     String string5 = """
             other string
             """; // occurrence #1
     String string6 = """
             other string
-            """; // violation #1
+            """;
     // violation below 'The String "<html>.*" appears 2 times in the file.'
     String escape1 = """
             <html>\u000D\u000A\n\u2000
@@ -55,23 +55,23 @@ public class InputMultipleStringLiteralsTextBlocks1 {
                     <p>Hello, world</p>\u000D\u000A\n\u2000
                 </body>\u000D\u000A\n\u2000
             </html>\u000D\u000A\u2000
-            """; // violation #1
+            """;
     String testMoreEscapes2 = """
             fun with\n
              whitespace\t\r
              and other escapes \"""
-            """; // violation #1
+            """;
     String evenMoreEscapes2 = """
             \b \f \\ \0 \1 \2 \r \r\n \\r\\n \\''
             \\11 \\57 \n\\n\n\\\n\n \\ ""a "a
             \\' \\\' \'
-            """; // violation #1
+            """;
 
     // violation below 'The String "foo" appears 4 times in the file.'
     String str1a = "foo"; // occurrence #1
-    String str1b = "foo"; // violation #1
+    String str1b = "foo";
     String str2a = """
-            foo"""; // violation #2
+            foo""";
     String str2b = """
-            foo"""; // violation #3
+            foo""";
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks2.java
@@ -14,19 +14,19 @@ public class InputMultipleStringLiteralsTextBlocks2 {
     // violation below 'The String "another test" appears 2 times in the file.'
     String str3 = "another test"; // occurrence #1
     String str4 = """
-            another test"""; // violation #1
+            another test""";
 
     // violation below 'The String "" appears 6 times in the file.'
     String str5a = ""; // occurrence #1
     String str5b = """
-            """; // violation #1
+            """;
     String str6 = """
-                        """; // violation #2
+                        """;
     String str7 = """
-"""; // violation #3
+""";
 
     String str8 = """
-                             """; // violation #4
+                             """;
     // violation below 'The String "        .\\n         .\\n.\\n" appears 2 times in the file.'
     String str8b = """
         .

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder1.java
@@ -28,7 +28,7 @@ class InputOverloadMethodsDeclarationOrder1
 
     }
 
-    // violation : because overloads never split
+    // because overloads never split
     // violation below 'All overloaded methods should be placed next to each other.'
     public void overloadMethod(String s, Boolean b, int i)
     {
@@ -57,7 +57,7 @@ class InputOverloadMethodsDeclarationOrder1
 
         }
 
-        // violation : because overloads never split
+        // because overloads never split
         // violation below 'All overloaded methods should be placed next to each other.'
         public void overloadMethod(String s, Boolean b, int i)
         {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder2.java
@@ -48,7 +48,7 @@ class InputOverloadMethodsDeclarationOrder2 {
 
         }
 
-        // violation : because overloads never split
+        // because overloads never split
         // violation below 'All overloaded methods should be placed next to each other.'
         public void overloadMethod(String s, Boolean b, int i)
         {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderMisc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderMisc.java
@@ -12,7 +12,7 @@ public class InputOverloadMethodsDeclarationOrderMisc {
 
     void foo() {}
 
-    // violation : because overloads never split
+    // because overloads never split
     // violation below 'All overloaded methods should be placed next to each other.'
     void test(int a, int b) {}
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisAllowLambdaParameters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisAllowLambdaParameters.java
@@ -18,7 +18,7 @@ public class InputRequireThisAllowLambdaParameters {
     void foo1() {
         final java.util.List<String> strings = new java.util.ArrayList<>();
         strings.add("foo1");
-        strings.stream().filter(s1 -> s1.contains("f"))  // NO violation; s1 is a lambda parameter
+        strings.stream().filter(s1 -> s1.contains("f"))  // ok, s1 is a lambda parameter
                 .collect(java.util.stream.Collectors.toList());
 
         s1 = "foo1"; // violation 'Reference to instance variable 's1' needs "this.".'
@@ -27,7 +27,7 @@ public class InputRequireThisAllowLambdaParameters {
     void foo2() {
         final java.util.List<String> strings = new java.util.ArrayList<>();
         strings.add("foo1");
-        strings.stream().filter(s1 -> s1.contains(s1 = s1 + "2"))// NO violation;s1 is lambda param
+        strings.stream().filter(s1 -> s1.contains(s1 = s1 + "2"))// ok,s1 is lambda param
                 .collect(java.util.stream.Collectors.toList());
     }
 
@@ -37,10 +37,10 @@ public class InputRequireThisAllowLambdaParameters {
         int y;
         int z;
         void methodInFirstLevel(int x) {
-            Consumer<Integer> myConsumer = (y) ->   // NO violation; y is a lambda parameter
+            Consumer<Integer> myConsumer = (y) ->   // ok, y is a lambda parameter
             {
                 new String("x = " + x);
-                new String("y = " + y);  // NO violation; y is a lambda parameter
+                new String("y = " + y);  // ok, y is a lambda parameter
                 new String("InputRequireThisAllowLambdaParameters.this.x = " +
                         InputRequireThisAllowLambdaParameters.this.x);
                 y=x+z++;  // violation 'Reference to instance variable 'z' needs "this.".'
@@ -65,8 +65,8 @@ class Calculator {
     public void addSub(String... args) {
 
         Calculator myApp = new Calculator();
-        IntegerMath addition = (a, b) -> a = a + b;  // NO violations
-        IntegerMath subtraction = (a, b) -> a = a - b; // NO violations
+        IntegerMath addition = (a, b) -> a = a + b;
+        IntegerMath subtraction = (a, b) -> a = a - b;
         myApp.operateBinary(20, 10, subtraction);
         myApp.operateBinary(a++, b, addition);  // 2 violations
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisAllowLocalVars.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisAllowLocalVars.java
@@ -17,21 +17,21 @@ class InputRequireThisAllowLocalVars {
     InputRequireThisAllowLocalVars() {
         s1 = "bar1"; // violation 'Reference to instance variable 's1' needs "this.".'
         String s2;
-        s2 = "bar2"; // No violation. Local var allowed.
+        s2 = "bar2"; // ok, Local var allowed.
     }
 
     public int getS1() {
         String s1 = null;
-        s1 = "bar"; // No violation
+        s1 = "bar";
         s1 = s1; // violation 'Reference to instance variable 's1' needs "this.".'
         return 1;
     }
 
     public String getS1(String param) {
         String s1 = null;
-        s1 = param; // No violation
-        s1 += s1;   // No violation. s1 is being returned.
-        return s1;  // No violation
+        s1 = param;
+        s1 += s1;   // ok, s1 is being returned.
+        return s1;
     }
 
     String getS2() {
@@ -42,7 +42,7 @@ class InputRequireThisAllowLocalVars {
 
     String getS2(String s2) {
         s2 = null; // violation 'Reference to instance variable 's2' needs "this.".'
-        return s2; // No violation. param is returned.
+        return s2; // ok, param is returned.
     }
 
     String getS2(int a) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisValidateOnlyOverlappingFalse.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisValidateOnlyOverlappingFalse.java
@@ -221,7 +221,7 @@ public class InputRequireThisValidateOnlyOverlappingFalse {
 
     void foo24() {
         String field1 = "Hello";
-        field1 = "Java"; // No violation. Local var allowed
+        field1 = "Java"; // ok, Local var allowed
         this.booleanField = true;
         this.booleanField = booleanField; // violation '.* variable 'booleanField' needs "this.".'
     }
@@ -231,7 +231,7 @@ public class InputRequireThisValidateOnlyOverlappingFalse {
             if (true) {
                 String field1 = "Hello, World!";
                 if (true) {
-                    field1 = new String(); // No violation. Local var allowed
+                    field1 = new String(); // ok, Local var allowed
                 }
                 else {
                     field1 += field1; // violation '.* variable 'field1' needs "this.".'
@@ -389,7 +389,7 @@ public class InputRequireThisValidateOnlyOverlappingFalse {
                 action = "" + action;
             }
         }
-        action = "action"; // No violation. Local var allowed
+        action = "action"; // ok, Local var allowed
         return processAction(action); // violation 'Method call to 'processAction' needs "this.".'
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisValidateOnlyOverlappingTrue.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisValidateOnlyOverlappingTrue.java
@@ -276,7 +276,7 @@ public class InputRequireThisValidateOnlyOverlappingTrue {
     }
 
     String foo32(String field1) {
-        field1 = addSuf2F(field1); //no violation! modification of parameter which is returned
+        field1 = addSuf2F(field1); //ok, modification of parameter which is returned
         return field1;
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonaftertypememberdeclaration/InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonaftertypememberdeclaration/InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords.java
@@ -40,15 +40,15 @@ public record InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords() {
     ; // violation, 'Unnecessary semicolon.'
 
     static {
-        ; // no violation, it is empty statement inside init block
+        ; // ok, it is empty statement inside init block
     }
 
     static {
-        ; // no violation, it is empty statement inside static init block
+        ; // ok, it is empty statement inside static init block
     }
 
     void anotherMethod() {
-        ; // no violation, it is empty statement
-        if (true) ; // no violation, it is empty statement
+        ; // ok, it is empty statement
+        if (true) ; // ok, it is empty statement
     }
 }; // ok, this check does not apply to outer types

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceTryBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceTryBlock.java
@@ -50,7 +50,7 @@ public class InputVariableDeclarationUsageDistanceTryBlock {
         }
     }
 
-    // no violation - distance is within allowed limit
+    // ok, distance is within allowed limit
     void tryWithinAllowedDistance() {
         int a = 1;
         System.lineSeparator();
@@ -62,7 +62,7 @@ public class InputVariableDeclarationUsageDistanceTryBlock {
         }
     }
 
-    // no violation - usage immediately in try
+    // ok, usage immediately in try
     void tryImmediateUsage() {
         int a = 1;
         try {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionOverridableMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionOverridableMethods.java
@@ -216,7 +216,7 @@ public class InputDesignForExtensionOverridableMethods {
         @Deprecated /** */
         public void foo39() {return; }
 
-        void foo40() { // no violation: empty body
+        void foo40() { // ok, empty body
             /** */
         }
 
@@ -226,7 +226,7 @@ public class InputDesignForExtensionOverridableMethods {
         }
 
         /** */
-        void foo42() { // no violation: has javadoc comment
+        void foo42() { // ok, has javadoc comment
         }
 
         /** */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorDesignForExtension.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorDesignForExtension.java
@@ -12,7 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.design.hideutilityclassconstructo
  **/
 public abstract class InputHideUtilityClassConstructorDesignForExtension
 {
-    // some methods that are OK
+    // some methods that are ok
 
     public interface InterfaceOK
     {
@@ -67,7 +67,7 @@ public abstract class InputHideUtilityClassConstructorDesignForExtension
     {
         public int compare(Object o1, Object o2)
         {
-            // some complex stuff that would normally trigger a violation report
+            // some complex stuff
             if (o1.hashCode() > o2.hashCode()) {
                 return -1;
             }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/InputVisibilityModifierInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/InputVisibilityModifierInner.java
@@ -27,14 +27,14 @@ package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
  **/
 class InputVisibilityModifierInner
 {
-    // Ignore - two violations
+
     class InnerInner2
     {
         // Ignore
         public int fData;
     }
 
-    // Ignore - 2 violations
+
     interface InnerInterface2
     {
         // Ignore - should be all upper case

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/InputVisibilityModifierInner1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/InputVisibilityModifierInner1.java
@@ -27,7 +27,7 @@ package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
  **/
 class InputVisibilityModifierInner1
 {
-    // Ignore - two violations
+
     class InnerInner2
     {
         // Ignore
@@ -35,7 +35,7 @@ class InputVisibilityModifierInner1
         // violation above 'Variable 'fData' must be private and have accessor methods.'
     }
 
-    // Ignore - 2 violations
+
     interface InnerInterface2
     {
         // Ignore - should be all upper case

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsOne.java
@@ -68,7 +68,7 @@ public class InputJavadocMethodIgnoreThrowsOne {
                 throw new IllegalArgumentException("null"); // ok, try
             }
         } catch (IllegalArgumentException ex) {
-            throw ex; // no violation
+            throw ex;
         }
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsTwo.java
@@ -32,7 +32,7 @@ public class InputJavadocMethodIgnoreThrowsTwo {
             System.out.println(s);
             if (s.length() == 0) {
                 // false negative, unable to tell what was caught
-                throw new IllegalArgumentException("empty input"); // no violation
+                throw new IllegalArgumentException("empty input");
             }
             else {
                 throw new IOException(); // ok, exception was caught

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionOne.java
@@ -16,7 +16,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 public class InputJavadocMethodThrowsDetectionOne {
 
     void noJavadoc() {
-        // no javadoc, no violations
+        // no javadoc
         throw new UnsupportedOperationException("");
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeInner.java
@@ -20,7 +20,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  **/
 class InputJavadocTypeInner
 {
-    // ok , two violations
+
     class InnerInner2
     {
         // ok , Ignore

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner.java
@@ -14,14 +14,14 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
  */
 class InputJavadocVariableInner
 {
-    // Ignore - two violations
+
     class InnerInner2
     {
         // Ignore
         public int fData; // violation, 'Missing a Javadoc comment'
     }
 
-    // Ignore - 2 violations
+
     interface InnerInterface2
     {
         // Ignore - should be all upper case

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner2.java
@@ -19,7 +19,7 @@ class InputJavadocVariableInner2
         int fData;
     }
 
-    // Ignore - 1 violations
+
     interface InnerInterface2
     {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInner.java
@@ -16,7 +16,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
  **/
 class InputMissingJavadocTypeInner
 {
-    // Ignore - two violations
+
     // violation below 'Missing a Javadoc comment.'
     class InnerInner2
     {
@@ -24,7 +24,7 @@ class InputMissingJavadocTypeInner
         public int fData;
     }
 
-    // Ignore - 2 violations
+
     // violation below 'Missing a Javadoc comment.'
     interface InnerInterface2
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadocOnInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeNoJavadocOnInterface.java
@@ -11,7 +11,7 @@ tokens = INTERFACE_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
-class InputMissingJavadocTypeNoJavadocOnInterface { // no violation,
+class InputMissingJavadocTypeNoJavadocOnInterface {
     // CLASS_DEF not in the list of tokens
     // violation below 'Missing a Javadoc comment.'
     interface NoJavadoc {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/InputClassDataAbstractionCouplingRecords.java
@@ -39,7 +39,7 @@ record MyRecord1(boolean a, boolean b) {
 
     private boolean myBool() {
         Date date = new Date(); // Counted, 1
-        Time time = new Time(2, 2, 2); // should be violation
+        Time time = new Time(2, 2, 2);
         return true;
     }
 
@@ -51,7 +51,7 @@ record MyRecord2(String myString, boolean a, boolean b) {
     // in compact ctor
     public MyRecord2 {
         Date date = new Date(); // Counted, 1
-        Time time = new Time(2, 2, 2); // should be violation
+        Time time = new Time(2, 2, 2);
     }
 }
 
@@ -61,7 +61,7 @@ record MyRecord3(int x) { // violation, 'Class Data Abstraction Coupling is 2 (m
     MyRecord3() {
         this(4);
         Date date = new Date(); // Counted, 1
-        Time time = new Time(2, 2, 2); // should be violation
+        Time time = new Time(2, 2, 2);
 
     }
 }
@@ -72,8 +72,8 @@ record MyRecord4(int y) {
         static Set<Integer> set = new HashSet<>(); // HashSet ignored
         static Map<String, Integer> map = new HashMap<>(); // HashMap ignored
         static Date date = new Date(); // Counted, 1
-        static Time time = new Time(); // should be violation
-        static Place place = new Place(); // should be violation
+        static Time time = new Time();
+        static Place place = new Place();
 
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSRecordsAndCompactCtors.java
@@ -50,7 +50,7 @@ public class InputJavaNCSSRecordsAndCompactCtors {  // violation '.* is 54 (max 
 
     } // 6
 
-    //should give an ncss of 8 , violation for method
+    //should give an ncss of 8
     private void testMethod() { // violation 'NCSS for this method is 8 (max allowed is 7).'
 
       for (int i=0; i<10; i++) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierFinalInInterface.java
@@ -16,12 +16,12 @@ public interface InputRedundantModifierFinalInInterface {
 
     default int defaultMethod(final int x) {
             if (k == 5) {
-                    final int t = 24;  //No violation here!
+                    final int t = 24;
                     for (; ;) {
-                            final String s = "some";  //No violation here!
+                            final String s = "some";
                     }
             }
-        final int square = x * x;  //No violation here!
+        final int square = x * x;
         return square;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameInner.java
@@ -17,14 +17,14 @@ package com.puppycrawl.tools.checkstyle.checks.naming.constantname;
  **/
 class InputConstantNameInner
 {
-    // Ignore - two violations
+
     class InnerInner2
     {
         // Ignore
         public int fData;
     }
 
-    // Ignore - 2 violations
+
     interface InnerInterface2
     {
         // Ignore - should be all upper case

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableNameInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableNameInnerClass.java
@@ -14,14 +14,14 @@ package com.puppycrawl.tools.checkstyle.checks.naming.localfinalvariablename;
  **/
 class InputLocalFinalVariableNameInnerClass
 {
-    // Ignore - two violations
+
     class InnerInner2
     {
         // Ignore
         public int fData;
     }
 
-    // Ignore - 2 violations
+
     interface InnerInterface2
     {
         // Ignore - should be all upper case

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableNameInnerClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localvariablename/InputLocalVariableNameInnerClass.java
@@ -15,14 +15,14 @@ package com.puppycrawl.tools.checkstyle.checks.naming.localvariablename;
  **/
 class InputLocalVariableNameInnerClass
 {
-    // Ignore - two violations
+
     class InnerInner2
     {
         // Ignore
         public int fData;
     }
 
-    // Ignore - 2 violations
+
     interface InnerInterface2
     {
         // Ignore - should be all upper case

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/membername/InputMemberNameInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/membername/InputMemberNameInner.java
@@ -17,14 +17,14 @@ package com.puppycrawl.tools.checkstyle.checks.naming.membername;
  **/
 class InputMemberNameInner
 {
-    // Ignore - two violations
+
     class InnerInner2
     {
         // Ignore
         public int fData;
     }
 
-    // Ignore - 2 violations
+
     interface InnerInterface2
     {
         // Ignore - should be all upper case

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder8.java
@@ -20,5 +20,5 @@ public class InputSuppressWarningsHolder8 {
 
    // violation below 'Name 'K' must match pattern'
    private int K;   @SuppressWarnings("membername")
-   private int J; // violation suppressed
+   private int J;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderAlias6.java
@@ -40,11 +40,10 @@ public class InputSuppressWarningsHolderAlias6 {
     void testMethod2(String str) {
         str = MSG_KEY;
         System.out.println("This is a short line.");
-
+        // filtered violation below 'Line is longer than 75 characters'
         System.out.println("This line is long and exceeds the default limit of 80 characters.");
-        // filtered 2 violations above:
-        //  'Line is longer than 75 characters'
-        //  'Line is longer than 80 characters'
+        // filtered violation above 'Line is longer than 80 characters'
+
     }
 
     @SuppressWarnings("LIne")
@@ -53,7 +52,7 @@ public class InputSuppressWarningsHolderAlias6 {
         System.out.println("This is a short line.");
 
         System.out.println("This line exceeds the limit of 75 characters.");
-        // filtered violation above, 'Line is longer than 75 characters'
+        // filtered violation above 'Line is longer than 75 characters'
     }
 
     void testMethod4(String str) {
@@ -75,11 +74,10 @@ public class InputSuppressWarningsHolderAlias6 {
     }
 
     @SuppressWarnings("LINE")
-    // filtered violation 3 lines below, 'Line is longer than 75 characters'
     /**
     * This is a short Javadoc comment.
     * ThisJavadocCommentIsAReallyLongWordThatExceedsDefaultLineLimitOfEightyCharacters.
-    */
+    */ // filtered violation above 'Line is longer than 75 characters'
     void testMethod6(String str) {
         str = MSG_KEY;
         System.out.println("This is a short line.");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment.java
@@ -47,7 +47,7 @@ public class InputTrailingComment {
 */
     /* package */ void method3() {
 
-        // violation here for format NOT FOUND
+        // ok, format NOT FOUND
     }
 
     private static class TimerEntry {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment2.java
@@ -46,7 +46,7 @@ public class InputTrailingComment2 {
 */
     /* package */ void method3() {
         /* bla on this block */
-        // violation here for format NOT FOUND
+
     }
 
     private static class TimerEntry {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment3.java
@@ -57,7 +57,7 @@ public class InputTrailingComment3 {
         // violation below 'Don't use trailing comments.'
         /* bla on this block */
         // violation below 'Don't use trailing comments.'
-        // violation here for format NOT FOUND
+        // ok, format NOT FOUND
     }
 
     private static class TimerEntry {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparator.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparator.java
@@ -10,7 +10,7 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; //no violation: trailing comment
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; //ok, trailing comment
 import java.io.Serializable; // violation ''import' should be separated from previous line.'
 import java.util.ArrayList; /*ok: trailing comment*/
 import java.util.HashMap;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorMultipleEmptyLinesInside.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorMultipleEmptyLinesInside.java
@@ -41,13 +41,13 @@ public abstract class InputEmptyLineSeparatorMultipleEmptyLinesInside
     private static void foo() { // violation 'There is more than 1 empty line after this line.'
 
 
-        // 1 empty line above should cause a violation
+        // 1 empty line above
 
         // violation 'There is more than 1 empty line after this line.'
 
 
 
-        // 2 empty lines above should cause violations
+        // 2 empty lines above
     }
 }
 class // violation ''CLASS_DEF' should be separated from previous line.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments.java
@@ -12,9 +12,9 @@ tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, 
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
 
-import java.lang.Object; // no violation
+import java.lang.Object;
 
-import java.lang.Class; // no violation
+import java.lang.Class;
 
 // ok below
 import java.lang.Long;
@@ -48,7 +48,7 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
 
     public int testNoViolation1 = 1;
 
-    public int testNoViolation2 = 2; // no violation
+    public int testNoViolation2 = 2;
 
     // Should
     // not
@@ -68,17 +68,17 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
     public int testNoViolationWithJavadoc = 5;
 
     public void testNoViolationMethod1() {
-    } // no violation
+    }
 
     public void testNoViolationMethod2() {
-    } // no violation
+    }
 
     // Should not have
 
     public void testNoViolationMethod3() {
 
 
-        // no violation
+
 
     }
 
@@ -89,7 +89,7 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
      * violation
      */
     public void testNoViolationMethod4() {
-        // no violation
+
     }
 
     /*
@@ -109,10 +109,10 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
 
     }
 
-    // no violation
 
-    // no violation
-    // no violation
+
+
+
 
     /**
      * Should have
@@ -121,7 +121,7 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
     public void testNoViolationWithJavadoc1() {
 
 
-        // no violation
+
 
 
 
@@ -129,7 +129,7 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
 
 
 
-        // no violation
+
 
     }
 
@@ -137,33 +137,33 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
      * Should not have
      * violation
      */
-    public void testNoViolationWithJavadoc2() { // no violation
+    public void testNoViolationWithJavadoc2() {
     }
 
-    public static class Class1 { } // no violation
+    public static class Class1 { }
 
 
     public static class Class2 { }
 
-    // no violation
+
 
     public static class Class3 {
 
 
-        // no violation
+
 
 
 
         /* no violation */
 
 
-        // no violation
+
 
     }
 
-    // no violation
 
-    // no violation
+
+
 
     public static class Class4 {
 
@@ -180,18 +180,18 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
 
     /* no violation */
     public
-    // no violation
+
     static class Class5 {
 
 
-        // no violation
+
 
     }
 
     public
     /* no violation */
 
-    // no violation
+
     static class Class6 { }
 
     /*
@@ -200,11 +200,11 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
      */
     public static class Class7 { }
 
-    // no violation
 
-    // no violation
 
-    // no violation
+
+
+
 
     /*
      * Should have
@@ -218,15 +218,15 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
      */
     public static class Class9 {
         {
-            // no violation
+
         }
     }
 
-    // no violation
+
     public interface Interface1 {
 
 
-        // no violation
+
 
 
 
@@ -234,14 +234,14 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
 
 
 
-        // no violation
+
 
 
     }
 
     /** no violation */
     public interface Interface2 { }
-    // no violation
+
 
     public
     // .
@@ -254,13 +254,13 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
     interface Interface4 {
 
 
-        // no violation
+
 
     }
 
-    // no violation
 
-    // no violation
+
+
     // .
     // .
     // .
@@ -277,7 +277,7 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
 
     }
 
-    // no violation
+
     public enum Enum1 {
         E1, E2
     }
@@ -287,11 +287,11 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
      * violation.
      */
 
-    // no violation
+
     public enum Enum2 {
 
 
-        // no violation
+
 
 
 
@@ -299,22 +299,22 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
 
 
 
-        // no violation
+
 
 
     }
 
-    // no violation
-    // no violation
 
-    // no violation
+
+
+
     public enum Enum3 {
 
 
-        // no violation
+
 
     }
-    // no violation
+
 
     public enum Enum4 {
         /*
@@ -322,11 +322,11 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
          * violation
          */
     }
-    // no violation
+
 
     public enum Enum5 { /* no violation */ }
 
-    // no violation
+
 
     public
 
@@ -335,19 +335,19 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
 
     enum Enum6 { }
 
-    // no violation
+
     static {
         Math.abs(2);
     }
 
-    // no violation
 
-    // no violation
+
+
     {
         Math.abs(1);
 
 
-        // no violation
+
 
     }
 
@@ -369,13 +369,13 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
         int i = 1;
     }
 
-    // no violation
+
     // .
     /* . */ public InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments() {
         testNoViolationWithJavadoc = 1;
 
 
-        //no violation
+
 
 
 
@@ -389,28 +389,28 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
 
     }
 
-    // no violation
+
     /* . */ public InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments(int i) {
         testNoViolationWithJavadoc = 1;
-        // no violation
+
     }
 
-    // no violation
-    // no violation
 
-    // no violation
+
+
+
     public InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments(int i, int j) {
         testNoViolationWithJavadoc = 1;
     }
 
     /* no violation */
 
-    // no violation
-    // no violation
 
-    // no violation
 
-    // no violation
+
+
+
+
     public InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments(int i, int j, int k) {
         testNoViolationWithJavadoc = 1;
     }
@@ -418,7 +418,7 @@ public class InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments {
 
 
 
-    // no violation
+
 
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorPostFixCornerCases.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorPostFixCornerCases.java
@@ -43,7 +43,7 @@ public class InputEmptyLineSeparatorPostFixCornerCases {
             "String One", 13,
 
 
-            "String Two", // violation above this line.
+            "String Two",
         };
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorRecursive.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorRecursive.java
@@ -23,7 +23,7 @@ public class InputEmptyLineSeparatorRecursive {
             if (a != b) {
                 throw new IOException();
             }
-            // empty lines below should cause a violation
+            // empty lines below
             // violation 'There is more than 1 empty line after this line.'
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithComments.java
@@ -140,8 +140,8 @@ public class InputEmptyLineSeparatorWithComments {
     public void testViolationWithSingleLineComment() {
     }
 
-    // Should not have
-    // a violation
+    // Should be ok
+
     public void testNoViolationWithSingleLineComment() {
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithComments2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorWithComments2.java
@@ -96,10 +96,10 @@ public class InputEmptyLineSeparatorWithComments2 {
     public int testNoViolationWithoutComment = 2;
 
 
-    // Should have violation
+
     public int testViolationWithSingleLineComment = 3;
 
-    // Should not have violations
+
     public int testNoViolationWithSingleLineComment = 4;
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPadCheckConstructors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPadCheckConstructors.java
@@ -31,7 +31,7 @@ public class InputMethodParamPadCheckConstructors extends ArrayList {
 
     public InputMethodParamPadCheckConstructors(String a, String b) {
         this
-            (a.length() + b.length()); // line break is ok, no violation
+            (a.length() + b.length()); // line break is ok
     }
 
     public InputMethodParamPadCheckConstructors(String a, String b, Object c) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterTestAllTokens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterTestAllTokens.java
@@ -9,7 +9,7 @@ tokens = ARRAY_INIT, AT, INC, DEC, UNARY_MINUS, UNARY_PLUS, BNOT, LNOT, DOT, \
 
 package com . puppycrawl // violation, ''.' is followed by whitespace.'
     .tools. // violation, ''.' is followed by whitespace.'
-    checkstyle.checks.whitespace.nowhitespaceafter; // ^ 2 violations above
+    checkstyle.checks.whitespace.nowhitespaceafter;
 
 class InputNoWhitespaceAfterTestAllTokens
 {
@@ -305,7 +305,7 @@ class SpecialCasesInForLoopTestAllTokens
 
     Object foo() {
         return ( (Object // violation, '')' is followed by whitespace.'
-                ) ""); // ^ violation
+                ) "");
     }
 
     public Object[]

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterTestAssignment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterTestAssignment.java
@@ -7,7 +7,7 @@ tokens = (default)ARRAY_INIT, AT, INC, DEC, UNARY_MINUS, UNARY_PLUS, BNOT, LNOT,
 
 */
 
-package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter; // ^ 2 violations above
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
 
 public class InputNoWhitespaceAfterTestAssignment {
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterTestDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterTestDefault.java
@@ -9,7 +9,7 @@ tokens = (default)ARRAY_INIT, AT, INC, DEC, UNARY_MINUS, UNARY_PLUS, BNOT, LNOT,
 
 package com . puppycrawl // violation, ''.' is followed by whitespace'
     .tools. // violation, ''.' is followed by whitespace'
-    checkstyle.checks.whitespace.nowhitespaceafter; // ^ 2 violations above
+    checkstyle.checks.whitespace.nowhitespaceafter;
 
 class InputNoWhitespaceAfterTestDefault
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterTestMethodRefAfter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterTestMethodRefAfter.java
@@ -26,6 +26,6 @@ public class InputNoWhitespaceAfterTestMethodRefAfter {
         // violation above, ''::' is followed by whitespace.'
         Supplier<SomeClass.Nested<V>> passes = SomeClass.Nested:: new;
         // violation above, ''::' is followed by whitespace.'
-        Supplier<SomeClass.Nested<V>> fails = SomeClass.Nested<V>::new; //no violation
+        Supplier<SomeClass.Nested<V>> fails = SomeClass.Nested<V>::new;
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore/InputNoWhitespaceBeforeDefault.java
@@ -301,7 +301,7 @@ class SpecialCasesInForLoop_NoWhitespaceBeforeDefault
     }
 
     public void foo() {
-        label2: // no violation
+        label2:
         while (true) {}
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrap1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrap1.java
@@ -45,7 +45,7 @@ class InputOperatorWrap1
     void testAssignment()
     {
         int x
-            = 0; // violation when checking assignment operators with EOL wrap option
+            = 0;
         int y =
             0;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrap2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrap2.java
@@ -45,7 +45,7 @@ class InputOperatorWrap2
     void testAssignment()
     {
         int x
-            = 0; // violation when checking assignment operators with EOL wrap option
+            = 0;
         int y =
             0;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrap3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrap3.java
@@ -43,7 +43,7 @@ class InputOperatorWrap3
     void testAssignment()
     {
         int x
-            = 0; // violation when checking assignment operators with EOL wrap option
+            = 0;
         int y =
             0;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrap4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrap4.java
@@ -43,7 +43,7 @@ class InputOperatorWrap4
     void testAssignment()
     {
         int x
-            = 0; // violation when checking assignment operators with EOL wrap option
+            = 0;
         int y =
             0;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/InputWhitespaceAroundAllowEmptyCompactCtors.java
@@ -83,7 +83,7 @@ class foo2 {
 
 class foo3 {
     public foo3(){System.out.println();} // 3 violations
-                                    //-^--- violation, no WS before '}'
+                                    // ok, no WS before '}'
 }
 
 record TestRecord8(int a, int b) {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example1.java
@@ -19,16 +19,16 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarningsholder
 class Example1 {
   private int K; // violation, 'Name 'K' must match pattern'
   @SuppressWarnings({"membername"})
-  private int J; // violation suppressed
+  private int J;
 
   @SuppressWarnings("ParamListShouldBeShort")
-    public void needsLotsOfParameters1 (int a, // violation suppressed
+    public void needsLotsOfParameters1 (int a,
      int b, int c, int d, int e, int f, int g, int h) {}
 
   private int [] ARR; // violation ''int' is followed by whitespace'
   // violation above, 'Name 'ARR' must match pattern'
   @SuppressWarnings("all")
-  private int [] ARRAY; // violation suppressed
+  private int [] ARRAY;
   // violation 2 lines below 'More than 7 parameters (found 8)'
   @SuppressWarnings("paramcounter")
     public void needsLotsOfParameters2 (int a,

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/Example2.java
@@ -23,7 +23,7 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarningsholder
 class Example2 {
   private int K; // violation, 'Name 'K' must match pattern'
   @SuppressWarnings({"membername"})
-  private int J; // violation suppressed
+  private int J;
 
   @SuppressWarnings("ParamListShouldBeShort")
   public void needsLotsOfParameters1 (int a,
@@ -32,10 +32,10 @@ class Example2 {
   private int [] ARR; // violation ''int' is followed by whitespace'
   // violation above, 'Name 'ARR' must match pattern'
   @SuppressWarnings("all")
-  private int [] ARRAY; // violation suppressed
+  private int [] ARRAY;
 
   @SuppressWarnings("paramcounter")
-  public void needsLotsOfParameters2 (int a, // violation suppressed
+  public void needsLotsOfParameters2 (int a,
     int b, int c, int d, int e, int f, int g, int h) {}
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/UseCase1.java
@@ -39,7 +39,7 @@ public class UseCase1 {
   @SuppressWarnings("paramcounter")
   public void needsLotsOfParameters2(
           int a, int b, int c, int d,
-          int e, int f, int g, int h) {} // violation suppressed
+          int e, int f, int g, int h) {}
 
   private int [] ARR;
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/UseCase2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder/UseCase2.java
@@ -39,7 +39,7 @@ public class UseCase2 {
   @SuppressWarnings("paramcounter")
   public void needsLotsOfParameters2(
           int a, int b, int c, int d,
-          int e, int f, int g, int h) {} // violation suppressed
+          int e, int f, int g, int h) {}
 
   private int [] ARR;
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/covariantequals/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/covariantequals/Example2.java
@@ -10,7 +10,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.covariantequals;
 
 // xdoc section -- start
 public class Example2 {
-  public boolean equals(Example2 same) {  // no violation
+  public boolean equals(Example2 same) {
     return false;
   }
 
@@ -19,7 +19,7 @@ public class Example2 {
   }
 
   record Test(String str) {
-    public boolean equals(Test same) {  // no violation
+    public boolean equals(Test same) {
       return false;
     }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/UseCase1.java
@@ -14,7 +14,7 @@ import java.util.Calendar;
 public class UseCase1 {
 
   public void case1(long timeNow, int hh, int min) {
-    int minutes = min + 5; // ok, No violation reported
+    int minutes = min + 5;
     Calendar cal = Calendar.getInstance();
     cal.setTimeInMillis(timeNow);
     cal.set(Calendar.SECOND, 0);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/Example3.java
@@ -14,7 +14,7 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.filelength;
 public class Example3 {
   public void myTest() {
     // small class with more than 5 lines less than 2000 lines
-    String test = "Some content"; // ok, no violation as only txt file validated
+    String test = "Some content"; // ok, as only txt file validated
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/Example6.java
@@ -10,7 +10,7 @@
 package com.puppycrawl.tools.checkstyle.checks.sizes.methodcount;
 
 // xdoc section -- start
-class Example6 { // ok, no violation there are no protected methods in this class
+class Example6 { // ok, there are no protected methods in this class
 
   public void outerMethod1(int i) {}
   public void outerMethod2() {}


### PR DESCRIPTION
## Refactor `InlineConfigParser` violation-message enforcement

#15456 

### Reference PR https://github.com/checkstyle/checkstyle/pull/20715

### Summary
Extends and fixes violation-message enforcement (tracked in (https://github.com/checkstyle/checkstyle/issues/15456)(https://github.com/checkstyle/checkstyle/issues/15456)) and refactors the multi-violation parsing logic in `InlineConfigParser`.

### Changes
- **Fixed `SUPPRESSED_FILES` matching bug**: was matching bare filenames only, causing accidental cross-package matches. Now matches full normalized path via `endsWith`; entries updated to include package paths.
- **Added `SUPPRESSED_CHECKS`**: check-level suppression by fully-qualified class name, complementing the existing file-level and permanent suppression sets.
- **Closed a message-enforcement gap**: `checkWhetherViolationSpecified` is now called from the multi-violation and filtered-violation code paths, which previously skipped it.
- **Extracted `isRelativeLineViolationProcessed` / `isMultipleViolationProcessed`**: split out of the old monolithic block for clarity, composed via early-exit chaining.
- **Added `isFilteredViolationComment`**: consolidates all five "filtered violation" comment patterns into one helper, fixing an issue where only the bare form was recognized in `isViolationComment` and the default fallback.
- **Fixed `VIOLATION_DEFAULT` regex**: `"//.*violation.*"` → `".*//.*violation.*"` (previously only matched violation comments at line start).
