### PR TITLE
Issue #19764: Move violation comments out of Javadoc for JavadocLeadingAsteriskAlign

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -464,11 +464,6 @@
             files="[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity[\\/]InputClassFanOutComplexityRemoveIncorrectAnnotationToken.java"/>
 
 
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignIncorrect.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="[\\/]checks[\\/]javadoc[\\/]javadocleadingasteriskalign[\\/]InputJavadocLeadingAsteriskAlignTabs.java"/>
-
 
   <suppress id="noViolationCommentsInJavadoc"
             files="[\\/]checks[\\/]javadoc[\\/]summaryjavadoc[\\/]InputSummaryJavadocInlineReturn.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheckTest.java
@@ -44,21 +44,21 @@ public class JavadocLeadingAsteriskAlignCheckTest extends AbstractModuleTestSupp
     @Test
     public void testIncorrectJavadoc() throws Exception {
         final String[] expected = {
-            "12:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 2),
-            "17:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
-            "23:3: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 3, 4),
-            "29:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
-            "33:3: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 3, 4),
-            "37:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 4),
-            "42:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 4),
-            "48:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 4),
-            "53:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 4),
-            "57:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 4),
-            "58:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
-            "62:9: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 9, 6),
-            "67:8: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 8, 6),
-            "76:4: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 4, 6),
-            "81:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 6),
+            "13:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 2),
+            "19:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
+            "26:3: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 3, 4),
+            "33:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
+            "38:3: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 3, 4),
+            "43:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 4),
+            "49:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 4),
+            "56:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 4),
+            "62:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 4),
+            "68:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 4),
+            "69:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
+            "74:9: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 9, 6),
+            "80:8: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 8, 6),
+            "90:4: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 4, 6),
+            "96:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 6),
         };
 
         final String filePath = getPath("InputJavadocLeadingAsteriskAlignIncorrect.java");
@@ -68,11 +68,11 @@ public class JavadocLeadingAsteriskAlignCheckTest extends AbstractModuleTestSupp
     @Test
     public void testTabs() throws Exception {
         final String[] expected = {
-            "49:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
-            "60:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 6),
-            "61:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 6),
-            "70:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 6),
-            "71:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 6),
+            "50:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
+            "62:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 6),
+            "63:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 6),
+            "74:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 6),
+            "75:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 6),
         };
 
         final String filePath = getPath("InputJavadocLeadingAsteriskAlignTabs.java");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignIncorrect.java
@@ -8,77 +8,92 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocleadingasteriskalign;
 
+// violation 2 lines below 'Leading asterisk has .* indentation .* 1, expected is 2.'
 /**
 * This is the class level javadoc.
- * // violation above 'Leading asterisk has .* indentation .* 1, expected is 2.'
+ *
  */
 public class InputJavadocLeadingAsteriskAlignIncorrect {
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 5, expected is 4.'
   /**
     * Javadoc for instance variable
-   * // violation above 'Leading asterisk has .* indentation .* 5, expected is 4.'
+   *
    */
   private int age;
 
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 3, expected is 4.'
   /**
-  *  // violation 'Leading asterisk has .* indentation .* 3, expected is 4.'
+  *
    */
   private String name;
 
+  // violation 3 lines below 'Leading asterisk has .* indentation .* 5, expected is 4.'
   /**
    * Javadoc for foo.
-    */ // violation 'Leading asterisk has .* indentation .* 5, expected is 4.'
+    */
   public void foo() {}
 
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 3, expected is 4.'
   /**
-  */ // violation 'Leading asterisk has .* indentation .* 3, expected is 4.'
+  */
   public void foo2() {}
 
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 7, expected is 4.'
   /**
-      * // violation 'Leading asterisk has .* indentation .* 7, expected is 4.'
+      *
    */
   public void foo3() {}
 
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 1, expected is 4.'
   /**
-*   // violation 'Leading asterisk has .* indentation .* 1, expected is 4.'
+*
    */
   public void foo4() {}
 
+  // violation 3 lines below 'Leading asterisk has .* indentation .* 7, expected is 4.'
   /**
    * Default Constructor.
-      */ // violation 'Leading asterisk has .* indentation .* 7, expected is 4.'
+      */
   public InputJavadocLeadingAsteriskAlignIncorrect() {}
 
+  // violation 3 lines below 'Leading asterisk has .* indentation .* 1, expected is 4.'
   /**
    * Parameterized Constructor.
-*/ // violation 'Leading asterisk has .* indentation .* 1, expected is 4.'
+*/
   public InputJavadocLeadingAsteriskAlignIncorrect(String a) {}
 
+  // violation 3 lines below 'Leading asterisk has .* indentation .* 7, expected is 4.'
+  // violation 3 lines below 'Leading asterisk has .* indentation .* 5, expected is 4.'
   /**
-      * // violation 'Leading asterisk has .* indentation .* 7, expected is 4.'
-    * Inner Class. */ // violation 'Leading asterisk has .* indentation .* 5, expected is 4.'
+      *
+    * Inner Class. */
   private static class Inner {
+    // violation 3 lines below 'Leading asterisk has .* indentation .* 9, expected is 6.'
     /**
 
-        */ // violation 'Leading asterisk has .* indentation .* 9, expected is 6.'
+        */
     private Object obj;
 
+    // violation 3 lines below 'Leading asterisk has .* indentation .* 8, expected is 6.'
     /**
      * @param testing
        *         Testing......
-     * // violation above 'Leading asterisk has .* indentation .* 8, expected is 6.'
+     *
      */
     void foo(String testing) {}
   }
 
   private enum incorrectJavadocEnum {
 
+    // violation 2 lines below 'Leading asterisk has .* indentation .* 4, expected is 6.'
     /**
-   */ // violation 'Leading asterisk has .* indentation .* 4, expected is 6.'
+   */
     ONE,
 
 
+    // violation 2 lines below 'Leading asterisk has .* indentation .* 7, expected is 6.'
     /**
-      * Wrong Alignment */ // violation 'Leading asterisk has .* indentation .* 7, expected is 6.'
+      * Wrong Alignment */
     TWO
   }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignTabs.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignTabs.java
@@ -45,9 +45,9 @@ public class InputJavadocLeadingAsteriskAlignTabs {
 		 */
 	public InputJavadocLeadingAsteriskAlignTabs() {}
 
+	// violation 2 lines below 'Leading asterisk has .* indentation .* 5, expected is 4.'
 	/***
 	  * @param x testing..... */
-  // violation above 'Leading asterisk has .* indentation .* 5, expected is 4.'
 	public InputJavadocLeadingAsteriskAlignTabs(int x) {}
 
 	/*****
@@ -56,9 +56,11 @@ public class InputJavadocLeadingAsteriskAlignTabs {
 
 	private enum enumWithTabs {
 
+	  // violation 3 lines below 'Leading asterisk has .* indentation .* 5, expected is 6.'
+	  // violation 3 lines below 'Leading asterisk has .* indentation .* 7, expected is 6.'
 	  /**
-		*  // violation 'Leading asterisk has .* indentation .* 5, expected is 6.'
-		  */ // violation 'Leading asterisk has .* indentation .* 7, expected is 6.'
+		*
+		  */
 		ONE,
 
 		/**
@@ -66,9 +68,11 @@ public class InputJavadocLeadingAsteriskAlignTabs {
 		 */
 		TWO,
 
+		// violation 3 lines below 'Leading asterisk has .* indentation .* 7, expected is 6.'
+		// violation 3 lines below 'Leading asterisk has .* indentation .* 5, expected is 6.'
 		/**
-			* // violation 'Leading asterisk has .* indentation .* 7, expected is 6.'
-		*/ // violation 'Leading asterisk has .* indentation .* 5, expected is 6.'
+			*
+		*/
 		THREE,
 
 		/**


### PR DESCRIPTION
Issue #19764

## Summary

- Move all violation comments outside Javadocs in the `javadocleadingasteriskalign` input package.
- Update expected violation line numbers in `JavadocLeadingAsteriskAlignCheckTest`.
- Remove the two obsolete `noViolationCommentsInJavadoc` suppressions.

## Testing

- `.\mvnw.cmd clean -Dtest=JavadocLeadingAsteriskAlignCheckTest test` (3 tests, 0 failures)
- `.\mvnw.cmd clean verify` with the forked JVM locale set to `en_US` (build success)