### PR TITLE
Issue #20880: Align StaticVariableName example violation comments

### DIFF
--- a/src/site/xdoc/checks/naming/staticvariablename.xml
+++ b/src/site/xdoc/checks/naming/staticvariablename.xml
@@ -79,13 +79,13 @@
 class Example1 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
-  public static int ItStatic1 = 2; // violation, 'must match pattern'
+  public static int ItStatic1 = 2;    // violation, 'must match pattern'
   protected static int ItStatic2 = 2; // violation, 'must match pattern'
-  private static int ItStatic = 2; // violation, 'must match pattern'
-  public static int it_static = 2; // violation, 'must match pattern'
-  public static int It_Static = 2; // violation, 'must match pattern'
-  private static int It_Static1 = 2; // violation, 'must match pattern'
-  static int It_Static2 = 2; // violation, 'must match pattern'
+  private static int ItStatic = 2;    // violation, 'must match pattern'
+  public static int it_static = 2;    // violation, 'must match pattern'
+  public static int It_Static = 2;    // violation, 'must match pattern'
+  private static int It_Static1 = 2;  // violation, 'must match pattern'
+  static int It_Static2 = 2;          // violation, 'must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -106,13 +106,13 @@ class Example1 {
 class Example2 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
-  public static int ItStatic1 = 2; // violation, 'must match pattern'
+  public static int ItStatic1 = 2;    // violation, 'must match pattern'
   protected static int ItStatic2 = 2; // violation, 'must match pattern'
-  private static int ItStatic = 2; // violation, 'must match pattern'
+  private static int ItStatic = 2;    // violation, 'must match pattern'
   public static int it_static = 2;
-  public static int It_Static = 2; // violation, 'must match pattern'
-  private static int It_Static1 = 2; // violation, 'must match pattern'
-  static int It_Static2 = 2; // violation, 'must match pattern'
+  public static int It_Static = 2;    // violation, 'must match pattern'
+  private static int It_Static1 = 2;  // violation, 'must match pattern'
+  static int It_Static2 = 2;          // violation, 'must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -134,11 +134,11 @@ class Example3 {
   private static int badStatic = 2;
   public static int ItStatic1 = 2;
   protected static int ItStatic2 = 2; // violation, 'must match pattern'
-  private static int ItStatic = 2; // violation, 'must match pattern'
+  private static int ItStatic = 2;    // violation, 'must match pattern'
   public static int it_static = 2;
   public static int It_Static = 2;
-  private static int It_Static1 = 2; // violation, 'must match pattern'
-  static int It_Static2 = 2; // violation, 'must match pattern'
+  private static int It_Static1 = 2;  // violation, 'must match pattern'
+  static int It_Static2 = 2;          // violation, 'must match pattern'
 }
 </code></pre></div>
         <hr class="example-separator"/>
@@ -159,13 +159,13 @@ class Example3 {
 class Example4 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
-  public static int ItStatic1 = 2; // violation, 'must match pattern'
+  public static int ItStatic1 = 2;    // violation, 'must match pattern'
   protected static int ItStatic2 = 2;
-  private static int ItStatic = 2; // violation, 'must match pattern'
-  public static int it_static = 2; // violation, 'must match pattern'
-  public static int It_Static = 2; // violation, 'must match pattern'
-  private static int It_Static1 = 2; // violation, 'must match pattern'
-  static int It_Static2 = 2; // violation, 'must match pattern'
+  private static int ItStatic = 2;    // violation, 'must match pattern'
+  public static int it_static = 2;    // violation, 'must match pattern'
+  public static int It_Static = 2;    // violation, 'must match pattern'
+  private static int It_Static1 = 2;  // violation, 'must match pattern'
+  static int It_Static2 = 2;          // violation, 'must match pattern'
 }
 </code></pre></div>
         <hr class="example-separator"/>
