### PR TITLE
Issue #20838: enforce referencing of all examples in xdocs template

### DIFF
--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml
@@ -95,12 +95,12 @@ import com.puppycrawl.tools. // violation 'should not be line-wrapped'
 import static java.math.     // violation 'should not be line-wrapped'
   BigInteger.ZERO;
 
-class                        // violation 'should not be line-wrapped'
+class
   Example1 {
 
-  public                     // violation 'should not be line-wrapped'
+  public
     Example1() {}
-  public void                // violation 'should not be line-wrapped'
+  public void
     doSomething() {}
 }
 </code></pre></div><hr class="example-separator"/>
@@ -138,7 +138,37 @@ class
   public void
     doSomething() {}
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check for Java 21+ (default values):
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="NoLineWrap"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
 </code></pre></div>
+        <p id="Example3-code">
+          Example of line-wrapped statements for Java 21+ (bad case):
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation below 'should not be line-wrapped'
+package com.puppycrawl.
+  tools.checkstyle.checks.whitespace.nolinewrap;
+
+// violation below 'should not be line-wrapped'
+import java.util.
+  List;
+
+// violation below 'should not be line-wrapped'
+import module
+  java.base;
+
+// violation below 'should not be line-wrapped'
+import static java.math.
+  BigInteger.ZERO;
+</code></pre></div><hr class="example-separator"/>
       </subsection>
 
       <subsection name="Use Cases" id="NoLineWrap_Use_Cases">

--- a/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
+++ b/src/site/xdoc/checks/whitespace/nolinewrap.xml.template
@@ -61,7 +61,23 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example2.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example3-config">
+          To configure the check for Java 21+ (default values):
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example3.java"/>
+          <param name="type" value="config"/>
         </macro>
+        <p id="Example3-code">
+          Example of line-wrapped statements for Java 21+ (bad case):
+        </p>
+        <macro name="example">
+          <param name="path"
+          value="resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example3.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
       </subsection>
 
       <subsection name="Use Cases" id="NoLineWrap_Use_Cases">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,10 +38,14 @@ import java.util.stream.Stream;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.internal.utils.XdocUtil;
+import com.puppycrawl.tools.checkstyle.internal.utils.XmlUtil;
 
 public class XdocsExampleFileTest {
 
@@ -113,6 +118,90 @@ public class XdocsExampleFileTest {
                     + String.join("\n", failures))
                     .fail();
         }
