### PR TITLE
Issue #11140: Solve CLI_CONSTANT_LIST_INDEX

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -8461,6 +8461,13 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java</fileName>
+    <specifier>initialization.fields.uninitialized</specifier>
+    <message>the constructor does not initialize fields: xdocPath, outputFilePath</message>
+    <lineContent>private CliOptions() {</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
     <lineContent>return result;</lineContent>

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -8397,6 +8397,13 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java</fileName>
+    <specifier>initialization.fields.uninitialized</specifier>
+    <message>the constructor does not initialize fields: xdocPath, outputFilePath</message>
+    <lineContent>private CliOptions() {</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
     <lineContent>return result;</lineContent>

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -186,7 +186,6 @@
        there should be one section per one bug pattern, with list of allowed classes or methods -->
   <Match>
     <Bug pattern="
-      CLI_CONSTANT_LIST_INDEX,
       EXS_EXCEPTION_SOFTENING_NO_CHECKED,
       EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS,
       FCCD_FIND_CLASS_CIRCULAR_DEPENDENCY,

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -193,7 +193,6 @@
        there should be one section per one bug pattern, with list of allowed classes or methods -->
   <Match>
     <Bug pattern="
-      CLI_CONSTANT_LIST_INDEX,
       EXS_EXCEPTION_SOFTENING_NO_CHECKED,
       EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS,
       FCCD_FIND_CLASS_CIRCULAR_DEPENDENCY,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/AllCheckSummaries.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/AllCheckSummaries.java
@@ -275,12 +275,12 @@ public class AllCheckSummaries extends AbstractMacro {
                 final String description = JavadocScraperResultUtil.getModuleDescription();
                 if (!description.isEmpty()) {
 
-                    final String[] moduleInfo = determineModuleInfo(path, moduleName);
-                    final String packageName = moduleInfo[1];
+                    final ModuleInfo moduleInfo = determineModuleInfo(path, moduleName);
+                    final String packageName = moduleInfo.packageName();
                     if (packageFilter == null || packageFilter.equals(packageName)) {
                         final String sanitizedDescription = sanitizeAnchorUrls(description);
 
-                        final String simpleName = moduleInfo[0];
+                        final String simpleName = moduleInfo.simpleName();
                         final String summary = sanitizeAndFirstSentence(sanitizedDescription);
                         final String href = resolveHref(xmlHrefMap, packageName, simpleName,
                                 packageFilter);
@@ -300,9 +300,9 @@ public class AllCheckSummaries extends AbstractMacro {
      *
      * @param path the check class file
      * @param moduleName the full module name
-     * @return array with [simpleName, packageName]
+     * @return data holder with simpleName and packageName
      */
-    private static String[] determineModuleInfo(Path path, String moduleName) {
+    private static ModuleInfo determineModuleInfo(Path path, String moduleName) {
         String packageName = extractCategoryFromJavaPath(path);
 
         if ("indentation".equals(packageName)) {
@@ -319,7 +319,7 @@ public class AllCheckSummaries extends AbstractMacro {
             simpleName = moduleName.substring(0, moduleName.length() - "Check".length());
         }
 
-        return new String[] {simpleName, packageName};
+        return new ModuleInfo(simpleName, packageName);
     }
 
     /**
@@ -826,6 +826,15 @@ public class AllCheckSummaries extends AbstractMacro {
      * @param summary module summary
      */
     private record CheckInfo(String simpleName, String link, String summary) {
+    }
+
+    /**
+     * Data holder for simple name and package name for a check module.
+     *
+     * @param simpleName check module simple name
+     * @param packageName check module package name
+     */
+    private record ModuleInfo(String simpleName, String packageName) {
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
@@ -47,6 +47,11 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.Parameters;
+
 /**
  * Generates {@code search-index.json} from the Checkstyle XDoc source files.
  *
@@ -346,25 +351,29 @@ public final class SearchIndexGenerator {
      * @noinspectionreason UseOfSystemOutOrSystemErr - main method of a CLI utility
      */
     public static void main(String... args) throws IOException {
-        new SearchIndexGenerator().execute(args);
+        final CliOptions cliOptions = new CliOptions();
+        final CommandLine cmd = new CommandLine(cliOptions);
+        try {
+            cmd.parseArgs(args);
+            new SearchIndexGenerator().execute(cliOptions);
+        }
+        catch (ParameterException exc) {
+            throw new IllegalArgumentException(
+                    "Usage: SearchIndexGenerator <xdocsDir> <outputFilePath>", exc);
+        }
     }
 
     /**
      * Internal execution method to avoid static context for the logger.
      *
-     * @param args args[0] = path to src/xdocs, args[1] = output file path
+     * @param cliOptions with path to src/xdocs and output file path
      * @throws IOException on file write failure
-     * @throws IllegalArgumentException if args are missing
      * @throws IllegalStateException if xdocsDir is missing
      */
-    private void execute(String... args) throws IOException {
-        if (args.length < 2) {
-            throw new IllegalArgumentException(
-                    "Usage: SearchIndexGenerator <xdocsDir> <outputFilePath>");
-        }
+    private void execute(CliOptions cliOptions) throws IOException {
 
-        final Path xdocsPath = Path.of(args[0]);
-        final Path outputFilePath = Path.of(args[1]);
+        final Path xdocsPath = Path.of(cliOptions.xdocPath);
+        final Path outputFilePath = Path.of(cliOptions.outputFilePath);
         final File xdocsDir = xdocsPath.toFile();
 
         if (!Files.exists(xdocsPath)) {
@@ -1285,6 +1294,32 @@ public final class SearchIndexGenerator {
             result = Character.toUpperCase(input.charAt(0)) + input.substring(1);
         }
         return result;
+    }
+
+    /**
+     * Helper class encapsulating the command line positional parameters.
+     */
+    @Command(name = "java com.puppycrawl.tools.checkstyle.site.SearchIndexGenerator")
+    private static final class CliOptions {
+
+        /**
+         * The command line positional parameter to specify the path to src/xdocs.
+         */
+        @Parameters(index = "0", description = "Path to src/xdocs.")
+        private String xdocPath;
+
+        /**
+         * The command line positional parameter to specify the path to target/site.
+         */
+        @Parameters(index = "1", description = "Path to target/site.")
+        private String outputFilePath;
+
+        /**
+         * Creates a new instance.
+         */
+        private CliOptions() {
+            // no code by default
+        }
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
@@ -46,6 +46,11 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.Parameters;
+
 /**
  * Generates {@code search-index.json} from the Checkstyle XDoc source files.
  *
@@ -317,25 +322,29 @@ public final class SearchIndexGenerator {
      * @noinspectionreason UseOfSystemOutOrSystemErr - main method of a CLI utility
      */
     public static void main(String... args) throws IOException {
-        new SearchIndexGenerator().execute(args);
+        final CliOptions cliOptions = new CliOptions();
+        final CommandLine cmd = new CommandLine(cliOptions);
+        try {
+            cmd.parseArgs(args);
+            new SearchIndexGenerator().execute(cliOptions);
+        }
+        catch (ParameterException exc) {
+            throw new IllegalArgumentException(
+                    "Usage: SearchIndexGenerator <xdocsDir> <outputFilePath>", exc);
+        }
     }
 
     /**
      * Internal execution method to avoid static context for the logger.
      *
-     * @param args args[0] = path to src/xdocs, args[1] = output file path
+     * @param cliOptions with path to src/xdocs and output file path
      * @throws IOException on file write failure
-     * @throws IllegalArgumentException if args are missing
      * @throws IllegalStateException if xdocsDir is missing
      */
-    private void execute(String... args) throws IOException {
-        if (args.length < 2) {
-            throw new IllegalArgumentException(
-                    "Usage: SearchIndexGenerator <xdocsDir> <outputFilePath>");
-        }
+    private void execute(CliOptions cliOptions) throws IOException {
 
-        final Path xdocsPath = Path.of(args[0]);
-        final Path outputFilePath = Path.of(args[1]);
+        final Path xdocsPath = Path.of(cliOptions.xdocPath);
+        final Path outputFilePath = Path.of(cliOptions.outputFilePath);
         final File xdocsDir = xdocsPath.toFile();
 
         if (!Files.exists(xdocsPath)) {
@@ -1189,6 +1198,32 @@ public final class SearchIndexGenerator {
             result = Character.toUpperCase(input.charAt(0)) + input.substring(1);
         }
         return result;
+    }
+
+    /**
+     * Helper class encapsulating the command line positional parameters.
+     */
+    @Command(name = "java com.puppycrawl.tools.checkstyle.site.SearchIndexGenerator")
+    private static final class CliOptions {
+
+        /**
+         * The command line positional parameter to specify the path to src/xdocs.
+         */
+        @Parameters(index = "0", description = "Path to src/xdocs.")
+        private String xdocPath;
+
+        /**
+         * The command line positional parameter to specify the path to target/site.
+         */
+        @Parameters(index = "1", description = "Path to target/site.")
+        private String outputFilePath;
+
+        /**
+         * Creates a new instance.
+         */
+        private CliOptions() {
+            // no code by default
+        }
     }
 
 }


### PR DESCRIPTION
Issue #11140

```plain
CLI_CONSTANT_LIST_INDEX
This method accesses an array or list using a constant integer index. Often, this is a typo where a loop variable is intended to be used. If however, specific list indices mean different specific things, then perhaps replacing the list with a first-class object with meaningful accessors would make the code less brittle.
```