### PR TITLE
Issue #19803: move violation comment in IllegalThrows

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -752,8 +752,6 @@
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]missingoverride[\\/]InputMissingOverrideBadOverrideFromObject\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]annotation[\\/]suppresswarnings[\\/]InputSuppressWarningsSingle1\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]illegalthrows[\\/]InputIllegalThrowsNotIgnoreOverriddenMethod\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]illegaltoken[\\/]InputIllegalTokensCheckBlockCommentEnd\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheckTest.java
@@ -109,8 +109,8 @@ public class IllegalThrowsCheckTest extends AbstractModuleTestSupport {
     public void testNotIgnoreOverriddenMethods() throws Exception {
 
         final String[] expected = {
-            "17:36: " + getCheckMessage(MSG_KEY, "RuntimeException"),
-            "22:51: " + getCheckMessage(MSG_KEY, "RuntimeException"),
+            "18:36: " + getCheckMessage(MSG_KEY, "RuntimeException"),
+            "24:51: " + getCheckMessage(MSG_KEY, "RuntimeException"),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows/InputIllegalThrowsNotIgnoreOverriddenMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows/InputIllegalThrowsNotIgnoreOverriddenMethod.java
@@ -12,13 +12,15 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegalthrows;
 
 public class InputIllegalThrowsNotIgnoreOverriddenMethod
              extends InputIllegalThrowsTestDefault
-{
-    @Override // violation below, 'Throwing 'RuntimeException' is not allowed'
+{   
+    // violation 1 line below, 'Throwing 'RuntimeException' is not allowed'
+    @Override
     public void methodTwo() throws RuntimeException {
 
     }
 
-    @Override // violation below, 'Throwing 'RuntimeException' is not allowed'
+    // violation 1 line below, 'Throwing 'RuntimeException' is not allowed'
+    @Override
     public java.lang.Throwable methodOne() throws RuntimeException {
         return null;
     }


### PR DESCRIPTION
part of https://github.com/checkstyle/checkstyle/issues/19803

Moved the violation comment in InputIllegalThrowsNotIgnoreOverriddenMethod.java.

Removed the matching suppression from checkstyle-input-suppressions.xml and updated the expected violation line in IllegalThrowsCheckTest.java