### PR TITLE
Issue #20624: Adding Example for missing property - suppresswithnearb…

### DIFF
--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml
@@ -200,6 +200,109 @@ public class Example3 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure a filter so that only C++ style comments
+          (<code>//</code>) are checked for suppression, disabling C style
+          (<code>/* ... */</code>) comment matching:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="SuppressWithNearbyCommentFilter"&gt;
+      &lt;property name="checkC" value="false"/&gt;
+    &lt;/module&gt;
+    &lt;module name="NoWhitespaceAfter"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example4 {
+  // filtered violation below ''int' is followed by whitespace'
+  public static final int [] array = {}; // SUPPRESS CHECKSTYLE NoWhitespaceAfter
+
+  public static final int lowerCaseConstant = 1; // CHECKSTYLE IGNORE THIS LINE
+
+  public void testMethod() {
+    try {
+    }
+
+    catch (RuntimeException ex) {
+
+    }
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure a filter so that only C style comments
+          (<code>/* ... */</code>) are checked for suppression, disabling
+          C++ style (<code>//</code>) comment matching:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="SuppressWithNearbyCommentFilter"&gt;
+      &lt;property name="checkCPP" value="false"/&gt;
+    &lt;/module&gt;
+    &lt;module name="NoWhitespaceAfter"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example5 {
+  // violation below ''int' is followed by whitespace'
+  public static final int [] array = {}; // SUPPRESS CHECKSTYLE NoWhitespaceAfter
+
+  public static final int lowerCaseConstant = 1; // CHECKSTYLE IGNORE THIS LINE
+
+  public void testMethod() {
+    try {
+    }
+
+    catch (RuntimeException ex) {
+
+    }
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example6-config">
+          To configure a filter so that
+          <code>// SUPPRESS CHECKSTYLE NoWhitespaceAfter</code>
+          only suppresses audit events reported by a check with a matching module ID:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="SuppressWithNearbyCommentFilter"&gt;
+      &lt;property name="commentFormat" value="SUPPRESS CHECKSTYLE (\w+) id:(\S+)"/&gt;
+      &lt;property name="checkFormat" value="$1"/&gt;
+      &lt;property name="idFormat" value="$2"/&gt;
+    &lt;/module&gt;
+    &lt;module name="NoWhitespaceAfter"&gt;
+      &lt;property name="id" value="whitespaceCheckId"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example6-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example6 {
+  // violation below ''int' is followed by whitespace'
+  public static final int [] array = {}; // SUPPRESS CHECKSTYLE NoWhitespaceAfter
+
+  public static final int lowerCaseConstant = 1; // CHECKSTYLE IGNORE THIS LINE
+
+  public void testMethod() {
+    try {
+    }
+
+    catch (RuntimeException ex) {
+
+    }
+  }
+}
+</code></pre></div>
         </subsection>
         <subsection name="Use Cases" id="SuppressWithNearbyCommentFilter_Use_Cases">
         <p id="UseCase1-config">

--- a/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml.template
+++ b/src/site/xdoc/filters/suppresswithnearbycommentfilter.xml.template
@@ -79,6 +79,54 @@
                  value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example3.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure a filter so that only C++ style comments
+          (<code>//</code>) are checked for suppression, disabling C style
+          (<code>/* ... *&#47;</code>) comment matching:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure a filter so that only C style comments
+          (<code>/* ... *&#47;</code>) are checked for suppression, disabling
+          C++ style (<code>//</code>) comment matching:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example5-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example5.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example6-config">
+          To configure a filter so that
+          <code>// SUPPRESS CHECKSTYLE NoWhitespaceAfter</code>
+          only suppresses audit events reported by a check with a matching module ID:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example6-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java"/>
+          <param name="type" value="code"/>
+        </macro>
         </subsection>
         <subsection name="Use Cases" id="SuppressWithNearbyCommentFilter_Use_Cases">
         <p id="UseCase1-config">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -208,8 +208,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/modifier/classmemberimpliedmodifier",
             "checks/naming/illegalidentifiername",
             "checks/regexp/regexponfilename",
-            "filters/suppressionsinglefilter",
-            "filters/suppresswithnearbycommentfilter"
+            "filters/suppressionsinglefilter"
     );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterExamplesTest.java
@@ -70,6 +70,45 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
     }
 
     @Test
+    public void testExample4() throws Exception {
+        final String[] expectedWithFilter = {
+
+        };
+        final String[] expectedWithoutFilter = {
+            "15:27: 'int' is followed by whitespace.",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example4.java"), expectedWithoutFilter,
+                expectedWithFilter);
+    }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expectedWithFilter = {
+            "15:27: 'int' is followed by whitespace.",
+        };
+        final String[] expectedWithoutFilter = {
+            "15:27: 'int' is followed by whitespace.",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example5.java"), expectedWithoutFilter,
+                expectedWithFilter);
+    }
+
+    @Test
+    public void testExample6() throws Exception {
+        final String[] expectedWithFilter = {
+            "19:27: 'int' is followed by whitespace.",
+        };
+        final String[] expectedWithoutFilter = {
+            "19:27: 'int' is followed by whitespace.",
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example6.java"), expectedWithoutFilter,
+                expectedWithFilter);
+    }
+
+    @Test
     public void testUseCase1() throws Exception {
         final String[] expectedWithFilter = {
             "26:20: Name 'lowerCaseConstant5' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example4.java
@@ -1,0 +1,28 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="checkC" value="false"/>
+    </module>
+    <module name="NoWhitespaceAfter"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
+// xdoc section -- start
+public class Example4 {
+  // filtered violation below ''int' is followed by whitespace'
+  public static final int [] array = {}; // SUPPRESS CHECKSTYLE NoWhitespaceAfter
+
+  public static final int lowerCaseConstant = 1; // CHECKSTYLE IGNORE THIS LINE
+
+  public void testMethod() {
+    try {
+    }
+
+    catch (RuntimeException ex) {
+
+    }
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example5.java
@@ -1,0 +1,28 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="checkCPP" value="false"/>
+    </module>
+    <module name="NoWhitespaceAfter"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
+// xdoc section -- start
+public class Example5 {
+  // violation below ''int' is followed by whitespace'
+  public static final int [] array = {}; // SUPPRESS CHECKSTYLE NoWhitespaceAfter
+
+  public static final int lowerCaseConstant = 1; // CHECKSTYLE IGNORE THIS LINE
+
+  public void testMethod() {
+    try {
+    }
+
+    catch (RuntimeException ex) {
+
+    }
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/Example6.java
@@ -1,0 +1,32 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="SUPPRESS CHECKSTYLE (\w+) id:(\S+)"/>
+      <property name="checkFormat" value="$1"/>
+      <property name="idFormat" value="$2"/>
+    </module>
+    <module name="NoWhitespaceAfter">
+      <property name="id" value="whitespaceCheckId"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
+// xdoc section -- start
+public class Example6 {
+  // violation below ''int' is followed by whitespace'
+  public static final int [] array = {}; // SUPPRESS CHECKSTYLE NoWhitespaceAfter
+
+  public static final int lowerCaseConstant = 1; // CHECKSTYLE IGNORE THIS LINE
+
+  public void testMethod() {
+    try {
+    }
+
+    catch (RuntimeException ex) {
+
+    }
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
#20624 

added examples for missing property:
`checkC`, `checkCPP`, and `idFormat` for suppresswithnearbycommentfilter