### PR TITLE
Issue #20923: fail build on PMD processing errors

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -586,22 +586,10 @@ checkstyle-and-sevntu)
   ;;
 
 spotbugs-and-pmd)
-  mkdir -p .ci-temp/spotbugs-and-pmd
-  CHECKSTYLE_DIR=$(pwd)
   export MAVEN_OPTS="-Xmx4g"
   ./mvnw -e --no-transfer-progress clean pmd:check
   ./mvnw -e --no-transfer-progress clean test-compile spotbugs:check
-  cd .ci-temp/spotbugs-and-pmd
-  grep "Processing_Errors" "$CHECKSTYLE_DIR/target/site/pmd.html" | cat > errors.log
-  RESULT=$(cat errors.log | wc -l)
-  if [[ $RESULT != 0 ]]; then
-    echo "Errors are detected in target/site/pmd.html."
-    sleep 5s
-  fi
-  cd ..
-  removeFolderWithProtectedFiles spotbugs-and-pmd
-  exit "$RESULT"
-;;
+  ;;
 
 site)
   ./mvnw -e --no-transfer-progress clean site -Pno-validations

--- a/pom.xml
+++ b/pom.xml
@@ -729,6 +729,7 @@
             <minimumTokens>20</minimumTokens>
             <skipEmptyReport>false</skipEmptyReport>
             <failOnViolation>true</failOnViolation>
+            <skipPmdError>false</skipPmdError>
             <printFailingErrors>true</printFailingErrors>
             <includeTests>true</includeTests>
             <rulesets>


### PR DESCRIPTION
Fixes #20923

**Problem:**

An invalid XPath in a `violationSuppressXPath` property does not fail the build. `mvn pmd:check` logs `[WARNING] There are 2 PMD processing errors:` and reports `BUILD SUCCESS`, so a malformed suppression can land on master.

`maven-pmd-plugin` has two independent failure switches. `failOnViolation` governs rule *violations* and is already `true`. A malformed XPath is not a violation — it is a PMD *processing error*, governed by `skipPmdError`, which defaults to `true` (warn only). From `PmdExecutor.run()`:

```java
if (!request.isSkipPmdError()) {
    throw new MavenReportException("Found " + errors.size() + " PMD processing errors");
}
LOG.warn("There are " + errors.size() + " PMD processing errors:");   // our case
```

The failure is not only silent, it suppresses checking. PMD recovers with "continuing with next rule", so the affected rule's violations in those files are neither suppressed nor reported. Measured on the issue's reproduction: with a valid config `CloseResource` records 4 suppressed violations in `src/main` (`XmlLoader`, `CheckstyleAntTask` x3); with the extra `]` it records 0 suppressed and 0 reported.

A guard for exactly this already existed in `.ci/validation.sh`, job `spotbugs-and-pmd`, but has been inert since d68a19d8a8 (2025-01-06, plugin bump 3.24.0 -> 3.26.0):

```bash
grep "Processing_Errors" "$CHECKSTYLE_DIR/target/site/pmd.html" | cat > errors.log
```

maven-pmd-plugin 3.25.0 changed the `pmd` goal's `outputDirectory` default from `${project.reporting.outputDirectory}` to `${project.build.directory}/reports`, so the report is now `target/reports/pmd.html` and the grepped path does not exist. `| cat` masks grep's non-zero exit, so `RESULT` was always 0 and the job always passed. Independently, the second `./mvnw ... clean test-compile spotbugs:check` in that job deletes `target/` before the grep runs, so the check could not work even with the path corrected.

**Fix:**

`pom.xml` — added `<skipPmdError>false</skipPmdError>` to the `maven-pmd-plugin` configuration, so PMD processing errors throw instead of warn.

`.ci/validation.sh` — removed the inert `Processing_Errors` grep block from `spotbugs-and-pmd`, along with its now-unused `CHECKSTYLE_DIR` variable and `.ci-temp` scratch directory. The job now relies on the Maven exit code, matching how every other job in that file already behaves (it was the only one with an explicit `exit`).

**Testing:**

| scenario | result |
| --- | --- |
| extra `]`, before fix | BUILD SUCCESS, `There are 2 PMD processing errors:` (reproduces issue) |
| extra `]`, after fix, `pmd:check` | BUILD FAILURE (exit 1), `Found 2 PMD processing errors` |
| extra `]`, after fix, `pmd:check@default` (`verify`-bound execution) | BUILD FAILURE (exit 1), same message |
| valid config, after fix, cold analysis cache | BUILD SUCCESS |
| valid config, after fix, no compiled classes (the `clean pmd:check` shape CI uses) | BUILD SUCCESS |

The last two check for false positives: the full ruleset was re-analysed from scratch with `target/pmd/pmd.cache` deleted, and again with `target/classes` and `target/test-classes` removed, so degraded type resolution does not introduce processing errors.

Scope confirmed via `help:effective-pom`: `skipPmdError` lands only in `<build>`, not `<reporting>`, and the `no-validations` profile sets `pmd.skip=true`, so `mvn site` is unaffected. The `cpd` and `cpd-check` goals are not used in this project, so sharing the plugin-level configuration block is safe.

Config files validated with the project's own gates: `checkstyle-non-main-files-checks.xml` reports no violations on either changed file, `mvn xml:check-format` passes, and `bash -n .ci/validation.sh` is clean.
