### PR TITLE
Issue #16807: remove NonEmptyAtclauseDescription inputs from default-property suppressions

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -631,7 +631,6 @@ public final class InlineConfigParser {
         "checks/javadoc/javadocvariable/InputJavadocVariableTagsMethods2.java",
         "checks/javadoc/javadocvariable/InputJavadocVariableTagsMethods3.java",
         "checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodBasic.java",
-        "checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionOne.java",
         "checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexity.java",
         "checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityLeaves.java",
         "checks/metrics/booleanexpressioncomplexity/InputBooleanExpressionComplexityNPE.java",


### PR DESCRIPTION
## Summary
Issue #16807: remove NonEmptyAtclauseDescription inputs from default-property suppressions

Single-module PR for #16807. Input files already document properties with `(default)` tags.

## Testing
- Header inspection confirmed defaults present before removal
- CI will run InlineConfigParser validation
