### PR TITLE
Issue #20711: Fix comment mismatches in xdocs examples currently supp…

### DIFF
--- a/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
+++ b/src/site/xdoc/checks/javadoc/summaryjavadoc.xml
@@ -76,50 +76,36 @@
         <p id="Example1-code"> Example1: </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
-
-  /**
-   * {@inheritDoc}
-   */
-  public String m1(){ return ""; }
   // violation below, 'Summary javadoc is missing'
   /** */
-  public String m2(){ return ""; }
+  public String withoutJavadoc() { return ""; }
 
   /**
    * {@summary  }
    */
-  public String m3(){ return ""; }
+  public String withJavadoc() { return ""; }
   // violation 3 lines above 'Summary javadoc is missing'
-  /**
-   * {@summary &lt;p&gt; &lt;p/&gt;}
-   */
-  public String m4() { return ""; }
-  // violation 3 lines above 'Summary javadoc is missing'
-  /**
-   * {@summary &lt;p&gt;This is a javadoc with period.&lt;p/&gt;}
-   */
-  public void m5() {}
 
+  /**
+   * {@summary This is a java doc with dot period.}
+   */
+  public void withPeriod() {}
+
+  /**
+   * {@summary This is a java doc with ideographic period。}
+   */
+  public void withoutPeriod() {}
+  // violation 3 lines above 'Summary of Javadoc is missing an ending period'
   /**
    * This method returns nothing.
    */
-  void m6() {}
+  void withDotPeriod() {}
 
   /**
-  * {@summary This is a java doc with period symbol。}
-  */
-  public void m7() {}
-  // violation 3 lines above 'Summary of Javadoc is missing an ending period'
-  /**
-  * {@summary First sentence is normally the summary.
-  * Use of html tags:
-  * &lt;ul&gt;
-  * &lt;li&gt;Item one.&lt;/li&gt;
-  * &lt;li&gt;Item two.&lt;/li&gt;
-  * &lt;/ul&gt;}
-  */
-  public void m8() {}
-
+   * This method returns nothing。
+   */
+  void withoutDotPeriod() {}
+  // violation 4 lines above 'First sentence of Javadoc is missing an ending period'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -139,50 +125,36 @@ class Example1 {
         <p id="Example2-code"> Example2: </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
-
-  /**
-   * {@inheritDoc}
-   */
-  public String m1(){ return ""; }
   // violation below, 'Summary javadoc is missing'
   /** */
-  public String m2(){ return ""; }
+  public String withoutJavadoc() { return ""; }
 
   /**
    * {@summary  }
    */
-  public String m3(){ return ""; }
+  public String withJavadoc() { return ""; }
   // violation 3 lines above 'Summary javadoc is missing'
-  /**
-   * {@summary &lt;p&gt; &lt;p/&gt;}
-   */
-  public String m4() { return ""; }
-  // violation 3 lines above 'Summary javadoc is missing'
-  /**
-   * {@summary &lt;p&gt;This is a javadoc with period.&lt;p/&gt;}
-   */
-  public void m5() {}
 
+  /**
+   * {@summary This is a java doc with dot period.}
+   */
+  public void withPeriod() {}
+
+  /**
+   * {@summary This is a java doc with ideographic period。}
+   */
+  public void withoutPeriod() {}
+  // violation 3 lines above 'Summary of Javadoc is missing an ending period'
   /**
    * This method returns nothing.
    */
