### PR TITLE
Issue #20749: fix EmptyStatement false negative on top-level empty declaration in compact source files

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheck.java
@@ -53,12 +53,15 @@ public class EmptyStatementCheck extends AbstractCheck {
 
     @Override
     public int[] getRequiredTokens() {
-        return new int[] {TokenTypes.EMPTY_STAT};
+        return new int[] {TokenTypes.EMPTY_STAT, TokenTypes.SEMI};
     }
 
     @Override
     public void visitToken(DetailAST ast) {
-        log(ast, MSG_KEY);
+        if (ast.getType() == TokenTypes.EMPTY_STAT
+                || ast.getParent().getType() == TokenTypes.COMPACT_COMPILATION_UNIT) {
+            log(ast, MSG_KEY);
+        }
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheckTest.java
@@ -77,6 +77,7 @@ public class EmptyStatementCheckTest
     @Test
     public void testCompactSourceFile() throws Exception {
         final String[] expected = {
+            "9:1: " + getCheckMessage(MSG_KEY),
             "12:5: " + getCheckMessage(MSG_KEY),
             "15:18: " + getCheckMessage(MSG_KEY),
             "17:14: " + getCheckMessage(MSG_KEY),

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/emptystatement/compact/InputEmptyStatementCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/emptystatement/compact/InputEmptyStatementCompactSourceFile.java
@@ -6,7 +6,7 @@ EmptyStatement
 
 // non-compiled with javac: Compilable with Java25
 
-; // ok until https://github.com/checkstyle/checkstyle/issues/20749
+; // violation 'Empty statement'
 
 void main() {
     ; // violation 'Empty statement'


### PR DESCRIPTION
closes #20749 


EmptyStatementCheck did not flag top-level `;` in compact source files (JEP 512).

The grammar parses top-level semicolons via `typeDeclaration -> semi+=SEMI+`, producing `SEMI` AST nodes. EmptyStatementCheck only listened for `EMPTY_STAT` tokens, so it never saw them.

### Fix: 
add `TokenTypes.SEMI` to the check's token set and report violations only when the parent is `COMPACT_COMPILATION_UNIT`, keeping the check isolated with no impact on other checks or the AST structure.
