### PR TITLE
Issue #19803: Fix inline config parser issues and adjust line numbers

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -421,8 +421,7 @@
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity[\\/]InputClassFanOutComplexityAnnotations\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]metrics[\\/]cyclomaticcomplexity[\\/]InputCyclomaticComplexity2\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
-            files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]sizes[\\/]methodlength[\\/]InputMethodLengthSimpleTwo\.java"/>
+
   <suppress id="violationBetweenAnnotationAndMethod"
             files="[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]suppresswarningsholder[\\/]InputSuppressWarningsHolderAlias2\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthSimpleTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthSimpleTwo.java
@@ -12,8 +12,8 @@ import java.io.*;
 
 final class InputMethodLengthSimpleTwo
 {
+    // violation 2 lines below 'Method longMethod length is 20 lines (max allowed is 19)'
     /** method that is 20 lines long **/
-    // violation below 'Method longMethod length is 20 lines (max allowed is 19)'
     private void longMethod()
     {
         // a line


### PR DESCRIPTION
Issue: #19803

### Description
This PR fixes inline configuration parser issues and adjusts the corresponding line numbers. Specifically, it updates the test cases in `MethodLengthCheckTest` and rearranges the comments/code structure in `InputMethodLengthSimpleTwo.java` to properly align the expected violation line numbers.


 