-  void m6() {}
+  void withDotPeriod() {}
   // violation 4 lines above 'Forbidden summary fragment'
   /**
-  * {@summary This is a java doc with period symbol。}
-  */
-  public void m7() {}
-  // violation 3 lines above 'Summary of Javadoc is missing an ending period'
-  /**
-  * {@summary First sentence is normally the summary.
-  * Use of html tags:
-  * &lt;ul&gt;
-  * &lt;li&gt;Item one.&lt;/li&gt;
-  * &lt;li&gt;Item two.&lt;/li&gt;
-  * &lt;/ul&gt;}
-  */
-  public void m8() {}
-
+   * This method returns nothing。
+   */
+  void withoutDotPeriod() {}
+  // violation 4 lines above 'First sentence of Javadoc is missing an ending period'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -200,50 +172,36 @@ class Example2 {
         <p id="Example3-code"> Example3: </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 {
-
-  /**
-   * {@inheritDoc}
-   */
-  public String m1(){ return ""; }
   // violation below, 'Summary javadoc is missing'
   /** */
-  public String m2(){ return ""; }
+  public String withoutJavadoc() { return ""; }
 
   /**
    * {@summary  }
    */
-  public String m3(){ return ""; }
+  public String withJavadoc() { return ""; }
   // violation 3 lines above 'Summary javadoc is missing'
+
   /**
-   * {@summary &lt;p&gt; &lt;p/&gt;}
+   * {@summary This is a java doc with dot period.}
    */
-  public String m4() { return ""; }
-  // violation 3 lines above 'Summary javadoc is missing'
-  /**
-   * {@summary &lt;p&gt;This is a javadoc with period.&lt;p/&gt;}
-   */
-  public void m5() {}
+  public void withPeriod() {}
   // violation 3 lines above 'Summary of Javadoc is missing an ending period'
+  /**
+   * {@summary This is a java doc with ideographic period。}
+   */
+  public void withoutPeriod() {}
+
   /**
    * This method returns nothing.
    */
-  void m6() {}
+  void withDotPeriod() {}
   // violation 4 lines above 'First sentence of Javadoc is missing an ending period'
   /**
-  * {@summary This is a java doc without period。}
-  */
-  public void m7() {}
+   * This method returns nothing。
+   */
+  void withoutDotPeriod() {}
 
-  /**
-  * {@summary First sentence is normally the summary。
-  * Use of html tags:
-  * &lt;ul&gt;
-  * &lt;li&gt;Item one.&lt;/li&gt;
-  * &lt;li&gt;Item two.&lt;/li&gt;
-  * &lt;/ul&gt;}
-  */
-  public void m8() {}
-  // violation 8 lines above 'Summary of Javadoc is missing an ending period'
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -252,8 +252,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/javadoc/missingjavadoctype/Example2",
             "checks/javadoc/missingjavadoctype/Example3",
             "checks/javadoc/missingjavadoctype/Example4",
-            "checks/javadoc/missingjavadoctype/Example5",
-            "checks/javadoc/summaryjavadoc/Example3"
+            "checks/javadoc/missingjavadoctype/Example5"
         );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckExamplesTest.java
