### PR TITLE
Issue #20711: Fix comment mismatches in xdocs examples currently supp…

### DIFF
--- a/src/site/xdoc/checks/annotation/missingdeprecated.xml
+++ b/src/site/xdoc/checks/annotation/missingdeprecated.xml
@@ -96,12 +96,12 @@ class Example1 {
    * &lt;p&gt;&lt;/p&gt;
    */
   @Deprecated
-    public static final int NUM = 123456;
+  public static final int NUM = 123456;
 
   /**
    * @deprecated
-   *  &lt;p&gt;
-   */
+   * &lt;p&gt;
+  */
   @Deprecated
   public static final int CONST = 12;
 }

--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml
@@ -244,7 +244,7 @@ public class Example3 {
   /**
    * Some javadoc.
    *
-   * @author Some javadoc.
+   * @author max
    * @version Some javadoc.
    * @see Some javadoc.
    * @since Some javadoc.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -249,8 +249,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/imports/importorder/Example8",
             "checks/imports/importorder/Example9",
             // until https://github.com/checkstyle/checkstyle/issues/20711
-            "checks/annotation/missingdeprecated/Example2",
-            "checks/javadoc/atclauseorder/Example3",
             "checks/javadoc/javadocvariable/Example4",
             "checks/javadoc/missingjavadoctype/Example2",
             "checks/javadoc/missingjavadoctype/Example3",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example1.java
@@ -24,12 +24,12 @@ class Example1 {
    * <p></p>
    */
   @Deprecated
-    public static final int NUM = 123456;
+  public static final int NUM = 123456;
 
   /**
    * @deprecated
-   *  <p>
-   */
+   * <p>
+  */
   @Deprecated
   public static final int CONST = 12;
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example3.java
@@ -49,7 +49,7 @@ public class Example3 {
   /**
    * Some javadoc.
    *
-   * @author Some javadoc.
+   * @author max
    * @version Some javadoc.
    * @see Some javadoc.
    * @since Some javadoc.


### PR DESCRIPTION
#20711

fixes comment mismatch for :
`missingdeprecated `
`atclauseorder`

removed 2 suppressions