### PR TITLE
Issue #20827: Missing violateExecutionOnNonTightHtml exclusion in tes…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -161,13 +161,7 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/coding/illegaltokentext",
             "checks/coding/magicnumber",
             "checks/descendanttoken",
-            "checks/imports/unusedimports",
             "checks/javadoc/javadocblocktaglocation",
-            "checks/javadoc/javadocmethod",
-            "checks/javadoc/javadocparagraph",
-            "checks/javadoc/missingjavadoctype",
-            "checks/javadoc/nonemptyatclausedescription",
-            "checks/javadoc/summaryjavadoc",
             "checks/javadoc/writetag",
             "checks/metrics/cyclomaticcomplexity",
             "checks/modifier/interfacememberimpliedmodifier",
@@ -961,8 +955,9 @@ public class XdocsExamplesAstConsistencyTest {
         int count = -1;
         try {
             final Object instance = SiteUtil.getModuleInstance(moduleName);
-            final Set<String> properties = SiteUtil.getPropertiesForDocumentation(
-                instance.getClass(), instance);
+            final Set<String> properties = new HashSet<>(SiteUtil.getPropertiesForDocumentation(
+                    instance.getClass(), instance));
+            properties.removeAll(IGNORED_PROPERTIES_FOR_COVERAGE);
             count = properties.size();
         }
         catch (MacroExecutionException exception) {


### PR DESCRIPTION
#20827 

added missing `violateExecutionOnNonTightHtml  `exclusion
removed unnecessary suppressions