### PR TITLE
Issue #16807: remove SuppressionXpathSingleFilter inputs from default-property suppressions

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -782,9 +782,6 @@ public final class InlineConfigParser {
         "checks/whitespace/whitespacearound/InputWhitespaceAroundUnnamedPattern.java",
         "filefilters/beforeexecutionexclusionfilefilter/"
             + "InputBeforeExecutionExclusionFileFilter.java",
-        "filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterComplexQuery.java",
-        "filters/suppressionxpathsinglefilter/"
-            + "InputSuppressionXpathSingleFilterDecideByMessage.java",
         "filters/suppresswithnearbytextfilter/"
             + "InputSuppressWithNearbyTextFilterNearbyTextPatternCompactVariableCheckPattern.java",
         "treewalker/InputTreeWalkerSuppressionCommentFilter.java",


### PR DESCRIPTION
## Summary
Issue #16807: remove SuppressionXpathSingleFilter inputs from default-property suppressions

Single-module PR for #16807. Input files already document properties with `(default)` tags.

## Testing
- Header inspection confirmed defaults present before removal
- CI will run InlineConfigParser validation
