### PR TITLE
Issue #20624: Adding Example for missing property - regexpmultiline

### DIFF
--- a/src/site/xdoc/checks/regexp/regexpmultiline.xml
+++ b/src/site/xdoc/checks/regexp/regexpmultiline.xml
@@ -356,6 +356,55 @@ class Example5 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 /var/tmp/Test.java // violation, a file must not be empty.
         </code></pre></div>
+        <hr class="example-separator"/>
+        <p id="Example7-config">
+        To configure the check to match a minimum of two test strings:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="RegexpMultiline"&gt;
+    &lt;property name="format" value="Test.*string"/&gt;
+    &lt;property name="fileExtensions" value="java"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example7-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example7 {
+  void testMethod1() {
+
+    System.out.print("Example");
+
+    System.err.println("Example");
+    System
+            .out.print("Example");
+    System
+            .err.println("Example");
+    System.
+            out.print("Example");
+    System.
+            err.println("Example");
+  }
+
+  void testMethod2() {
+    // violation below, 'Line matches the illegal pattern'
+    System.out.println("Test #1: this is a test string");
+
+    System.out.println("TeSt #2: This is a test string");
+
+    System.out.println("TEST #3: This is a test string");
+    int i = 5;
+
+    System.out.println("Value of i: " + i);
+    // violation below, 'Line matches the illegal pattern'
+    System.out.println("Test #4: This is a test string");
+
+    System.out.println("TEst #5: This is a test string");
+  }
+}
+</code></pre></div>
       </subsection>
 
       <subsection name="Example of Usage" id="RegexpMultiline_Example_of_Usage">

--- a/src/site/xdoc/checks/regexp/regexpmultiline.xml.template
+++ b/src/site/xdoc/checks/regexp/regexpmultiline.xml.template
@@ -139,6 +139,23 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 /var/tmp/Test.java // violation, a file must not be empty.
         </code></pre></div>
+        <hr class="example-separator"/>
+        <p id="Example7-config">
+        To configure the check to match a minimum of two test strings:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example7.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example7-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example7.java"/>
+          <param name="type" value="code"/>
+        </macro>
       </subsection>
 
       <subsection name="Example of Usage" id="RegexpMultiline_Example_of_Usage">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -207,7 +207,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling",
             "checks/modifier/classmemberimpliedmodifier",
             "checks/naming/illegalidentifiername",
-            "checks/regexp/regexpmultiline",
             "checks/regexp/regexponfilename",
             "checks/sizes/methodcount",
             "filters/suppressionsinglefilter",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckExamplesTest.java
@@ -84,4 +84,15 @@ public class RegexpMultilineCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
+
+    @Test
+    public void testExample7() throws Exception {
+        final String[] expected = {
+            "4: " + getCheckMessage(MSG_ILLEGAL_REGEXP, "Test.*string"),
+            "30: " + getCheckMessage(MSG_ILLEGAL_REGEXP, "Test.*string"),
+            "39: " + getCheckMessage(MSG_ILLEGAL_REGEXP, "Test.*string"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example7.java"), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example7.java
@@ -1,0 +1,44 @@
+/*xml
+<module name="Checker">
+  <module name="RegexpMultiline">
+    <property name="format" value="Test.*string"/>
+    <property name="fileExtensions" value="java"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.regexp.regexpmultiline;
+// violation 6 lines above 'Line matches the illegal pattern'
+// xdoc section -- start
+class Example7 {
+  void testMethod1() {
+
+    System.out.print("Example");
+
+    System.err.println("Example");
+    System
+            .out.print("Example");
+    System
+            .err.println("Example");
+    System.
+            out.print("Example");
+    System.
+            err.println("Example");
+  }
+
+  void testMethod2() {
+    // violation below, 'Line matches the illegal pattern'
+    System.out.println("Test #1: this is a test string");
+
+    System.out.println("TeSt #2: This is a test string");
+
+    System.out.println("TEST #3: This is a test string");
+    int i = 5;
+
+    System.out.println("Value of i: " + i);
+    // violation below, 'Line matches the illegal pattern'
+    System.out.println("Test #4: This is a test string");
+
+    System.out.println("TEst #5: This is a test string");
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/20624

added example for `regexpmultiline `- `fileExtensions `property