### PR TITLE
Issue #20686: Update violation message in Inputs of DesignForExtension

### DIFF
--- a/src/site/xdoc/checks/design/designforextension.xml
+++ b/src/site/xdoc/checks/design/designforextension.xml
@@ -180,10 +180,10 @@ public abstract class Plant {
 public abstract class Example1 {
   private int bar;
 
-  // violation below 'Class 'Example1' looks like designed for extension'
+  // violation below ''m1' does not have javadoc that explains how to do that safely'
   public int m1() {return 2;}
 
-  // violation below 'Class 'Example1' looks like designed for extension'
+  // violation below ''m2' does not have javadoc that explains how to do that safely'
   public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.
@@ -208,7 +208,7 @@ public abstract class Example1 {
    * implementation ...
    */
   public int m8() {return 2;}  // ok, Have javadoc on overridable method.
-  // violation below 'Class 'Example1' looks like designed for extension'
+  // violation below ''toString' does not have javadoc that explains
   @Override
   public String toString() {
     return "";
@@ -233,10 +233,10 @@ public abstract class Example1 {
 public abstract class Example2 {
   private int bar;
 
-  // violation below 'Class 'Example2' looks like designed for extension'
+  // violation below ''m1' does not have javadoc that explains how to do that safely'
   public int m1() {return 2;}
 
-  // violation below 'Class 'Example2' looks like designed for extension'
+  // violation below ''m2' does not have javadoc that explains how to do that safely'
   public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.
@@ -286,10 +286,10 @@ public abstract class Example2 {
 public abstract class Example3 {
   private int bar;
 
-  // violation below 'Class 'Example3' looks like designed for extension'
+  // violation below ''m1' does not have javadoc that explains how to do that safely'
   public int m1() {return 2;}
 
-  // violation below 'Class 'Example3' looks like designed for extension'
+  // violation below ''m2' does not have javadoc that explains how to do that safely'
   public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.
@@ -306,15 +306,15 @@ public abstract class Example3 {
 
   /**
    * Some comments ...
-   */ // violation below 'Class 'Example3' looks like designed for extension'
+   */ // violation below ''m7' does not have javadoc that explains
   public int m7() {return 1;}
 
   /**
    * This
    * implementation ...
-   */ // violation below 'Class 'Example3' looks like designed for extension'
+   */ // violation below ''m8' does not have javadoc that explains
   public int m8() {return 2;}
-  // violation below 'Class 'Example3' looks like designed for extension'
+  // violation below ''toString' does not have javadoc that explains
   @Override
   public String toString() {
     return "";
@@ -340,10 +340,10 @@ public abstract class Example3 {
 public abstract class Example4 {
   private int bar;
 
-  // violation below 'Class 'Example4' looks like designed for extension'
+  // violation below ''m1' does not have javadoc that explains how to do that safely'
   public int m1() {return 2;}
 
-  // violation below 'Class 'Example4' looks like designed for extension'
+  // violation below ''m2' does not have javadoc that explains how to do that safely'
   public int m2() {return 8;}
 
   private void m3() {m4();}
@@ -360,7 +360,7 @@ public abstract class Example4 {
 
   /**
    * Some comments ...
-   */ // violation below 'Class 'Example4' looks like designed for extension'
+   */ // violation below ''m7' does not have javadoc that explains
   public int m7() {return 1;}
 
   /**
@@ -368,7 +368,7 @@ public abstract class Example4 {
    * implementation ...
    */
   public int m8() {return 2;}  // ok, Have required javadoc.
-  // violation below 'Class 'Example4' looks like designed for extension'
+  // violation below ''toString' does not have javadoc that explains
   @Override
   public String toString() {
     return "";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtension.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtension.java
@@ -47,7 +47,7 @@ public abstract class InputDesignForExtension
 
     // this one is bad: neither abstract, final, nor empty
 
-    // violation below 'Class 'InputDesignForExtension' looks like designed'
+    // violation below ''doh' does not have javadoc that explains how to do that safely'
     protected void doh()
     {
         System.identityHashCode("nonempty and overriding possible");
@@ -102,7 +102,7 @@ public abstract class InputDesignForExtension
     {
     // nonPrivate ctor
     public anotherNonFinalClass(){}
-        // violation below 'Class 'anotherNonFinalClass' looks like designed'
+        // violation below ''someMethod' does not have javadoc that explains how to do that safely'
         public void someMethod()
         {
         System.identityHashCode("nonempty and overriding is possible");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionIgnoredAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionIgnoredAnnotations.java
@@ -36,7 +36,7 @@ public class InputDesignForExtensionIgnoredAnnotations {
         return super.toString();
     }
 
-    // violation below 'Class 'InputDesignForExtensionIgnoredAnnotations'
+    // violation below ''foo1' does not have javadoc that explains how to do that safely'
     public int foo1() {return  1;}
 
     /**
@@ -147,13 +147,13 @@ public class InputDesignForExtensionIgnoredAnnotations {
     @InputDesignForExtensionsLocalAnnotations.ClassRule
     public void foo20() { return; }
 
-    // violation below 'Class 'InputDesignForExtensionIgnoredAnnotations'
+    // violation below ''foo21' does not have javadoc that explains how to do that safely'
     @InputDesignForExtensionsLocalAnnotations.ClassRule
     public void foo21() { return; }
 
     private int age;
 
-    // violation below 'Class 'InputDesignForExtensionIgnoredAnnotations'
+    // violation below ''setAge' does not have javadoc that explains how to do that safely'
     @Inject
     public void setAge(int age) {
         this.age = age;
@@ -169,7 +169,7 @@ public class InputDesignForExtensionIgnoredAnnotations {
         foo1();
     }
 
-    // violation below 'Class 'InputDesignForExtensionIgnoredAnnotations'
+    // violation below ''foo24' does not have javadoc that explains how to do that safely'
     public void foo24(@MyAnnotation int a) {
         foo1();
     }
@@ -177,7 +177,7 @@ public class InputDesignForExtensionIgnoredAnnotations {
     /**
      * @deprecated
      */
-    // violation below 'Class 'InputDesignForExtensionIgnoredAnnotations'
+    // violation below ''dontUse4' does not have javadoc that explains how to do that safely'
     <T> T dontUse4() {
         return null;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionInterfaceMemberScopeIsPublic.java
@@ -12,7 +12,7 @@ public interface InputDesignForExtensionInterfaceMemberScopeIsPublic {
 
     class Inner {
 
-        // violation below 'Class 'Inner' looks like designed'
+        // violation below ''getProperty' does not have javadoc that explains how to do that safely'
         public String getProperty() {
             return null;
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionNativeMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionNativeMethods.java
@@ -10,7 +10,7 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 
 public class InputDesignForExtensionNativeMethods {
 
-    // violation below 'Class 'InputDesignForExtensionNativeMethods'
+    // violation below ''foo1' does not have javadoc that explains how to do that safely'
     public native void foo1();
 
     public static native void foo2();
@@ -27,7 +27,7 @@ public class InputDesignForExtensionNativeMethods {
     /*
      * Violation. Block-commend doc for native method.
      */
-    // violation below 'Class 'InputDesignForExtensionNativeMethods'
+    // violation below ''foo6' does not have javadoc that explains how to do that safely'
     public native void foo6();
 
     @Deprecated

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionOverridableMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionOverridableMethods.java
@@ -11,7 +11,7 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 public class InputDesignForExtensionOverridableMethods {
 
     public class A {
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo1' does not have javadoc that explains how to do that safely'
         public int foo1(int a, int b) {return a + b;}
 
         public void foo2() { }
@@ -36,13 +36,13 @@ public class InputDesignForExtensionOverridableMethods {
              */
         }
 
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo8' does not have javadoc that explains how to do that safely'
         public int foo8(int a, int b) {
             // single-line comment before content
             return a + b;
         }
 
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo9' does not have javadoc that explains how to do that safely'
         public int foo9(int a, int b) {
             /*
              * block comment before content
@@ -50,7 +50,7 @@ public class InputDesignForExtensionOverridableMethods {
             return a + b;
         }
 
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo10' does not have javadoc that explains how to do that safely'
         public int foo10(int a, int b) {
             /**
              * javadoc block comment before content
@@ -58,13 +58,13 @@ public class InputDesignForExtensionOverridableMethods {
             return a + b;
         }
 
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo11' does not have javadoc that explains how to do that safely'
         public int foo11(int a, int b) {
             return a + b;
             // single-line comment after content
         }
 
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo12' does not have javadoc that explains how to do that safely'
         public int foo12(int a, int b) {
             return a + b;
             /*
@@ -72,7 +72,7 @@ public class InputDesignForExtensionOverridableMethods {
              */
         }
 
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo13' does not have javadoc that explains how to do that safely'
         public int foo13(int a, int b) {
             return a + b;
             /**
@@ -80,7 +80,7 @@ public class InputDesignForExtensionOverridableMethods {
              */
         }
 
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo14' does not have javadoc that explains how to do that safely'
         protected int foo14(int a) {return a -1;}
 
         public final int foo15(int a) {return a - 2;}
@@ -103,14 +103,14 @@ public class InputDesignForExtensionOverridableMethods {
         protected final int foo21(int a) {return a - 2;}
 
         // Single line comment
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo22' does not have javadoc that explains how to do that safely'
         public void foo22() {
             return;
         }
 
         // Single line comments
         // organized in a block
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo23' does not have javadoc that explains how to do that safely'
         public void foo23() {
             return;
         }
@@ -120,13 +120,13 @@ public class InputDesignForExtensionOverridableMethods {
         public void foo24() {}
 
         /* Block comment violation */
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo25' does not have javadoc that explains how to do that safely'
         public void foo25() {
             return;
         }
 
         // Single line comment
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo26' does not have javadoc that explains how to do that safely'
         @Deprecated
         public void foo26() {
             return;
@@ -134,7 +134,7 @@ public class InputDesignForExtensionOverridableMethods {
 
         // Single line comments
         // organized in a block
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo27' does not have javadoc that explains how to do that safely'
         @Deprecated
         public void foo27() {
             return;
@@ -147,7 +147,7 @@ public class InputDesignForExtensionOverridableMethods {
         }
 
         /* Block comment violation */
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo29' does not have javadoc that explains how to do that safely'
         @Deprecated
         public void foo29() {
             return;
@@ -170,7 +170,7 @@ public class InputDesignForExtensionOverridableMethods {
         }
 
         /* */
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo31' does not have javadoc that explains how to do that safely'
         public int foo31() {
             /** */
             return 1;
@@ -182,14 +182,14 @@ public class InputDesignForExtensionOverridableMethods {
             return 1;
         }
 
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo33' does not have javadoc that explains how to do that safely'
         @Deprecated
         /** */
         public int foo33() {
             return 1;
         }
 
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo34' does not have javadoc that explains how to do that safely'
         @Deprecated
         /* */
         public int foo34() {
@@ -212,7 +212,7 @@ public class InputDesignForExtensionOverridableMethods {
         // comment
         public void foo38() { }
 
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo39' does not have javadoc that explains how to do that safely'
         @Deprecated /** */
         public void foo39() {return; }
 
@@ -220,7 +220,7 @@ public class InputDesignForExtensionOverridableMethods {
             /** */
         }
 
-        // violation below 'Class 'A' looks like designed'
+        // violation below ''foo41' does not have javadoc that explains how to do that safely'
         void foo41() {
             return;
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhrase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhrase.java
@@ -37,7 +37,7 @@ public class InputDesignForExtensionRequiredJavadocPhrase {
      */
     public int foo4(int a, int b) {return a + b;}  // ok, required comment pattern in javadoc
 
-    // violation 2 lines below 'Class 'InputDesignForExtensionRequiredJa'
+    // violation 2 lines below ''foo5' does not have javadoc that explains'
     /** This method can safely be overridden. */
     public int foo5(int a, int b) {return a + b;}
 
@@ -45,12 +45,12 @@ public class InputDesignForExtensionRequiredJavadocPhrase {
 
     protected final int foo7(int a) {return a - 2;} // ok, final
 
-    // violation 2 lines below 'Class 'InputDesignForExtensionRequiredJa'
+    // violation 2 lines below ''foo8' does not have javadoc that explains'
     /** */
     public int foo8(int a) {return a - 2;}
 
     // This implementation
-    // violation below 'Class 'InputDesignForExtensionRequiredJa'
+    // violation below 'method 'foo9' does not have javadoc that explains how to do that safely'
     public int foo9(int a, int b) {return a + b;}
 
     @Deprecated
@@ -66,7 +66,7 @@ public class InputDesignForExtensionRequiredJavadocPhrase {
      */
     public int foo11(int a, int b) {return a + b;} // ok, required comment pattern in javadoc
 
-    // violation 2 lines below 'Class 'InputDesignForExtensionRequiredJa'
+    // violation 2 lines below ''foo12' does not have javadoc that explains'
     /**This method can safely be overridden. */
     public int foo12(int a, int b) {
         return a + b;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhraseMultiLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhraseMultiLine.java
@@ -17,7 +17,7 @@ public class InputDesignForExtensionRequiredJavadocPhraseMultiLine {
         return a * b;
     }
 
-    // violation 4 lines below 'Class 'InputDesignForExtensionRequiredJa'
+    // violation 4 lines below ''foo2' does not have javadoc that explains'
     /**
      * This method can safely be overridden.
      */

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example1.java
@@ -11,10 +11,10 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 public abstract class Example1 {
   private int bar;
 
-  // violation below 'Class 'Example1' looks like designed for extension'
+  // violation below ''m1' does not have javadoc that explains how to do that safely'
   public int m1() {return 2;}
 
-  // violation below 'Class 'Example1' looks like designed for extension'
+  // violation below ''m2' does not have javadoc that explains how to do that safely'
   public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.
@@ -39,7 +39,7 @@ public abstract class Example1 {
    * implementation ...
    */
   public int m8() {return 2;}  // ok, Have javadoc on overridable method.
-  // violation below 'Class 'Example1' looks like designed for extension'
+  // violation below ''toString' does not have javadoc that explains
   @Override
   public String toString() {
     return "";

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example2.java
@@ -13,10 +13,10 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 public abstract class Example2 {
   private int bar;
 
-  // violation below 'Class 'Example2' looks like designed for extension'
+  // violation below ''m1' does not have javadoc that explains how to do that safely'
   public int m1() {return 2;}
 
-  // violation below 'Class 'Example2' looks like designed for extension'
+  // violation below ''m2' does not have javadoc that explains how to do that safely'
   public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example3.java
@@ -13,10 +13,10 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 public abstract class Example3 {
   private int bar;
 
-  // violation below 'Class 'Example3' looks like designed for extension'
+  // violation below ''m1' does not have javadoc that explains how to do that safely'
   public int m1() {return 2;}
 
-  // violation below 'Class 'Example3' looks like designed for extension'
+  // violation below ''m2' does not have javadoc that explains how to do that safely'
   public int m2() {return 8;}
 
   private void m3() {m4();}  // ok, Private method.
@@ -33,15 +33,15 @@ public abstract class Example3 {
 
   /**
    * Some comments ...
-   */ // violation below 'Class 'Example3' looks like designed for extension'
+   */ // violation below ''m7' does not have javadoc that explains
   public int m7() {return 1;}
 
   /**
    * This
    * implementation ...
-   */ // violation below 'Class 'Example3' looks like designed for extension'
+   */ // violation below ''m8' does not have javadoc that explains
   public int m8() {return 2;}
-  // violation below 'Class 'Example3' looks like designed for extension'
+  // violation below ''toString' does not have javadoc that explains
   @Override
   public String toString() {
     return "";

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example4.java
@@ -14,10 +14,10 @@ package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 public abstract class Example4 {
   private int bar;
 
-  // violation below 'Class 'Example4' looks like designed for extension'
+  // violation below ''m1' does not have javadoc that explains how to do that safely'
   public int m1() {return 2;}
 
-  // violation below 'Class 'Example4' looks like designed for extension'
+  // violation below ''m2' does not have javadoc that explains how to do that safely'
   public int m2() {return 8;}
 
   private void m3() {m4();}
@@ -34,7 +34,7 @@ public abstract class Example4 {
 
   /**
    * Some comments ...
-   */ // violation below 'Class 'Example4' looks like designed for extension'
+   */ // violation below ''m7' does not have javadoc that explains
   public int m7() {return 1;}
 
   /**
@@ -42,7 +42,7 @@ public abstract class Example4 {
    * implementation ...
    */
   public int m8() {return 2;}  // ok, Have required javadoc.
-  // violation below 'Class 'Example4' looks like designed for extension'
+  // violation below ''toString' does not have javadoc that explains
   @Override
   public String toString() {
     return "";


### PR DESCRIPTION
Issue: #20686

Updated the violation message for DesignForExtensionCheck from the confusing
"Class 'X' looks like designed for extension" wording to a clearer message
that leads with the actual problem: the method missing javadoc explaining
safe overriding.

Confirmed exact wording with the maintainer on the issue before implementing.

Changes:
- Updated `design.forExtension` message key in messages.properties
- Updated all inline `// violation` comments in xdocs-examples (Example1-4.java)
  and designforextension.xml to match the new message text
- Updated all inline `// violation` comments in the test resource files
  (InputDesignForExtension*.java) to match

Testing done locally:
- `mvn clean test -Dtest=DesignForExtensionCheckTest` — passes
- `mvn clean test -Dtest=XdocsExamplesAstConsistencyTest` — passes
- `mvn clean verify` — passes (full build, self-lint, full test suite)