### PR TITLE
Issue #20743: Update report issue page link

### DIFF
--- a/src/site/xdoc/report_issue.xml
+++ b/src/site/xdoc/report_issue.xml
@@ -10,7 +10,7 @@
       </p>
       <p>
         Please see
-        <a href="https://github.com/checkstyle/checkstyle/blob/master/.github/report-issue.md">
+        <a href="https://github.com/checkstyle/checkstyle/blob/master/docs/report-issue.md">
           report-issue.md
         </a>
         for the complete and up-to-date guidelines.


### PR DESCRIPTION
Fixes #20743.

Updates the Report Issue website page to link to `docs/report-issue.md`, where the issue-report documentation now lives, instead of the removed `.github/report-issue.md` path.

Validation:
- `./mvnw clean site -Pno-validations`
- verified generated `target/site/report_issue.html` points to `docs/report-issue.md`
- `./mvnw clean verify`