### PR TITLE
Issue #20712: Avoid modifying collection during verification

### DIFF
--- a/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
+++ b/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -413,8 +414,8 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
         stream.reset();
         final List<File> theFiles = new ArrayList<>();
         Collections.addAll(theFiles, processedFiles);
-        final List<Integer> theWarnings = new ArrayList<>();
-        Collections.addAll(theWarnings, warnsExpected);
+        final List<Integer> expectedWarnings = Arrays.asList(warnsExpected);
+        final List<Integer> actualWarnings = new ArrayList<>();
         final int errs = checker.process(theFiles);
 
         // process each of the lines
@@ -435,21 +436,25 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
                 parseInt = parseInt.substring(parseInt.indexOf(':') + 1);
                 parseInt = parseInt.substring(0, parseInt.indexOf(':'));
                 final Integer lineNumber = Integer.parseInt(parseInt);
-                assertWithMessage(
-                        "input file is expected to have a warning comment on line number %s",
-                        lineNumber)
-                    .that(previousLineNumber.equals(lineNumber)
-                            || theWarnings.remove(lineNumber)) // remove by element
-                    .isTrue();
+                if (!previousLineNumber.equals(lineNumber)) {
+                    assertWithMessage(
+                            "input file is expected to have a warning comment on line number %s",
+                            lineNumber)
+                        .that(expectedWarnings.contains(lineNumber))
+                        .isTrue();
+
+                    actualWarnings.add(lineNumber);
+                }
                 previousLineNumber = lineNumber;
             }
 
             assertWithMessage("unexpected output: %s", lnr.readLine())
                 .that(errs)
                 .isEqualTo(expected.length);
-            assertWithMessage("unexpected warnings %s", theWarnings)
-                .that(theWarnings)
-                .isEmpty();
+            assertWithMessage("warning line numbers should match expected")
+                .that(actualWarnings)
+                .containsExactlyElementsIn(expectedWarnings)
+                .inOrder();
         }
 
         checker.destroy();


### PR DESCRIPTION
Fixes #20712

## Summary

Avoid modifying the warning collection while verifying expected warning line numbers.

## Changes

- Replaced the collection mutation logic with a non-mutating comparison.
- Collected actual warning line numbers into a separate list before verification.
- Preserved the original warning collection during verification.

## Testing

Executed the following commands successfully:

```bash
groovy ./.ci/error-prone-check.groovy compile
```

```bash
groovy ./.ci/error-prone-check.groovy test-compile
```

```bash
./mvnw clean compile
```

```bash
./mvnw clean test-compile -DskipTests -e
```

```bash
./mvnw clean verify -DskipTests
```

Result:

```text
BUILD SUCCESS
```