### PR TITLE
Issue #20590: Add NoFinalizer compact source coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoFinalizerCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoFinalizerCheckTest.java
@@ -77,4 +77,14 @@ public class NoFinalizerCheckTest
                 getNonCompilablePath("InputNoFinalizerFallThrough.java"), expected);
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "10:1: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("compact/InputNoFinalizerCompactSourceFile.java"),
+                expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -198,7 +198,6 @@ public class AllChecksCompactSourceCoverageTest {
         "NoCloneCheck",
         "NoCodeInFileCheck",
         "NoEnumTrailingCommaCheck",
-        "NoFinalizerCheck",
         "NoLineWrapCheck",
         "NoWhitespaceAfterCheck",
         "NoWhitespaceBeforeCaseDefaultColonCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/nofinalizer/compact/InputNoFinalizerCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/nofinalizer/compact/InputNoFinalizerCompactSourceFile.java
@@ -1,0 +1,17 @@
+/*
+NoFinalizer
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+// violation below, 'Avoid using finalizer method.'
+protected void finalize() {
+}
+
+void finalize(String value) {
+}
+
+void main() {
+}


### PR DESCRIPTION
Issue: #20590

Adds compact source coverage for `NoFinalizerCheck` and removes the check from `SUPPRESSED_CHECKS`.

The compact input verifies that a zero-argument top-level `finalize()` method is reported while a parameterized `finalize(String)` overload is not.

Validation:

- `./mvnw clean test -Dtest=NoFinalizerCheckTest,AllChecksCompactSourceCoverageTest` (6 tests)
- `./mvnw clean verify`
