### PR TITLE
Issue #20675: remove javadocpropertiesgenerator from javadoc exclusio…

### DIFF
--- a/.ci/javadoc-tool-excluded-packages.sh
+++ b/.ci/javadoc-tool-excluded-packages.sh
@@ -8,5 +8,4 @@ checks_package=com.puppycrawl.tools.checkstyle.checks
 javadoc_package=$checks_package.javadoc
 
 JAVADOC_TOOL_EXCLUDED_PACKAGES=(
-  "$source_root com.puppycrawl.tools.checkstyle.javadocpropertiesgenerator"
 )


### PR DESCRIPTION
…n list

Issue: #20675

Removed the stale exclusion for `com.puppycrawl.tools.checkstyle.javadocpropertiesgenerator`
from `.ci/javadoc-tool-excluded-packages.sh`.

Ran the Javadoc validation against this package after removing the exclusion and found
zero syntax errors — the exclusion was no longer needed. No input files required moving
to `resources-with-javadoc-error` since nothing invalid was actually detected at the
syntax level.

This was confirmed to be the last remaining entry in the exclusion list, so this PR
fully closes out `.ci/javadoc-tool-excluded-packages.sh` for this issue.