### PR TITLE
Issue #20505: Fix GenericWhitespace false positive for parameterized record pattern

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -229,9 +229,12 @@ public class GenericWhitespaceCheck extends AbstractCheck {
      * @return true if generic is before record header
      */
     private static boolean isGenericBeforeRecordHeader(DetailAST ast) {
-        final DetailAST grandParent = ast.getParent().getParent();
-        return grandParent.getType() == TokenTypes.RECORD_DEF
-                || grandParent.getParent().getType() == TokenTypes.RECORD_PATTERN_DEF;
+        DetailAST typeNode = ast.getParent().getParent();
+        if (typeNode.getType() == TokenTypes.DOT) {
+            typeNode = typeNode.getParent();
+        }
+        return typeNode.getType() == TokenTypes.RECORD_DEF
+                || typeNode.getParent().getType() == TokenTypes.RECORD_PATTERN_DEF;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheckTest.java
@@ -339,4 +339,15 @@ public class GenericWhitespaceCheckTest
                 expected);
     }
 
+    @Test
+    public void testParameterizedRecordPattern() throws Exception {
+        final String[] expected = {
+            "22:36: " + getCheckMessage(MSG_WS_FOLLOWED, ">"),
+            "33:42: " + getCheckMessage(MSG_WS_FOLLOWED, ">"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputGenericWhitespaceParameterizedRecordPattern.java"),
+                expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceParameterizedRecordPattern.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/genericwhitespace/InputGenericWhitespaceParameterizedRecordPattern.java
@@ -1,0 +1,38 @@
+/*
+GenericWhitespace
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.genericwhitespace;
+
+public class InputGenericWhitespaceParameterizedRecordPattern {
+
+      record Pair<T>(T left, T right) {}
+
+      static class Outer {
+          record Pair<T>(T left, T right) {}
+      }
+
+      void test(Object obj) {
+          // ok - parameterized record pattern without whitespace after '>'
+          if (obj instanceof Pair<?>(var left, var right)) {
+              left.toString();
+          }
+
+          if (obj instanceof Pair<?> // violation ''>' is followed by whitespace.'
+                  (var left, var right)) {
+              left.toString();
+          }
+
+          // ok - qualified name without space (DOT in AST, must not be flagged)
+          if (obj instanceof Outer.Pair<?>(var left, var right)) {
+              left.toString();
+          }
+
+          // qualified name with space after '>'
+          if (obj instanceof Outer.Pair<?> // violation ''>' is followed by whitespace.'
+                  (var left, var right)) {
+              left.toString();
+          }
+      }
+}


### PR DESCRIPTION
Fixes #20505.

Summary:
- Update `GenericWhitespaceCheck` to correctly recognize parameterized record patterns when the record type is qualified (for example, `Outer.Pair<?>`).
- Traverse the AST through the intermediate `DOT` node before checking for `RECORD_PATTERN_DEF`, preventing false positives while preserving the existing behavior for unqualified record patterns.
- Add regression coverage to ensure both qualified and unqualified parameterized record patterns are handled consistently.

Tests:
- Added a regression test for unqualified parameterized record patterns (`Pair<?>`) covering both valid and violation cases.
- Added a regression test for qualified parameterized record patterns (`Outer.Pair<?>`) covering both valid and violation cases.

Verification:
- `./mvnw -Dtest=GenericWhitespaceCheckTest#testParameterizedRecordPattern test`
- `./mvnw clean verify`