### PR TITLE
Issue #20877: compile input resources by default to match IDE source roots

### DIFF
--- a/.ci/release-maven-perform.sh
+++ b/.ci/release-maven-perform.sh
@@ -15,7 +15,7 @@ checkForVariable "GITHUB_REPOSITORY_OWNER"
 TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
-SKIP_TEST="-DskipTests -DskipITs"
+SKIP_TEST="-Dcheckstyle.skipCompileInputResources=true -DskipTests -DskipITs"
 SKIP_CHECKSTYLE="-Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true"
 SKIP_OTHERS="-Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dxml.skip=true \
   --no-transfer-progress"

--- a/.ci/release-maven-prepare.sh
+++ b/.ci/release-maven-prepare.sh
@@ -28,7 +28,7 @@ if [[ $(grep "<section name=\"Release $TARGET_VERSION\">" src/site/xdoc/releasen
   exit 1
 fi
 
-SKIP_TEST="-DskipTests -DskipITs"
+SKIP_TEST="-Dcheckstyle.skipCompileInputResources=true -DskipTests -DskipITs"
 SKIP_CHECKSTYLE="-Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true"
 SKIP_OTHERS="-Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dxml.skip=true -Dgpg.skip"
 

--- a/.ci/run-link-check-plugin.sh
+++ b/.ci/run-link-check-plugin.sh
@@ -8,6 +8,7 @@ uname -a
 ./mvnw --version
 curl --fail-with-body -I https://sourceforge.net/projects/checkstyle/
 ./mvnw -e --no-transfer-progress clean site -Dcheckstyle.ant.skip=true -DskipTests -DskipITs \
+   -Dcheckstyle.skipCompileInputResources=true \
    -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dcheckstyle.skip=true
 mkdir -p .ci-temp
 

--- a/.ci/validation.cmd
+++ b/.ci/validation.cmd
@@ -21,7 +21,9 @@ if "%OPTION%" == "run_checkstyle" (
 )
 
 if "%OPTION%" ==  "verify_without_checkstyle" (
-  call mvnw.cmd -e --no-transfer-progress verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true^
+  :: Appveyor has old jdk21 there is problem compilation of Inputs
+  call mvnw.cmd -e --no-transfer-progress verify -Dcheckstyle.skipCompileInputResources=true^
+    -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true^
     || goto :ERROR
   goto :END_CASE
 )

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -613,6 +613,7 @@ release-dry-run)
     ./mvnw -e --no-transfer-progress release:prepare -DdryRun=true --batch-mode \
     -Darguments='-DskipTests -DskipITs -Djacoco.skip=true -Dpmd.skip=true \
       -Dspotbugs.skip=true -Dxml.skip=true -Dcheckstyle.ant.skip=true \
+      -Dcheckstyle.skipCompileInputResources=true \
       -Dcheckstyle.skip=true -Dgpg.skip=true --no-transfer-progress'
     ./mvnw -e --no-transfer-progress release:clean
   fi
@@ -714,13 +715,6 @@ check-since-version)
   else
     echo "No new Check, all is good."
   fi
-  ;;
-
-compile-test-resources)
-  # this task is useful during migration to new JDK to let compile resources on new jdk only
-  ./mvnw -e --no-transfer-progress clean test-compile \
-  -Dcheckstyle.skipCompileInputResources=false \
-  -Dmaven.compiler.release=21
   ;;
 
 javac21-exceptional)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,10 +323,6 @@ workflows:
           image-name: cimg/openjdk:21.0.6
           command: ./.ci/validation.sh javac21-exceptional
       - validate-with-script:
-          name: java 21 test resources compile
-          image-name: cimg/openjdk:21.0.8
-          command: ./.ci/validation.sh compile-test-resources
-      - validate-with-script:
           name: javac25
           image-name: cimg/openjdk:25.0
           command: ./.ci/validation.sh javac25

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Visual Studio 2026
 version: '{build}'
 skip_tags: true
 

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
     </sevntu-checkstyle-check.checkstyle.version>
     <versions.plugin.version>2.21.0</versions.plugin.version>
     <compiler.plugin.version>3.15.0</compiler.plugin.version>
-    <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
+    <checkstyle.skipCompileInputResources>false</checkstyle.skipCompileInputResources>
     <checkstyle.openrewrite.version>1.0.0-SNAPSHOT</checkstyle.openrewrite.version>
     <java.version>21</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
