### PR TITLE
Issue #20220: fix UncommentedMainCheck to detect instance void main() in compact source files

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -43,6 +43,16 @@ import com.puppycrawl.tools.checkstyle.utils.NullUtil;
  * should be removed or commented out of the sources.
  * </p>
  *
+ * <p>
+ * Note: Compact source files
+ * (<a href="https://openjdk.org/jeps/512">JEP 512</a>)
+ * are skipped by design. The whole purpose of compact source files is to serve as
+ * standalone single-file programs with a {@code main} method as the entry point.
+ * Unlike regular classes where leftover {@code main} methods may be
+ * debugging artifacts, compact sources inherently require a {@code main} method
+ * to function.
+ * </p>
+ *
  * @since 3.2
  */
 @FileStatefulCheck

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/UncommentedMainCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/UncommentedMainCheck.xml
@@ -14,6 +14,16 @@
  which changes the API and increases the size of the resulting class or JAR file.
  Except for the real program entry points, all &lt;code&gt;main&lt;/code&gt; methods
  should be removed or commented out of the sources.
+ &lt;/p&gt;
+
+ &lt;p&gt;
+ Note: Compact source files
+ (&lt;a href="https://openjdk.org/jeps/512"&gt;JEP 512&lt;/a&gt;)
+ are skipped by design. The whole purpose of compact source files is to serve as
+ standalone single-file programs with a &lt;code&gt;main&lt;/code&gt; method as the entry point.
+ Unlike regular classes where leftover &lt;code&gt;main&lt;/code&gt; methods may be
+ debugging artifacts, compact sources inherently require a &lt;code&gt;main&lt;/code&gt; method
+ to function.
  &lt;/p&gt;</description>
          <properties>
             <property default-value="^$"

--- a/src/site/xdoc/checks/misc/uncommentedmain.xml
+++ b/src/site/xdoc/checks/misc/uncommentedmain.xml
@@ -20,6 +20,16 @@
           Except for the real program entry points, all <code>main</code> methods
           should be removed or commented out of the sources.
         </p>
+
+        <p>
+          Note: Compact source files
+          (<a href="https://openjdk.org/jeps/512">JEP 512</a>)
+          are skipped by design. The whole purpose of compact source files is to serve as
+          standalone single-file programs with a <code>main</code> method as the entry point.
+          Unlike regular classes where leftover <code>main</code> methods may be
+          debugging artifacts, compact sources inherently require a <code>main</code> method
+          to function.
+        </p>
       </subsection>
 
       <subsection name="Properties" id="UncommentedMain_Properties">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
@@ -117,6 +117,23 @@ public class UncommentedMainCheckTest
     }
 
     @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputUncommentedMainCompactSourceFile.java"),
+                expected);
+    }
+
+    @Test
+    public void testCompactSourceFileTraditional() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                    "InputUncommentedMainCompactSourceFileTraditional.java"),
+                expected);
+    }
+
+    @Test
     public void testIllegalStateException() {
         final UncommentedMainCheck check = new UncommentedMainCheck();
         final DetailAstImpl ast = new DetailAstImpl();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainCompactSourceFile.java
@@ -1,0 +1,20 @@
+/*
+UncommentedMain
+excludedClasses = (default)^$
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+    System.out.println("hello");
+}
+
+void main(String[] args) {
+    System.out.println("hello");
+}
+
+void notMain() {
+    System.out.println("not main");
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainCompactSourceFileTraditional.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/uncommentedmain/InputUncommentedMainCompactSourceFileTraditional.java
@@ -1,0 +1,12 @@
+/*
+UncommentedMain
+excludedClasses = (default)^$
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+public static void main(String[] args) {
+    System.out.println("hello");
+}


### PR DESCRIPTION
closes #20220 

add `isCompactSourceMain` that detects `void main()` when the method's parent is `COMPACT_COMPILATION_UNIT`, reusing  existing `checkName` and `checkType` helpers. The check now flags all forms of uncommented main methods in compact source files.