### PR TITLE
Issue #20711: Fix comment mismatches in xdocs examples currently supp…

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadocvariable.xml
+++ b/src/site/xdoc/checks/javadoc/javadocvariable.xml
@@ -193,7 +193,7 @@ public class Example4 {
 
   /**
    * Some description here
-  */
+   */
   private int b;
   protected int c; // violation, 'Missing a Javadoc comment'
   public int d; // violation, 'Missing a Javadoc comment'

--- a/src/site/xdoc/checks/javadoc/writetag.xml
+++ b/src/site/xdoc/checks/javadoc/writetag.xml
@@ -221,16 +221,16 @@ public class Example3 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 /**
  * Some class
- * @since 1.2
+ *
  */
 public class Example4 {
-  // violation 3 lines below 'Type Javadoc tag @since'
+  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
   /**
    * some doc
    * @since
    */
   void testMethod1() {}
-
+  // violation 3 lines above 'Type Javadoc tag @since'
   /** some doc */
   public void testMethod2() {}
   // violation 1 lines above 'Type Javadoc comment is missing @since tag.'

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -249,13 +249,11 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/imports/importorder/Example8",
             "checks/imports/importorder/Example9",
             // until https://github.com/checkstyle/checkstyle/issues/20711
-            "checks/javadoc/javadocvariable/Example4",
             "checks/javadoc/missingjavadoctype/Example2",
             "checks/javadoc/missingjavadoctype/Example3",
             "checks/javadoc/missingjavadoctype/Example4",
             "checks/javadoc/missingjavadoctype/Example5",
-            "checks/javadoc/summaryjavadoc/Example3",
-            "checks/javadoc/writetag/Example4"
+            "checks/javadoc/summaryjavadoc/Example3"
         );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckExamplesTest.java
@@ -60,6 +60,7 @@ public class WriteTagCheckExamplesTest extends AbstractExamplesModuleTestSupport
     public void testExample4() throws Exception {
         final String pattern = "[1-9\\.]";
         final String[] expected = {
+            "23: " + getCheckMessage(WriteTagCheck.MSG_MISSING_TAG, "@since"),
             "27: " + getCheckMessage(WriteTagCheck.MSG_TAG_FORMAT, "@since", pattern),
             "32: " + getCheckMessage(WriteTagCheck.MSG_MISSING_TAG, "@since"),
         };

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/Example4.java
@@ -15,7 +15,7 @@ public class Example4 {
 
   /**
    * Some description here
-  */
+   */
   private int b;
   protected int c; // violation, 'Missing a Javadoc comment'
   public int d; // violation, 'Missing a Javadoc comment'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example4.java
@@ -18,16 +18,16 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
 /**
  * Some class
- * @since 1.2
+ *
  */
 public class Example4 {
-  // violation 3 lines below 'Type Javadoc tag @since'
+  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
   /**
    * some doc
    * @since
    */
   void testMethod1() {}
-
+  // violation 3 lines above 'Type Javadoc tag @since'
   /** some doc */
   public void testMethod2() {}
   // violation 1 lines above 'Type Javadoc comment is missing @since tag.'


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/20711

fixes comment mismatch for :
`javadocvariable`
`writetag`

removed 2 suppressions