+    }
+
+    @Test
+    public void testAllExampleFilesAreReferencedInXdocs() throws Exception {
+        final Set<String> referencedPaths = collectReferencedExamplePaths();
+        final Path xdocsExamplesBase = Path.of("src/xdocs-examples");
+        final List<Path> exampleRoots = List.of(
+            xdocsExamplesBase.resolve("resources"),
+            xdocsExamplesBase.resolve("resources-noncompilable")
+        );
+        final List<String> failures = new ArrayList<>();
+
+        for (Path root : exampleRoots) {
+            if (Files.exists(root)) {
+                try (Stream<Path> paths = Files.walk(root)) {
+                    paths
+                        .filter(path -> {
+                            final String fileName = path.getFileName().toString();
+                            return Files.isRegularFile(path)
+                                && (fileName.startsWith("Example")
+                                    || fileName.startsWith("UseCase"));
+                        })
+                        .forEach(exampleFile -> {
+                            final String relative = xdocsExamplesBase
+                                .relativize(exampleFile)
+                                .toString()
+                                .replace(File.separatorChar, '/');
+                            if (!referencedPaths.contains(relative)) {
+                                failures.add(relative);
+                            }
+                        });
+                }
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            assertWithMessage(
+                "The following example files are not referenced in any xml.template file:\n"
+                    + String.join("\n", failures))
+                .fail();
+        }
+    }
+
+    private static Set<String> collectReferencedExamplePaths() throws Exception {
+        final Set<String> referenced = new HashSet<>();
+
+        for (Path template : XdocUtil.getXdocsTemplatesFilePaths()) {
+            final String input = Files.readString(template);
+            final Document document = XmlUtil.getRawXml(template.toString(), input, input);
+            final NodeList macros = document.getElementsByTagName("macro");
+
+            for (int idx = 0; idx < macros.getLength(); idx++) {
+                final Element macro = (Element) macros.item(idx);
+                if ("example".equals(macro.getAttribute("name"))) {
+                    final String path = getMacroParamValue(macro, "path");
+                    if (path != null && !path.isEmpty()) {
+                        referenced.add(normalizePath(path));
+                    }
+                }
+            }
+        }
+        return referenced;
+    }
+
+    private static String getMacroParamValue(Element macro, String paramName) {
+        String result = null;
+        final NodeList params = macro.getElementsByTagName("param");
+
+        for (int idx = 0; idx < params.getLength(); idx++) {
+            final Element param = (Element) params.item(idx);
+            if (paramName.equals(param.getAttribute("name"))) {
+                result = param.getAttribute("value");
+                break;
+            }
+        }
+        return result;
+    }
+
+    private static String normalizePath(String path) {
+        String result = path;
+        if (result.startsWith("/")) {
+            result = result.substring(1);
+        }
+        return result;
     }
 
     private static void scanFile(Path testFile, Path examplesResources, Path examplesNonCompilable,

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapExamplesTest.java
@@ -35,13 +35,11 @@ public class NoLineWrapExamplesTest extends AbstractExamplesModuleTestSupport {
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_KEY, "package"),
-            "18:1: " + getCheckMessage(MSG_KEY, "import"),
-            "22:1: " + getCheckMessage(MSG_KEY, "import"),
-            "26:1: " + getCheckMessage(MSG_KEY, "import"),
+            "10:1: " + getCheckMessage(MSG_KEY, "package"),
+            "13:1: " + getCheckMessage(MSG_KEY, "import"),
+            "16:1: " + getCheckMessage(MSG_KEY, "import"),
         };
-
-        verifyWithInlineConfigParser(getNonCompilablePath("Example1.java"), expected);
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
 
     @Test
@@ -51,6 +49,18 @@ public class NoLineWrapExamplesTest extends AbstractExamplesModuleTestSupport {
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = {
+            "14:1: " + getCheckMessage(MSG_KEY, "package"),
+            "18:1: " + getCheckMessage(MSG_KEY, "import"),
+            "22:1: " + getCheckMessage(MSG_KEY, "import"),
+            "26:1: " + getCheckMessage(MSG_KEY, "import"),
+        };
+
+        verifyWithInlineConfigParser(getNonCompilablePath("Example3.java"), expected);
     }
 
     @Test

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example3.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example3.java
@@ -27,4 +27,4 @@ import static java.math.
   BigInteger.ZERO;
 // xdoc section -- end
 
-class Example1 { }
+class Example3 { }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/Example1.java
@@ -16,12 +16,12 @@ import com.puppycrawl.tools. // violation 'should not be line-wrapped'
 import static java.math.     // violation 'should not be line-wrapped'
   BigInteger.ZERO;
 
-class                        // violation 'should not be line-wrapped'
+class
   Example1 {
 
-  public                     // violation 'should not be line-wrapped'
+  public
     Example1() {}
-  public void                // violation 'should not be line-wrapped'
+  public void
     doSomething() {}
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue #20838

This PR introduces a new test `testAllExampleFilesAreReferencedInXdocs` in `XdocsExampleFileTest` to enforce that all example files present in `src/xdocs-examples/resources/` and `src/xdocs-examples/resources-noncompilable/` are explicitly referenced by at least one `<macro name="example">` in the `xml.template` files. This prevents unused example files from lingering in the codebase.

Changes:

- Added `testAllExampleFilesAreReferencedInXdocs`: Scans all example directories and verifies each file is referenced in the Xdocs templates.
- Fixed `NoLineWrap` Examples:
  - Renamed the unreferenced non-compilable `Example1.java` to `Example3.java` to resolve Xdocs paragraph ID collisions.
  - Added `testExample3()` in `NoLineWrapExamplesTest`.