### PR TITLE
Issue #20625: Add baseline example for LocalFinalVariableName

### DIFF
--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml
@@ -96,6 +96,33 @@ class Example1 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
+        <p id="Example2-config">
+          To configure the check with default properties:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="LocalFinalVariableName"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example2-code">Code Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example2 {
+  void MyMethod() {
+    try (Scanner scanner = new Scanner(System.in)) {
+
+      final int VAR1 = 5;  // violation 'Name 'VAR1' must match pattern'
+      final int var1 = 10;
+    }
+    catch (final Exception ex) {
+
+      final int VAR2 = 15; // violation 'Name 'VAR2' must match pattern'
+      final int var2 = 20;
+    }
+  }
+}
+</code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
           An example of how to configure the check for names of local final parameters and
           resources in try statements (without checks on variables):

--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml.template
@@ -42,6 +42,20 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example1.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
+        <p id="Example2-config">
+          To configure the check with default properties:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code">Code Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example2.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
         <p id="Example3-config">
           An example of how to configure the check for names of local final parameters and
           resources in try statements (without checks on variables):

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -166,7 +166,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/modifier/interfacememberimpliedmodifier",
             "checks/naming/abbreviationaswordinname",
             "checks/naming/constantname",
-            "checks/naming/localfinalvariablename",
             "checks/naming/membername",
             "checks/naming/methodname",
             "checks/naming/staticvariablename",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckExamplesTest.java
@@ -43,15 +43,15 @@ public class LocalFinalVariableNameCheckExamplesTest extends AbstractExamplesMod
     }
 
     @Test
-    public void testUseCase1() throws Exception {
+    public void testExample2() throws Exception {
         final String[] expected = {
-            "18:18: " + getCheckMessage(MSG_INVALID_PATTERN, "scanner", "^[A-Z][A-Z0-9]*$"),
-            "21:17: " + getCheckMessage(MSG_INVALID_PATTERN, "var1", "^[A-Z][A-Z0-9]*$"),
-            "23:28: " + getCheckMessage(MSG_INVALID_PATTERN, "ex", "^[A-Z][A-Z0-9]*$"),
-            "26:17: " + getCheckMessage(MSG_INVALID_PATTERN, "var2", "^[A-Z][A-Z0-9]*$"),
+            "18:17: " + getCheckMessage(
+                    MSG_INVALID_PATTERN, "VAR1", "^([a-z][a-zA-Z0-9]*|_)$"),
+            "23:17: " + getCheckMessage(
+                    MSG_INVALID_PATTERN, "VAR2", "^([a-z][a-zA-Z0-9]*|_)$"),
         };
 
-        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
+        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
 
     @Test
@@ -62,6 +62,18 @@ public class LocalFinalVariableNameCheckExamplesTest extends AbstractExamplesMod
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+    }
+
+    @Test
+    public void testUseCase1() throws Exception {
+        final String[] expected = {
+            "18:18: " + getCheckMessage(MSG_INVALID_PATTERN, "scanner", "^[A-Z][A-Z0-9]*$"),
+            "21:17: " + getCheckMessage(MSG_INVALID_PATTERN, "var1", "^[A-Z][A-Z0-9]*$"),
+            "23:28: " + getCheckMessage(MSG_INVALID_PATTERN, "ex", "^[A-Z][A-Z0-9]*$"),
+            "26:17: " + getCheckMessage(MSG_INVALID_PATTERN, "var2", "^[A-Z][A-Z0-9]*$"),
+        };
+
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example2.java
@@ -1,0 +1,28 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="LocalFinalVariableName"/>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.naming.localfinalvariablename;
+
+import java.util.Scanner;
+
+// xdoc section -- start
+class Example2 {
+  void MyMethod() {
+    try (Scanner scanner = new Scanner(System.in)) {
+
+      final int VAR1 = 5;  // violation 'Name 'VAR1' must match pattern'
+      final int var1 = 10;
+    }
+    catch (final Exception ex) {
+
+      final int VAR2 = 15; // violation 'Name 'VAR2' must match pattern'
+      final int var2 = 20;
+    }
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
Part of #20625

Adds a default-configuration baseline example for
`LocalFinalVariableNameCheck`.

The module documents two properties, `format` and `tokens`, so its
AST-consistent example group now contains three examples:

- a baseline example using the default configuration;
- an example demonstrating `format`;
- an example demonstrating `tokens` with a custom `format`.

The module was also removed from
`EXAMPLE_COUNT_SUPPRESSED_MODULES`.