### PR TITLE
Issue #16807: update NoLineWrap default token tests

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -727,8 +727,6 @@ public final class InlineConfigParser {
         "checks/whitespace/emptylineseparator/packageinfo/test3/package-info.java",
         "checks/whitespace/emptylineseparator/packageinfo/test4/package-info.java",
         "checks/whitespace/emptylineseparator/packageinfo/test5/package-info.java",
-        "checks/whitespace/nolinewrap/InputNoLineWrapBad.java",
-        "checks/whitespace/nolinewrap/InputNoLineWrapGood.java",
         "checks/whitespace/parenpad/InputParenPadCheckEmoji.java",
         "checks/whitespace/parenpad/InputParenPadCheckRecords.java",
         "checks/whitespace/parenpad/InputParenPadCheckRecordsSpace.java",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapBad.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapBad.java
@@ -1,6 +1,6 @@
 /*
 NoLineWrap
-tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT
+tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, MODULE_IMPORT
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapGood.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nolinewrap/InputNoLineWrapGood.java
@@ -1,6 +1,6 @@
 /*
 NoLineWrap
-tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT
+tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, MODULE_IMPORT
 
 
 */


### PR DESCRIPTION
Issue: #16807

This updates the inline configuration comments for `NoLineWrapCheck` to include `MODULE_IMPORT`, which is part of the current default token set. It also removes the two corresponding temporary entries from `SUPPRESSED_VALIDATE_DEFAULT_FILES`.

Validation:
- `git diff --check` passes.
- Java tests were not run locally because no JDK is installed in the environment.