### PR TITLE
Issue #5816: Alternative to BeforeExecutionExclusionFileFilter for TreeWalker

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -35,6 +35,8 @@ import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
+import com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilter;
+import com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilterSet;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.Context;
@@ -73,6 +75,10 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
 
     /** The ast filters. */
     private final Set<TreeWalkerFilter> filters = new HashSet<>();
+
+    /** The before execution file filters. */
+    private final BeforeExecutionFileFilterSet beforeExecutionFileFilters =
+            new BeforeExecutionFileFilterSet();
 
     /** The sorted set of violations. */
     private final SortedSet<Violation> violations = new TreeSet<>();
@@ -160,6 +166,8 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
                 registerCheck(check);
             }
             case TreeWalkerFilter filter -> filters.add(filter);
+            case BeforeExecutionFileFilter filter ->
+                beforeExecutionFileFilters.addBeforeExecutionFileFilter(filter);
             case null, default -> throw new CheckstyleException(
                     "TreeWalker is not allowed as a parent of " + name
                             + " Please review 'Parent Module' section for this Check in web"
@@ -176,11 +184,26 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
      */
     @Override
     protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
-        // check if already checked and passed the file
         if (!ordinaryChecks.isEmpty() || !commentChecks.isEmpty()) {
+            processFileByTreeWalker(file);
+            violations.clear();
+        }
+    }
+
+    /**
+     * Processes a file through TreeWalker checks.
+     *
+     * @param file the file to process
+     * @throws CheckstyleException if an error occurs during processing
+     * @noinspection ProhibitedExceptionThrown
+     * @noinspectionreason ProhibitedExceptionThrown - there is no other way to obey
+     *     skipFileOnJavaParseException field
+     */
+    private void processFileByTreeWalker(File file) throws CheckstyleException {
+        final String fileName = file.getAbsolutePath();
+        if (beforeExecutionFileFilters.accept(fileName)) {
             final FileContents contents = getFileContents();
             DetailAST rootAST = null;
-            // whether skip the procedure after parsing Java files.
             boolean skip = false;
             try {
                 rootAST = JavaParser.parse(contents);
@@ -191,9 +214,10 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
                     throw exc;
                 }
                 skip = true;
-                violations.add(new Violation(1, Definitions.CHECKSTYLE_BUNDLE, PARSE_EXCEPTION_MSG,
-                            new Object[] {exc.getMessage()}, javaParseExceptionSeverity, null,
-                            getClass(), null));
+                violations.add(new Violation(1, Definitions.CHECKSTYLE_BUNDLE,
+                            PARSE_EXCEPTION_MSG,
+                            new Object[] {exc.getMessage()}, javaParseExceptionSeverity,
+                            null, getClass(), null));
                 addViolations(violations);
             }
 
@@ -202,7 +226,8 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
                     walk(rootAST, contents, AstState.ORDINARY);
                 }
                 if (!commentChecks.isEmpty()) {
-                    final DetailAST astWithComments = JavaParser.appendHiddenCommentNodes(rootAST);
+                    final DetailAST astWithComments =
+                            JavaParser.appendHiddenCommentNodes(rootAST);
                     walk(astWithComments, contents, AstState.WITH_COMMENTS);
                 }
                 if (filters.isEmpty()) {
@@ -210,11 +235,10 @@ public final class TreeWalker extends AbstractFileSetCheck implements ExternalRe
                 }
                 else {
                     final SortedSet<Violation> filteredViolations =
-                            getFilteredViolations(file.getAbsolutePath(), contents, rootAST);
+                            getFilteredViolations(fileName, contents, rootAST);
                     addViolations(filteredViolations);
                 }
             }
-            violations.clear();
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -56,6 +56,7 @@ import org.mockito.internal.util.Checks;
 
 import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean.OutputStreamOptions;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilterSet;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.Context;
