### PR TITLE
Issue #20690: register custom javadoc tags to fix warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -619,14 +619,17 @@
               <tag>
                 <name>noinspection</name>
                 <placement>X</placement>
+                <head>noinspection</head>
               </tag>
               <tag>
                 <name>noinspectionreason</name>
                 <placement>X</placement>
+                <head>noinspectionreason</head>
               </tag>
               <tag>
                 <name>propertySince</name>
                 <placement>X</placement>
+                <head>propertySince</head>
               </tag>
             </tags>
           </configuration>


### PR DESCRIPTION
 for Issue #20690.

Summary:
- Register custom Javadoc tags by adding `head` entries to the Maven Javadoc Plugin configuration.
- Eliminates Javadoc warnings for:
  - `@noinspection`
  - `@noinspectionreason`
  - `@propertySince`

Verification:
- `./mvnw clean javadoc:javadoc` → BUILD SUCCESS
- `./mvnw clean verify` → BUILD SUCCESS

The custom tag warnings are no longer emitted.