### PR TITLE
Issue #20896: log closing javadoc tag violation on DetailAST node

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheck.java
@@ -64,12 +64,6 @@ public class JavadocLeadingAsteriskAlignCheck extends AbstractJavadocCheck {
     /** Specifies the column number of starting block of the javadoc comment with tabs expanded. */
     private int expectedColumnNumberTabsExpanded;
 
-    /**
-     * Specifies the column number of the leading asterisk
-     * without tabs expanded.
-     */
-    private int expectedColumnNumberWithoutExpandedTabs;
-
     /** Specifies the lines of the file being processed. */
     private String[] fileLines;
 
@@ -111,16 +105,16 @@ public class JavadocLeadingAsteriskAlignCheck extends AbstractJavadocCheck {
             final Optional<Integer> leadingAsteriskColumnNumber =
                                         getAsteriskColumnNumber(ast.getText());
 
-            leadingAsteriskColumnNumber
-                    .map(columnNumber -> expandedTabs(ast.getText(), columnNumber))
-                    .filter(columnNumber -> {
-                        return !hasValidAlignment(expectedColumnNumberTabsExpanded, columnNumber);
-                    })
-                    .ifPresent(columnNumber -> {
-                        logViolation(ast.getLineNumber(),
-                                columnNumber,
-                                expectedColumnNumberTabsExpanded);
-                    });
+            leadingAsteriskColumnNumber.ifPresent(columnNumber -> {
+                final int columnNumberTabsExpanded = CommonUtil.lengthExpandedTabs(
+                        ast.getText(), columnNumber, getTabWidth());
+
+                if (!hasValidAlignment(
+                        expectedColumnNumberTabsExpanded, columnNumberTabsExpanded)) {
+                    log(ast.getLineNumber(), columnNumber - 1, MSG_KEY,
+                            columnNumberTabsExpanded, expectedColumnNumberTabsExpanded);
+                }
+            });
         }
     }
 
@@ -132,30 +126,17 @@ public class JavadocLeadingAsteriskAlignCheck extends AbstractJavadocCheck {
         final Optional<Integer> endingBlockColumnNumber = getAsteriskColumnNumber(lastLine);
 
         endingBlockColumnNumber
-                .map(columnNumber -> expandedTabs(lastLine, columnNumber))
-                .filter(columnNumber -> {
-                    return !hasValidAlignment(expectedColumnNumberTabsExpanded, columnNumber);
-                })
+                .filter(columnNumber -> columnNumber - 1 == javadocEndToken.getColumnNo())
                 .ifPresent(columnNumber -> {
-                    logViolation(javadocEndToken.getLineNo(),
-                            columnNumber,
-                            expectedColumnNumberTabsExpanded);
-                });
-    }
+                    final int columnNumberTabsExpanded = CommonUtil.lengthExpandedTabs(
+                            lastLine, columnNumber, getTabWidth());
 
