### PR TITLE
Issue #19803: move violation comment above annotation in InputSuperFinalizeVariations

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -745,8 +745,6 @@
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]magicnumber[\\/]InputMagicNumberWaiverParentToken3\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]superfinalize[\\/]InputSuperFinalizeVariations\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]designforextension[\\/]InputDesignForExtensionIgnoredAnnotations\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]design[\\/]designforextension[\\/]InputDesignForExtensionOverridableMethods\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperFinalizeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperFinalizeCheckTest.java
@@ -38,7 +38,7 @@ public class SuperFinalizeCheckTest
         final String[] expected = {
             "34:17: " + getCheckMessage(MSG_KEY, "finalize", "super.finalize"),
             "41:17: " + getCheckMessage(MSG_KEY, "finalize", "super.finalize"),
-            "83:20: " + getCheckMessage(MSG_KEY, "finalize", "super.finalize"),
+            "84:20: " + getCheckMessage(MSG_KEY, "finalize", "super.finalize"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputSuperFinalizeVariations.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superfinalize/InputSuperFinalizeVariations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superfinalize/InputSuperFinalizeVariations.java
@@ -79,7 +79,8 @@ class FinalizeWithArgs {
 }
 
 class OverrideClass extends FinalizeWithArgs {
-    @Override // violation below, Method 'finalize' should call 'super.finalize'
+    // violation 2 lines below "Method 'finalize' should call 'super.finalize'"
+    @Override
     protected void finalize() throws Throwable {
         super.finalize(new Object());
     }


### PR DESCRIPTION
Issue: #19803

Moved the `// violation` comment above the `@Override` annotation in
`InputSuperFinalizeVariations.java`, updated the expected line number in
`SuperFinalizeCheckTest.java` from 83 to 84, and removed the now-unneeded
suppression entry for this file from `checkstyle-input-suppressions.xml`.

Before:
```java
@Override // violation below, Method 'finalize' should call 'super.finalize'
protected void finalize() throws Throwable {
```

After:
```java
// violation 2 lines below "Method 'finalize' should call 'super.finalize'"
@Override
protected void finalize() throws Throwable {
```