### PR TITLE
Issue #20522: Escape property keys in UniquePropertiesCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -143,8 +143,11 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
      * @return regular expression pattern given key name
      */
     private static Pattern getKeyPattern(String keyName) {
-        final String keyPatternString = "^" + SPACE_PATTERN.matcher(keyName)
-                .replaceAll(Matcher.quoteReplacement("\\\\ ")) + "[\\s:=].*$";
+        final String keyNameWithEscapedSpaces = SPACE_PATTERN.matcher(keyName)
+                .replaceAll(Matcher.quoteReplacement("\\ "));
+        final String keyPatternString = "^"
+                + Pattern.quote(keyNameWithEscapedSpaces)
+                + "[\\s:=].*$";
         return Pattern.compile(keyPatternString);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -170,6 +170,15 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
             .isEqualTo(expected2);
     }
 
+    @Test
+    public void testRegexMetaCharacters() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(UniquePropertiesCheck.class);
+        final String[] expected = {
+            "1: " + getCheckMessage(MSG_KEY, "some.key[index-with-dash]", 2),
+        };
+        verify(checkConfig, getPath("InputUniquePropertiesRegex.properties"), expected);
+    }
+
     /**
      * Method generates NoSuchFileException details. It tries to open a file that does not exist.
      *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/uniqueproperties/InputUniquePropertiesRegex.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/uniqueproperties/InputUniquePropertiesRegex.properties
@@ -1,0 +1,2 @@
+some.key[index-with-dash]=value
+some.key[index-with-dash]=value


### PR DESCRIPTION
Fixes #20522.

### Changes
- Quote property keys with `Pattern.quote()` before constructing the lookup pattern.
- Preserve escaped-space handling for property keys.
- Add a regression test for property keys containing regex metacharacters (`[index-with-dash]`).

### Testing

```bash
./mvnw clean verify
./mvnw test -Dtest=UniquePropertiesCheckTest
```