### PR TITLE
Issue #20711: Fix comment mismatches in xdocs examples currently supp…

### DIFF
--- a/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadoctype.xml
@@ -109,9 +109,9 @@
 public class Example1 {
   /** Javadoc. */
   public class A {}
-  /** Javadoc. */
+
   private class B {}
-  /** Javadoc. */
+
   protected class C {}
   /** Javadoc. */
   class D {}
@@ -123,8 +123,8 @@ public class Example1 {
   private class Config {}
   /** Javadoc. */
   private class E {}
-  /** Javadoc. */
-  public interface F {}
+
+  public interface F {} // violation, 'Missing a Javadoc comment'
   /** Javadoc. */
   public interface G {}
 }
@@ -144,15 +144,16 @@ public class Example1 {
 
         <p id="Example2-code">Example2:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example2 {        // violation, 'Missing a Javadoc comment'
+/** Documented. */
+public class Example2 {
   /** Javadoc. */
   public class A {}
 
-  private class B {}    // violation, 'Missing a Javadoc comment'
+  private class B {}   // violation, 'Missing a Javadoc comment'
 
-  protected class C {}  // violation, 'Missing a Javadoc comment'
-
-  class D {}            // violation, 'Missing a Javadoc comment'
+  protected class C {} // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  class D {}
   /** Javadoc. */
   @SpringBootApplication
   private class App {}
@@ -182,6 +183,7 @@ public class Example2 {        // violation, 'Missing a Javadoc comment'
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-code">Example3:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/** Documented. */
 public class Example3 {
   /** Javadoc. */
   public class A {}
@@ -226,10 +228,10 @@ public class Example3 {
 public class Example4 {
   /** Javadoc. */
   public class A {}
-  /** Javadoc. */
-  private class B {}
-  /** Javadoc. */
-  protected class C {}
+
+  private class B {}   // violation, 'Missing a Javadoc comment'
+
+  protected class C {} // violation, 'Missing a Javadoc comment'
   /** Javadoc. */
   class D {}
   /** Javadoc. */
@@ -238,8 +240,8 @@ public class Example4 {
   /** Javadoc. */
   @Configuration
   private class Config {}
-
-  private class E {}    // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  private class E {}
 
   public interface F {} // violation, 'Missing a Javadoc comment'
   /** Javadoc. */
@@ -260,6 +262,7 @@ public class Example4 {
 </code></pre></div>
         <p id="Example5-code">Example5:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/** Documented. */
 public class Example5 {
   /** Javadoc. */
   public class A {}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -247,13 +247,8 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/imports/importorder/Example6",
             "checks/imports/importorder/Example7",
             "checks/imports/importorder/Example8",
-            "checks/imports/importorder/Example9",
-            // until https://github.com/checkstyle/checkstyle/issues/20711
-            "checks/javadoc/missingjavadoctype/Example2",
-            "checks/javadoc/missingjavadoctype/Example3",
-            "checks/javadoc/missingjavadoctype/Example4",
-            "checks/javadoc/missingjavadoctype/Example5"
-        );
+            "checks/imports/importorder/Example9"
+    );
 
     /**
      * Tests that examples with the same code structure maintain consistency.

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckExamplesTest.java
@@ -24,7 +24,6 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableChec
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MissingJavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     @Override
@@ -34,17 +33,17 @@ public class MissingJavadocTypeCheckExamplesTest extends AbstractExamplesModuleT
 
     @Test
     public void testExample1() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "30:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
 
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "18:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "20:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
-            "22:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "32:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
@@ -63,7 +62,8 @@ public class MissingJavadocTypeCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "37:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "25:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "39:3: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example1.java
@@ -12,9 +12,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 public class Example1 {
   /** Javadoc. */
   public class A {}
-  /** Javadoc. */
+
   private class B {}
-  /** Javadoc. */
+
   protected class C {}
   /** Javadoc. */
   class D {}
@@ -26,8 +26,8 @@ public class Example1 {
   private class Config {}
   /** Javadoc. */
   private class E {}
-  /** Javadoc. */
-  public interface F {}
+
+  public interface F {} // violation, 'Missing a Javadoc comment'
   /** Javadoc. */
   public interface G {}
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example2.java
@@ -10,16 +10,16 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 // xdoc section -- start
-
-public class Example2 {        // violation, 'Missing a Javadoc comment'
+/** Documented. */
+public class Example2 {
   /** Javadoc. */
   public class A {}
 
-  private class B {}    // violation, 'Missing a Javadoc comment'
+  private class B {}   // violation, 'Missing a Javadoc comment'
 
-  protected class C {}  // violation, 'Missing a Javadoc comment'
-
-  class D {}            // violation, 'Missing a Javadoc comment'
+  protected class C {} // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  class D {}
   /** Javadoc. */
   @SpringBootApplication
   private class App {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example3.java
@@ -11,7 +11,7 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 // xdoc section -- start
-
+/** Documented. */
 public class Example3 {
   /** Javadoc. */
   public class A {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example4.java
@@ -21,10 +21,10 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 public class Example4 {
   /** Javadoc. */
   public class A {}
-  /** Javadoc. */
-  private class B {}
-  /** Javadoc. */
-  protected class C {}
+
+  private class B {}   // violation, 'Missing a Javadoc comment'
+
+  protected class C {} // violation, 'Missing a Javadoc comment'
   /** Javadoc. */
   class D {}
   /** Javadoc. */
@@ -33,8 +33,8 @@ public class Example4 {
   /** Javadoc. */
   @Configuration
   private class Config {}
-
-  private class E {}    // violation, 'Missing a Javadoc comment'
+  /** Javadoc. */
+  private class E {}
 
   public interface F {} // violation, 'Missing a Javadoc comment'
   /** Javadoc. */

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/Example5.java
@@ -10,7 +10,7 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
 
 // xdoc section -- start
-
+/** Documented. */
 public class Example5 {
   /** Javadoc. */
   public class A {}


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/20711

fixes comment mismatch for :
`missingjavadoc`

removed all suppressions