### PR TITLE
Issue #20625: Add property examples for ParenPad

### DIFF
--- a/src/site/xdoc/checks/whitespace/parenpad.xml
+++ b/src/site/xdoc/checks/whitespace/parenpad.xml
@@ -207,8 +207,7 @@ class Example1 {
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
-          To configure the check to require spaces for the parentheses of
-          constructor, method, and super constructor calls:
+          To configure the check for selected tokens:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -216,7 +215,6 @@ class Example1 {
     &lt;module name="ParenPad"&gt;
       &lt;property name="tokens"
                 value="LITERAL_FOR, LITERAL_CATCH, SUPER_CTOR_CALL"/&gt;
-      &lt;property name="option" value="space"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -232,12 +230,12 @@ class Example2 {
   public void fun() {
     try {
       throw new IOException();
-    } catch( IOException e) {} // violation 'not preceded with whitespace'
-    catch(Exception e ) {} // violation 'not followed by whitespace'
+    } catch( IOException e) {} // violation 'is followed by whitespace'
+    catch(Exception e ) {}  // violation 'is preceded with whitespace'
     for ( int i = 0; i &lt; x; i++ ) {
-
-
-
+      // 2 violations above:
+      // ''(' is followed by whitespace'
+      // '')' is preceded with whitespace'
     }
   }
 
@@ -252,9 +250,66 @@ class Example2 {
 
   class Example3 extends Example2 {
     public Example3() {
-      super(1 ); // violation 'not followed by whitespace'
+      super(1 ); // violation '')' is preceded with whitespace'
     }
     public Example3(int k) {
+      super( k );
+      // 2 violations above:
+      // ''(' is followed by whitespace'
+      // '')' is preceded with whitespace'
+      for ( int i = 0; i &lt; k; i++) { // violation ''(' is followed by whitespace'
+      }
+    }
+  }
+}
+</code></pre></div>
+        <hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check to require spaces inside parentheses:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ParenPad"&gt;
+      &lt;property name="option" value="space"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example3 {
+  int x;
+  public Example3( int n) {} // violation '')' is not preceded with whitespace'
+
+  public void fun() {
+    try {
+      throw new IOException();
+    } catch( IOException e) {} // violation 'not preceded with whitespace'
+    catch(Exception e ) {} // violation 'not followed by whitespace'
+    for ( int i = 0; i &lt; x; i++ ) {
+
+
+
+    }
+  }
+
+  public void fun2() {
+    switch( x) { // violation 'not preceded with whitespace'
+      case 2:
+        break;
+      default:
+        break;
+    }
+  }
+
+  class Example4 extends Example3 {
+    public Example4() {
+      super(1 ); // violation 'not followed by whitespace'
+    }
+    public Example4( int k) { // violation '')' is not preceded with whitespace'
       super( k );
 
 

--- a/src/site/xdoc/checks/whitespace/parenpad.xml.template
+++ b/src/site/xdoc/checks/whitespace/parenpad.xml.template
@@ -45,8 +45,7 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example2-config">
-          To configure the check to require spaces for the parentheses of
-          constructor, method, and super constructor calls:
+          To configure the check for selected tokens:
         </p>
         <macro name="example">
           <param name="path"
@@ -59,6 +58,23 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example2.java"/>
+          <param name="type" value="code"/>
+        </macro>
+        <hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check to require spaces inside parentheses:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example3.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -182,7 +182,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/whitespace/methodparampad",
             "checks/whitespace/nowhitespaceafter",
             "checks/whitespace/operatorwrap",
-            "checks/whitespace/parenpad",
             "checks/whitespace/separatorwrap",
             "filters/suppressioncommentfilter",
             "filters/suppressionsinglefilter",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadExamplesTest.java
@@ -55,13 +55,32 @@ public class ParenPadExamplesTest extends AbstractExamplesModuleTestSupport {
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "27:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
-            "28:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
-            "47:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
-            "54:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "26:12: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
+            "27:23: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
+            "28:9: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
+            "28:33: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
+            "46:15: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
+            "49:12: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
+            "49:16: " + getCheckMessage(MSG_WS_PRECEDED, ")"),
+            "53:11: " + getCheckMessage(MSG_WS_FOLLOWED, "("),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = {
+            "18:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "23:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "24:10: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
+            "33:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "43:12: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "("),
+            "45:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+            "50:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ")"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example2.java
@@ -4,7 +4,6 @@
     <module name="ParenPad">
       <property name="tokens"
                 value="LITERAL_FOR, LITERAL_CATCH, SUPER_CTOR_CALL"/>
-      <property name="option" value="space"/>
     </module>
   </module>
 </module>
@@ -24,12 +23,12 @@ class Example2 {
   public void fun() {
     try {
       throw new IOException();
-    } catch( IOException e) {} // violation 'not preceded with whitespace'
-    catch(Exception e ) {} // violation 'not followed by whitespace'
+    } catch( IOException e) {} // violation 'is followed by whitespace'
+    catch(Exception e ) {}  // violation 'is preceded with whitespace'
     for ( int i = 0; i < x; i++ ) {
-
-
-
+      // 2 violations above:
+      // ''(' is followed by whitespace'
+      // '')' is preceded with whitespace'
     }
   }
 
@@ -44,14 +43,14 @@ class Example2 {
 
   class Example3 extends Example2 {
     public Example3() {
-      super(1 ); // violation 'not followed by whitespace'
+      super(1 ); // violation '')' is preceded with whitespace'
     }
     public Example3(int k) {
       super( k );
-
-
-      // violation below 'not preceded with whitespace'
-      for ( int i = 0; i < k; i++) {
+      // 2 violations above:
+      // ''(' is followed by whitespace'
+      // '')' is preceded with whitespace'
+      for ( int i = 0; i < k; i++) { // violation ''(' is followed by whitespace'
       }
     }
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/parenpad/Example3.java
@@ -1,0 +1,55 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ParenPad">
+      <property name="option" value="space"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.parenpad;
+
+import java.io.IOException;
+
+// xdoc section -- start
+class Example3 {
+  int x;
+  public Example3( int n) {} // violation '')' is not preceded with whitespace'
+
+  public void fun() {
+    try {
+      throw new IOException();
+    } catch( IOException e) {} // violation 'not preceded with whitespace'
+    catch(Exception e ) {} // violation 'not followed by whitespace'
+    for ( int i = 0; i < x; i++ ) {
+
+
+
+    }
+  }
+
+  public void fun2() {
+    switch( x) { // violation 'not preceded with whitespace'
+      case 2:
+        break;
+      default:
+        break;
+    }
+  }
+
+  class Example4 extends Example3 {
+    public Example4() {
+      super(1 ); // violation 'not followed by whitespace'
+    }
+    public Example4( int k) { // violation '')' is not preceded with whitespace'
+      super( k );
+
+
+      // violation below 'not preceded with whitespace'
+      for ( int i = 0; i < k; i++) {
+      }
+    }
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
Part of #20625

Separates the `ParenPadCheck` examples so its two documented properties are
demonstrated independently.

The AST-consistent example group now contains:

- a baseline example using default configuration;
- an example demonstrating `tokens`;
- an example demonstrating `option`.

The module was also removed from
`EXAMPLE_COUNT_SUPPRESSED_MODULES`.