### PR TITLE
Issue #20624: Adding Example for missing property - regexp

### DIFF
--- a/src/site/xdoc/checks/regexp/regexp.xml
+++ b/src/site/xdoc/checks/regexp/regexp.xml
@@ -140,7 +140,7 @@
       </subsection>
 
       <subsection name="Examples" id="Regexp_Examples">
-        <p id="Example0-config"> Default configuration does nothing: </p>
+        <p id="Example1-config"> Default configuration does nothing: </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
@@ -148,7 +148,7 @@
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example1-config">
+        <p id="Example2-config">
           An example of how to configure the check to make sure a copyright
           statement is included in the file:
         </p>
@@ -161,11 +161,12 @@
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example1-code"> Example1: </p>
+        <p id="Example2-code"> Example2: </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// (c) MyCompany
+// (c) MyCompany
 // This code is copyrighted.
-public class Example1 {
-
+public class Example2 {
   private void foo() {
     System.out.println("");
     // System.out.println("debug");
@@ -174,7 +175,92 @@ public class Example1 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example7-config">Configure to ignore comments:</p>
+        <p id="Example3-config">
+          An example of how to configure the check to make sure a duplicate
+          pattern is not used:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="Regexp"&gt;
+      &lt;property name="format" value="// \(c\) MyCompany"/&gt;
+      &lt;property name="duplicateLimit" value="0"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code"> Example3: </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// (c) MyCompany
+// (c) MyCompany
+// This code is copyrighted.
+public class Example3 { // violation 2 lines above 'Found duplicate pattern'
+  private void foo() {
+    System.out.println("");
+    // System.out.println("debug");
+    // fix me.
+    // fix me.
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-config">
+          An example of how to configure the check to avoid using
+          System.out.println:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="Regexp"&gt;
+      &lt;property name="format" value="System\.out\.println"/&gt;
+      &lt;property name="illegalPattern" value="true"/&gt;
+      &lt;property name="message" value="Avoid using System.out.println"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-code"> Example4: </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// (c) MyCompany
+// (c) MyCompany
+// This code is copyrighted.
+public class Example4 {
+  private void foo() { // violation below 'Avoid using System.out...'
+    System.out.println("");
+    // System.out.println("debug");
+    // fix me.
+    // fix me.
+  } // violation 3 lines above 'Avoid using System.out...'
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          An example of how to configure the check to configure the error limit:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="Regexp"&gt;
+      &lt;property name="format" value="fix me\."/&gt;
+      &lt;property name="illegalPattern" value="true"/&gt;
+      &lt;property name="errorLimit" value="1"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code"> Example5: </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// (c) MyCompany
+// (c) MyCompany
+// This code is copyrighted.
+public class Example5 {
+  private void foo() {
+    System.out.println("");
+    // System.out.println("debug");
+    // fix me.
+    // fix me.
+  } // violation 2 lines above 'The error limit has been exceeded'
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example6-config">Configure to ignore comments:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
@@ -186,11 +272,12 @@ public class Example1 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example7-code">Example7:</p>
+        <p id="Example6-code">Example6:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// (c) MyCompany
+// (c) MyCompany
 // This code is copyrighted.
-public class Example7 {
-
+public class Example6 {
   private void foo() {  // violation below 'Line matches the illegal pattern'
     System.out.println("");
     // System.out.println("debug");

--- a/src/site/xdoc/checks/regexp/regexp.xml.template
+++ b/src/site/xdoc/checks/regexp/regexp.xml.template
@@ -28,37 +28,81 @@
       </subsection>
 
       <subsection name="Examples" id="Regexp_Examples">
-        <p id="Example0-config"> Default configuration does nothing: </p>
+        <p id="Example1-config"> Default configuration does nothing: </p>
         <macro name="example">
           <param name="path"
-            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example0.java"/>
+            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example1.java"/>
           <param name="type" value="config"/>
         </macro><hr class="example-separator"/>
-        <p id="Example1-config">
+        <p id="Example2-config">
           An example of how to configure the check to make sure a copyright
           statement is included in the file:
         </p>
         <macro name="example">
           <param name="path"
-            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example1.java"/>
+            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example2.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example1-code"> Example1: </p>
+        <p id="Example2-code"> Example2: </p>
         <macro name="example">
           <param name="path"
-            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example1.java"/>
+            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example2.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example7-config">Configure to ignore comments:</p>
+        <p id="Example3-config">
+          An example of how to configure the check to make sure a duplicate
+          pattern is not used:
+        </p>
         <macro name="example">
           <param name="path"
-            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example7.java"/>
+            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example3.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example7-code">Example7:</p>
+        <p id="Example3-code"> Example3: </p>
         <macro name="example">
           <param name="path"
-            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example7.java"/>
+            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example4-config">
+          An example of how to configure the check to avoid using
+          System.out.println:
+        </p>
+        <macro name="example">
+          <param name="path"
+            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-code"> Example4: </p>
+        <macro name="example">
+          <param name="path"
+            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example5-config">
+          An example of how to configure the check to configure the error limit:
+        </p>
+        <macro name="example">
+          <param name="path"
+            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example5.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example5-code"> Example5: </p>
+        <macro name="example">
+          <param name="path"
+            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example5.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example6-config">Configure to ignore comments:</p>
+        <macro name="example">
+          <param name="path"
+            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example6.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example6-code">Example6:</p>
+        <macro name="example">
+          <param name="path"
+            value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example6.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -203,7 +203,6 @@ public class XdocsExamplesAstConsistencyTest {
      */
     private static final Set<String> EXAMPLE_PROPERTY_COVERAGE_SUPPRESSED_MODULES = Set.of(
             // until https://github.com/checkstyle/checkstyle/issues/20624
-            "checks/regexp/regexp",
             "checks/metrics/classdataabstractioncoupling"
     );
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckExamplesTest.java
@@ -31,19 +31,50 @@ public class RegexpCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     }
 
     @Test
-    public void testExample0() throws Exception {
+    public void testExample1() throws Exception {
         final String[] expected = {
 
         };
 
-        verifyWithInlineConfigParser(getPath("Example0.java"), expected);
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
 
     @Test
-    public void testExample1() throws Exception {
+    public void testExample2() throws Exception {
         final String[] expected = {};
 
-        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = {
+            "15: Found duplicate pattern '// \\(c\\) MyCompany'.",
+        };
+
+        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+    }
+
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {
+            "7: Line matches the illegal pattern 'Avoid using System.out.println'.",
+            "21: Line matches the illegal pattern 'Avoid using System.out.println'.",
+            "22: Line matches the illegal pattern 'Avoid using System.out.println'.",
+        };
+
+        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+    }
+
+    @Test
+    public void testExample5() throws Exception {
+        final String[] expected = {
+            "22: Line matches the illegal pattern"
+                + " 'The error limit has been exceeded, the check is aborting,"
+                + " there may be more unreported errors.fix me\\.'.",
+        };
+
+        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
     }
 
     @Test
@@ -93,12 +124,12 @@ public class RegexpCheckExamplesTest extends AbstractExamplesModuleTestSupport {
     }
 
     @Test
-    public void testExample7() throws Exception {
+    public void testExample6() throws Exception {
         final String[] expected = {
-            "24: Line matches the illegal pattern 'System\\.out\\.println'.",
+            "20: Line matches the illegal pattern 'System\\.out\\.println'.",
         };
 
-        verifyWithInlineConfigParser(getPath("Example7.java"), expected);
+        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
     }
 
     @Test
@@ -138,5 +169,4 @@ public class RegexpCheckExamplesTest extends AbstractExamplesModuleTestSupport {
 
         verifyWithInlineConfigParser(getPath("UseCase7.java"), expected);
     }
-
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example2.java
@@ -1,7 +1,9 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="Regexp"/>
+    <module name="Regexp">
+      <property name="format" value="// This code is copyrighted\."/>
+    </module>
   </module>
 </module>
 */
@@ -11,7 +13,7 @@ package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 // (c) MyCompany
 // (c) MyCompany
 // This code is copyrighted.
-public class Example1 {
+public class Example2 {
   private void foo() {
     System.out.println("");
     // System.out.println("debug");

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example3.java
@@ -1,21 +1,20 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="Regexp"/>
+    <module name="Regexp">
+      <property name="format" value="// \(c\) MyCompany"/>
+      <property name="duplicateLimit" value="0"/>
+    </module>
   </module>
 </module>
 */
 
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
-
-// (c) MyCompany
-
-// (c) MyCompany
-
 // xdoc section -- start
+// (c) MyCompany
+// (c) MyCompany
 // This code is copyrighted.
-public class Example0 {
-
+public class Example3 { // violation 2 lines above 'Found duplicate pattern'
   private void foo() {
     System.out.println("");
     // System.out.println("debug");

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example4.java
@@ -4,27 +4,24 @@
     <module name="Regexp">
       <property name="format" value="System\.out\.println"/>
       <property name="illegalPattern" value="true"/>
-      <property name="ignoreComments" value="true"/>
+      <property name="message" value="Avoid using System.out.println"/>
     </module>
   </module>
 </module>
 */
 
+// violation 6 lines above 'Avoid using System...'
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
-
-// (c) MyCompany
-
-// (c) MyCompany
-
 // xdoc section -- start
+// (c) MyCompany
+// (c) MyCompany
 // This code is copyrighted.
-public class Example7 {
-
-  private void foo() {  // violation below 'Line matches the illegal pattern'
+public class Example4 {
+  private void foo() { // violation below 'Avoid using System.out...'
     System.out.println("");
     // System.out.println("debug");
     // fix me.
     // fix me.
-  }
+  } // violation 3 lines above 'Avoid using System.out...'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example5.java
@@ -1,7 +1,11 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="Regexp"/>
+    <module name="Regexp">
+      <property name="format" value="fix me\."/>
+      <property name="illegalPattern" value="true"/>
+      <property name="errorLimit" value="1"/>
+    </module>
   </module>
 </module>
 */
@@ -11,12 +15,12 @@ package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 // (c) MyCompany
 // (c) MyCompany
 // This code is copyrighted.
-public class Example1 {
+public class Example5 {
   private void foo() {
     System.out.println("");
     // System.out.println("debug");
     // fix me.
     // fix me.
-  }
+  } // violation 2 lines above 'The error limit has been exceeded'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexp/Example6.java
@@ -1,7 +1,11 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="Regexp"/>
+    <module name="Regexp">
+      <property name="format" value="System\.out\.println"/>
+      <property name="illegalPattern" value="true"/>
+      <property name="ignoreComments" value="true"/>
+    </module>
   </module>
 </module>
 */
@@ -11,8 +15,8 @@ package com.puppycrawl.tools.checkstyle.checks.regexp.regexp;
 // (c) MyCompany
 // (c) MyCompany
 // This code is copyrighted.
-public class Example1 {
-  private void foo() {
+public class Example6 {
+  private void foo() {  // violation below 'Line matches the illegal pattern'
     System.out.println("");
     // System.out.println("debug");
     // fix me.


### PR DESCRIPTION
#20624

Added examples for `errorLimit, message, duplicateLimit` regexp check