### PR TITLE
Issue #20625: Add examples for JavadocBlockTagLocation and RegexpOnFilename

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
@@ -81,12 +81,20 @@
 </code></pre></div>
         <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-/**
- * Escaped tag &amp;#64;version (OK)
- * Plain text with {@code @see} (OK)
- * A @custom tag (OK)
- *
- */
+// violation 7 lines below 'The Javadoc block tag '@return' should be placed'
+  // ok, apiNote is not configured
+  // ok, noinspection is not configured
+  /**
+   * Escaped tag &amp;#64;version is plain text.
+   * Plain text with {@code @see} is ignored.
+   * A @custom tag is not configured.
+   * Returns the result. @return the result
+   * Implementation note. @apiNote use this method carefully
+   * Suppression note. @noinspection unused
+   */
+  int method() {
+    return 1;
+  }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
           To configure the check to verify tags from
@@ -100,9 +108,27 @@
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
+</code></pre></div>
+        <p id="Example2-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// ok, return is not configured
+  // violation 7 lines below 'The Javadoc block tag '@apiNote' should be placed'
+  // ok, noinspection is not configured
+  /**
+   * Escaped tag &amp;#64;version is plain text.
+   * Plain text with {@code @see} is ignored.
+   * A @custom tag is not configured.
+   * Returns the result. @return the result
+   * Implementation note. @apiNote use this method carefully
+   * Suppression note. @noinspection unused
+   */
+  int method() {
+    return 1;
+  }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
-          To configure the check to verify all default tags and some custom tags in addition:
+          To configure the check to verify all default tags plus a custom
+          <code>noinspection</code> tag:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -118,6 +144,23 @@
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation 7 lines below 'The Javadoc block tag '@return' should be placed'
+  // ok, apiNote is not configured
+  // violation 7 lines below 'The Javadoc block tag '@noinspection' should be placed'
+  /**
+   * Escaped tag &amp;#64;version is plain text.
+   * Plain text with {@code @see} is ignored.
+   * A @custom tag is not configured.
+   * Returns the result. @return the result
+   * Implementation note. @apiNote use this method carefully
+   * Suppression note. @noinspection unused
+   */
+  int method() {
+    return 1;
+  }
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
@@ -56,14 +56,27 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example2.java"/>
           <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example2.java"/>
+          <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example3-config">
-          To configure the check to verify all default tags and some custom tags in addition:
+          To configure the check to verify all default tags plus a custom
+          <code>noinspection</code> tag:
         </p>
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example3.java"/>
           <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example3.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/site/xdoc/checks/regexp/regexponfilename.xml
+++ b/src/site/xdoc/checks/regexp/regexponfilename.xml
@@ -111,14 +111,17 @@
 </code></pre></div>
         <p id="Example1-code">Example1:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-.../checkstyle.xml
-.../Test Example1.xml // violation, 'File match folder pattern '' and file pattern '\s'.'
-.../TestExample2.xml
-.../TestExample3.md
-.../TestExample4.xml
+class Example1 {
+  // ok, checkstyle.xml
+  // violation 'File name 'Test Example1.xml' matches the pattern '\s'.'
+  // ok, TestExample2.xml
+  // ok, TestExample3.md
+  // ok, TestExample4.xml
+  // ok, Example1.java
+}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
-          To configure the check to forbid 'xml' files in folders:
+          To configure the <code>fileNamePattern</code> property to forbid matching XML files:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -131,15 +134,17 @@
 </code></pre></div>
         <p id="Example2-code">Example2:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-.../checkstyle.xml
-.../Test Example1.xml
-.../TestExample2.xml // violation, 'xml files should not match '^TestExample\d+\.xml$''
-.../TestExample3.md
-.../TestExample4.xml // violation, 'xml files should not match '^TestExample\d+\.xml$''
+class Example2 {
+  // ok, checkstyle.xml
+  // ok, Test Example1.xml
+  // violation 'xml files should not match '^TestExample\\d+\\.xml$''
+  // ok, TestExample3.md
+  // violation 'xml files should not match '^TestExample\\d+\\.xml$''
+  // ok, Example2.java
+}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
-          To configure the check to forbid 'md' files except 'README.md file' in folders,
-          with custom message:
+          To configure the <code>fileExtensions</code> property to process only Markdown files:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -154,15 +159,18 @@
 </code></pre></div>
         <p id="Example3-code">Example3:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-.../checkstyle.xml
