### PR TITLE
minor: resolve TypeBodyPaddingCheck violations in xdocs-examples

### DIFF
--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ArrayTypeStyleCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/arraytypestyle";
@@ -50,4 +51,5 @@ public class ArrayTypeStyleCheckExamplesTest extends AbstractExamplesModuleTestS
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AvoidEscapedUnicodeCharactersCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters";
@@ -91,4 +92,5 @@ public class AvoidEscapedUnicodeCharactersCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheckExamplesTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class DescendantTokenCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/descendanttoken";
@@ -185,4 +186,5 @@ public class DescendantTokenCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example17.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class FinalParametersCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/finalparameters";
@@ -66,4 +67,5 @@ public class FinalParametersCheckExamplesTest extends AbstractExamplesModuleTest
         verifyWithInlineConfigParser(
                 getNonCompilablePath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/HexLiteralCaseCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/HexLiteralCaseCheckExamplesTest.java
@@ -54,4 +54,5 @@ public class HexLiteralCaseCheckExamplesTest extends AbstractExamplesModuleTestS
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/LineEndingCheckExampleTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/LineEndingCheckExampleTest.java
@@ -30,6 +30,7 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class LineEndingCheckExampleTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/lineending";
@@ -91,4 +92,5 @@ public class LineEndingCheckExampleTest extends AbstractExamplesModuleTestSuppor
                 getPath("Example4.java"), expected
         );
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckExamplesTest.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class NewlineAtEndOfFileCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/newlineatendoffile";
@@ -82,4 +83,5 @@ public class NewlineAtEndOfFileCheckExamplesTest extends AbstractExamplesModuleT
 
         verifyWithInlineConfigParser(getPath("Example6.txt"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NoCodeInFileCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NoCodeInFileCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NoCodeInFileCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/nocodeinfile";
@@ -48,4 +49,5 @@ public class NoCodeInFileCheckExamplesTest extends AbstractExamplesModuleTestSup
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NumericalPrefixesInfixesSuffixesCharacterCaseCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NumericalPrefixesInfixesSuffixesCharacterCaseCheckExamplesTest.java
@@ -52,4 +52,5 @@ public class NumericalPrefixesInfixesSuffixesCharacterCaseCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class OrderedPropertiesCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/orderedproperties";
@@ -40,4 +41,5 @@ public class OrderedPropertiesCheckExamplesTest extends AbstractExamplesModuleTe
         verifyWithInlineConfigParserSeparateConfigAndTarget(
                 getPath("Example1.java"), getPath("Example1.properties"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class OuterTypeFilenameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/outertypefilename";
@@ -75,4 +76,5 @@ public class OuterTypeFilenameCheckExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class TodoCommentCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/todocomment";
@@ -63,4 +64,5 @@ public class TodoCommentCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/trailingcomment";
@@ -91,4 +92,5 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("UseCase3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckExamplesTest.java
@@ -35,6 +35,7 @@ import com.puppycrawl.tools.checkstyle.bdd.InlineConfigParser;
 import com.puppycrawl.tools.checkstyle.bdd.TestInputConfiguration;
 
 public class TranslationCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/translation";
@@ -111,4 +112,5 @@ public class TranslationCheckExamplesTest extends AbstractExamplesModuleTestSupp
                 testInputConfiguration.createConfiguration();
         verify(createChecker(parsedConfig), propertyFiles, getPath(""), expectedMessages);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UncommentedMainCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/uncommentedmain";
@@ -49,4 +50,5 @@ public class UncommentedMainCheckExamplesTest extends AbstractExamplesModuleTest
         verifyWithInlineConfigParser(
                 getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class UniquePropertiesCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/uniqueproperties";
@@ -65,4 +66,5 @@ public class UniquePropertiesCheckExamplesTest extends AbstractExamplesModuleTes
         verifyWithInlineConfigParserSeparateConfigAndTarget(configFilePath,
                 propertyFilePath, expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UpperEllCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/upperell";
@@ -39,4 +40,5 @@ public class UpperEllCheckExamplesTest extends AbstractExamplesModuleTestSupport
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AnnotationLocationExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation";
@@ -71,4 +72,5 @@ public class AnnotationLocationExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AnnotationOnSameLineCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline";
@@ -53,4 +54,5 @@ public class AnnotationOnSameLineCheckExamplesTest extends AbstractExamplesModul
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckExamplesTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AnnotationUseStyleCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle";
@@ -81,4 +82,5 @@ public class AnnotationUseStyleCheckExamplesTest extends AbstractExamplesModuleT
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MissingDeprecatedCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated";
@@ -50,4 +51,5 @@ public class MissingDeprecatedCheckExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckExamplesTest.java
@@ -55,4 +55,5 @@ public class MissingOverrideCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideOnRecordAccessorCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideOnRecordAccessorCheckExamplesTest.java
@@ -48,4 +48,5 @@ public class MissingOverrideOnRecordAccessorCheckExamplesTest
         };
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class PackageAnnotationCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation";
@@ -54,4 +55,5 @@ public class PackageAnnotationCheckExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("example3/package-info.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SuppressWarningsCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings";
@@ -52,4 +53,5 @@ public class SuppressWarningsCheckExamplesTest extends AbstractExamplesModuleTes
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsHolderExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsHolderExamplesTest.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck;
 
 public class SuppressWarningsHolderExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarningsholder";
@@ -89,4 +90,5 @@ public class SuppressWarningsHolderExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("UseCase2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AvoidNestedBlocksCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/avoidnestedblocks";
@@ -49,4 +50,5 @@ public class AvoidNestedBlocksCheckExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class EmptyBlockCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/emptyblock";
@@ -64,4 +65,5 @@ public class EmptyBlockCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class EmptyCatchBlockCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/emptycatchblock";
@@ -78,4 +79,5 @@ public class EmptyCatchBlockCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("UseCase2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckExamplesTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class LeftCurlyCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly";
@@ -73,4 +74,5 @@ public class LeftCurlyCheckExamplesTest extends AbstractExamplesModuleTestSuppor
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class NeedBracesCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/needbraces";
@@ -92,4 +93,5 @@ public class NeedBracesCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("UseCase2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class RightCurlyCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly";
@@ -77,4 +78,5 @@ public class RightCurlyCheckExamplesTest extends AbstractExamplesModuleTestSuppo
         };
         verifyWithInlineConfigParser(getPath("UseCase2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ArrayTrailingCommaCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/arraytrailingcomma";
@@ -54,4 +55,5 @@ public class ArrayTrailingCommaCheckExamplesTest extends AbstractExamplesModuleT
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AvoidDoubleBraceInitializationCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/avoiddoublebraceinitialization";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AvoidInlineConditionalsCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/avoidinlineconditionals";
@@ -38,4 +39,5 @@ public class AvoidInlineConditionalsCheckExamplesTest extends AbstractExamplesMo
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidNoArgumentSuperConstructorCallCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidNoArgumentSuperConstructorCallCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AvoidNoArgumentSuperConstructorCallCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/avoidnoargumentsuperconstructorcall";
@@ -40,4 +41,5 @@ public class AvoidNoArgumentSuperConstructorCallCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ConstructorsDeclarationGroupingCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ConstructorsDeclarationGroupingCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/constructorsdeclarationgrouping";
@@ -53,4 +54,5 @@ public class ConstructorsDeclarationGroupingCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class CovariantEqualsCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/covariantequals";
@@ -49,4 +50,5 @@ public class CovariantEqualsCheckExamplesTest extends AbstractExamplesModuleTest
         verifyWithInlineConfigParser(
                 getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckExamplesTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class DeclarationOrderCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/declarationorder";
@@ -63,4 +64,5 @@ public class DeclarationOrderCheckExamplesTest extends AbstractExamplesModuleTes
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class DefaultComesLastCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast";
@@ -52,4 +53,5 @@ public class DefaultComesLastCheckExamplesTest extends AbstractExamplesModuleTes
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class EmptyStatementCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/emptystatement";
@@ -40,4 +41,5 @@ public class EmptyStatementCheckExamplesTest extends AbstractExamplesModuleTestS
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class EqualsAvoidNullCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull";
@@ -50,4 +51,5 @@ public class EqualsAvoidNullCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class EqualsHashCodeCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode";
@@ -43,4 +44,5 @@ public class EqualsHashCodeCheckExamplesTest extends AbstractExamplesModuleTestS
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ExplicitInitializationCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/explicitinitialization";
@@ -53,4 +54,5 @@ public class ExplicitInitializationCheckExamplesTest extends AbstractExamplesMod
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class HiddenFieldCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield";
@@ -109,4 +110,5 @@ public class HiddenFieldCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class IllegalCatchCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/illegalcatch";
@@ -50,4 +51,5 @@ public class IllegalCatchCheckExamplesTest extends AbstractExamplesModuleTestSup
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class IllegalInstantiationCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/illegalinstantiation";
@@ -51,4 +52,5 @@ public class IllegalInstantiationCheckExamplesTest extends AbstractExamplesModul
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalSymbolCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalSymbolCheckExamplesTest.java
@@ -95,4 +95,5 @@ public class IllegalSymbolCheckExamplesTest extends AbstractExamplesModuleTestSu
         verifyWithInlineConfigParser(
                 getPath("UseCase2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class IllegalThrowsCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows";
@@ -72,4 +73,5 @@ public class IllegalThrowsCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class IllegalTokenCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken";
@@ -46,4 +47,5 @@ public class IllegalTokenCheckExamplesTest extends AbstractExamplesModuleTestSup
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext";
@@ -79,4 +80,5 @@ public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTes
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class IllegalTypeCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/illegaltype";
@@ -156,4 +157,5 @@ public class IllegalTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example9.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class InnerAssignmentCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/innerassignment";
@@ -58,4 +59,5 @@ public class InnerAssignmentCheckExamplesTest extends AbstractExamplesModuleTest
         verifyWithInlineConfigParser(
                 getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MagicNumberCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/magicnumber";
@@ -130,4 +131,5 @@ public class MagicNumberCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example6.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MatchXpathCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/matchxpath";
@@ -85,4 +86,5 @@ public class MatchXpathCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("UseCase5.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MissingCtorCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/missingctor";
@@ -37,4 +38,5 @@ public class MissingCtorCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingNullCaseInSwitchCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingNullCaseInSwitchCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MissingNullCaseInSwitchCheckExamplesTest extends
         AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/missingnullcaseinswitch";
@@ -40,4 +41,5 @@ public class MissingNullCaseInSwitchCheckExamplesTest extends
         };
         verifyWithInlineConfigParser(getNonCompilablePath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MissingSwitchDefaultCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault";
@@ -53,4 +54,5 @@ public class MissingSwitchDefaultCheckExamplesTest extends AbstractExamplesModul
         verifyWithInlineConfigParser(
                 getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ModifiedControlVariableCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/modifiedcontrolvariable";
@@ -47,4 +48,5 @@ public class ModifiedControlVariableCheckExamplesTest extends AbstractExamplesMo
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckExamplesTest.java
@@ -74,4 +74,5 @@ public class MultipleStringLiteralsCheckExamplesTest extends AbstractExamplesMod
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MultipleVariableDeclarationsCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/multiplevariabledeclarations";
@@ -41,4 +42,5 @@ public class MultipleVariableDeclarationsCheckExamplesTest
         };
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NestedForDepthCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/nestedfordepth";
@@ -50,4 +51,5 @@ public class NestedForDepthCheckExamplesTest extends AbstractExamplesModuleTestS
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NestedIfDepthCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth";
@@ -53,4 +54,5 @@ public class NestedIfDepthCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NestedTryDepthCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/nestedtrydepth";
@@ -49,4 +50,5 @@ public class NestedTryDepthCheckExamplesTest extends AbstractExamplesModuleTestS
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NoArrayTrailingCommaCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/noarraytrailingcomma";
@@ -38,4 +39,5 @@ public class NoArrayTrailingCommaCheckExamplesTest extends AbstractExamplesModul
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NoCloneCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/noclone";
@@ -37,4 +38,5 @@ public class NoCloneCheckExamplesTest extends AbstractExamplesModuleTestSupport 
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NoEnumTrailingCommaCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NoEnumTrailingCommaCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NoEnumTrailingCommaCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/noenumtrailingcomma";
@@ -41,4 +42,5 @@ public class NoEnumTrailingCommaCheckExamplesTest extends AbstractExamplesModule
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NoFinalizerCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/NoFinalizerCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NoFinalizerCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/nofinalizer";
@@ -37,4 +38,5 @@ public class NoFinalizerCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class OneStatementPerLineCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline";
@@ -57,4 +58,5 @@ public class OneStatementPerLineCheckExamplesTest extends AbstractExamplesModule
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class OverloadMethodsDeclarationOrderCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder";
@@ -52,4 +53,5 @@ public class OverloadMethodsDeclarationOrderCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class PackageDeclarationCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/packagedeclaration";
@@ -46,4 +47,5 @@ public class PackageDeclarationCheckExamplesTest extends AbstractExamplesModuleT
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ParameterAssignmentCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/parameterassignment";
@@ -42,4 +43,5 @@ public class ParameterAssignmentCheckExamplesTest extends AbstractExamplesModule
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/PatternVariableAssignmentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/PatternVariableAssignmentCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class PatternVariableAssignmentCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/patternvariableassignment";
@@ -43,4 +44,5 @@ public class PatternVariableAssignmentCheckExamplesTest extends AbstractExamples
         verifyWithInlineXmlConfig(getNonCompilablePath(
             "Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class RequireThisCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/requirethis";
@@ -85,4 +86,5 @@ public class RequireThisCheckExamplesTest extends AbstractExamplesModuleTestSupp
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(getPath("UseCase2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ReturnCountCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/returncount";
@@ -80,4 +81,5 @@ public class ReturnCountCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SimplifyBooleanExpressionCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanexpression";
@@ -42,4 +43,5 @@ public class SimplifyBooleanExpressionCheckExamplesTest extends AbstractExamples
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SimplifyBooleanReturnCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanreturn";
@@ -38,4 +39,5 @@ public class SimplifyBooleanReturnCheckExamplesTest extends AbstractExamplesModu
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class StringLiteralEqualityCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality";
@@ -39,4 +40,5 @@ public class StringLiteralEqualityCheckExamplesTest extends AbstractExamplesModu
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckExamplesTest.java
@@ -40,4 +40,5 @@ public class SuperCloneCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperFinalizeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperFinalizeCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SuperFinalizeCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/superfinalize";
@@ -39,4 +40,5 @@ public class SuperFinalizeCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryNullCheckWithInstanceOfCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryNullCheckWithInstanceOfCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UnnecessaryNullCheckWithInstanceOfCheckExamplesTest
     extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/unnecessarynullcheckwithinstanceof";
@@ -43,4 +44,5 @@ public class UnnecessaryNullCheckWithInstanceOfCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckExamplesTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UnnecessaryParenthesesCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses";
@@ -64,4 +65,5 @@ public class UnnecessaryParenthesesCheckExamplesTest extends AbstractExamplesMod
         };
         verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UnnecessarySemicolonAfterOuterTypeDeclarationCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks"
@@ -50,4 +51,5 @@ public class UnnecessarySemicolonAfterOuterTypeDeclarationCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterTypeMemberDeclarationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterTypeMemberDeclarationCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UnnecessarySemicolonAfterTypeMemberDeclarationCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks"
@@ -46,4 +47,5 @@ public class UnnecessarySemicolonAfterTypeMemberDeclarationCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInEnumerationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInEnumerationCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UnnecessarySemicolonInEnumerationCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicoloninenumeration";
@@ -50,4 +51,5 @@ public class UnnecessarySemicolonInEnumerationCheckExamplesTest
         final String[] expected = {};
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInTryWithResourcesCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInTryWithResourcesCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UnnecessarySemicolonInTryWithResourcesCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks"
@@ -53,4 +54,5 @@ public class UnnecessarySemicolonInTryWithResourcesCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLambdaParameterShouldBeUnnamedCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLambdaParameterShouldBeUnnamedCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UnusedLambdaParameterShouldBeUnnamedCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/unusedlambdaparametershouldbeunnamed";
@@ -42,4 +43,5 @@ public class UnusedLambdaParameterShouldBeUnnamedCheckExamplesTest
                 getNonCompilablePath("Example1.java"),
                 expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UnusedLocalVariableCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UseEnhancedSwitchCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/UseEnhancedSwitchCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UseEnhancedSwitchCheckExamplesTest
     extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/useenhancedswitch";
@@ -49,4 +50,5 @@ public class UseEnhancedSwitchCheckExamplesTest
         verifyWithInlineConfigParser(
             getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckExamplesTest.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class VariableDeclarationUsageDistanceCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/WhenShouldBeUsedCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/WhenShouldBeUsedCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class WhenShouldBeUsedCheckExamplesTest
     extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/whenshouldbeused";
@@ -41,4 +42,5 @@ public class WhenShouldBeUsedCheckExamplesTest
         verifyWithInlineConfigParser(
                 getNonCompilablePath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class DesignForExtensionCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/design/designforextension";
@@ -76,4 +77,5 @@ public class DesignForExtensionCheckExamplesTest extends AbstractExamplesModuleT
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class FinalClassCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/design/finalclass";
@@ -40,4 +41,5 @@ public class FinalClassCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class HideUtilityClassConstructorCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor";
@@ -51,4 +52,5 @@ public class HideUtilityClassConstructorCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class InnerTypeLastCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/design/innertypelast";
@@ -40,4 +41,5 @@ public class InnerTypeLastCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class InterfaceIsTypeCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/design/interfaceistype";
@@ -49,4 +50,5 @@ public class InterfaceIsTypeCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MutableExceptionCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/design/mutableexception";
@@ -60,4 +61,5 @@ public class MutableExceptionCheckExamplesTest extends AbstractExamplesModuleTes
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class OneTopLevelClassCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/SealedShouldHavePermitsListCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/SealedShouldHavePermitsListCheckExamplesTest.java
@@ -42,4 +42,5 @@ public class SealedShouldHavePermitsListCheckExamplesTest extends
                 getPath("Example1.java"),
                 expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ThrowsCountCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/design/throwscount";
@@ -59,4 +60,5 @@ public class ThrowsCountCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier";
@@ -260,4 +261,5 @@ public class VisibilityModifierCheckExamplesTest extends AbstractExamplesModuleT
 
         verifyWithInlineConfigParser(getPath("Example12.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class HeaderCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/header/header";
@@ -73,4 +74,5 @@ public class HeaderCheckExamplesTest extends AbstractExamplesModuleTestSupport {
                                     getPath("Example4.java"),
                                     expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/header/MultiFileRegexpHeaderCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MultiFileRegexpHeaderCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/header/multifileregexpheader";
@@ -82,5 +83,6 @@ public class MultiFileRegexpHeaderCheckExamplesTest extends AbstractExamplesModu
                                     getPath("Example4.java"),
                                      expected);
     }
+
 }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class RegexpHeaderCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/header/regexpheader";
@@ -68,4 +69,5 @@ public class RegexpHeaderCheckExamplesTest extends AbstractExamplesModuleTestSup
                                     getPath("Example4.java"),
                                      expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AvoidStarImportCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport";
@@ -101,4 +102,5 @@ public class AvoidStarImportCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AvoidStaticImportCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport";
@@ -50,4 +51,5 @@ public class AvoidStaticImportCheckExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckExamplesTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class CustomImportOrderCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/imports/customimportorder";
@@ -209,4 +210,5 @@ public class CustomImportOrderCheckExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("Example15.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class IllegalImportCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/imports/illegalimport";
@@ -106,4 +107,5 @@ public class IllegalImportCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getNonCompilablePath("Example6.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ImportControlCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/imports/importcontrol";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckExamplesTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ImportOrderCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/imports/importorder";
@@ -177,4 +178,5 @@ public class ImportOrderCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example12.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckExamplesTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class RedundantImportCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/imports/redundantimport";
@@ -53,4 +54,5 @@ public class RedundantImportCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getNonCompilablePath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class UnusedImportsCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/imports/unusedimports";
@@ -53,4 +54,5 @@ public class UnusedImportsCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class CommentsIndentationCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckExamplesTest.java
@@ -146,4 +146,5 @@ public class IndentationCheckExamplesTest extends AbstractExamplesModuleTestSupp
         };
         verifyWithInlineConfigParser(getPath("Example9.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AtclauseOrderCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder";
@@ -69,4 +70,5 @@ public class AtclauseOrderCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/InvalidJavadocPositionCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/InvalidJavadocPositionCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class InvalidJavadocPositionCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/invalidjavadocposition";
@@ -39,4 +40,5 @@ public class InvalidJavadocPositionCheckExamplesTest extends AbstractExamplesMod
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class JavadocBlockTagLocationCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation";
@@ -55,4 +56,5 @@ public class JavadocBlockTagLocationCheckExamplesTest extends AbstractExamplesMo
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class JavadocContentLocationCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadoccontentlocation";
@@ -49,4 +50,5 @@ public class JavadocContentLocationCheckExamplesTest extends AbstractExamplesMod
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class JavadocLeadingAsteriskAlignExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign";
@@ -44,4 +45,5 @@ public class JavadocLeadingAsteriskAlignExamplesTest extends AbstractExamplesMod
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckExamplesTest.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class JavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod";
@@ -122,4 +123,5 @@ public class JavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSu
         };
         verifyWithInlineConfigParser(getPath("Example8.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingLeadingAsteriskCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingLeadingAsteriskCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class JavadocMissingLeadingAsteriskCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmissingleadingasterisk";
@@ -42,4 +43,5 @@ public class JavadocMissingLeadingAsteriskCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class JavadocMissingWhitespaceAfterAsteriskCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc"
@@ -42,4 +43,5 @@ public class JavadocMissingWhitespaceAfterAsteriskCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckExamplesTest.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class JavadocPackageCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckExamplesTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class JavadocParagraphCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocparagraph";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckExamplesTest.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class JavadocTagContinuationIndentationCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation";
@@ -69,4 +70,5 @@ public class JavadocTagContinuationIndentationCheckExamplesTest
         };
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class JavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype";
@@ -126,4 +127,5 @@ public class JavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example9.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class JavadocVariableCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable";
@@ -104,4 +105,5 @@ public class JavadocVariableCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("UseCase2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MissingJavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod";
@@ -118,4 +119,5 @@ public class MissingJavadocMethodCheckExamplesTest extends AbstractExamplesModul
 
         verifyWithInlineConfigParser(getPath("Example8.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MissingJavadocPackageCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage";
@@ -46,4 +47,5 @@ public class MissingJavadocPackageCheckExamplesTest extends AbstractExamplesModu
 
         verifyWithInlineConfigParser(getPath("nojavadoc/package-info.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MissingJavadocTypeCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype";
@@ -87,4 +88,5 @@ public class MissingJavadocTypeCheckExamplesTest extends AbstractExamplesModuleT
 
         verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NonEmptyAtclauseDescriptionCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc"
@@ -54,4 +55,5 @@ public class NonEmptyAtclauseDescriptionCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class RequireEmptyLineBeforeBlockTagGroupCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/requireemptylinebeforeblocktaggroup";
@@ -39,4 +40,5 @@ public class RequireEmptyLineBeforeBlockTagGroupCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SingleLineJavadocCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/singlelinejavadoc";
@@ -69,4 +70,5 @@ public class SingleLineJavadocCheckExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckExamplesTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SummaryJavadocCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc";
@@ -70,4 +71,5 @@ public class SummaryJavadocCheckExamplesTest extends AbstractExamplesModuleTestS
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class WriteTagCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/javadoc/writetag";
@@ -79,4 +80,5 @@ public class WriteTagCheckExamplesTest extends AbstractExamplesModuleTestSupport
 
         verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class BooleanExpressionComplexityCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/metrics/booleanexpressioncomplexity";
@@ -59,4 +60,5 @@ public class BooleanExpressionComplexityCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheckExamplesTest.java
@@ -29,6 +29,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ClassDataAbstractionCouplingCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling";
@@ -222,4 +223,5 @@ public class ClassDataAbstractionCouplingCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("UseCase6.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckExamplesTest.java
@@ -26,6 +26,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class ClassFanOutComplexityCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity";
@@ -77,4 +78,5 @@ public class ClassFanOutComplexityCheckExamplesTest
 
         verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class CyclomaticComplexityCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/metrics/cyclomaticcomplexity";
@@ -55,4 +56,5 @@ public class CyclomaticComplexityCheckExamplesTest extends AbstractExamplesModul
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheckExamplesTest.java
@@ -31,6 +31,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 // -@cs[AbbreviationAsWordInName] Test should be named as its main class.
 public class JavaNCSSCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/metrics/javancss";
@@ -78,4 +79,5 @@ public class JavaNCSSCheckExamplesTest extends AbstractExamplesModuleTestSupport
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 // -@cs[AbbreviationAsWordInName] Test should be named as its main class.
 public class NPathComplexityCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity";
@@ -48,4 +49,5 @@ public class NPathComplexityCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ClassMemberImpliedModifierCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier";
@@ -78,4 +79,5 @@ public class ClassMemberImpliedModifierCheckExamplesTest extends AbstractExample
         verifyWithInlineConfigParser(
                 getPath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class InterfaceMemberImpliedModifierCheckExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier";
@@ -88,4 +89,5 @@ public class InterfaceMemberImpliedModifierCheckExamplesTest
         };
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ModifierOrderCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder";
@@ -41,4 +42,5 @@ public class ModifierOrderCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class RedundantModifierCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier";
@@ -69,4 +70,5 @@ public class RedundantModifierCheckExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModuleTestSupport {
+
     private static final int DEFAULT_EXPECTED_CAPITAL_COUNT = 4;
 
     @Override
@@ -127,4 +128,5 @@ public class AbbreviationAsWordInNameExamplesTest extends AbstractExamplesModule
 
         verifyWithInlineXmlConfig(getPath("UseCase3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class AbstractClassNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     private static final String DEFAULT_PATTERN = "^Abstract.+$";
 
     @Override
@@ -81,4 +82,5 @@ public class AbstractClassNameCheckExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheckExamplesTest.java
@@ -64,4 +64,5 @@ public class CatchParameterNameCheckExamplesTest extends AbstractExamplesModuleT
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ClassTypeParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ClassTypeParameterNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ClassTypeParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername";
@@ -68,4 +69,5 @@ public class ClassTypeParameterNameCheckExamplesTest extends AbstractExamplesMod
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ConstantNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     private static final String DEFAULT_PATTERN = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
 
     @Override

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class IllegalIdentifierNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername";
@@ -74,4 +75,5 @@ public class IllegalIdentifierNameCheckExamplesTest extends AbstractExamplesModu
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/InterfaceTypeParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/InterfaceTypeParameterNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class InterfaceTypeParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/interfacetypeparametername";
@@ -50,4 +51,5 @@ public class InterfaceTypeParameterNameCheckExamplesTest extends AbstractExample
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LambdaParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LambdaParameterNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class LambdaParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/lambdaparametername";
@@ -51,4 +52,5 @@ public class LambdaParameterNameCheckExamplesTest extends AbstractExamplesModule
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class LocalFinalVariableNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename";
@@ -62,4 +63,5 @@ public class LocalFinalVariableNameCheckExamplesTest extends AbstractExamplesMod
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class LocalVariableNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/localvariablename";
@@ -96,4 +97,5 @@ public class LocalVariableNameCheckExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("UseCase2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MemberNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/membername";
@@ -64,4 +65,5 @@ public class MemberNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MethodNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/methodname";
@@ -105,4 +106,5 @@ public class MethodNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodTypeParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodTypeParameterNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MethodTypeParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/methodtypeparametername";
@@ -49,4 +50,5 @@ public class MethodTypeParameterNameCheckExamplesTest extends AbstractExamplesMo
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class PackageNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/packagename";
@@ -52,4 +53,5 @@ public class PackageNameCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/parametername";
@@ -83,4 +84,5 @@ public class ParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class PatternVariableNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename";
@@ -79,5 +80,6 @@ public class PatternVariableNameCheckExamplesTest extends AbstractExamplesModule
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
 }
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/RecordComponentNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/RecordComponentNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class RecordComponentNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname";
@@ -57,4 +58,5 @@ public class RecordComponentNameCheckExamplesTest extends AbstractExamplesModule
         verifyWithInlineConfigParser(
                 getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/RecordTypeParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/RecordTypeParameterNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class RecordTypeParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/recordtypeparametername";
@@ -55,4 +56,5 @@ public class RecordTypeParameterNameCheckExamplesTest extends AbstractExamplesMo
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckExamplesTest.java
@@ -84,4 +84,5 @@ public class StaticVariableNameCheckExamplesTest extends AbstractExamplesModuleT
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class TypeNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/naming/typename";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class RegexpCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/regexp/regexp";
@@ -137,4 +138,5 @@ public class RegexpCheckExamplesTest extends AbstractExamplesModuleTestSupport {
 
         verifyWithInlineConfigParser(getPath("UseCase7.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class RegexpMultilineCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline";
@@ -95,4 +96,5 @@ public class RegexpMultilineCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckExamplesTest.java
@@ -40,6 +40,7 @@ import com.puppycrawl.tools.checkstyle.bdd.InlineConfigParser;
 import com.puppycrawl.tools.checkstyle.bdd.TestInputConfiguration;
 
 public class RegexpOnFilenameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename";
@@ -175,4 +176,5 @@ public class RegexpOnFilenameCheckExamplesTest extends AbstractExamplesModuleTes
 
         verify(createChecker(parsedConfig), getFilesInFolder(path), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class RegexpSinglelineCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline";
@@ -95,4 +96,5 @@ public class RegexpSinglelineCheckExamplesTest extends AbstractExamplesModuleTes
         verifyWithInlineConfigParserSeparateConfigAndTarget(
                 getPath("Example7.java"), getPath("Example7.sql"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class RegexpSinglelineJavaCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/regexp/regexpsinglelinejava";
@@ -99,4 +100,5 @@ public class RegexpSinglelineJavaCheckExamplesTest extends AbstractExamplesModul
 
         verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class AnonInnerLengthCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/sizes/anoninnerlength";
@@ -46,4 +47,5 @@ public class AnonInnerLengthCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ExecutableStatementCountCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/sizes/executablestatementcount";
@@ -54,4 +55,5 @@ public class ExecutableStatementCountCheckExamplesTest extends AbstractExamplesM
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class FileLengthCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/sizes/filelength";
@@ -57,4 +58,5 @@ public class FileLengthCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LambdaBodyLengthExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LambdaBodyLengthExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class LambdaBodyLengthExamplesTest extends AbstractExamplesModuleTestSupport {
+
     private static final int DEFAULT_MAX = 10;
 
     @Override
@@ -54,4 +55,5 @@ public class LambdaBodyLengthExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class LineLengthCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/sizes/linelength";
@@ -88,4 +89,5 @@ public class LineLengthCheckExamplesTest extends AbstractExamplesModuleTestSuppo
         };
         verifyWithInlineConfigParser(getPath("Example6.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MethodCountCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/sizes/methodcount";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MethodLengthCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/sizes/methodlength";
@@ -64,4 +65,5 @@ public class MethodLengthCheckExamplesTest extends AbstractExamplesModuleTestSup
         };
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheckExamplesTest.java
@@ -49,4 +49,5 @@ public class OuterTypeNumberCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ParameterNumberCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber";
@@ -73,4 +74,5 @@ public class ParameterNumberCheckExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheckExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class RecordComponentNumberCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber";
@@ -60,4 +61,5 @@ public class RecordComponentNumberCheckExamplesTest extends AbstractExamplesModu
         verifyWithInlineConfigParser(
                 getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class EmptyForInitializerPadExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforinitializerpad";
@@ -51,4 +52,5 @@ public class EmptyForInitializerPadExamplesTest extends AbstractExamplesModuleTe
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class EmptyForIteratorPadExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad";
@@ -49,4 +50,5 @@ public class EmptyForIteratorPadExamplesTest extends AbstractExamplesModuleTestS
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorExamplesTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class EmptyLineSeparatorExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator";
@@ -115,4 +116,5 @@ public class EmptyLineSeparatorExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterExamplesTest.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class FileTabCharacterExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter";
@@ -76,4 +77,5 @@ public class FileTabCharacterExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example5.html"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckExamplesTest.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class GenericWhitespaceCheckExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace";
@@ -52,4 +53,5 @@ public class GenericWhitespaceCheckExamplesTest extends AbstractExamplesModuleTe
         verifyWithInlineConfigParser(
                 getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadExamplesTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class MethodParamPadExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad";
@@ -52,4 +53,5 @@ public class MethodParamPadExamplesTest extends AbstractExamplesModuleTestSuppor
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NoLineWrapExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap";
@@ -62,4 +63,5 @@ public class NoLineWrapExamplesTest extends AbstractExamplesModuleTestSupport {
 
         verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NoWhitespaceAfterExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter";
@@ -51,4 +52,5 @@ public class NoWhitespaceAfterExamplesTest extends AbstractExamplesModuleTestSup
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCaseDefaultColonExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCaseDefaultColonExamplesTest.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NoWhitespaceBeforeCaseDefaultColonExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace"
@@ -45,4 +46,5 @@ public class NoWhitespaceBeforeCaseDefaultColonExamplesTest
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class NoWhitespaceBeforeExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespacebefore";
@@ -80,4 +81,5 @@ public class NoWhitespaceBeforeExamplesTest extends AbstractExamplesModuleTestSu
 
         verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class OperatorWrapExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap";
@@ -60,4 +61,5 @@ public class OperatorWrapExamplesTest extends AbstractExamplesModuleTestSupport 
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadExamplesTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class ParenPadExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad";
@@ -68,4 +69,5 @@ public class ParenPadExamplesTest extends AbstractExamplesModuleTestSupport {
         final String[] expected = {};
         verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SeparatorWrapExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap";
@@ -60,4 +61,5 @@ public class SeparatorWrapExamplesTest extends AbstractExamplesModuleTestSupport
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SingleSpaceSeparatorExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator";
@@ -55,4 +56,5 @@ public class SingleSpaceSeparatorExamplesTest extends AbstractExamplesModuleTest
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadExamplesTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class TypecastParenPadExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/typecastparenpad";
@@ -61,4 +62,5 @@ public class TypecastParenPadExamplesTest extends AbstractExamplesModuleTestSupp
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class WhitespaceAfterExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/whitespaceafter";
@@ -56,4 +57,5 @@ public class WhitespaceAfterExamplesTest extends AbstractExamplesModuleTestSuppo
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundExamplesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilterExamplesTest.java
@@ -38,6 +38,7 @@ import com.puppycrawl.tools.checkstyle.bdd.TestInputConfiguration;
 
 public class BeforeExecutionExclusionFileFilterExamplesTest
         extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/filefilters/beforeexecutionexclusionfilefilter";

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterExamplesTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SeverityMatchFilterExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/filters/severitymatchfilter";
@@ -48,4 +49,5 @@ public class SeverityMatchFilterExamplesTest extends AbstractExamplesModuleTestS
                 expectedWithoutFilter,
                 expectedWithFilter);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SuppressWarningsFilterExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter";
@@ -66,4 +67,5 @@ public class SuppressWarningsFilterExamplesTest extends AbstractExamplesModuleTe
         verifyFilterWithInlineConfigParser(getPath("Example2.java"),
                 expectedWithoutFilter, expectedWithFilter);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter";
@@ -179,4 +180,5 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
         verifyFilterWithInlineConfigParser(getPath("UseCase5.java"), expectedWithoutFilter,
                 expectedWithFilter);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/filters/suppresswithnearbytextfilter";
@@ -205,4 +206,5 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
         verifyFilterWithInlineConfigParser(getPath("Example9.java"),
                 expectedWithoutFilter, expectedWithFilter);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterExamplesTest.java
@@ -201,4 +201,5 @@ public class SuppressWithPlainTextCommentFilterExamplesTest
         verifyFilterWithInlineConfigParser(getPath("UseCase1.java"),
                 expectedWithoutFilter, expectedWithFilter);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SuppressionCommentFilterExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/filters/suppressioncommentfilter";
@@ -218,4 +219,5 @@ public class SuppressionCommentFilterExamplesTest extends AbstractExamplesModule
         verifyFilterWithInlineConfigParser(getPath("Example8.java"),
                 expectedWithoutFilter, expectedWithFilter);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterExamplesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class SuppressionFilterExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/filters/suppressionfilter";
@@ -102,4 +103,5 @@ public class SuppressionFilterExamplesTest extends AbstractExamplesModuleTestSup
         verifyFilterWithInlineConfigParser(getPath("UseCase3.java"),
                 expectedWithoutFilter, expectedWithFilter);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilterExamplesTest.java
@@ -31,6 +31,7 @@ import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck;
 
 public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter";
@@ -93,4 +94,5 @@ public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleT
         verifyFilterWithInlineConfigParser(getPath("Example4.java"),
                 expectedWithoutFilter, expectedWithFilter);
     }
+
 }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterExamplesTest.java
@@ -47,6 +47,7 @@ import com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
 
 public class SuppressionXpathSingleFilterExamplesTest extends AbstractExamplesModuleTestSupport {
+
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter";
@@ -306,4 +307,5 @@ public class SuppressionXpathSingleFilterExamplesTest extends AbstractExamplesMo
                     .toArray(File[]::new);
         }
     }
+
 }


### PR DESCRIPTION
Pull: #20724

This PR resolves the remaining `TypeBodyPaddingCheck` violations in `xdocs-examples` that were missed in the previous cleanup PR.