@@ -184,13 +184,13 @@ class Example4 {
 class Example5 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
-  public static int ItStatic1 = 2; // violation, 'must match pattern'
+  public static int ItStatic1 = 2;    // violation, 'must match pattern'
   protected static int ItStatic2 = 2; // violation, 'must match pattern'
   private static int ItStatic = 2;
-  public static int it_static = 2; // violation, 'must match pattern'
-  public static int It_Static = 2; // violation, 'must match pattern'
+  public static int it_static = 2;    // violation, 'must match pattern'
+  public static int It_Static = 2;    // violation, 'must match pattern'
   private static int It_Static1 = 2;
-  static int It_Static2 = 2; // violation, 'must match pattern'
+  static int It_Static2 = 2;          // violation, 'must match pattern'
 }
 </code></pre></div>
         <hr class="example-separator"/>
@@ -211,12 +211,12 @@ class Example5 {
 class Example6 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
-  public static int ItStatic1 = 2; // violation, 'must match pattern'
+  public static int ItStatic1 = 2;    // violation, 'must match pattern'
   protected static int ItStatic2 = 2; // violation, 'must match pattern'
-  private static int ItStatic = 2; // violation, 'must match pattern'
-  public static int it_static = 2; // violation, 'must match pattern'
-  public static int It_Static = 2; // violation, 'must match pattern'
-  private static int It_Static1 = 2; // violation, 'must match pattern'
+  private static int ItStatic = 2;    // violation, 'must match pattern'
+  public static int it_static = 2;    // violation, 'must match pattern'
+  public static int It_Static = 2;    // violation, 'must match pattern'
+  private static int It_Static1 = 2;  // violation, 'must match pattern'
   static int It_Static2 = 2;
 }
 </code></pre></div>

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example1.java
@@ -16,12 +16,12 @@ package com.puppycrawl.tools.checkstyle.checks.naming.staticvariablename;
 class Example1 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
-  public static int ItStatic1 = 2; // violation, 'must match pattern'
+  public static int ItStatic1 = 2;    // violation, 'must match pattern'
   protected static int ItStatic2 = 2; // violation, 'must match pattern'
-  private static int ItStatic = 2; // violation, 'must match pattern'
-  public static int it_static = 2; // violation, 'must match pattern'
-  public static int It_Static = 2; // violation, 'must match pattern'
-  private static int It_Static1 = 2; // violation, 'must match pattern'
-  static int It_Static2 = 2; // violation, 'must match pattern'
+  private static int ItStatic = 2;    // violation, 'must match pattern'
+  public static int it_static = 2;    // violation, 'must match pattern'
+  public static int It_Static = 2;    // violation, 'must match pattern'
+  private static int It_Static1 = 2;  // violation, 'must match pattern'
+  static int It_Static2 = 2;          // violation, 'must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example2.java
@@ -16,12 +16,12 @@ package com.puppycrawl.tools.checkstyle.checks.naming.staticvariablename;
 class Example2 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
-  public static int ItStatic1 = 2; // violation, 'must match pattern'
+  public static int ItStatic1 = 2;    // violation, 'must match pattern'
   protected static int ItStatic2 = 2; // violation, 'must match pattern'
-  private static int ItStatic = 2; // violation, 'must match pattern'
+  private static int ItStatic = 2;    // violation, 'must match pattern'
   public static int it_static = 2;