@@ -37,10 +37,10 @@ public class SummaryJavadocCheckExamplesTest extends AbstractExamplesModuleTestS
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "18:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "22:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "27:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "42:5: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "13:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "17:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "28:6: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "37:6: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -49,11 +49,11 @@ public class SummaryJavadocCheckExamplesTest extends AbstractExamplesModuleTestS
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "21:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "25:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "30:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "39:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
-            "45:5: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "16:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "20:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "31:6: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "35:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "40:6: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -62,12 +62,10 @@ public class SummaryJavadocCheckExamplesTest extends AbstractExamplesModuleTestS
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "20:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "24:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "29:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
-            "34:6: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
-            "38:6: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
-            "49:5: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "15:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "19:6: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "25:6: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "34:6: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/Example1.java
@@ -9,49 +9,35 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
 
 // xdoc section -- start
 class Example1 {
-
-  /**
-   * {@inheritDoc}
-   */
-  public String m1(){ return ""; }
   // violation below, 'Summary javadoc is missing'
   /** */
-  public String m2(){ return ""; }
+  public String withoutJavadoc() { return ""; }
 
   /**
    * {@summary  }
    */
-  public String m3(){ return ""; }
+  public String withJavadoc() { return ""; }
   // violation 3 lines above 'Summary javadoc is missing'
-  /**
-   * {@summary <p> <p/>}
-   */
-  public String m4() { return ""; }
-  // violation 3 lines above 'Summary javadoc is missing'
-  /**
-   * {@summary <p>This is a javadoc with period.<p/>}
-   */
-  public void m5() {}
 
+  /**
+   * {@summary This is a java doc with dot period.}
+   */
+  public void withPeriod() {}
+
+  /**
+   * {@summary This is a java doc with ideographic period。}
+   */
+  public void withoutPeriod() {}
+  // violation 3 lines above 'Summary of Javadoc is missing an ending period'
   /**
    * This method returns nothing.
    */
-  void m6() {}
+  void withDotPeriod() {}
 
   /**
-  * {@summary This is a java doc with period symbol。}
-  */
-  public void m7() {}
-  // violation 3 lines above 'Summary of Javadoc is missing an ending period'
-  /**
-  * {@summary First sentence is normally the summary.
-  * Use of html tags:
-  * <ul>
-  * <li>Item one.</li>
-  * <li>Item two.</li>
-  * </ul>}
-  */
-  public void m8() {}
-
+   * This method returns nothing。
+   */
+  void withoutDotPeriod() {}
+  // violation 4 lines above 'First sentence of Javadoc is missing an ending period'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/Example2.java
@@ -12,49 +12,35 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
 
 // xdoc section -- start
 class Example2 {
-
-  /**
-   * {@inheritDoc}
-   */
-  public String m1(){ return ""; }
   // violation below, 'Summary javadoc is missing'
   /** */
-  public String m2(){ return ""; }
+  public String withoutJavadoc() { return ""; }
 
   /**
    * {@summary  }
    */
-  public String m3(){ return ""; }
+  public String withJavadoc() { return ""; }
   // violation 3 lines above 'Summary javadoc is missing'
-  /**
-   * {@summary <p> <p/>}
-   */
-  public String m4() { return ""; }
-  // violation 3 lines above 'Summary javadoc is missing'
-  /**
-   * {@summary <p>This is a javadoc with period.<p/>}
-   */
-  public void m5() {}
 
+  /**
+   * {@summary This is a java doc with dot period.}
+   */
+  public void withPeriod() {}
+
+  /**
+   * {@summary This is a java doc with ideographic period。}
+   */
+  public void withoutPeriod() {}
+  // violation 3 lines above 'Summary of Javadoc is missing an ending period'
   /**
    * This method returns nothing.
    */
-  void m6() {}
+  void withDotPeriod() {}
   // violation 4 lines above 'Forbidden summary fragment'
   /**
-  * {@summary This is a java doc with period symbol。}
-  */
-  public void m7() {}
-  // violation 3 lines above 'Summary of Javadoc is missing an ending period'
-  /**
-  * {@summary First sentence is normally the summary.
-  * Use of html tags:
-  * <ul>
-  * <li>Item one.</li>
-  * <li>Item two.</li>
-  * </ul>}
-  */
-  public void m8() {}
-
+   * This method returns nothing。
+   */
+  void withoutDotPeriod() {}
+  // violation 4 lines above 'First sentence of Javadoc is missing an ending period'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/Example3.java
@@ -11,49 +11,35 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
 
 // xdoc section -- start
 class Example3 {
-
-  /**
-   * {@inheritDoc}
-   */
-  public String m1(){ return ""; }
   // violation below, 'Summary javadoc is missing'
   /** */
-  public String m2(){ return ""; }
+  public String withoutJavadoc() { return ""; }
 
   /**
    * {@summary  }
    */
-  public String m3(){ return ""; }
+  public String withJavadoc() { return ""; }
   // violation 3 lines above 'Summary javadoc is missing'
+
   /**
-   * {@summary <p> <p/>}
+   * {@summary This is a java doc with dot period.}
    */
-  public String m4() { return ""; }
-  // violation 3 lines above 'Summary javadoc is missing'
-  /**
-   * {@summary <p>This is a javadoc with period.<p/>}
-   */
-  public void m5() {}
+  public void withPeriod() {}
   // violation 3 lines above 'Summary of Javadoc is missing an ending period'
+  /**
+   * {@summary This is a java doc with ideographic period。}
+   */
+  public void withoutPeriod() {}
+
   /**
    * This method returns nothing.
    */
-  void m6() {}
+  void withDotPeriod() {}
   // violation 4 lines above 'First sentence of Javadoc is missing an ending period'
   /**
-  * {@summary This is a java doc without period。}
-  */
-  public void m7() {}
+   * This method returns nothing。
+   */
+  void withoutDotPeriod() {}
 
-  /**
-  * {@summary First sentence is normally the summary。
-  * Use of html tags:
-  * <ul>
-  * <li>Item one.</li>
-  * <li>Item two.</li>
-  * </ul>}
-  */
-  public void m8() {}
-  // violation 8 lines above 'Summary of Javadoc is missing an ending period'
 }
 // xdoc section -- end


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/20711

fixes comment mismatch for :
`summaryjavadoc`

removed 1 suppression