@@ -2173,6 +2173,16 @@
               <excludes>
                 <exclude>**/Example*</exclude>
                 <exclude>**/Input*</exclude>
+                <!-- input helper classes co-located in Input*/Example* files (or named
+                     UseCase*) that do not match the Input*/Example* naming; compiled since
+                     checkstyle.skipCompileInputResources=false and use forbidden apis by
+                     design as test fixtures -->
+                <exclude>**/UseCase*</exclude>
+                <exclude>**/classdataabstractioncoupling/MyRecord*</exclude>
+                <exclude>**/whitespacearound/foo3*</exclude>
+                <exclude>**/missingoverrideonrecordaccessor/Person*</exclude>
+                <exclude>**/missingoverrideonrecordaccessor/Document*</exclude>
+                <exclude>**/rule61overridealwaysused/Document*</exclude>
                 <!-- usage of system output by design -->
                 <exclude>**/MainTest.class</exclude>
                 <!-- tests need forbidden apis to test the main code fully -->
@@ -2607,6 +2617,7 @@
       <id>no-validations</id>
       <properties>
         <skipTests>true</skipTests>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
         <checkstyle.ant.skip>true</checkstyle.ant.skip>
         <pmd.skip>true</pmd.skip>
         <spotbugs.skip>true</spotbugs.skip>


### PR DESCRIPTION
Fixes #20877

### Root cause

Maven and IDEA share `target/test-classes` and disagree about what the Input dirs are.

IDEA registers `src/test/resources`, `src/it/resources` and `src/xdocs-examples/resources` as test source roots and compiles them regardless of `checkstyle.skipCompileInputResources`. Its importer (`BuildHelperMavenPluginUtil`) reads only the build-helper execution's `<sources>`; `skipAddTestSource` does not occur anywhere in the IDE's Maven plugin. The property only ever controlled Maven.

| | Input `.class` in `target/test-classes` |
| --- | --- |
| IDEA Rebuild Project | 9783 |
| `mvn clean test-compile` (property `true`) | 0 |
| `mvn clean test-compile` (property `false`) | 9783 |

At `true`, Maven deletes 9783 class files the IDE model requires and copies the `.java` in as resources. The next incremental IDE build compiles whichever Inputs are dirty against that gutted directory, their same-package siblings are gone, and the reported errors appear. The failing set equals the dirty set, hence "unstable and unpredictable".

### Reproduction

```bash
./mvnw clean test-compile   # property true: leaves 0 Input .class
touch src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestLegalAbstractClassNames.java
```

Build | Build Project then shows the five errors from the issue verbatim. Populating the directory makes the same build green.

### Fix

`pom.xml` only, no Input modified.

1. Default `checkstyle.skipCompileInputResources` to `false` — Maven compiles the Inputs into the same `target/test-classes` IDEA expects them in, so the inconsistent state cannot occur. A fresh clone needs no IDE configuration: no custom scope, no manual *Excluded* marks.
2. Six `<exclude>` entries in `forbiddenapis-test`. Compiled Inputs reach `forbiddenapis:testCheck`, whose `**/Input*` / `**/Example*` excludes match class names rather than file names, so helpers declared inside `Input*`/`Example*` files leak through (52 violations). None shadows real test code; `**/rule61overridealwaysused/Document*` is class-precise because that package also holds `OverrideAlwaysUsedTest`.
3. Property back to `true` in `no-validations`, so the external `no-error-*` jobs skip Inputs.

Not a reversal of #17168 — the step of it never finished. Its checklist still carries an unchecked "revert changes in pom.xml to make Inputs be compiled by maven". The skip arrived in 290458b727 as a temporary migration measure, and #17321 closed on the JDK baseline without covering it.

### Verification

`./mvnw clean verify` on JDK 21: 6236 unit tests and 1257 integration tests green, `forbiddenapis` 0 errors on 3869 classes, PMD / SpotBugs / Modernizer clean, `ant-phase-verify` clean.

### Notes

- `test-compile` now compiles ~5900 test sources instead of 910; `clean verify` about 18 min locally. Not new work — `.ci/validation.sh`'s `compile-test-resources` job already did it every CI run, so that job is now redundant. Left in place to keep the diff minimal; can remove here or separately.
- Adjacent: `src/*/resources-noncompilable` are neither source roots nor excluded, so IDEA shows red code there and https://checkstyle.org/idea.html asks users to mark them *Excluded* by hand. Separate issue.