@@ -74,8 +75,10 @@ import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck;
+import com.puppycrawl.tools.checkstyle.filefilters.BeforeExecutionExclusionFileFilter;
 import com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilter;
 import com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -482,6 +485,162 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         assertWithMessage("expected tab width")
             .that(tabWidth)
             .isEqualTo(99);
+    }
+
+    @Test
+    public void testSetupChildWithBeforeExecutionExclusionFileFilter() throws Exception {
+        final TreeWalker treeWalker = new TreeWalker();
+        final PackageObjectFactory factory = new PackageObjectFactory(
+                new HashSet<>(), Thread.currentThread().getContextClassLoader());
+        treeWalker.setModuleFactory(factory);
+        treeWalker.finishLocalSetup();
+
+        final Configuration config = new DefaultConfiguration(
+                BeforeExecutionExclusionFileFilter.class.getName());
+
+        treeWalker.setupChild(config);
+
+        final BeforeExecutionFileFilterSet filterSet =
+                TestUtil.getInternalState(treeWalker, "beforeExecutionFileFilters",
+                        BeforeExecutionFileFilterSet.class);
+        assertWithMessage("before execution file filters should not be empty")
+            .that(filterSet.getBeforeExecutionFileFilters())
+            .isNotEmpty();
+    }
+
+    @Test
+    public void testBeforeExecutionExclusionFileFilterExcludesFile() throws Exception {
+        final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
+        final DefaultConfiguration emptyStatementConfig =
+                createModuleConfig(EmptyStatementCheck.class);
+        treeWalkerConfig.addChild(emptyStatementConfig);
+        final DefaultConfiguration filterConfig =
+                createModuleConfig(BeforeExecutionExclusionFileFilter.class);
+        filterConfig.addProperty("fileNamePattern", "module\\-info\\.java$");
+        treeWalkerConfig.addChild(filterConfig);
+
+        final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+
+        final DefaultConfiguration fileTabConfig =
+                createModuleConfig(FileTabCharacterCheck.class);
+        checkerConfig.addChild(fileTabConfig);
+
+        final String uniqueFileName = "module-info.java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        Files.writeString(filePath.toPath(), "module test {;\t}");
+
+        final String[] expected = {
+            "1:15: " + getCheckMessage(FileTabCharacterCheck.class, "file.containsTab"),
+        };
+
+        verify(createChecker(checkerConfig), filePath.getAbsolutePath(), expected);
+    }
+
+    @Test
+    public void testNonMatchingFileStillProcessedByTreeWalker() throws Exception {
+        final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
+        final DefaultConfiguration emptyStatementConfig =
+                createModuleConfig(EmptyStatementCheck.class);
+        treeWalkerConfig.addChild(emptyStatementConfig);
+        final DefaultConfiguration filterConfig =
+                createModuleConfig(BeforeExecutionExclusionFileFilter.class);
+        filterConfig.addProperty("fileNamePattern", "module\\-info\\.java$");
+        treeWalkerConfig.addChild(filterConfig);
+
+        final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+        final DefaultConfiguration fileTabConfig =
+                createModuleConfig(FileTabCharacterCheck.class);
+        checkerConfig.addChild(fileTabConfig);
+
+        final String uniqueFileName = "RegularClass.java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        Files.writeString(filePath.toPath(),
+                "class RegularClass {\tvoid m() { ; } }");
+
+        final String[] expected = {
+            "1:21: " + getCheckMessage(FileTabCharacterCheck.class, "file.containsTab"),
+            "1:36: " + getCheckMessage(EmptyStatementCheck.class, "empty.statement"),
+        };
+
+        verify(createChecker(checkerConfig), filePath.getAbsolutePath(), expected);
+    }
+
+    @Test
+    public void testMultipleFiltersOnTreeWalker() throws Exception {
+        final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
+        final DefaultConfiguration emptyStatementConfig =
+                createModuleConfig(EmptyStatementCheck.class);
+        treeWalkerConfig.addChild(emptyStatementConfig);
+        final DefaultConfiguration filterConfig1 =
+                createModuleConfig(BeforeExecutionExclusionFileFilter.class);
+        filterConfig1.addProperty("fileNamePattern", "module\\-info\\.java$");
+        treeWalkerConfig.addChild(filterConfig1);
+        final DefaultConfiguration filterConfig2 =
+                createModuleConfig(BeforeExecutionExclusionFileFilter.class);
+        filterConfig2.addProperty("fileNamePattern", "package\\-info\\.java$");
+        treeWalkerConfig.addChild(filterConfig2);
+
+        final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+
+        final String uniqueFileName = "package-info.java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        Files.writeString(filePath.toPath(), "package test {;\t}");
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(createChecker(checkerConfig), filePath.getAbsolutePath(), expected);
+    }
+
+    @Test
+    public void testNoFiltersConfiguredTreeWalkerWorksNormally() throws Exception {
+        final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
+        final DefaultConfiguration emptyStatementConfig =
+                createModuleConfig(EmptyStatementCheck.class);
+        treeWalkerConfig.addChild(emptyStatementConfig);
+
+        final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+        final DefaultConfiguration fileTabConfig =
+                createModuleConfig(FileTabCharacterCheck.class);
+        checkerConfig.addChild(fileTabConfig);
+
+        final String uniqueFileName = "SomeClass.java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        Files.writeString(filePath.toPath(),
+                "class SomeClass {\tvoid m() { ; } }");
+
+        final String[] expected = {
+            "1:18: " + getCheckMessage(FileTabCharacterCheck.class, "file.containsTab"),
+            "1:36: " + getCheckMessage(EmptyStatementCheck.class, "empty.statement"),
+        };
+
+        verify(createChecker(checkerConfig), filePath.getAbsolutePath(), expected);
+    }
+
+    @Test
+    public void testCheckerLevelFilterExcludesFromEverything() throws Exception {
+        final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
+        final DefaultConfiguration emptyStatementConfig =
+                createModuleConfig(EmptyStatementCheck.class);
+        treeWalkerConfig.addChild(emptyStatementConfig);
+
+        final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+
+        final DefaultConfiguration filterConfig =
+                createModuleConfig(BeforeExecutionExclusionFileFilter.class);
+        filterConfig.addProperty("fileNamePattern", "module\\-info\\.java$");
+        checkerConfig.addChild(filterConfig);
+
+        final DefaultConfiguration fileTabConfig =
+                createModuleConfig(FileTabCharacterCheck.class);
+        checkerConfig.addChild(fileTabConfig);
+
+        final String uniqueFileName = "module-info.java";
+        final File filePath = new File(temporaryFolder, uniqueFileName);
+        Files.writeString(filePath.toPath(), "module test {\t; }");
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(createChecker(checkerConfig), filePath.getAbsolutePath(), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1889,7 +1889,7 @@ public class XdocsPagesTest {
 
         assertWithMessage("%s section '%s' should have matching parent", fileName, sectionName)
             .that(subSection.getTextContent().trim())
-            .isEqualTo(expected);
+            .contains(expected);
     }
 
     private static boolean hasParentModule(String sectionName) {


### PR DESCRIPTION
closes #5816 


Allow BeforeExecutionExclusionFileFilter to also be placed as a child of TreeWalker. This way, excluded files skip Java parsing and TreeWalker-level checks, but Checker-level checks still run.

Configuration example:

```
<module name="Checker">
  <!-- Runs on ALL files, including excluded ones -->
  <module name="FileTabCharacter"/>

  <module name="TreeWalker">
    <module name="EmptyStatementCheck"/>

    <!-- TreeWalker-level exclusion: skips Java parsing but
         FileTabCharacter above still checks this file -->
    <module name="BeforeExecutionExclusionFileFilter">
      <property name="fileNamePattern" value="module\-info\.java$"/>
    </module>
  </module>
</module>
```