### PR TITLE
Issue #20894: replace boolean parameter in CheckUtil.getCheckMessages with With/WithoutDeepScan helpers

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -539,7 +539,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
     public void testAllCheckstyleChecksHaveMessage() throws Exception {
         for (Class<?> module : CheckUtil.getCheckstyleChecks()) {
             final String name = module.getSimpleName();
-            final Set<Field> messages = CheckUtil.getCheckMessages(module, false);
+            final Set<Field> messages = CheckUtil.getCheckMessagesWithoutDeepScan(module);
 
             // No messages in just module
             if ("SuppressWarningsHolder".equals(name)) {
@@ -562,7 +562,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
 
         // test validity of messages from modules
         for (Class<?> module : CheckUtil.getCheckstyleModules()) {
-            for (Field message : CheckUtil.getCheckMessages(module, true)) {
+            for (Field message : CheckUtil.getCheckMessagesWithDeepScan(module)) {
                 assertWithMessage("%s.%s should be 'public static final'", module.getSimpleName(),
                     message.getName())
                     .that(message.getModifiers())

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1689,7 +1689,7 @@ public class XdocsPagesTest {
                                                  Node subSection,
                                                  Object instance) throws Exception {
         final Class<?> clss = instance.getClass();
-        final Set<Field> fields = CheckUtil.getCheckMessages(clss, true);
+        final Set<Field> fields = CheckUtil.getCheckMessagesWithDeepScan(clss);
         final Set<String> list = new TreeSet<>();
 
         for (Field field : fields) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
@@ -57,6 +57,18 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 public final class CheckUtil {
 
+    /**
+     * Defines whether a class hierarchy should be scanned deeply for messages.
+     */
+    private enum ScanMode {
+
+        /** Scan the class hierarchy deeply. */
+        DEEP_SCAN,
+        /** Scan only the given class. */
+        NO_DEEP_SCAN
+
+    }
+
     public static final String CRLF = "\r\n";
 
     private CheckUtil() {
@@ -211,15 +223,33 @@ public final class CheckUtil {
     }
 
     /**
+     * Gets the check's messages without scanning the class hierarchy.
+     *
+     * @param module class to examine.
+     * @return a set of checkstyle's module message fields.
+     */
+    public static Set<Field> getCheckMessagesWithoutDeepScan(Class<?> module) {
+        return getCheckMessages(module, ScanMode.NO_DEEP_SCAN);
+    }
+
+    /**
+     * Gets the check's messages, scanning the class hierarchy deeply.
+     *
+     * @param module class to examine.
+     * @return a set of checkstyle's module message fields.
+     */
+    public static Set<Field> getCheckMessagesWithDeepScan(Class<?> module) {
+        return getCheckMessages(module, ScanMode.DEEP_SCAN);
+    }
+
+    /**
      * Gets the check's messages.
      *
      * @param module class to examine.
-     * @param deepScan scan subclasses.
+     * @param scanMode mode defining whether to scan subclasses.
      * @return a set of checkstyle's module message fields.
-     * @noinspection BooleanParameter
-     * @noinspectionreason BooleanParameter - boolean parameter eases testing
      */
-    public static Set<Field> getCheckMessages(Class<?> module, boolean deepScan) {
+    private static Set<Field> getCheckMessages(Class<?> module, ScanMode scanMode) {
         final Set<Field> checkstyleMessages = new HashSet<>();
 
         // get all fields from current class
@@ -234,17 +264,19 @@ public final class CheckUtil {
         // deep scan class through hierarchy
         final Class<?> superModule = module.getSuperclass();
 
-        if (superModule != null && (deepScan || shouldScanDeepClassForMessages(superModule))) {
-            checkstyleMessages.addAll(getCheckMessages(superModule, deepScan));
+        if (superModule != null
+                && (scanMode == ScanMode.DEEP_SCAN
+                    || shouldScanDeepClassForMessages(superModule))) {
+            checkstyleMessages.addAll(getCheckMessages(superModule, scanMode));
         }
 
         // special cases that require additional classes
         if (module == RegexpMultilineCheck.class) {
-            checkstyleMessages.addAll(getCheckMessages(MultilineDetector.class, deepScan));
+            checkstyleMessages.addAll(getCheckMessages(MultilineDetector.class, scanMode));
         }
         else if (module == RegexpSinglelineCheck.class
                 || module == RegexpSinglelineJavaCheck.class) {
-            checkstyleMessages.addAll(getCheckMessages(SinglelineDetector.class, deepScan));
+            checkstyleMessages.addAll(getCheckMessages(SinglelineDetector.class, scanMode));
         }
 
         return checkstyleMessages;


### PR DESCRIPTION
Fixes #20894

Resolves the `BooleanParameter` design problem in `CheckUtil.getCheckMessages(Class<?>, boolean)` by replacing the `boolean deepScan` parameter with a `ScanMode` enum (`DEEP_SCAN` / `NO_DEEP_SCAN`), matching the approach used in #20878 for the analogous `RequireThisCheck.LookMode` fix (#20800).

All callers (`AllChecksTest`, `XdocsPagesTest`) updated accordingly. The `@noinspection BooleanParameter` suppression on the method is no longer needed and was removed.