-.../Test Example1.xml
-.../TestExample2.xml
-.../TestExample3.md  // violation, 'No *.md files other than README.md'
-.../TestExample4.xml
+class Example3 {
+  // ok, checkstyle.xml is not processed
+  // ok, Test Example1.xml is not processed
+  // ok, TestExample2.xml is not processed
+  // violation 'No *.md files other than README.md'
+  // ok, TestExample4.xml is not processed
+  // ok, Example3.java is not processed
+}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
-          To configure the check to only allow property and xml files to be located
-          in the resource folder:
+          To configure the <code>match</code> property to report files that do not match
+          the supplied pattern:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -176,14 +184,18 @@
 </code></pre></div>
         <p id="Example4-code">Example4:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-.../checkstyle.xml
-.../Test Example1.xml
-.../TestExample2.xml
-.../TestExample3.md  // violation, 'Only property and xml files to be located in the resource folder'
-.../TestExample4.xml
+class Example4 {
+  // ok, checkstyle.xml matches an allowed extension
+  // ok, Test Example1.xml matches an allowed extension
+  // ok, TestExample2.xml matches an allowed extension
+  // violation 'Only property and xml files to be located in the resource folder'
+  // ok, TestExample4.xml matches an allowed extension
+  // violation 'Only property and xml files to be located in the resource folder'
+}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example5-config">
-          To configure the check to only allow only camelcase
+          To configure <code>ignoreFileNameExtensions</code> so the pattern is applied
+          without file extensions:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -198,15 +210,18 @@
 </code></pre></div>
         <p id="Example5-code">Example5:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-.../checkstyle.xml    // violation, 'only filenames in camelcase is allowed'
-.../Test Example1.xml // violation, 'only filenames in camelcase is allowed'
-.../TestExample2.xml
-.../TestExample3.md
-.../TestExample4.xml
+class Example5 {
+  // violation 'only filenames in camelcase is allowed'
+  // violation 'only filenames in camelcase is allowed'
+  // ok, TestExample2.xml
+  // ok, TestExample3.md
+  // ok, TestExample4.xml
+  // ok, Example5.java
+}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example6-config">
-          To configure the check to forbid files that do not start with 'Test' in folders
-          named 'regexponfilename':
+          To configure <code>folderPattern</code> so matching is restricted to folders
+          named <code>regexponfilename</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -219,8 +234,14 @@
 </code></pre></div>
         <p id="Example6-code">Example6:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-.../TestExample2.xml
