### PR TITLE
Issue #16807: remove UnnecessaryParentheses inputs from default-property suppressions

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -526,18 +526,6 @@ public final class InlineConfigParser {
             + "InputModifiedControlVariableRecordDecomposition.java",
         "checks/coding/modifiedcontrolvariable/"
             + "InputModifiedControlVariableTestVariousAssignments.java",
-        "checks/coding/unnecessaryparentheses/InputUnnecessaryParentheses15Extensions.java",
-        "checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckPatterns.java",
-        "checks/coding/unnecessaryparentheses/"
-            + "InputUnnecessaryParenthesesCheckSwitchExpression.java",
-        "checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckTextBlocks.java",
-        "checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesIdentifier.java",
-        "checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesIfStatement.java",
-        "checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesIfStatement2.java",
-        "checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesOperator3.java",
-        "checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesOperatorsAndCasts.java",
-        "checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesReturnValue.java",
-        "checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesWhenExpressions.java",
         "checks/imports/importorder/InputImportOrder1.java",
         "checks/imports/importorder/InputImportOrder2.java",
         "checks/imports/importorder/InputImportOrder3.java",


### PR DESCRIPTION
## Summary
Issue #16807: remove UnnecessaryParentheses inputs from default-property suppressions

Single-module PR for #16807. Input files already document properties with `(default)` tags.

## Testing
- Header inspection confirmed defaults present before removal
- CI will run InlineConfigParser validation
