### PR TITLE
Issue #16807: remove ModifiedControlVariable inputs from default-property suppressions

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -514,18 +514,6 @@ public final class InlineConfigParser {
         "checks/coding/illegaltype/InputIllegalTypeTestStaticImports.java",
         "checks/coding/illegaltype/InputIllegalTypeWhitespaceInConfig.java",
         "checks/coding/illegaltype/InputIllegalTypeWithRecordPattern.java",
-        "checks/coding/modifiedcontrolvariable/"
-            + "InputModifiedControlVariableBothForLoops.java",
-        "checks/coding/modifiedcontrolvariable/"
-            + "InputModifiedControlVariableEnhancedForLoopVariable.java",
-        "checks/coding/modifiedcontrolvariable/"
-            + "InputModifiedControlVariableEnhancedForLoopVariable2.java",
-        "checks/coding/modifiedcontrolvariable/"
-            + "InputModifiedControlVariableEnhancedForLoopVariable3.java",
-        "checks/coding/modifiedcontrolvariable/"
-            + "InputModifiedControlVariableRecordDecomposition.java",
-        "checks/coding/modifiedcontrolvariable/"
-            + "InputModifiedControlVariableTestVariousAssignments.java",
         "checks/coding/unnecessaryparentheses/InputUnnecessaryParentheses15Extensions.java",
         "checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckPatterns.java",
         "checks/coding/unnecessaryparentheses/"


### PR DESCRIPTION
## Summary
Issue #16807: ModifiedControlVariable inputs already use `(default)` tags. Remove them from `SUPPRESSED_VALIDATE_DEFAULT_FILES`.

## Testing
- Header inspection confirmed defaults
- CI validates InlineConfigParser
