### PR TITLE
Issue #20793: use getCheckMessage in filter example tests

### DIFF
--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterExamplesTest.java
@@ -24,6 +24,8 @@ import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MS
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck;
 
 public class SeverityMatchFilterExamplesTest extends AbstractExamplesModuleTestSupport {
 
@@ -37,12 +39,15 @@ public class SeverityMatchFilterExamplesTest extends AbstractExamplesModuleTestS
         final String pattern = "^[a-z][a-zA-Z0-9]*$";
 
         final String[] expectedWithoutFilter = {
-            "20:27: Name 'V1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "22:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", pattern),
+            "20:27: " + getCheckMessage(ParameterNameCheck.class, MSG_INVALID_PATTERN,
+                    "V1", pattern),
+            "22:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Method2", pattern),
         };
 
         final String[] expectedWithFilter = {
-            "22:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", pattern),
+            "22:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Method2", pattern),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example1.java"),

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterExamplesTest.java
@@ -19,9 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 
 public class SuppressWarningsFilterExamplesTest extends AbstractExamplesModuleTestSupport {
 
@@ -32,19 +35,24 @@ public class SuppressWarningsFilterExamplesTest extends AbstractExamplesModuleTe
 
     @Test
     public void testExample1() throws Exception {
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+
         final String[] expectedWithoutFilter = {
-            "17:7: Name 'J' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "18:7: Name 'JJ' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "17:7: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN, "J", pattern),
+            "18:7: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN, "JJ", pattern),
             "21:7: 'int' is followed by whitespace.",
-            "21:10: Name 'ARRAY' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "21:10: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN, "ARRAY",
+                    pattern),
             "23:7: 'int' is followed by whitespace.",
-            "23:10: Name 'ARRAY2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "23:10: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN, "ARRAY2",
+                    pattern),
         };
 
         final String[] expectedWithFilter = {
-            "18:7: Name 'JJ' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "18:7: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN, "JJ", pattern),
             "23:7: 'int' is followed by whitespace.",
-            "23:10: Name 'ARRAY2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "23:10: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN, "ARRAY2",
+                    pattern),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example1.java"),


### PR DESCRIPTION
Issue #20793 Replace hardcoded name check messages with getCheckMessage calls.