### PR TITLE
Issue #20831: Fixed links for usecase section

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -107,7 +107,11 @@ section p {
   float: right;
 }
 
-h1:hover .anchor, h2:hover .anchor, h3:hover .anchor, p[id^="Example"]:hover .anchor {
+h1:hover .anchor,
+h2:hover .anchor,
+h3:hover .anchor,
+p[id^="Example"]:hover .anchor,
+p[id^="UseCase"]:hover .anchor {
   visibility: visible;
 }
 

--- a/src/site/resources/js/anchors.js
+++ b/src/site/resources/js/anchors.js
@@ -89,13 +89,13 @@
             createAnchor(anchorItem, link, name, relativePath, anchorItem);
         });
 
-        // Example sections
-        const exampleDivs = document.querySelectorAll('p[id^="Example"]');
-        [].forEach.call(exampleDivs, function (exampleDiv) {
-            const name = exampleDiv.id;
+        // Example and Use Case sections
+        const linkableDivs = document.querySelectorAll('p[id^="Example"], p[id^="UseCase"]');
+        [].forEach.call(linkableDivs, function (linkableDiv) {
+            const name = linkableDiv.id;
             const link = url + "#" + name;
 
-            createAnchor(exampleDiv, link, name, relativePath, exampleDiv);
+            createAnchor(linkableDiv, link, name, relativePath, linkableDiv);
         });
     });
 


### PR DESCRIPTION
Fixes #20831
Anchor hover-links stopped working for Use Case blocks after Examples/UseCases were split into separate subsections. Two spots were hardcoded to Example* only:

**anchors.js** :  selector only matched` p[id^="Example"]`, so `UseCase `paragraphs never got the anchor div injected.
**site.css** :  hover-visibility rule only listed `p[id^="Example"]`:hover .anchor, so even with the JS fix the icon stayed hidden.