### PR TITLE
Issue #20624: Adding Example for missing property - regexponfilename

### DIFF
--- a/src/site/xdoc/checks/regexp/regexponfilename.xml
+++ b/src/site/xdoc/checks/regexp/regexponfilename.xml
@@ -203,6 +203,24 @@
 .../TestExample2.xml
 .../TestExample3.md
 .../TestExample4.xml
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example6-config">
+          To configure the check to forbid files that do not start with 'Test' in folders
+          named 'regexponfilename':
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="RegexpOnFilename"&gt;
+    &lt;property name="folderPattern" value="[\\/]regexponfilename$"/&gt;
+    &lt;property name="fileNamePattern" value="^Test.*\.xml$"/&gt;
+    &lt;property name="match" value="false"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example6-code">Example6:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+.../TestExample2.xml
+.../Example1.java // violation, 'File match folder pattern'
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/regexp/regexponfilename.xml.template
+++ b/src/site/xdoc/checks/regexp/regexponfilename.xml.template
@@ -99,6 +99,21 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example5.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example6-config">
+          To configure the check to forbid files that do not start with 'Test' in folders
+          named 'regexponfilename':
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example6.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example6-code">Example6:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example6.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -207,7 +207,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/metrics/classdataabstractioncoupling",
             "checks/modifier/classmemberimpliedmodifier",
             "checks/naming/illegalidentifiername",
-            "checks/regexp/regexponfilename",
             "filters/suppressionsinglefilter"
     );
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckExamplesTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.regexp;
 
 import static com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck.MSG_MATCH;
+import static com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck.MSG_MISMATCH;
 
 import java.io.File;
 import java.io.IOException;
@@ -109,6 +110,7 @@ public class RegexpOnFilenameCheckExamplesTest extends AbstractExamplesModuleTes
         expected.put(getPath("Example3.java"), messages);
         expected.put(getPath("Example4.java"), messages);
         expected.put(getPath("Example5.java"), messages);
+        expected.put(getPath("Example6.java"), messages);
 
         final Path path = Paths.get("src/xdocs-examples/resources/" + getPackageLocation() + "/");
 
@@ -147,4 +149,30 @@ public class RegexpOnFilenameCheckExamplesTest extends AbstractExamplesModuleTes
         }
     }
 
+    @Test
+    public void testExample6() throws Exception {
+        final Map<String, List<String>> expected = new HashMap<>();
+        final List<String> messages = List.of(
+                "1: " + getCheckMessage(MSG_MISMATCH,
+                        "[\\\\/]regexponfilename$", "^Test.*\\.xml$"));
+
+        expected.put(getPath("checkstyle.xml"), messages);
+        expected.put(getPath("TestExample3.md"), messages);
+        expected.put(getPath("Example1.java"), messages);
+        expected.put(getPath("Example2.java"), messages);
+        expected.put(getPath("Example3.java"), messages);
+        expected.put(getPath("Example4.java"), messages);
+        expected.put(getPath("Example5.java"), messages);
+        expected.put(getPath("Example6.java"), messages);
+
+        final Path path = Paths.get("src/xdocs-examples/resources/" + getPackageLocation() + "/");
+
+        final String configFilePath = getPath("Example6.java");
+        final TestInputConfiguration testInputConfiguration1 =
+                InlineConfigParser.parse(configFilePath);
+        final DefaultConfiguration parsedConfig =
+                testInputConfiguration1.createConfiguration();
+
+        verify(createChecker(parsedConfig), getFilesInFolder(path), expected);
+    }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example6.java
@@ -1,0 +1,17 @@
+/*xml
+<module name="Checker">
+  <module name="RegexpOnFilename">
+    <property name="folderPattern" value="[\\/]regexponfilename$"/>
+    <property name="fileNamePattern" value="^Test.*\.xml$"/>
+    <property name="match" value="false"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
+/*
+// xdoc section -- start
+.../TestExample2.xml
+.../Example1.java // violation, 'File match folder pattern'
+// xdoc section -- end
+*/
+class Example6 {}


### PR DESCRIPTION
#20624
Added `folderpattern `property for `regexponfilename`