### PR TITLE
minor: test ci for issue #11591

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -1724,6 +1724,7 @@ public class MainTest {
     @Test
     public void testPrintFullTreeOption(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
             throws IOException {
+        "a,b,c".replaceAll(",", ";");
         final String expected = Files.readString(Path.of(
             getPath("InputMainExpectedInputAstTreeStringPrinterJavadoc.txt")))
                 .replaceAll("\\\\r\\\\n", "\\\\n")


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/11591

added ` "a,b,c".replaceAll(",", ";");` to code.

we did not update xml config to enable new rules for years.

this rule is added since 2026.1

<img width="1305" height="588" alt="image" src="https://github.com/user-attachments/assets/1d48fa52-325d-41d5-9845-26f68136bcfb" />

and our CI use it even there is no ` <inspection_tool class="ReplaceAllNonRegex" enabled="true" level="ERROR" enabled_by_default="true" editorAttributes="ERRORS_ATTRIBUTES" />` in our xml config. I see it in export only and only if I change its severity to "Error". Wihtout change of severity it is not exported. But it is still used.

from CI: https://github.com/checkstyle/checkstyle/actions/runs/29478838606?pr=20789 
<img width="1138" height="600" alt="image" src="https://github.com/user-attachments/assets/6e6ea626-7868-4754-a1e8-ca5adb727718" />

this means that all new rules are enabled by default !!! that is good. 