### PR TITLE
Issue #20895: use LineWrappingOptions enum instead of boolean in LineWrappingHandler

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -386,10 +386,10 @@ public abstract class AbstractExpressionHandler {
      * @param ignoreFirstLine Test if first line's indentation should be checked or not.
      */
     protected void checkWrappingIndentation(DetailAST firstNode, DetailAST lastNode,
-            int wrappedIndentLevel, int startIndent, boolean ignoreFirstLine) {
+            int wrappedIndentLevel, int startIndent,
+            LineWrappingHandler.LineWrappingOptions ignoreFirstLine) {
         indentCheck.getLineWrappingHandler().checkIndentation(firstNode, lastNode,
-                wrappedIndentLevel, startIndent,
-                LineWrappingHandler.LineWrappingOptions.ofBoolean(ignoreFirstLine));
+                wrappedIndentLevel, startIndent, ignoreFirstLine);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
@@ -91,7 +91,8 @@ public class ClassDefHandler extends BlockParentHandler {
             final DetailAST atAst = getMainAst().findFirstToken(TokenTypes.AT);
             if (isOnStartOfLine(atAst)) {
                 checkWrappingIndentation(getMainAst(), getListChild(), 0,
-                        getIndent().getFirstIndentLevel(), false);
+                        getIndent().getFirstIndentLevel(),
+                        LineWrappingHandler.LineWrappingOptions.NONE);
             }
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -49,24 +49,7 @@ public class LineWrappingHandler {
         /**
          * First line's indentation should be checked.
          */
-        NONE;
-
-        /**
-         * Builds enum value from boolean.
-         *
-         * @param val value.
-         * @return enum instance.
-         *
-         * @noinspection BooleanParameter
-         * @noinspectionreason BooleanParameter - check property is essentially boolean
-         */
-        public static LineWrappingOptions ofBoolean(boolean val) {
-            LineWrappingOptions option = NONE;
-            if (val) {
-                option = IGNORE_FIRST_LINE;
-            }
-            return option;
-        }
+        NONE
 
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -66,9 +66,16 @@ public class MethodDefHandler extends BlockParentHandler {
         final DetailAST throwsAst = getMainAst().findFirstToken(TokenTypes.LITERAL_THROWS);
 
         if (throwsAst != null) {
+            final LineWrappingHandler.LineWrappingOptions ignoreFirstLine;
+            if (isOnStartOfLine(throwsAst)) {
+                ignoreFirstLine = LineWrappingHandler.LineWrappingOptions.NONE;
+            }
+            else {
+                ignoreFirstLine = LineWrappingHandler.LineWrappingOptions.IGNORE_FIRST_LINE;
+            }
             checkWrappingIndentation(throwsAst, throwsAst.getNextSibling(), getIndentCheck()
                     .getThrowsIndent(), getLineStart(getMethodDefLineStart(getMainAst())),
-                    !isOnStartOfLine(throwsAst));
+                    ignoreFirstLine);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
@@ -160,7 +160,7 @@ public class TryHandler extends BlockParentHandler {
                         nextSibling,
                         getIndentCheck().getLineWrappingIndentation(),
                         expectedResourceIndent.getFirstIndentLevel(),
-                        true);
+                        LineWrappingHandler.LineWrappingOptions.IGNORE_FIRST_LINE);
                 }
                 else {
                     checkWrappingIndentation(resourceAst, nextSibling);


### PR DESCRIPTION
**Issue**: #20895

**Problem**:
`LineWrappingOptions.ofBoolean(boolean val)` in `LineWrappingHandler` takes a boolean parameter, flagged by the JetBrains `BooleanParameter` inspection (`ERROR` level in `config/intellij-idea-inspections.xml`; `config/qodana.yml` sets `severityThresholds: any: 0`, so it is build-breaking). It was a `public static` factory whose only job was to translate a boolean into the already-existing `LineWrappingOptions` enum, and it carried a deferred `@noinspection BooleanParameter` suppression.

**Fix**:
Removed `ofBoolean` (and its `@noinspection` javadoc lines) and operated on the existing enum directly. The intermediate `AbstractExpressionHandler.checkWrappingIndentation` overload now takes a `LineWrappingOptions` parameter instead of a boolean, and the three call sites pass enum constants:
- `TryHandler`: `true` → `IGNORE_FIRST_LINE`
- `ClassDefHandler`: `false` → `NONE`
- `MethodDefHandler`: `!isOnStartOfLine(throwsAst)` becomes an `if`/`else` selecting `NONE` when the `throws` clause starts the line, `IGNORE_FIRST_LINE` otherwise.

No functional change: `ofBoolean` mapped `true` → `IGNORE_FIRST_LINE` and `false` → `NONE`, and each call site preserves that exact mapping.

**Testing**:
Behavior-preserving refactoring; existing tests already cover both branches. `IndentationCheckTest` passes 225/225, and running the Checkstyle CLI with the project's `config/checkstyle-checks.xml` and `config/checkstyle-sevntu-checks.xml` over the modified files reports no violations.
