### PR TITLE
Issue #20675: isolate javadoc invalid snippets of javadocmethod

### DIFF
--- a/.ci/javadoc-tool-excluded-packages.sh
+++ b/.ci/javadoc-tool-excluded-packages.sh
@@ -8,7 +8,6 @@ checks_package=com.puppycrawl.tools.checkstyle.checks
 javadoc_package=$checks_package.javadoc
 
 JAVADOC_TOOL_EXCLUDED_PACKAGES=(
-  "$source_root $javadoc_package.javadocmethod"
   "$source_root $javadoc_package.javadocpackage.annotation"
   "$source_root $javadoc_package.javadoctype"
   "$source_root com.puppycrawl.tools.checkstyle.javadocpropertiesgenerator"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -116,6 +116,9 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocMethodThrowsDetectionTwo.java"), expected);
+        verifyWithInlineConfigParser(
+                getJavadocWithErrorPath("InputJavadocMethodThrowsDetectionTwo.java"),
+                CommonUtil.EMPTY_STRING_ARRAY);
     }
 
     @Test
@@ -340,8 +343,6 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "38:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<BB>"),
             "41:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "<Z>"),
-            "66:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<Z"),
-            "69:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "<Z>"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocMethodTypeParamsTags.java"), expected);
@@ -539,16 +540,6 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocMethod1.java"), expected);
-    }
-
-    @Test
-    public void test2() throws Exception {
-        final String[] expected = {
-            "22:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<"),
-            "26:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "<X>"),
-        };
-        verifyWithInlineConfigParser(
-                getPath("InputJavadocMethod2.java"), expected);
     }
 
     @Test

--- a/src/test/resources-with-javadoc-error/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionTwo.java
+++ b/src/test/resources-with-javadoc-error/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionTwo.java
@@ -1,7 +1,7 @@
 /*
 JavadocMethod
 allowedAnnotations = (default)Override
-validateThrows = (default)false
+validateThrows = true
 accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
@@ -13,17 +13,11 @@ tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
-public class InputJavadocMethod2 {
+public class InputJavadocMethodThrowsDetectionTwo {
 
-    // violation 4 lines below 'Unused @param tag for '<''
     /**
-     * Some explanation.
-     *
-     * @param < X >  A type param
-     * @param <Y1> Another type param
-     * @return a string
+     * No identifier for this throws.
+     * @throws
      */
-    public <X, Y1> String doSomething() { // violation 'Expected @param tag for '<X>''
-        return null;
-    }
+    public void Label() {}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionTwo.java
@@ -86,10 +86,4 @@ public class InputJavadocMethodThrowsDetectionTwo {
             }
         }
     }
-
-    /**
-     * No identifier for this throws.
-     * @throws
-     */
-    public void Label() {}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTypeParamsTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTypeParamsTags.java
@@ -60,15 +60,6 @@ public class InputJavadocMethodTypeParamsTags<A,B1,C456 extends Comparable>
     public static class InnerClass<A,B>
     {
     }
-
-    /**
-     * Some explanation.
-     * @param <Z The wrong type param
-     */
-    // violation 2 lines above 'Unused @param tag for '<Z.'
-    public <Z> void unclosedGenericParam() // violation 'Expected @param tag for '<Z>'.'
-    {
-    }
 }
 
 /** @param x */


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/20675

### Summary

- removed javadocmethod from javadoc-tool-excluded-packages.sh
- removed invalid javadoc snippet from InputJavadocMethodTypeParamsTags 
- deleted InputJavadocMethod2 and removed respective test in JavaDocMethodTest
- changed violation message line numbers of JavaDocMethodTest
- added a new input file under resources-with-javadoc-error for a pitest  mutation failure

### Pitest failure
Pitest mutation fails for @throws identifier text, it expects a null pointer exception to be  thrown  for identifier text to kill the mutation, that invalid javadoc snippet is needed and added in resources-with-javadoc-error 