### PR TITLE
Issue #20675: Validate JavadocPackage annotation input

### DIFF
--- a/.ci/javadoc-tool-excluded-packages.sh
+++ b/.ci/javadoc-tool-excluded-packages.sh
@@ -8,7 +8,6 @@ checks_package=com.puppycrawl.tools.checkstyle.checks
 javadoc_package=$checks_package.javadoc
 
 JAVADOC_TOOL_EXCLUDED_PACKAGES=(
-  "$source_root $javadoc_package.javadocpackage.annotation"
   "$source_root $javadoc_package.javadoctype"
   "$source_root com.puppycrawl.tools.checkstyle.javadocpropertiesgenerator"
 )

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/annotation/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/annotation/package-info.java
@@ -7,8 +7,7 @@ fileExtensions = (default).java
 */
 
 /**
- * This is a valid package documentation.  <--- See the period after the
- * first sentence.
+ * This is valid package documentation. See the period after the first sentence.
  *
  * <p>
  * hurray for javadocs in html


### PR DESCRIPTION
Part of #20675.

Removes the `javadocpackage.annotation` package from the JDK Javadoc syntax-validation exclusions after fixing accidental malformed HTML in its package documentation.

The explanatory `<---` text was parsed as malformed HTML by JDK Doclint. It is unrelated to the `JavadocPackage` test behavior, so this change replaces it with valid prose instead of moving the input to `resources-with-javadoc-error`.

Validation:

- package-scoped JDK Javadoc validation with `-Xdoclint:syntax` (reproduced the malformed HTML error before the fix and passes afterward)
- `./mvnw clean test -Dtest=JavadocPackageCheckTest` (10 tests)
- `./mvnw clean verify`
