### PR TITLE
Issue #20819: XdocsExamplesAstConsistencyTest.testEveryPropertyHasAnE…

### DIFF
--- a/src/site/xdoc/checks/imports/importcontrol.xml
+++ b/src/site/xdoc/checks/imports/importcontrol.xml
@@ -147,9 +147,9 @@
           Results:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-package com.puppycrawl.tools.checkstyle.checks.imports.importcontrol;
-
 import java.awt.Image;     // violation, 'Disallowed import - java.awt.Image'
+import java.lang.ref.SoftReference;
+// violation above 'Disallowed import - java.lang.ref.SoftReference'
 import java.io.File;       // violation, 'Disallowed import - java.io.File'
 import java.io.FileReader;
 import java.util.Date;     // violation, 'Disallowed import - java.util.Date'
@@ -191,9 +191,9 @@ public class Example1 {}
           Results:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-package com.puppycrawl.tools.checkstyle.checks.imports.importcontrol;
-
 import java.awt.Image;
+import java.lang.ref.SoftReference;
+
 import java.io.File;
 import java.io.FileReader;
 import java.util.Date;
@@ -254,20 +254,13 @@ public class Example2 {}
           Results:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-package com.puppycrawl.tools.checkstyle.checks.imports.importcontrol.filters;
-
-import com.google.common.io.Files;
-import com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck;
-// violation above, 'Disallowed import'
-
-import java.lang.ref.ReferenceQueue;
-// violation above, 'Disallowed import - java.lang.ref.ReferenceQueue'
+import java.awt.Image;     // violation, 'Disallowed import - java.awt.Image'
 import java.lang.ref.SoftReference; // ok, specifically allowed by regex expression
 
-import java.util.Date; // violation 'Disallowed import - java.util.Date'
-import java.util.List; // violation 'Disallowed import - java.util.List'
-import java.util.Map;
-// violation above, 'Disallowed import - java.util.Map'
+import java.io.File;       // violation, 'Disallowed import - java.io.File'
+import java.io.FileReader; // violation, 'Disallowed import - java.io.FileReader'
+import java.util.Date;     // violation, 'Disallowed import - java.util.Date'
+import java.util.List;     // violation, 'Disallowed import - java.util.List'
 
 public class Example3 {}
 </code></pre></div><hr class="example-separator"/>

--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml
@@ -66,7 +66,6 @@
           package-info.java file is missing from directory.
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.nonlegacy;
 // violation first line 'Missing package-info.java file'
 public class Example1 { }
 </code></pre></div><hr class="example-separator"/>
@@ -91,9 +90,7 @@ public class Example1 { }
           file as an alternative to package-info.java removing violation
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.legacy;
-// ok as package.html file is present in directory
-public class Example2 { }
+public class Example2 { } // ok, package.html file is present in directory
 </code></pre></div><hr class="example-separator"/>
 
         <p id="Example3-config">
@@ -119,9 +116,34 @@ public class Example2 { }
           (either package-info.java or package.html) exists in a package.
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.legacywithboth;
 // violation first line 'Legacy package.html file should be removed'
 public class Example3 { }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure the check to only check <code>.properties</code> files
+          for a package documentation file:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="JavadocPackage"&gt;
+    &lt;property name="fileExtensions" value="properties"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example4-structure">
+          Directory structure with only a <code>.properties</code> file and no
+          <code>package-info.java</code>:<br/><br/>
+          Example4.java<br/><br/>
+          example.properties
+        </p>
+        <p id="Example4-code">
+          Since <code>fileExtensions</code> is set to <code>properties</code>,
+          the <code>.java</code> file is ignored, and the <code>.properties</code>
+          file is checked instead - triggering a violation since no
+          <code>package-info.java</code> is present:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example4 { } // ok, .java file is not checked
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
@@ -97,6 +97,32 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacywithboth/Example3.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example4-config">
+          To configure the check to only check <code>.properties</code> files
+          for a package documentation file:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/extensions/Example4.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example4-structure">
+          Directory structure with only a <code>.properties</code> file and no
+          <code>package-info.java</code>:<br/>
+          Example4.java<br/>
+          example.properties
+        </p>
+        <p id="Example4-code">
+          Since <code>fileExtensions</code> is set to <code>properties</code>,
+          the <code>.java</code> file is ignored, and the <code>.properties</code>
+          file is checked instead - triggering a violation since no
+          <code>package-info.java</code> is present:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/extensions/Example4.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
+++ b/src/site/xdoc/checks/metrics/classdataabstractioncoupling.xml
@@ -148,7 +148,8 @@ public class Example1 {
   private CharArrayWriter charArrayWriter = new CharArrayWriter();
 
   private PipedReader pipedReader = new PipedReader();
-  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
+  private BufferedReader bufferedReader =
+          new BufferedReader(pipedReader);
 }
 </code></pre></div><hr class="example-separator"/>
 
