### PR TITLE
Issue #19513: Add configurable order property to ModifierOrderCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.modifier;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -27,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.annotation.PreserveOrder;
 
 /**
  * <div>
@@ -89,20 +91,36 @@ public class ModifierOrderCheck
     public static final String MSG_MODIFIER_ORDER = "mod.order";
 
     /**
-     * The order of modifiers as suggested in sections 8.1.1,
+     * Default order of modifiers as suggested in sections 8.1.1,
      * 8.3.1 and 8.4.3 of the JLS.
      */
-    private static final String[] JLS_ORDER = {
+    private static final String[] DEFAULT_ORDER = {
         "public", "protected", "private", "abstract", "default", "static",
         "sealed", "non-sealed", "final", "transient", "volatile",
         "synchronized", "native", "strictfp",
     };
 
     /**
+     * Specify the order of modifiers.
+     */
+    @PreserveOrder
+    private List<String> order = Arrays.asList(DEFAULT_ORDER);
+
+    /**
      * Creates a new {@code ModifierOrderCheck} instance.
      */
     public ModifierOrderCheck() {
         // no code by default
+    }
+
+    /**
+     * Setter to specify the order of modifiers.
+     *
+     * @param modifierOrder user's modifier order.
+     * @since 13.9.0
+     */
+    public void setOrder(String... modifierOrder) {
+        order = Arrays.asList(modifierOrder);
     }
 
     @Override
@@ -154,7 +172,7 @@ public class ModifierOrderCheck
      * @return null if the order is correct, otherwise returns the offending
      *     modifier AST.
      */
-    private static DetailAST checkOrderSuggestedByJls(List<DetailAST> modifiers) {
+    private DetailAST checkOrderSuggestedByJls(List<DetailAST> modifiers) {
         final Iterator<DetailAST> iterator = modifiers.iterator();
 
         // Speed past all initial annotations
@@ -176,13 +194,13 @@ public class ModifierOrderCheck
                     break;
                 }
 
-                while (index < JLS_ORDER.length
-                       && !JLS_ORDER[index].equals(modifier.getText())) {
+                while (index < order.size()
+                       && !order.get(index).equals(modifier.getText())) {
                     index++;
                 }
 
-                if (index == JLS_ORDER.length) {
-                    // Current modifier is out of JLS order
+                if (index == order.size()) {
+                    // Current modifier is out of order
                     offendingModifier = modifier;
                 }
                 else if (iterator.hasNext()) {

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/ModifierOrderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/ModifierOrderCheck.xml
@@ -44,6 +44,13 @@
  &lt;a href="https://www.oracle.com/technical-resources/articles/java/ma14-architect-annotations.html"&gt;
  type annotations&lt;/a&gt; from validation.
  &lt;/p&gt;</description>
+         <properties>
+            <property default-value="public, protected, private, abstract, default, static, sealed, non-sealed, final, transient, volatile, synchronized, native, strictfp"
+                      name="order"
+                      type="java.lang.String[]">
+               <description>Specify the order of modifiers.</description>
+            </property>
+         </properties>
          <message-keys>
             <message-key key="annotation.order"/>
             <message-key key="mod.order"/>

--- a/src/site/xdoc/checks/modifier/modifierorder.xml.template
+++ b/src/site/xdoc/checks/modifier/modifierorder.xml.template
@@ -18,6 +18,15 @@
         </macro>
       </subsection>
 
+      <subsection name="Properties" id="ModifierOrder_Properties">
+        <div class="wrapper">
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java"/>
+          </macro>
+        </div>
+      </subsection>
+
       <subsection name="Examples" id="ModifierOrder_Examples">
         <p id="Example1-config"> To configure the check: </p>
         <macro name="example">
@@ -29,6 +38,20 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/Example1.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example2-config">
+          To configure the check with custom order of modifiers:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code"> Code: </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/Example2.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
@@ -176,4 +176,13 @@ public class ModifierOrderCheckTest
                 expected);
     }
 
+    @Test
+    public void testCustomOrder() throws Exception {
+        final String[] expected = {
+            "12:19: " + getCheckMessage(MSG_MODIFIER_ORDER, "static"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputModifierOrderCustomOrder.java"), expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ImmutabilityTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ImmutabilityTest.java
@@ -144,7 +144,7 @@ public class ImmutabilityTest {
         "com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck.DEFAULT_ORDER",
         "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.DEFAULT_TAGS",
         "com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck.ALLOWED_TYPES",
-        "com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck.JLS_ORDER",
+        "com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck.DEFAULT_ORDER",
         "com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck"
             + ".TOKENS_FOR_INTERFACE_MODIFIERS",
         "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck.detector",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -204,7 +204,8 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/imports/importorder/Example6",
             "checks/imports/importorder/Example7",
             "checks/imports/importorder/Example8",
-            "checks/imports/importorder/Example9"
+            "checks/imports/importorder/Example9",
+            "checks/modifier/modifierorder/Example2"
     );
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderCustomOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderCustomOrder.java
@@ -1,0 +1,15 @@
+/*
+ModifierOrder
+order = public, protected, private, abstract, static, final, transient, volatile, default, synchronized, native, strictfp
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.modifier.modifierorder;
+
+public class InputModifierOrderCustomOrder {
+    public static final int MAX_VALUE = 100;
+
+    private final static String S = "x"; // violation ''static'.*out of order.*'
+
+    private static final String OK = "y";
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckExamplesTest.java
@@ -43,4 +43,13 @@ public class ModifierOrderCheckExamplesTest extends AbstractExamplesModuleTestSu
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
 
+    @Test
+    public void testExample2() throws Exception {
+        final String[] expected = {
+            "15:17: " + getCheckMessage(MSG_MODIFIER_ORDER, "static"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+    }
+
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/Example2.java
@@ -1,0 +1,24 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ModifierOrder">
+      <property name="order"
+          value="public, protected, private, abstract, static, final,
+                 transient, volatile, default, synchronized, native, strictfp"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.modifier.modifierorder;
+
+// xdoc section -- start
+public class Example2 {
+  public static final int MAX_VALUE = 100;
+
+  // violation below "'static' modifier out of order with the JLS suggestions"
+  private final static String S = "x";
+
+  // OK
+  private static final String OK = "y";
+}
+// xdoc section -- end


### PR DESCRIPTION
Fixes #19513

### Description
Added a configurable `order` property to `ModifierOrderCheck` to allow users to specify custom modifier ordering (e.g. OpenJDK style) via XML configuration while maintaining backward compatibility with the default JLS modifier order.

### Changes
- Added `@PreserveOrder private List<String> order` property and `setOrder(String...)` setter in `ModifierOrderCheck`.
- Refactored `checkOrderSuggestedByJls` logic to validate modifiers against the configured `order`.
- Updated check metadata `ModifierOrderCheck.xml` and xdoc template `modifierorder.xml.template`.
- Added xdoc example `Example2.java` and unit test `InputModifierOrderCustomOrder.java`.
- Updated `ImmutabilityTest.java` suppression list.