-.../Example1.java // violation, 'File match folder pattern'
+class Example6 {
+  // violation 'does not match the pattern'
+  // ok, Test Example1.xml starts with Test
+  // ok, TestExample2.xml starts with Test
+  // violation 'does not match the pattern'
+  // ok, TestExample4.xml starts with Test
+  // violation 'does not match the pattern'
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/regexp/regexponfilename.xml.template
+++ b/src/site/xdoc/checks/regexp/regexponfilename.xml.template
@@ -43,7 +43,7 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example2-config">
-          To configure the check to forbid 'xml' files in folders:
+          To configure the <code>fileNamePattern</code> property to forbid matching XML files:
         </p>
         <macro name="example">
           <param name="path"
@@ -57,8 +57,7 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example3-config">
-          To configure the check to forbid 'md' files except 'README.md file' in folders,
-          with custom message:
+          To configure the <code>fileExtensions</code> property to process only Markdown files:
         </p>
         <macro name="example">
           <param name="path"
@@ -72,8 +71,8 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example4-config">
-          To configure the check to only allow property and xml files to be located
-          in the resource folder:
+          To configure the <code>match</code> property to report files that do not match
+          the supplied pattern:
         </p>
         <macro name="example">
           <param name="path"
@@ -87,7 +86,8 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example5-config">
-          To configure the check to only allow only camelcase
+          To configure <code>ignoreFileNameExtensions</code> so the pattern is applied
+          without file extensions:
         </p>
         <macro name="example">
           <param name="path"
@@ -101,8 +101,8 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example6-config">
-          To configure the check to forbid files that do not start with 'Test' in folders
-          named 'regexponfilename':
+          To configure <code>folderPattern</code> so matching is restricted to folders
+          named <code>regexponfilename</code>:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -119,7 +119,6 @@ public class XdocsExamplesAstConsistencyTest {
      *
      */
     private static final Set<String> UNPARSEABLE_EXAMPLES = Set.of(
-            "checks/regexp/regexponfilename/Example1",
             "checks/translation/Example1",
             "filters/suppressionxpathsinglefilter/Example14"
     );
@@ -157,11 +156,9 @@ public class XdocsExamplesAstConsistencyTest {
             // until https://github.com/checkstyle/checkstyle/issues/20625
             "checks/coding/illegaltokentext",
             "checks/descendanttoken",
-            "checks/javadoc/javadocblocktaglocation",
             "checks/modifier/interfacememberimpliedmodifier",
             "checks/regexp/regexp",
             "checks/regexp/regexpmultiline",
-            "checks/regexp/regexponfilename",
             "checks/regexp/regexpsingleline",
             "checks/regexp/regexpsinglelinejava",
             "checks/translation",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckExamplesTest.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.MSG_BLOCK_TAG_LOCATION;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
@@ -33,7 +35,7 @@ public class JavadocBlockTagLocationCheckExamplesTest extends AbstractExamplesMo
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-
+            "20: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "return"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -42,7 +44,7 @@ public class JavadocBlockTagLocationCheckExamplesTest extends AbstractExamplesMo
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-
+            "23: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "apiNote"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -51,7 +53,8 @@ public class JavadocBlockTagLocationCheckExamplesTest extends AbstractExamplesMo
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-
+            "28: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "return"),
+            "30: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "noinspection"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example1.java
@@ -9,13 +9,20 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
 class Example1 {
-// xdoc section -- start
-/**
- * Escaped tag &#64;version (OK)
- * Plain text with {@code @see} (OK)
- * A @custom tag (OK)
- *
- */
-// xdoc section -- end
-
+  // xdoc section -- start
+  // violation 7 lines below 'The Javadoc block tag '@return' should be placed'
+  // ok, apiNote is not configured
+  // ok, noinspection is not configured
+  /**
+   * Escaped tag &#64;version is plain text.
+   * Plain text with {@code @see} is ignored.
+   * A @custom tag is not configured.
+   * Returns the result. @return the result
+   * Implementation note. @apiNote use this method carefully
+   * Suppression note. @noinspection unused
+   */
+  int method() {
+    return 1;
+  }
+  // xdoc section -- end
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example2.java
@@ -8,12 +8,23 @@
 </module>
 */
 
-
-
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
 class Example2 {
-// xdoc section -- start
-// xdoc section -- end
+  // xdoc section -- start
+  // ok, return is not configured
+  // violation 7 lines below 'The Javadoc block tag '@apiNote' should be placed'
+  // ok, noinspection is not configured
+  /**
+   * Escaped tag &#64;version is plain text.
+   * Plain text with {@code @see} is ignored.
+   * A @custom tag is not configured.
+   * Returns the result. @return the result
+   * Implementation note. @apiNote use this method carefully
+   * Suppression note. @noinspection unused
+   */
+  int method() {
+    return 1;
+  }
+  // xdoc section -- end
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example3.java
@@ -16,7 +16,21 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
-public class Example3 {
-// xdoc section -- start
-// xdoc section -- end
+class Example3 {
+  // xdoc section -- start
+  // violation 7 lines below 'The Javadoc block tag '@return' should be placed'
+  // ok, apiNote is not configured
+  // violation 7 lines below 'The Javadoc block tag '@noinspection' should be placed'
+  /**
+   * Escaped tag &#64;version is plain text.
+   * Plain text with {@code @see} is ignored.
+   * A @custom tag is not configured.
+   * Returns the result. @return the result
+   * Implementation note. @apiNote use this method carefully
+   * Suppression note. @noinspection unused
+   */
+  int method() {
+    return 1;
+  }
+  // xdoc section -- end
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example1.java
@@ -4,13 +4,13 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
-.../checkstyle.xml
-.../Test Example1.xml // violation, 'File match folder pattern '' and file pattern '\s'.'
-.../TestExample2.xml
-.../TestExample3.md
-.../TestExample4.xml
+class Example1 {
+  // ok, checkstyle.xml
+  // violation 'File name 'Test Example1.xml' matches the pattern '\s'.'
+  // ok, TestExample2.xml
+  // ok, TestExample3.md
+  // ok, TestExample4.xml
+  // ok, Example1.java
+}
 // xdoc section -- end
-*/
-class Example1{}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example2.java
@@ -8,13 +8,13 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
-.../checkstyle.xml
-.../Test Example1.xml
-.../TestExample2.xml // violation, 'xml files should not match '^TestExample\d+\.xml$''
-.../TestExample3.md
-.../TestExample4.xml // violation, 'xml files should not match '^TestExample\d+\.xml$''
+class Example2 {
+  // ok, checkstyle.xml
+  // ok, Test Example1.xml
+  // violation 'xml files should not match '^TestExample\\d+\\.xml$''
+  // ok, TestExample3.md
+  // violation 'xml files should not match '^TestExample\\d+\\.xml$''
+  // ok, Example2.java
+}
 // xdoc section -- end
-*/
-class Example2 {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example3.java
@@ -10,13 +10,13 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
-.../checkstyle.xml
-.../Test Example1.xml
-.../TestExample2.xml
-.../TestExample3.md  // violation, 'No *.md files other than README.md'
-.../TestExample4.xml
+class Example3 {
+  // ok, checkstyle.xml is not processed
+  // ok, Test Example1.xml is not processed
+  // ok, TestExample2.xml is not processed
+  // violation 'No *.md files other than README.md'
+  // ok, TestExample4.xml is not processed
+  // ok, Example3.java is not processed
+}
 // xdoc section -- end
-*/
-class Example3{}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example4.java
@@ -9,13 +9,13 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
-.../checkstyle.xml
-.../Test Example1.xml
-.../TestExample2.xml
-.../TestExample3.md  // violation, 'Only property and xml files to be located in the resource folder'
-.../TestExample4.xml
+class Example4 {
+  // ok, checkstyle.xml matches an allowed extension
+  // ok, Test Example1.xml matches an allowed extension
+  // ok, TestExample2.xml matches an allowed extension
+  // violation 'Only property and xml files to be located in the resource folder'
+  // ok, TestExample4.xml matches an allowed extension
+  // violation 'Only property and xml files to be located in the resource folder'
+}
 // xdoc section -- end
-*/
-class Example4 {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example5.java
@@ -10,13 +10,13 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
-.../checkstyle.xml    // violation, 'only filenames in camelcase is allowed'
-.../Test Example1.xml // violation, 'only filenames in camelcase is allowed'
-.../TestExample2.xml
-.../TestExample3.md
-.../TestExample4.xml
+class Example5 {
+  // violation 'only filenames in camelcase is allowed'
+  // violation 'only filenames in camelcase is allowed'
+  // ok, TestExample2.xml
+  // ok, TestExample3.md
+  // ok, TestExample4.xml
+  // ok, Example5.java
+}
 // xdoc section -- end
-*/
-class Example5 {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example6.java
@@ -8,10 +8,13 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
-.../TestExample2.xml
-.../Example1.java // violation, 'File match folder pattern'
+class Example6 {
+  // violation 'does not match the pattern'
+  // ok, Test Example1.xml starts with Test
+  // ok, TestExample2.xml starts with Test
+  // violation 'does not match the pattern'
+  // ok, TestExample4.xml starts with Test
+  // violation 'does not match the pattern'
+}
 // xdoc section -- end
-*/
-class Example6 {}


### PR DESCRIPTION
Part of #20625

## Summary

Adds and restructures AST-consistent xdoc examples for:

- `JavadocBlockTagLocationCheck`
- `RegexpOnFilenameCheck`

Both modules are removed from `EXAMPLE_COUNT_SUPPRESSED_MODULES`.

## JavadocBlockTagLocation

The three-example AST-consistent group contains a default baseline preserving escaped, inline-code, and unconfigured-tag behavior; a JEP 8068562 configuration demonstrating `apiNote`; and all default tags plus custom `noinspection`.

All three examples use the same Java and Javadoc structure and differ only in ignored `ok` and `violation` markers.

## RegexpOnFilename

The six-example AST-consistent group covers `fileNamePattern`, `fileExtensions`, `match`, `ignoreFileNameExtensions`, and `folderPattern`. The obsolete `UNPARSEABLE_EXAMPLES` entry for `checks/regexp/regexponfilename/Example1` is removed.

## Validation

- JavadocBlockTagLocationCheckExamplesTest: 3 passed
- RegexpOnFilenameCheckExamplesTest: 6 passed
- XdocsExamplesAstConsistencyTest: 4 passed
- XdocsPagesTest: 19 passed
- XdocsCategoryIndexTest: 1 passed
- full `clean verify`: BUILD SUCCESS
- unit tests: 12,510 passed
- integration tests: 1,119 passed
- failures/errors/skips: 0/0/0
- PMD passed
- SpotBugs passed (0 bugs, 0 errors)
- forbidden APIs passed (0 errors)
- resource and documentation validation passed
- `git diff --check`: passed