-  public static int It_Static = 2; // violation, 'must match pattern'
-  private static int It_Static1 = 2; // violation, 'must match pattern'
-  static int It_Static2 = 2; // violation, 'must match pattern'
+  public static int It_Static = 2;    // violation, 'must match pattern'
+  private static int It_Static1 = 2;  // violation, 'must match pattern'
+  static int It_Static2 = 2;          // violation, 'must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example3.java
@@ -18,10 +18,10 @@ class Example3 {
   private static int badStatic = 2;
   public static int ItStatic1 = 2;
   protected static int ItStatic2 = 2; // violation, 'must match pattern'
-  private static int ItStatic = 2; // violation, 'must match pattern'
+  private static int ItStatic = 2;    // violation, 'must match pattern'
   public static int it_static = 2;
   public static int It_Static = 2;
-  private static int It_Static1 = 2; // violation, 'must match pattern'
-  static int It_Static2 = 2; // violation, 'must match pattern'
+  private static int It_Static1 = 2;  // violation, 'must match pattern'
+  static int It_Static2 = 2;          // violation, 'must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example4.java
@@ -16,12 +16,12 @@ package com.puppycrawl.tools.checkstyle.checks.naming.staticvariablename;
 class Example4 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
-  public static int ItStatic1 = 2; // violation, 'must match pattern'
+  public static int ItStatic1 = 2;    // violation, 'must match pattern'
   protected static int ItStatic2 = 2;
-  private static int ItStatic = 2; // violation, 'must match pattern'
-  public static int it_static = 2; // violation, 'must match pattern'
-  public static int It_Static = 2; // violation, 'must match pattern'
-  private static int It_Static1 = 2; // violation, 'must match pattern'
-  static int It_Static2 = 2; // violation, 'must match pattern'
+  private static int ItStatic = 2;    // violation, 'must match pattern'
+  public static int it_static = 2;    // violation, 'must match pattern'
+  public static int It_Static = 2;    // violation, 'must match pattern'
+  private static int It_Static1 = 2;  // violation, 'must match pattern'
+  static int It_Static2 = 2;          // violation, 'must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example5.java
@@ -16,12 +16,12 @@ package com.puppycrawl.tools.checkstyle.checks.naming.staticvariablename;
 class Example5 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
-  public static int ItStatic1 = 2; // violation, 'must match pattern'
+  public static int ItStatic1 = 2;    // violation, 'must match pattern'
   protected static int ItStatic2 = 2; // violation, 'must match pattern'
   private static int ItStatic = 2;
-  public static int it_static = 2; // violation, 'must match pattern'
-  public static int It_Static = 2; // violation, 'must match pattern'
+  public static int it_static = 2;    // violation, 'must match pattern'
+  public static int It_Static = 2;    // violation, 'must match pattern'
   private static int It_Static1 = 2;
-  static int It_Static2 = 2; // violation, 'must match pattern'
+  static int It_Static2 = 2;          // violation, 'must match pattern'
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/staticvariablename/Example6.java
@@ -16,12 +16,12 @@ package com.puppycrawl.tools.checkstyle.checks.naming.staticvariablename;
 class Example6 {
   public static int goodStatic = 2;
   private static int badStatic = 2;
-  public static int ItStatic1 = 2; // violation, 'must match pattern'
+  public static int ItStatic1 = 2;    // violation, 'must match pattern'
   protected static int ItStatic2 = 2; // violation, 'must match pattern'
-  private static int ItStatic = 2; // violation, 'must match pattern'
-  public static int it_static = 2; // violation, 'must match pattern'
-  public static int It_Static = 2; // violation, 'must match pattern'
-  private static int It_Static1 = 2; // violation, 'must match pattern'
+  private static int ItStatic = 2;    // violation, 'must match pattern'
+  public static int it_static = 2;    // violation, 'must match pattern'
+  public static int It_Static = 2;    // violation, 'must match pattern'
+  private static int It_Static1 = 2;  // violation, 'must match pattern'
   static int It_Static2 = 2;
 }
 // xdoc section -- end


### PR DESCRIPTION
Issue: #20880

Vertically align `// violation` comments in all `StaticVariableName` xdoc examples so they line up (same pattern as the issue sample).

## Changes
- Pad spaces before violation comments in `Example1`–`Example6`
- Sync generated `staticvariablename.xml` examples

## Test
- `./mvnw -Dtest=StaticVariableNameCheckExamplesTest test` (passed)

Made with [Cursor](https://cursor.com)