### PR TITLE
Issue #20675: Isolate invalid Javadoc snippets from nonemptyatclausedescription

### DIFF
--- a/.ci/javadoc-tool-excluded-packages.sh
+++ b/.ci/javadoc-tool-excluded-packages.sh
@@ -12,6 +12,5 @@ JAVADOC_TOOL_EXCLUDED_PACKAGES=(
   "$source_root $javadoc_package.javadocmethod"
   "$source_root $javadoc_package.javadocpackage.annotation"
   "$source_root $javadoc_package.javadoctype"
-  "$source_root $javadoc_package.nonemptyatclausedescription"
   "$source_root com.puppycrawl.tools.checkstyle.javadocpropertiesgenerator"
 )

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
@@ -98,8 +98,6 @@ public class NonEmptyAtclauseDescriptionCheckTest
             "60: " + getCheckMessage(MSG_KEY),
             "75: " + getCheckMessage(MSG_KEY),
             "77: " + getCheckMessage(MSG_KEY),
-            "88: " + getCheckMessage(MSG_KEY),
-            "97: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(getPath("InputNonEmptyAtclauseDescriptionTwo.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionThree.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionThree.java
@@ -36,19 +36,7 @@ class InputNonEmptyAtclauseDescriptionThree {
     return j-1;
   }
 
-  /**
-   * Some summary.
-   *
-   * @param j some param
-   * @see <a href="...">a</a><p>ending with paragraph tag</p>.
-   * @see <a href="...">b</a><h1>ending with h tag</h1>
-   *
-   * @see <a href="...">c</a>
-   * <h1>ending with h tag</h1>.
-   */
-  public int testWithHtmlTags(int j){
-    return j-1;
-  }
+
 
   /**
    * some docs.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionTwo.java
@@ -83,21 +83,4 @@ public class InputNonEmptyAtclauseDescriptionTwo
                 return 1;
         }
 
-    /**
-     *
-     * @param
-     *
-     */ // violation 2 lines above 'At-clause should have a non-empty description'
-        public int foo8(int a)
-        {
-                return 1;
-        }
-
-    /**
-     * @throws
-     */ // violation above 'At-clause should have a non-empty description'
-        public int foo9(String a) throws Exception
-        {
-            return 1;
-        }
 }


### PR DESCRIPTION
Issue #20675

Summary

- removed `nonemptyatclausedescription` from `.ci/javadoc-tool-excluded-packages.sh`
- removed standalone invalid Javadoc snippets from:
  - `InputNonEmptyAtclauseDescriptionTwo.java`
  - `InputNonEmptyAtclauseDescriptionThree.java`
- updated expected violations in `NonEmptyAtclauseDescriptionCheckTest`

Tests

./mvnw test -Dtest=NonEmptyAtclauseDescriptionCheckTest