-    /**
-     * Processes and returns the column number of
-     * leading asterisk with tabs expanded.
-     * Also sets 'expectedColumnNumberWithoutExpandedTabs' if the leading asterisk is present.
-     *
-     * @param line javadoc comment line
-     * @param columnNumber column number of leading asterisk
-     * @return column number of leading asterisk with tabs expanded
-     */
-    private int expandedTabs(String line, int columnNumber) {
-        expectedColumnNumberWithoutExpandedTabs = columnNumber - 1;
-        return CommonUtil.lengthExpandedTabs(
-                    line, columnNumber, getTabWidth());
+                    if (!hasValidAlignment(
+                            expectedColumnNumberTabsExpanded, columnNumberTabsExpanded)) {
+                        log(javadocEndToken, MSG_KEY,
+                                columnNumberTabsExpanded, expectedColumnNumberTabsExpanded);
+                    }
+                });
     }
 
     /**
@@ -176,24 +157,6 @@ public class JavadocLeadingAsteriskAlignCheck extends AbstractJavadocCheck {
                 .filter(Matcher::find)
                 .map(matcherInstance -> matcherInstance.group(1))
                 .map(groupLength -> groupLength.length() + 1);
-    }
-
-    /**
-     * Checks alignment of asterisks and logs violations.
-     *
-     * @param lineNumber line number of current comment line
-     * @param asteriskColNumber column number of leading asterisk
-     * @param expectedColNumber column number of javadoc starting token
-     */
-    private void logViolation(int lineNumber,
-                              int asteriskColNumber,
-                              int expectedColNumber) {
-
-        log(lineNumber,
-            expectedColumnNumberWithoutExpandedTabs,
-            MSG_KEY,
-            asteriskColNumber,
-            expectedColNumber);
     }
 
     /**


### PR DESCRIPTION
Partially addresses #20896

Fixes half of the design problem described in the issue: `JavadocLeadingAsteriskAlignCheck` mixed manual line/column tracking (`log(int lineNo, int colNo, ...)`) with a mutable instance field (`expectedColumnNumberWithoutExpandedTabs`) used purely as a hidden extra return value between `expandedTabs()` and `logViolation()`.

Changes:
- Removed the `expectedColumnNumberWithoutExpandedTabs` field entirely; the (un-expanded) column is now a local value computed inline at each call site, never stored as check state.
- `finishJavadocTree` (closing `*/` tag alignment) now logs via `log(DetailAST ast, ...)` using the real `BLOCK_COMMENT_END` node (`getBlockCommentAst().getLastChild()`) instead of `log(int lineNo, int colNo, ...)`.
- Removed the now-dead `expandedTabs`/`logViolation` helper methods.

## What's left of #20896

The issue's real acceptance criterion is removing `<exclude>**/JavadocLeadingAsteriskAlignCheck.class</exclude>` at `pom.xml:2143`, which sits under the `<!-- until https://github.com/checkstyle/checkstyle/issues/5770 -->` comment block. This PR cannot remove that exclude: `visitJavadocToken` (the mid-comment leading-asterisk violation) still calls the forbidden `log(int, int, ...)` overload (`JavadocLeadingAsteriskAlignCheck.java:114`), which `config/signatures.txt:4` bans for exactly this reason.

I looked at switching that call to `log(DetailNode node, ...)` (the wrapper `AbstractJavadocCheck` already provides at `AbstractJavadocCheck.java:411`, which itself just delegates to `log(node.getLineNumber(), node.getColumnNumber(), ...)`), but it doesn't work here: the `LEADING_ASTERISK` token in `JavadocCommentsLexer.g4:188-189` is defined as `[ \t]* '*' {isAfterNewline()}?`, i.e. it swallows the line's leading whitespace as part of the token itself and is only ever emitted right after a newline. That means the token always starts at column 1 of its line — using its `DetailNode` would turn every violation's reported column into `1`, e.g. `19:5` becomes `19:1`, which breaks all 15 expected violations in `JavadocLeadingAsteriskAlignCheckTest`. Also worth noting: `AbstractJavadocCheck.class` is itself still in the same pom.xml exclude block (right above this one, `#5770`-gated), so routing through its `log(DetailNode, ...)` wrapper wouldn't unblock removing the exclusion for `JavadocLeadingAsteriskAlignCheck` even if the column problem weren't there.

So the remaining half of #20896 needs a design decision on how to report the correct column for the `LEADING_ASTERISK` case (recompute it from the raw line text at logging time, extend the token, etc.) rather than a mechanical `log()` swap. I've asked about this on the issue.

## Guard for the closing-tag/leading-asterisk overlap

While making this change I found that the old code's line/column tracking, plus dedup via the `TreeSet<Violation>` in `AbstractCheck`, was implicitly relied on to produce the single correct violation when the closing line also has its own leading asterisk before other text (e.g. `  * Inner Class. */`). Both the leading-asterisk and closing-tag checks used to regex-search from column 0 and land on the same column, so the duplicate was silently absorbed by dedup. Switching the closing-tag path to `log(DetailAST ast, ...)` uses the token's real (later) column, so it no longer collides with the leading-asterisk violation — the refactor required an explicit guard (`columnNumber - 1 == javadocEndToken.getColumnNo()`) to preserve that documented behavior explicitly instead of relying on dedup. See `InputJavadocLeadingAsteriskAlignIncorrect.java:69` and `:96` for the pinning cases (closing line with its own leading asterisk before other text).

Verified with `JavadocLeadingAsteriskAlignCheckTest` (3/3 passing, including this edge case) plus the full `checks/javadoc` test package (551/551 passing) and the project's own `ant-phase-verify` self-checkstyle build (0 violations across all 2411 main files, including this one).
