### PR TITLE
Issue #16807: remove BeforeExecutionExclusionFileFilter inputs from default-property suppressions

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -780,8 +780,6 @@ public final class InlineConfigParser {
             + "InputWhitespaceAroundSwitchCasesParensWithAllowEmptySwitchBlockStatements.java",
         "checks/whitespace/whitespacearound/InputWhitespaceAroundSwitchExpressions.java",
         "checks/whitespace/whitespacearound/InputWhitespaceAroundUnnamedPattern.java",
-        "filefilters/beforeexecutionexclusionfilefilter/"
-            + "InputBeforeExecutionExclusionFileFilter.java",
         "filters/suppressionxpathsinglefilter/InputSuppressionXpathSingleFilterComplexQuery.java",
         "filters/suppressionxpathsinglefilter/"
             + "InputSuppressionXpathSingleFilterDecideByMessage.java",


### PR DESCRIPTION
## Summary
Issue #16807: remove BeforeExecutionExclusionFileFilter inputs from default-property suppressions

Single-module PR for #16807. Input files already document properties with `(default)` tags.

## Testing
- Header inspection confirmed defaults present before removal
- CI will run InlineConfigParser validation
