### PR TITLE
Issue #20625: Added example for regexpmultiline

### DIFF
--- a/src/site/xdoc/checks/regexp/regexpmultiline.xml
+++ b/src/site/xdoc/checks/regexp/regexpmultiline.xml
@@ -404,6 +404,103 @@ class Example7 {
     System.out.println("TEst #5: This is a test string");
   }
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example8-config">
+          To configure the check to find calls to print to the console
+          with a custom message:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="RegexpMultiline"&gt;
+    &lt;property name="format" value="System\.(out|err)\.print(ln)?\("/&gt;
+    &lt;property name="message" value="Avoid using System.out/err for printing."/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example8-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example8 {
+  void testMethod1() {
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.print("Example");
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.err.println("Example");
+    System
+            .out.print("Example");
+    System
+            .err.println("Example");
+    System.
+            out.print("Example");
+    System.
+            err.println("Example");
+  }
+
+  void testMethod2() {
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("Test #1: this is a test string");
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("TeSt #2: This is a test string");
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("TEST #3: This is a test string");
+    int i = 5;
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("Value of i: " + i);
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("Test #4: This is a test string");
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("TEst #5: This is a test string");
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example9-config">
+          To configure the check to match a maximum of three test strings:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="RegexpMultiline"&gt;
+    &lt;property name="format" value="Test #[0-9]+:[A-Za-z ]+"/&gt;
+    &lt;property name="maximum" value="1"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example9-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example9 {
+  void testMethod1() {
+
+    System.out.print("Example");
+
+    System.err.println("Example");
+    System
+            .out.print("Example");
+    System
+            .err.println("Example");
+    System.
+            out.print("Example");
+    System.
+            err.println("Example");
+  }
+
+  void testMethod2() {
+
+    System.out.println("Test #1: this is a test string");
+
+    System.out.println("TeSt #2: This is a test string");
+
+    System.out.println("TEST #3: This is a test string");
+    int i = 5;
+
+    System.out.println("Value of i: " + i);
+    // violation below, 'Line matches the illegal pattern'
+    System.out.println("Test #4: This is a test string");
+
+    System.out.println("TEst #5: This is a test string");
+  }
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/regexp/regexpmultiline.xml.template
+++ b/src/site/xdoc/checks/regexp/regexpmultiline.xml.template
@@ -155,6 +155,39 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example7.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example8-config">
+          To configure the check to find calls to print to the console
+          with a custom message:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example8.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example8-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example8.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example9-config">
+          To configure the check to match a maximum of three test strings:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example9.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example9-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example9.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -156,7 +156,6 @@ public class XdocsExamplesAstConsistencyTest {
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
             // until https://github.com/checkstyle/checkstyle/issues/20625
             "checks/javadoc/javadocblocktaglocation",
-            "checks/regexp/regexpmultiline",
             "checks/regexp/regexponfilename",
             "checks/translation"
     );

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckExamplesTest.java
@@ -97,4 +97,29 @@ public class RegexpMultilineCheckExamplesTest extends AbstractExamplesModuleTest
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
     }
 
+    @Test
+    public void testExample8() throws Exception {
+        final String[] expected = {
+            "15: Avoid using System.out/err for printing.",
+            "17: Avoid using System.out/err for printing.",
+            "30: Avoid using System.out/err for printing.",
+            "32: Avoid using System.out/err for printing.",
+            "34: Avoid using System.out/err for printing.",
+            "37: Avoid using System.out/err for printing.",
+            "39: Avoid using System.out/err for printing.",
+            "41: Avoid using System.out/err for printing.",
+        };
+
+        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
+    }
+
+    @Test
+    public void testExample9() throws Exception {
+        final String[] expected = {
+            "39: " + getCheckMessage(MSG_ILLEGAL_REGEXP, "Test #[0-9]+:[A-Za-z ]+"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example9.java"), expected);
+    }
+
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example8.java
@@ -1,0 +1,44 @@
+/*xml
+<module name="Checker">
+  <module name="RegexpMultiline">
+    <property name="format" value="System\.(out|err)\.print(ln)?\("/>
+    <property name="message" value="Avoid using System.out/err for printing."/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.regexp.regexpmultiline;
+
+// xdoc section -- start
+class Example8 {
+  void testMethod1() {
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.print("Example");
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.err.println("Example");
+    System
+            .out.print("Example");
+    System
+            .err.println("Example");
+    System.
+            out.print("Example");
+    System.
+            err.println("Example");
+  }
+
+  void testMethod2() {
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("Test #1: this is a test string");
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("TeSt #2: This is a test string");
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("TEST #3: This is a test string");
+    int i = 5;
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("Value of i: " + i);
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("Test #4: This is a test string");
+    // violation below, 'Avoid using System.out/err for printing.'
+    System.out.println("TEst #5: This is a test string");
+  }
+}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpmultiline/Example9.java
@@ -1,0 +1,44 @@
+/*xml
+<module name="Checker">
+  <module name="RegexpMultiline">
+    <property name="format" value="Test #[0-9]+:[A-Za-z ]+"/>
+    <property name="maximum" value="1"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.regexp.regexpmultiline;
+
+// xdoc section -- start
+class Example9 {
+  void testMethod1() {
+
+    System.out.print("Example");
+
+    System.err.println("Example");
+    System
+            .out.print("Example");
+    System
+            .err.println("Example");
+    System.
+            out.print("Example");
+    System.
+            err.println("Example");
+  }
+
+  void testMethod2() {
+
+    System.out.println("Test #1: this is a test string");
+
+    System.out.println("TeSt #2: This is a test string");
+
+    System.out.println("TEST #3: This is a test string");
+    int i = 5;
+
+    System.out.println("Value of i: " + i);
+    // violation below, 'Line matches the illegal pattern'
+    System.out.println("Test #4: This is a test string");
+
+    System.out.println("TEst #5: This is a test string");
+  }
+}
+// xdoc section -- end


### PR DESCRIPTION
#20625 

`testExampleCountMatchesPropertyCount` flagged `checks/regexp/regexpmultiline`:
```
Directory: checks/regexp/regexpmultiline
Properties: 7
Expected AST-matching examples (at least): 8
Actual largest AST-matching group: 6 (of 6 total example files)
```

`RegexpMultilineCheck` has 7 documented properties (`format`, `message`, `minimum`, `maximum`, `ignoreCase`, `matchAcrossLines`, `fileExtensions`), which requires 8 AST-matching Java examples (1 baseline + 1 per property). Only 6 existed, and two properties lacked a dedicated, isolated example:

- **`message`** was only demonstrated via `Example6.txt`, a non-Java file (used to test empty-file detection). so this property effectively had zero coverage toward the AST-matching count.
- **`maximum`** was only shown bundled together with `ignoreCase` inside `Example4`, so it never had a standalone example isolating its own effect.

### Changes

**`Example8.java`** — isolates `message` alone, reusing `Example2`'s exact code/AST structure with a custom message configured.

**`Example9.java`** — isolates `maximum` alone (without `ignoreCase`).