### PR TITLE
Issue #20812: Add MultiFileRegexpHeader to cover Sun style rule 3.1.1

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -104,6 +104,7 @@ bdc
 bdd
 beanutils
 beforeexecutionexclusionfilefilter
+beginningcomments
 bestpractices
 bew
 bitbucket

--- a/pom.xml
+++ b/pom.xml
@@ -1827,6 +1827,9 @@
             <header.file.paths.separated.by.coma>
               ${project.basedir}/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulecopyrightnotice/openjdk-style.header
             </header.file.paths.separated.by.coma>
+            <org.checkstyle.sun.header.files>
+              ${project.basedir}/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/sun-style.header
+            </org.checkstyle.sun.header.files>
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/src/it/java/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/BeginningCommentsTest.java
+++ b/src/it/java/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/BeginningCommentsTest.java
@@ -1,0 +1,48 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.sun.checkstyle.test.chapter3fileorganization.rule311beginningcomments;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.checkstyle.test.base.AbstractSunModuleTestSupport;
+
+public class BeginningCommentsTest extends AbstractSunModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments";
+    }
+
+    @Test
+    public void testBeginningCommentsValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputBeginningCommentsValid.java"));
+    }
+
+    @Test
+    public void testBeginningCommentsMismatch() throws Exception {
+        verifyWithWholeConfig(getPath("InputBeginningCommentsMismatch.java"));
+    }
+
+    @Test
+    public void testBeginningCommentsMissing() throws Exception {
+        verifyWithWholeConfig(getPath("InputBeginningCommentsMissing.java"));
+    }
+
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/InputBeginningCommentsMismatch.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/InputBeginningCommentsMismatch.java
@@ -1,0 +1,19 @@
+/*
+ * InputBeginningCommentsMismatch
+ *
+ * Version 1.0
+ *
+ * 20/07/2026
+ *
+ * Copyright (c) 2026 Some Company.
+ */
+// violation 2 lines above 'Header mismatch'
+// copyright line lacks the 'All rights reserved.' part of the template
+
+package com.sun.checkstyle.test.chapter3fileorganization.rule311beginningcomments;
+
+/**
+ * Test input with a mismatching beginning comment.
+ */
+public class InputBeginningCommentsMismatch {
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/InputBeginningCommentsMissing.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/InputBeginningCommentsMissing.java
@@ -1,0 +1,8 @@
+package com.sun.checkstyle.test.chapter3fileorganization.rule311beginningcomments;
+// violation first line 'Header is missing'
+
+/**
+ * Test input without any beginning comment.
+ */
+public class InputBeginningCommentsMissing {
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/InputBeginningCommentsValid.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/InputBeginningCommentsValid.java
@@ -1,0 +1,17 @@
+/*
+ * InputBeginningCommentsValid
+ *
+ * Version 1.0
+ *
+ * 20/07/2026
+ *
+ * Copyright (c) 2026 Some Company. All rights reserved.
+ */
+
+package com.sun.checkstyle.test.chapter3fileorganization.rule311beginningcomments;
+
+/**
+ * Test input with a valid beginning comment.
+ */
+public class InputBeginningCommentsValid {
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/package-info.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Test inputs for beginning comments check in Sun style.
+ */
+package com.sun.checkstyle.test.chapter3fileorganization.rule311beginningcomments;

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/sun-style.header
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments/sun-style.header
@@ -1,0 +1,9 @@
+^/\*$
+^ \* \w+$
+^ \*$
+^ \* Version \d+\.\d+$
+^ \*$
+^ \* \d{2}/\d{2}/\d{4}$
+^ \*$
+^ \* Copyright \(c\) \d{4} [A-Za-z0-9 .,]+\. All rights reserved\.$
+^ \*/$

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderAccessModifiers.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderAccessModifiers.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for declaration order with access modifier violations.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderConstructor.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderConstructor.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for declaration order with constructor order violation.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderDefault.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderDefault.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for declaration order with default scenarios.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderInstance.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderInstance.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for declaration order with instance variable order violation.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderMultipleViolations.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderMultipleViolations.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for declaration order with multiple violations.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderStaticMembers.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderStaticMembers.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for declaration order with static member violations.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderValid.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderValid.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for declaration order with valid order (no violations).
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderValidInnerClass.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule313classdeclarations/InputDeclarationOrderValidInnerClass.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter3fileorganization.rule313classdeclarations;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for valid declaration order with inner class.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineDefault.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineDefault.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter7statements.rule71simplestatements;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for one statement per line with default violations.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineForLoop.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineForLoop.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter7statements.rule71simplestatements;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for one statement per line in for loop.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineMultiple.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineMultiple.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter7statements.rule71simplestatements;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for multiple statements per line.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineValid.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule71simplestatements/InputOneStatementPerLineValid.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter7statements.rule71simplestatements;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for valid one statement per line.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughDefault.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughDefault.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter7statements.rule78switchstatements;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for fall through with default violations.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughValid.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughValid.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter7statements.rule78switchstatements;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for valid switch statements (no fall through violations).
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughWithBreak.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughWithBreak.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter7statements.rule78switchstatements;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for fall through with break statements.
  */

--- a/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughWithComment.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter7statements/rule78switchstatements/InputFallThroughWithComment.java
@@ -1,5 +1,7 @@
 package com.sun.checkstyle.test.chapter7statements.rule78switchstatements;
 
+// violation first line 'Header mismatch'
+
 /**
  * Test input for fall through with relief comment.
  */

--- a/src/main/resources/sun_checks.xml
+++ b/src/main/resources/sun_checks.xml
@@ -95,6 +95,16 @@
   <!--   <property name="fileExtensions" value="java"/> -->
   <!-- </module> -->
 
+  <!-- Checks that a file begins with a c-style comment that lists the  -->
+  <!-- class name, version information, date and copyright notice.     -->
+  <!-- See https://checkstyle.org/checks/header/multifileregexpheader.html -->
+  <module name="MultiFileRegexpHeader">
+    <property name="fileExtensions" value="java"/>
+    <property name="headerFiles"
+              value="${org.checkstyle.sun.header.files}"
+              default="/com/puppycrawl/tools/checkstyle/any.header"/>
+  </module>
+
   <module name="TreeWalker">
 
     <!-- Checks for Javadoc comments.                     -->

--- a/src/site/xdoc/checks/header/multifileregexpheader.xml
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml
@@ -184,6 +184,10 @@ public class Example4 { }
               Checkstyle Style
             </a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultiFileRegexpHeader">
+            Sun Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/header/multifileregexpheader.xml.template
+++ b/src/site/xdoc/checks/header/multifileregexpheader.xml.template
@@ -133,6 +133,10 @@
               Checkstyle Style
             </a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultiFileRegexpHeader">
+            Sun Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/sun_style.xml
+++ b/src/site/xdoc/sun_style.xml
@@ -226,8 +226,22 @@
                     3.1.1 Beginning Comments
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/header/multifileregexpheader.html#MultiFileRegexpHeader">
+                    MultiFileRegexpHeader
+                  </a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultiFileRegexpHeader">
+                    config
+                  </a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule311beginningcomments">
+                    samples
+                  </a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
Fixes #20812

**Problem**:
Sun style rule [3.1.1 Beginning Comments](https://checkstyle.sourceforge.io/styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a3441) ("All source files should begin with a c-style comment that lists the class name, version information, date, and copyright notice") is uncovered: the 3.1.1 row in `sun_style.xml` is `???` and `sun_checks.xml` has no header check.

The snippet in the issue does not work as written, on three counts:

- It is listed as **TreeWalker-level**. `MultiFileRegexpHeaderCheck` extends `AbstractFileSetCheck`, so `Checker` is its only valid parent; under `TreeWalker` the config fails to load with `TreeWalker is not allowed as a parent of MultiFileRegexpHeader`.
- A bare `<module name="MultiFileRegexpHeader"/>` is a **silent no-op**: `headerFiles` has no default, and `processFiltered` is guarded by `if (!headerFilesMetadata.isEmpty())`, so nothing is ever enforced.
- The heading says `openjdk_checks.xml`, which looks like a copy-paste from the OpenJDK tracking issue; parent issue #20811 specifies `src/main/resources/sun_checks.xml`.

**Fix**:
Added `MultiFileRegexpHeader` at `Checker` level in `sun_checks.xml`, with `headerFiles` exposed as a property the same way `openjdk_checks.xml` already does it:

```xml
<module name="MultiFileRegexpHeader">
  <property name="fileExtensions" value="java"/>
  <property name="headerFiles"
            value="${org.checkstyle.sun.header.files}"
            default="/com/puppycrawl/tools/checkstyle/any.header"/>
</module>
```

The required header text is project-specific, so it stays configurable. The default remains `any.header` (`^.*`), so **existing `sun_checks.xml` users get no new violations**. A property name distinct from OpenJDK's `header.file.paths.separated.by.coma` is necessary because `pom.xml` sets that one globally for the whole failsafe run, and reusing it would point the Sun tests at the OpenJDK header file.

Also:
- Filled the `???` in the 3.1.1 row of `sun_style.xml` and added the "Sun Style" usage link to `multifileregexpheader.xml` and its `.template`.
- New integration tests in `chapter3fileorganization/rule311beginningcomments` covering valid header, header mismatch, and header shorter than the template (which reports `multi.file.regexp.header.missing`, not `...mismatch`). `pom.xml` wires the property to a `sun-style.header` built from the style guide's template.
- The 16 existing Sun inputs each get one `// violation first line 'Header mismatch'` annotation. Sun integration tests run every input against the *whole* config, so a real header template makes them all report on line 1. This is what was done when the same check was added to OpenJDK style in #20660, which annotated ~110 inputs the same way. `InputInvalidJavadocPosition.java` and `InputMultipleVariableDeclarations.java` are deliberately untouched: they use the older single-module `verify(checkConfig, ...)` style rather than `verifyWithWholeConfig`, so they are unaffected and their hardcoded line numbers must not shift.
- `MultiFileRegexpHeader` was not in `XdocsPagesTest.IGNORED_SUN_MODULES`, so there is nothing to remove from that list.

**Testing**:
Full unit suite and 1126 integration tests pass under `mvn clean verify`, exercising the real `pom.xml` property wiring end to end. The self-check job (`clean verify -DskipTests -DskipITs -Dpmd.skip -Dspotbugs.skip -Djacoco.skip`) is BUILD SUCCESS with 0 violations. Sun 21/21, OpenJDK 113/113, Google 344/344, doc-comments 15/15, `...checkstyle.internal` 64/64 (`XdocsPagesTest`, `AllChecksTest`, `CommitValidationTest`), header checks 104/104. `sun_checks.xml` validates against `config/configuration-1-3.xsd`, and all four self-check configs (`checkstyle-checks`, `-non-main-files-`, `-input-`, `-resources-`) report no violations over the changed files.
