### PR TITLE
Issue #16807: remove TreeWalker suppression filter inputs from default-property suppressions

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -787,8 +787,6 @@ public final class InlineConfigParser {
             + "InputSuppressionXpathSingleFilterDecideByMessage.java",
         "filters/suppresswithnearbytextfilter/"
             + "InputSuppressWithNearbyTextFilterNearbyTextPatternCompactVariableCheckPattern.java",
-        "treewalker/InputTreeWalkerSuppressionCommentFilter.java",
-        "treewalker/InputTreeWalkerSuppressionXpathFilterAbsolute.java"
     );
 
     // This is a hack until https://github.com/checkstyle/checkstyle/issues/13845


### PR DESCRIPTION
## Summary
Issue #16807: remove TreeWalker suppression filter input files from `SUPPRESSED_VALIDATE_DEFAULT_FILES` (defaults already documented).

## Testing
- Header inspection; CI validates InlineConfigParser
