### PR TITLE
Issue #20521: Handle regex metacharacters in OrderedPropertiesCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
@@ -184,8 +184,12 @@ public class OrderedPropertiesCheck extends AbstractFileSetCheck {
      * @return regular expression pattern given key name
      */
     private static Pattern getKeyPattern(String keyName) {
-        final String keyPatternString = "^" + SPACE_PATTERN.matcher(keyName)
-                .replaceAll(Matcher.quoteReplacement("\\\\ ")) + "[\\s:=].*";
+        final String keyNameWithEscapedSpaces = SPACE_PATTERN.matcher(keyName)
+            .replaceAll(Matcher.quoteReplacement("\\ "));
+
+        final String keyPatternString = "^"
+            + Pattern.quote(keyNameWithEscapedSpaces)
+            + "[\\s=:].*";
         return Pattern.compile(keyPatternString);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
@@ -181,6 +181,25 @@ public class OrderedPropertiesCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testRegexInKey() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(OrderedPropertiesCheck.class);
+        final String[] expected = {
+            "2: " + getCheckMessage(MSG_KEY, "some.key[a-b-c]", "some.key[index-with-dash]"),
+            "3: " + getCheckMessage(MSG_KEY, "array[0-1]", "some.key[a-b-c]"),
+        };
+        verify(checkConfig, getPath("InputOrderedPropertiesRegex.properties"), expected);
+    }
+
+    @Test
+    public void testSpacesInKey() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(OrderedPropertiesCheck.class);
+        final String[] expected = {
+            "2: " + getCheckMessage(MSG_KEY, "key with spaces", "key2"),
+        };
+        verify(checkConfig, getPath("InputOrderedPropertiesSpaces.properties"), expected);
+    }
+
+    @Test
     public void test() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(OrderedPropertiesCheck.class);
         final String[] expected = {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/InputOrderedPropertiesRegex.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/InputOrderedPropertiesRegex.properties
@@ -1,0 +1,3 @@
+some.key[index-with-dash]=value
+some.key[a-b-c]=value
+array[0-1]=value

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/InputOrderedPropertiesSpaces.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/InputOrderedPropertiesSpaces.properties
@@ -1,0 +1,2 @@
+key2=value
+key\ with\ spaces=value


### PR DESCRIPTION
Fixes #20521.

### Changes
- Quote property keys with `Pattern.quote()` before constructing the lookup pattern.
- Preserve escaped-space handling for property keys.
- Add regression tests for:
  - property keys containing regex metacharacters (`[]`, `-`)
  - property keys containing escaped spaces.

### Testing
```bash
./mvnw clean verify
./mvnw test -Dtest=OrderedPropertiesCheckTest
```