@@ -191,7 +192,8 @@ public class Example3 {
   private CharArrayWriter charArrayWriter = new CharArrayWriter();
 
   private PipedReader pipedReader = new PipedReader();
-  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
+  private BufferedReader bufferedReader =
+          new BufferedReader(pipedReader);
 }
 </code></pre></div><hr class="example-separator"/>
 
@@ -235,7 +237,8 @@ public class Example5 {
   private CharArrayWriter charArrayWriter = new CharArrayWriter();
 
   private PipedReader pipedReader = new PipedReader();
-  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
+  private BufferedReader bufferedReader =
+          new BufferedReader(pipedReader);
 }
 </code></pre></div><hr class="example-separator"/>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -90,6 +91,13 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * (e.g. {@code /* ok, allowMissingReturnTag is true *}{@code /}) are forbidden;
  * use single-line {@code //} comments instead. The
  * {@link #testNoBlockCommentMarkers()} test enforces this.
+ *
+ * <p>Modules may organize their examples into subdirectories (e.g.
+ * {@code classdataabstractioncoupling/ignore/deeper}) to group related
+ * use-cases. Example discovery for a module directory walks recursively
+ * into its own subtree so such examples are still counted as belonging to
+ * that module, while those subdirectories themselves are never treated as
+ * separate modules (see {@link #isModuleDirectory(Path)}).
  *
  */
 public class XdocsExamplesAstConsistencyTest {
@@ -146,64 +154,50 @@ public class XdocsExamplesAstConsistencyTest {
      * one-example-per-property mapping.
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
-        // until https://github.com/checkstyle/checkstyle/issues/20625
-        "checks/javadoc/atclauseorder",
-        "checks/annotation/annotationlocation",
-        "checks/annotation/suppresswarnings",
-        "checks/blocks/leftcurly",
-        "checks/coding/illegaltokentext",
-        "checks/coding/magicnumber",
-        "checks/descendanttoken",
-        "checks/imports/importcontrol",
-        "checks/imports/unusedimports",
-        "checks/javadoc/javadocblocktaglocation",
-        "checks/javadoc/javadocmethod",
-        "checks/javadoc/javadocparagraph",
-        "checks/javadoc/missingjavadocmethod",
-        "checks/javadoc/missingjavadoctype",
-        "checks/javadoc/nonemptyatclausedescription",
-        "checks/javadoc/summaryjavadoc",
-        "checks/javadoc/writetag",
-        "checks/metrics/classdataabstractioncoupling",
-        "checks/metrics/cyclomaticcomplexity",
-        "checks/modifier/interfacememberimpliedmodifier",
-        "checks/naming/abbreviationaswordinname",
-        "checks/naming/constantname",
-        "checks/naming/illegalidentifiername",
-        "checks/naming/localfinalvariablename",
-        "checks/naming/membername",
-        "checks/naming/methodname",
-        "checks/naming/staticvariablename",
-        "checks/naming/typename",
-        "checks/regexp/regexp",
-        "checks/regexp/regexpmultiline",
-        "checks/regexp/regexponfilename",
-        "checks/regexp/regexpsingleline",
-        "checks/regexp/regexpsinglelinejava",
-        "checks/sizes/methodcount",
-        "checks/sizes/methodlength",
-        "checks/sizes/parameternumber",
-        "checks/translation",
-        "checks/whitespace/methodparampad",
-        "checks/whitespace/nowhitespaceafter",
-        "checks/whitespace/operatorwrap",
-        "checks/whitespace/parenpad",
-        "checks/whitespace/separatorwrap",
-        "filters/suppressioncommentfilter",
-        "filters/suppressionsinglefilter",
-        "filters/suppressionxpathfilter",
-        "filters/suppressionxpathsinglefilter",
-        "filters/suppresswithnearbycommentfilter",
-        "filters/suppresswithnearbytextfilter"
-    );
-
-    /**
-     * Modules where the every-property-has-an-example validation should be skipped,
-     * pending individual fixes.
-     */
-    private static final Set<String> EXAMPLE_PROPERTY_COVERAGE_SUPPRESSED_MODULES = Set.of(
-            // until https://github.com/checkstyle/checkstyle/issues/20624
-            "checks/metrics/classdataabstractioncoupling"
+            // until https://github.com/checkstyle/checkstyle/issues/20625
+            "checks/javadoc/atclauseorder",
+            "checks/annotation/annotationlocation",
+            "checks/annotation/suppresswarnings",
+            "checks/blocks/leftcurly",
+            "checks/coding/illegaltokentext",
+            "checks/coding/magicnumber",
+            "checks/descendanttoken",
+            "checks/imports/unusedimports",
+            "checks/javadoc/javadocblocktaglocation",
+            "checks/javadoc/javadocmethod",
+            "checks/javadoc/javadocparagraph",
+            "checks/javadoc/missingjavadoctype",
+            "checks/javadoc/nonemptyatclausedescription",
+            "checks/javadoc/summaryjavadoc",
+            "checks/javadoc/writetag",
+            "checks/metrics/cyclomaticcomplexity",
+            "checks/modifier/interfacememberimpliedmodifier",
+            "checks/naming/abbreviationaswordinname",
+            "checks/naming/constantname",
+            "checks/naming/localfinalvariablename",
+            "checks/naming/membername",
+            "checks/naming/methodname",
+            "checks/naming/staticvariablename",
+            "checks/naming/typename",
+            "checks/regexp/regexp",
+            "checks/regexp/regexpmultiline",
+            "checks/regexp/regexponfilename",
+            "checks/regexp/regexpsingleline",
+            "checks/regexp/regexpsinglelinejava",
+            "checks/sizes/methodlength",
+            "checks/sizes/parameternumber",
+            "checks/translation",
+            "checks/whitespace/methodparampad",
+            "checks/whitespace/nowhitespaceafter",
+            "checks/whitespace/operatorwrap",
+            "checks/whitespace/parenpad",
+            "checks/whitespace/separatorwrap",
+            "filters/suppressioncommentfilter",
+            "filters/suppressionsinglefilter",
+            "filters/suppressionxpathfilter",
+            "filters/suppressionxpathsinglefilter",
+            "filters/suppresswithnearbycommentfilter",
+            "filters/suppresswithnearbytextfilter"
     );
 
     /**
@@ -257,6 +251,7 @@ public class XdocsExamplesAstConsistencyTest {
         try (Stream<Path> pathStream = Files.walk(XDOCS_ROOT)) {
             final List<Path> exampleDirs = pathStream
                     .filter(Files::isDirectory)
+                    .filter(XdocsExamplesAstConsistencyTest::isModuleDirectory)
                     .filter(XdocsExamplesAstConsistencyTest::containsMultipleExamples)
                     .toList();
 
@@ -368,6 +363,7 @@ public class XdocsExamplesAstConsistencyTest {
         try (Stream<Path> pathStream = Files.walk(XDOCS_ROOT)) {
             pathStream
                 .filter(Files::isDirectory)
+                .filter(XdocsExamplesAstConsistencyTest::isModuleDirectory)
                 .parallel()
                 .forEach(dir -> processDirectory(dir, violations));
         }
@@ -407,6 +403,7 @@ public class XdocsExamplesAstConsistencyTest {
         try (Stream<Path> pathStream = Files.walk(XDOCS_ROOT)) {
             pathStream
                 .filter(Files::isDirectory)
+                .filter(XdocsExamplesAstConsistencyTest::isModuleDirectory)
                 .parallel()
                 .forEach(dir -> processDirectoryForPropertyCoverage(dir, violations));
         }
@@ -416,6 +413,63 @@ public class XdocsExamplesAstConsistencyTest {
         assertWithMessage(message)
             .that(violations)
             .isEmpty();
+    }
+
+    /**
+     * Collects files from {@code dir} and its subdirectories, but never descends
+     * into a subdirectory that is itself a resolvable module directory (per
+     * {@link #isModuleDirectory}).
+     *
+     * <p>This is what keeps recursion properly scoped: (e.g.
+     * {@code classdataabstractioncoupling/ignore/deeper}), and those should be
+     * walked into. But some modules are nested as filesystem subdirectories of
+     * another, unrelated module (e.g. {@code checks/regexp/regexpmultiline} is
+     * its own module living under the {@code checks/regexp} module's directory);
+     * such subdirectories must be treated as separate module roots, not folded
+     * into the parent's examples.
+     *
+     * @param dir the directory to search
+     * @param fileFilter predicate selecting which regular files to collect
+     * @return the collected files, in no particular order
+     * @throws IOException if an I/O error occurs
+     */
+    private static List<Path> collectFilesWithinModule(Path dir,
+                   Predicate<Path> fileFilter) throws IOException {
+        final List<Path> result = new ArrayList<>();
+
+        try (Stream<Path> pathStream = Files.list(dir)) {
+            for (Path entry : pathStream.toList()) {
+                if (Files.isDirectory(entry)) {
+                    if (!isModuleDirectory(entry)) {
+                        result.addAll(collectFilesWithinModule(entry, fileFilter));
+                    }
+                }
+                else if (fileFilter.test(entry)) {
+                    result.add(entry);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Checks whether the given directory resolves to an actual checkstyle module
+     * (i.e. its name maps to a check/filter class via {@link #toModuleClassSimpleName}).
+     *
+     * <p>Used to keep example discovery scoped correctly: a module directory's
+     * own subdirectories (e.g. {@code classdataabstractioncoupling/ignore},
+     * {@code classdataabstractioncoupling/ignore/deeper}) do not themselves
+     * resolve to a module, so they are excluded from being processed as
+     * separate, independent modules - while {@link #getExampleFiles} and
+     * {@link #getExamplePropertyCoverageFiles} still walk into them when
+     * collecting examples that belong to the enclosing module.
+     *
+     * @param dir the directory to check
+     * @return true if the directory name resolves to a known module
+     */
+    private static boolean isModuleDirectory(Path dir) {
+        return toModuleClassSimpleName(dir.getFileName().toString()) != null;
     }
 
     private static void processDirectoryForPropertyCoverage(Path dir, List<String> violations) {
@@ -494,11 +548,9 @@ public class XdocsExamplesAstConsistencyTest {
      */
     private static String checkPropertyCoverage(Path dir, List<Path> examples)
             throws IOException {
-        final String relativePath = getRelativePath(dir);
         String result = null;
 
-        if (!EXAMPLE_PROPERTY_COVERAGE_SUPPRESSED_MODULES.contains(relativePath)
-            && !isModuleWithNoProperties(examples)) {
+        if (!isModuleWithNoProperties(examples)) {
 
             final String moduleName = toModuleClassSimpleName(dir.getFileName().toString());
 
@@ -511,7 +563,7 @@ public class XdocsExamplesAstConsistencyTest {
                     final Set<String> configuredProperties = new HashSet<>();
                     for (Path example : examples) {
                         configuredProperties.addAll(
-                            extractConfiguredPropertyNames(example, xmlModuleName));
+                                extractConfiguredPropertyNames(example, xmlModuleName));
                     }
 
                     final Set<String> uncoveredProperties = new HashSet<>(documentedProperties);
@@ -519,9 +571,10 @@ public class XdocsExamplesAstConsistencyTest {
                     uncoveredProperties.removeAll(IGNORED_PROPERTIES_FOR_COVERAGE);
 
                     if (!uncoveredProperties.isEmpty()) {
+                        final String relativePath = getRelativePath(dir);
                         result = "Directory: " + relativePath
-                            + "\nDocumented properties: " + documentedProperties
-                            + "\nProperties with no covering example: " + uncoveredProperties;
+                                + "\nDocumented properties: " + documentedProperties
+                                + "\nProperties with no covering example: " + uncoveredProperties;
                     }
                 }
             }
@@ -1035,16 +1088,19 @@ public class XdocsExamplesAstConsistencyTest {
     }
 
     /**
-     * Checks if a directory contains multiple example files.
+     * Checks if a directory contains multiple example files, including any
+     * contained in its own non-module subdirectories (see
+     * {@link #collectFilesWithinModule}).
      *
      * @param dir the directory to check
-     * @return true if the directory contains 2 or more Example*.java files
+     * @return true if the directory (recursively, stopping at nested module
+     *         boundaries) contains 2 or more Example*.java files
      */
     private static boolean containsMultipleExamples(Path dir) {
-        try (Stream<Path> pathStream = Files.list(dir)) {
-            return pathStream
-                    .filter(path -> path.getFileName().toString().matches("Example\\d+\\.java"))
-                    .count() > 1;
+        try {
+            return collectFilesWithinModule(dir,
+                    path -> path.getFileName().toString().matches("Example\\d+\\.java"))
+                    .size() > 1;
         }
         catch (IOException exception) {
             throw new IllegalStateException("Failed to list files in directory: " + dir,
@@ -1071,27 +1127,34 @@ public class XdocsExamplesAstConsistencyTest {
     }
 
     /**
-     * Gets all Example*.java files from a directory.
+     * Gets all Example*.java files from a directory, including those found in
+     * its own subdirectories (e.g. modules that group related use-cases into
+     * folders such as {@code ignore} or {@code ignore/deeper}).
      *
-     * @param dir the directory to search
+     * <p>This walk is always rooted at a single module directory (callers only
+     * ever pass directories for which {@link #isModuleDirectory} is true), and
+     * via {@link #collectFilesWithinModule} it stops descending as soon as it
+     * hits a subdirectory that is itself a resolvable module directory - so it
+     * never crosses into sibling/nested module directories (e.g.
+     * {@code checks/regexp/regexpmultiline} is excluded from
+     * {@code checks/regexp}'s examples).
+     *
+     * @param dir the module directory to search
      * @return list of example file paths
      * @throws IOException if an I/O error occurs
      */
     private static List<Path> getExampleFiles(Path dir) throws IOException {
-        final List<Path> examples;
-        try (Stream<Path> pathStream = Files.list(dir)) {
-            examples = pathStream
-                    .filter(path -> path.getFileName().toString().matches("Example\\d+\\.java"))
-                    .sorted(Comparator.comparing(Path::toString))
-                    .toList();
-        }
-        return examples;
+        final List<Path> examples = collectFilesWithinModule(dir,
+                path -> path.getFileName().toString().matches("Example\\d+\\.java"));
+        return examples.stream()
+                .sorted(Comparator.comparing(Path::toString))
+                .toList();
     }
 
     /**
-     * Gets all Example* files from a directory that contain an embedded
-     * {@code /*xml ... *}{@code /} configuration block, regardless of file
-     * extension (or the lack of one).
+     * Gets all Example* files from a directory (and its own subdirectories)
+     * that contain an embedded {@code /*xml ... *}{@code /} configuration
+     * block, regardless of file extension (or the lack of one).
      *
      * <p>Used only for property-coverage checking ({@link #testEveryPropertyHasAnExample}),
      * which inspects that embedded block via plain text/DOM extraction rather
@@ -1103,21 +1166,22 @@ public class XdocsExamplesAstConsistencyTest {
      * are excluded, since they have nothing to contribute and aren't reliably
      * identifiable by extension alone.
      *
-     * @param dir the directory to search
+     * <p>As with {@link #getExampleFiles}, this walk is rooted at a single
+     * module directory and, via {@link #collectFilesWithinModule}, stops
+     * descending at any nested module directory boundary.
+     *
+     * @param dir the module directory to search
      * @return list of example file paths containing an XML config block
      * @throws IOException if an I/O error occurs
      */
     private static List<Path> getExamplePropertyCoverageFiles(Path dir) throws IOException {
-        final List<Path> examples;
-        try (Stream<Path> pathStream = Files.list(dir)) {
-            examples = pathStream
-                    .filter(Files::isRegularFile)
-                    .filter(path -> path.getFileName().toString().matches("Example\\d+(\\..+)?"))
-                    .filter(XdocsExamplesAstConsistencyTest::hasXmlConfigBlock)
-                    .sorted(Comparator.comparing(Path::toString))
-                    .toList();
-        }
-        return examples;
+        final List<Path> examples = collectFilesWithinModule(dir, path -> {
+            return path.getFileName().toString().matches("Example\\d+(\\..+)?")
+                    && hasXmlConfigBlock(path);
+        });
+        return examples.stream()
+                .sorted(Comparator.comparing(Path::toString))
+                .toList();
     }
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckExamplesTest.java
@@ -35,13 +35,15 @@ public class ImportControlCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(
+            "13:1: " + getCheckMessage(
                     ImportControlCheck.MSG_DISALLOWED, "java.awt.Image"),
-            "15:1: " + getCheckMessage(
+            "14:1: " + getCheckMessage(
+                    ImportControlCheck.MSG_DISALLOWED, "java.lang.ref.SoftReference"),
+            "16:1: " + getCheckMessage(
                     ImportControlCheck.MSG_DISALLOWED, "java.io.File"),
-            "17:1: " + getCheckMessage(
-                    ImportControlCheck.MSG_DISALLOWED, "java.util.Date"),
             "18:1: " + getCheckMessage(
+                    ImportControlCheck.MSG_DISALLOWED, "java.util.Date"),
+            "19:1: " + getCheckMessage(
                     ImportControlCheck.MSG_DISALLOWED, "java.util.List"),
         };
 
@@ -62,17 +64,16 @@ public class ImportControlCheckExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "15:1: " + getCheckMessage(
-                    ImportControlCheck.MSG_DISALLOWED,
-                "com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck"),
+            "13:1: " + getCheckMessage(
+                    ImportControlCheck.MSG_DISALLOWED, "java.awt.Image"),
+            "16:1: " + getCheckMessage(
+                    ImportControlCheck.MSG_DISALLOWED, "java.io.File"),
+            "17:1: " + getCheckMessage(
+                    ImportControlCheck.MSG_DISALLOWED, "java.io.FileReader"),
             "18:1: " + getCheckMessage(
-                    ImportControlCheck.MSG_DISALLOWED, "java.lang.ref.ReferenceQueue"),
-            "22:1: " + getCheckMessage(
                     ImportControlCheck.MSG_DISALLOWED, "java.util.Date"),
-            "23:1: " + getCheckMessage(
+            "19:1: " + getCheckMessage(
                     ImportControlCheck.MSG_DISALLOWED, "java.util.List"),
-            "24:1: " + getCheckMessage(
-                    ImportControlCheck.MSG_DISALLOWED, "java.util.Map"),
         };
 
         final String examplePath = new File("src/" + getResourceLocation()

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckExamplesTest.java
@@ -59,4 +59,11 @@ public class JavadocPackageCheckExamplesTest extends AbstractExamplesModuleTestS
         verifyWithInlineConfigParser(getPath("legacywithboth/Example3.java"), expected);
     }
 
+    @Test
+    public void testExample4() throws Exception {
+        final String[] expected = {};
+
+        verifyWithInlineConfigParser(getPath("extensions/Example4.java"), expected);
+    }
+
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/Example1.java
@@ -8,10 +8,11 @@
 </module>
 */
 
-// xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.imports.importcontrol;
-
+// xdoc section -- start
 import java.awt.Image;     // violation, 'Disallowed import - java.awt.Image'
+import java.lang.ref.SoftReference;
+// violation above 'Disallowed import - java.lang.ref.SoftReference'
 import java.io.File;       // violation, 'Disallowed import - java.io.File'
 import java.io.FileReader;
 import java.util.Date;     // violation, 'Disallowed import - java.util.Date'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/Example2.java
@@ -8,11 +8,11 @@
   </module>
 </module>
 */
-
-// xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.imports.importcontrol;
-
+// xdoc section -- start
 import java.awt.Image;
+import java.lang.ref.SoftReference;
+
 import java.io.File;
 import java.io.FileReader;
 import java.util.Date;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/filters/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/filters/Example3.java
@@ -8,21 +8,15 @@
 </module>
 */
 
-// xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.imports.importcontrol.filters;
-
-import com.google.common.io.Files;
-import com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck;
-// violation above, 'Disallowed import'
-
-import java.lang.ref.ReferenceQueue;
-// violation above, 'Disallowed import - java.lang.ref.ReferenceQueue'
+// xdoc section -- start
+import java.awt.Image;     // violation, 'Disallowed import - java.awt.Image'
 import java.lang.ref.SoftReference; // ok, specifically allowed by regex expression
 
-import java.util.Date; // violation 'Disallowed import - java.util.Date'
-import java.util.List; // violation 'Disallowed import - java.util.List'
-import java.util.Map;
-// violation above, 'Disallowed import - java.util.Map'
+import java.io.File;       // violation, 'Disallowed import - java.io.File'
+import java.io.FileReader; // violation, 'Disallowed import - java.io.FileReader'
+import java.util.Date;     // violation, 'Disallowed import - java.util.Date'
+import java.util.List;     // violation, 'Disallowed import - java.util.List'
 
 public class Example3 {}
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/extensions/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/extensions/Example4.java
@@ -1,0 +1,12 @@
+/*xml
+<module name="Checker">
+  <module name="JavadocPackage">
+    <property name="fileExtensions" value="properties"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.extensions;
+// xdoc section -- start
+
+public class Example4 { } // ok, .java file is not checked
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/extensions/example4.properties
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/extensions/example4.properties
@@ -1,0 +1,4 @@
+# xdoc section -- start
+# violation first line 'Missing package-info.java file'
+# xdoc section -- end
+example.key=example.value

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacy/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacy/Example2.java
@@ -5,8 +5,8 @@
   </module>
 </module>
 */
-// xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.legacy;
-// ok as package.html file is present in directory
-public class Example2 { }
+// xdoc section -- start
+
+public class Example2 { } // ok, package.html file is present in directory
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacywithboth/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacywithboth/Example3.java
@@ -5,8 +5,8 @@
   </module>
 </module>
 */
-// xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.legacywithboth;
+// xdoc section -- start
 // violation first line 'Legacy package.html file should be removed'
 public class Example3 { }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/nonlegacy/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/nonlegacy/Example1.java
@@ -3,8 +3,8 @@
   <module name="JavadocPackage"/>
 </module>
 */
-// xdoc section -- start
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.nonlegacy;
+// xdoc section -- start
 // violation first line 'Missing package-info.java file'
 public class Example1 { }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example1.java
@@ -41,6 +41,7 @@ public class Example1 {
   private CharArrayWriter charArrayWriter = new CharArrayWriter();
 
   private PipedReader pipedReader = new PipedReader();
-  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
+  private BufferedReader bufferedReader =
+          new BufferedReader(pipedReader);
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/Example3.java
@@ -43,6 +43,7 @@ public class Example3 {
   private CharArrayWriter charArrayWriter = new CharArrayWriter();
 
   private PipedReader pipedReader = new PipedReader();
-  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
+  private BufferedReader bufferedReader =
+          new BufferedReader(pipedReader);
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classdataabstractioncoupling/ignore/deeper/Example5.java
@@ -47,6 +47,7 @@ public class Example5 {
   private CharArrayWriter charArrayWriter = new CharArrayWriter();
 
   private PipedReader pipedReader = new PipedReader();
-  private BufferedReader bufferedReader = new BufferedReader(pipedReader);
+  private BufferedReader bufferedReader =
+          new BufferedReader(pipedReader);
 }
 // xdoc section -- end


### PR DESCRIPTION
#20819

### Fix
- Added a boundary-aware recursive file collector that walks into a module's own subfolders but stops at any subdirectory that is itself a separate module.
- Removed `classdataabstractioncoupling` from the property-coverage suppression list.
- Added a new example covering the previously-uncovered `fileExtensions` property on `JavadocPackage`.
