### PR TITLE
Issue #20793: use getCheckMessage in remaining filters example tests

### DIFF
--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterExamplesTest.java
@@ -19,9 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck;
+import com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck;
+import com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck;
 
 public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExamplesModuleTestSupport {
 
@@ -36,7 +44,8 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
 
         };
         final String[] expectedWithoutFilter = {
-            "13:27: 'int' is followed by whitespace.",
+            "13:27: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "int"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example1.java"), expectedWithoutFilter,
@@ -45,12 +54,17 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
 
     @Test
     public void testExample2() throws Exception {
+        final String pattern = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
+
         final String[] expectedWithFilter = {
-            "17:30: Name 'array' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "17:30: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "array", pattern),
         };
         final String[] expectedWithoutFilter = {
-            "17:30: Name 'array' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "19:27: Name 'lowerCaseConstant' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "17:30: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "array", pattern),
+            "19:27: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "lowerCaseConstant", pattern),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example2.java"), expectedWithoutFilter,
@@ -63,7 +77,8 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
 
         };
         final String[] expectedWithoutFilter = {
-            "27:5: Catching 'RuntimeException' is not allowed.",
+            "27:5: " + getCheckMessage(IllegalCatchCheck.class, IllegalCatchCheck.MSG_KEY,
+                    "RuntimeException"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example3.java"), expectedWithoutFilter,
@@ -76,7 +91,8 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
 
         };
         final String[] expectedWithoutFilter = {
-            "15:27: 'int' is followed by whitespace.",
+            "15:27: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "int"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example4.java"), expectedWithoutFilter,
@@ -86,10 +102,12 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
     @Test
     public void testExample5() throws Exception {
         final String[] expectedWithFilter = {
-            "15:27: 'int' is followed by whitespace.",
+            "15:27: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "int"),
         };
         final String[] expectedWithoutFilter = {
-            "15:27: 'int' is followed by whitespace.",
+            "15:27: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "int"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example5.java"), expectedWithoutFilter,
@@ -101,7 +119,8 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
         final String[] expectedWithFilter = {};
 
         final String[] expectedWithoutFilter = {
-            "15:27: 'int' is followed by whitespace.",
+            "15:27: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "int"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example7.java"), expectedWithoutFilter,
@@ -113,7 +132,8 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
         final String[] expectedWithFilter = {};
 
         final String[] expectedWithoutFilter = {
-            "15:27: 'int' is followed by whitespace.",
+            "15:27: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "int"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example8.java"), expectedWithoutFilter,
@@ -123,10 +143,12 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
     @Test
     public void testExample6() throws Exception {
         final String[] expectedWithFilter = {
-            "19:27: 'int' is followed by whitespace.",
+            "19:27: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "int"),
         };
         final String[] expectedWithoutFilter = {
-            "19:27: 'int' is followed by whitespace.",
+            "19:27: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "int"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example6.java"), expectedWithoutFilter,
@@ -135,15 +157,23 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
 
     @Test
     public void testUseCase1() throws Exception {
+        final String pattern = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
+
         final String[] expectedWithFilter = {
-            "26:20: Name 'lowerCaseConstant5' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "26:20: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "lowerCaseConstant5", pattern),
         };
         final String[] expectedWithoutFilter = {
-            "19:20: Name 'lowerCaseConstant1' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "21:20: Name 'lowerCaseConstant2' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "23:20: Name 'lowerCaseConstant3' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "25:20: Name 'lowerCaseConstant4' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "26:20: Name 'lowerCaseConstant5' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "19:20: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "lowerCaseConstant1", pattern),
+            "21:20: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "lowerCaseConstant2", pattern),
+            "23:20: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "lowerCaseConstant3", pattern),
+            "25:20: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "lowerCaseConstant4", pattern),
+            "26:20: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "lowerCaseConstant5", pattern),
         };
 
         verifyFilterWithInlineConfigParser(getPath("UseCase1.java"), expectedWithoutFilter,
@@ -156,7 +186,8 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
 
         };
         final String[] expectedWithoutFilter = {
-            "17:15: Name 'D2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "17:15: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN,
+                    "D2", "^[a-z][a-zA-Z0-9]*$"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("UseCase2.java"), expectedWithoutFilter,
@@ -169,8 +200,10 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
 
         };
         final String[] expectedWithoutFilters = {
-            "19:27: 'int' is followed by whitespace.",
-            "19:30: Name 'array' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "19:27: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "int"),
+            "19:30: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "array", "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("UseCase3.java"), expectedWithoutFilters,
@@ -196,9 +229,10 @@ public class SuppressWithNearbyCommentFilterExamplesTest extends AbstractExample
 
         };
         final String[] expectedWithoutFilter = {
-            "21:1: Class Data Abstraction Coupling is 2 (max allowed is 1) "
-                    + "classes [Example1, Example2].",
-            "24:23: '10022' is a magic number.",
+            "21:1: " + getCheckMessage(ClassDataAbstractionCouplingCheck.class,
+                    ClassDataAbstractionCouplingCheck.MSG_KEY, 2, 1, "[Example1, Example2]"),
+            "24:23: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY,
+                    "10022"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("UseCase5.java"), expectedWithoutFilter,

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyTextFilterExamplesTest.java
@@ -22,6 +22,9 @@ package com.puppycrawl.tools.checkstyle.filters;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck;
+import com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck;
+import com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck;
 
 public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesModuleTestSupport {
 
@@ -34,18 +37,18 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
     public void testExample1() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "18:11: '42' is a magic number.",
-            "19:11: '43' is a magic number.",
-            "21: Line is longer than 55 characters (found 74).",
-            "24: Line is longer than 55 characters (found 84).",
-            "28: Line is longer than 55 characters (found 72).",
+            "18:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "19:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
+            "21: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 74),
+            "24: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 84),
+            "28: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 72),
         };
 
         final String[] expectedWithFilter = {
-            "19:11: '43' is a magic number.",
-            "21: Line is longer than 55 characters (found 74).",
-            "24: Line is longer than 55 characters (found 84).",
-            "28: Line is longer than 55 characters (found 72).",
+            "19:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
+            "21: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 74),
+            "24: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 84),
+            "28: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 72),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example1.java"),
@@ -56,19 +59,19 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
     public void testExample2() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "21:11: '42' is a magic number.",
-            "22:11: '43' is a magic number.",
-            "24: Line is longer than 55 characters (found 74).",
-            "27: Line is longer than 55 characters (found 84).",
-            "31: Line is longer than 55 characters (found 72).",
+            "21:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "22:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
+            "24: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 74),
+            "27: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 84),
+            "31: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 72),
         };
 
         final String[] expectedWithFilter = {
-            "21:11: '42' is a magic number.",
-            "22:11: '43' is a magic number.",
-            "24: Line is longer than 55 characters (found 74).",
-            "27: Line is longer than 55 characters (found 84).",
-            "31: Line is longer than 55 characters (found 72).",
+            "21:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "22:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
+            "24: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 74),
+            "27: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 84),
+            "31: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 72),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example2.java"),
@@ -79,12 +82,12 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
     public void testUseCase1() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "15:11: '42' is a magic number.",
-            "16:11: '43' is a magic number.",
+            "15:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "16:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
         };
 
         final String[] expectedWithFilter = {
-            "16:11: '43' is a magic number.",
+            "16:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("UseCase1.java"),
@@ -95,16 +98,16 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
     public void testExample3() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "21:11: '42' is a magic number.",
-            "22:11: '43' is a magic number.",
-            "24: Line is longer than 55 characters (found 74).",
-            "27: Line is longer than 55 characters (found 84).",
-            "31: Line is longer than 55 characters (found 72).",
+            "21:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "22:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
+            "24: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 74),
+            "27: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 84),
+            "31: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 72),
         };
 
         final String[] expectedWithFilter = {
-            "21:11: '42' is a magic number.",
-            "22:11: '43' is a magic number.",
+            "21:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "22:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example3.java"),
@@ -115,18 +118,18 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
     public void testExample4() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "20:11: '42' is a magic number.",
-            "21:11: '43' is a magic number.",
-            "23: Line is longer than 55 characters (found 74).",
-            "26: Line is longer than 55 characters (found 84).",
-            "30: Line is longer than 55 characters (found 72).",
+            "20:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "21:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
+            "23: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 74),
+            "26: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 84),
+            "30: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 72),
         };
 
         final String[] expectedWithFilter = {
-            "21:11: '43' is a magic number.",
-            "23: Line is longer than 55 characters (found 74).",
-            "26: Line is longer than 55 characters (found 84).",
-            "30: Line is longer than 55 characters (found 72).",
+            "21:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
+            "23: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 74),
+            "26: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 84),
+            "30: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 72),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example4.java"),
@@ -137,17 +140,17 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
     public void testExample5() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "21:11: '42' is a magic number.",
-            "22:11: '43' is a magic number.",
-            "24: Line is longer than 55 characters (found 74).",
-            "27: Line is longer than 55 characters (found 84).",
-            "31: Line is longer than 55 characters (found 72).",
+            "21:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "22:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
+            "24: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 74),
+            "27: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 84),
+            "31: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 72),
         };
 
         final String[] expectedWithFilter = {
-            "24: Line is longer than 55 characters (found 74).",
-            "27: Line is longer than 55 characters (found 84).",
-            "31: Line is longer than 55 characters (found 72).",
+            "24: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 74),
+            "27: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 84),
+            "31: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 72),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example5.java"),
@@ -158,12 +161,15 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
     public void testUseCase2() throws Exception {
 
         final String[] expectedWithoutFilters = {
-            "2: Duplicated property 'key.one' (2 occurrence(s)).",
-            "4: Duplicated property 'key.two' (2 occurrence(s)).",
+            "2: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "key.one", 2),
+            "4: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "key.two", 2),
         };
 
         final String[] expectedWithFilters = {
-            "4: Duplicated property 'key.two' (2 occurrence(s)).",
+            "4: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "key.two", 2),
         };
 
         verifyFilterWithInlineConfigParserSeparateConfigAndTarget(
@@ -177,12 +183,12 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
     public void testUseCase3() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "17:11: '42' is a magic number.",
-            "18:11: '43' is a magic number.",
+            "17:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "18:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
         };
 
         final String[] expectedWithFilter = {
-            "18:11: '43' is a magic number.",
+            "18:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("UseCase3.java"),
@@ -193,15 +199,15 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
     public void testUseCase4() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "18:11: '42' is a magic number.",
-            "19:11: '43' is a magic number.",
-            "20:11: '44' is a magic number.",
-            "21:11: '45' is a magic number.",
-            "22:11: '46' is a magic number.",
+            "18:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "19:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
+            "20:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "44"),
+            "21:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "45"),
+            "22:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "46"),
         };
 
         final String[] expectedWithFilter = {
-            "22:11: '46' is a magic number.",
+            "22:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "46"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("UseCase4.java"),
@@ -212,18 +218,18 @@ public class SuppressWithNearbyTextFilterExamplesTest extends AbstractExamplesMo
     public void testExample9() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "23:11: '42' is a magic number.",
-            "24:11: '43' is a magic number.",
-            "26: Line is longer than 55 characters (found 74).",
-            "29: Line is longer than 55 characters (found 84).",
-            "33: Line is longer than 55 characters (found 72).",
+            "23:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "24:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
+            "26: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 74),
+            "29: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 84),
+            "33: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 72),
         };
 
         final String[] expectedWithFilter = {
-            "23:11: '42' is a magic number.",
-            "24:11: '43' is a magic number.",
-            "26: Line is longer than 55 characters (found 74).",
-            "29: Line is longer than 55 characters (found 84).",
+            "23:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "42"),
+            "24:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "43"),
+            "26: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 74),
+            "29: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 55, 84),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example9.java"),

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterExamplesTest.java
@@ -22,6 +22,9 @@ package com.puppycrawl.tools.checkstyle.filters;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck;
+import com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck;
+import com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class SuppressWithPlainTextCommentFilterExamplesTest
@@ -38,12 +41,15 @@ public class SuppressWithPlainTextCommentFilterExamplesTest
         final String targetFile = getPath("Example1.properties");
 
         final String[] expectedWithoutFilter = {
-            "2: Duplicated property 'keyB' (2 occurrence(s)).",
-            "6: Duplicated property 'keyC' (2 occurrence(s)).",
+            "2: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "keyB", 2),
+            "6: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "keyC", 2),
         };
 
         final String[] expectedWithFilter = {
-            "6: Duplicated property 'keyC' (2 occurrence(s)).",
+            "6: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "keyC", 2),
         };
 
         verifyFilterWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile,
@@ -57,12 +63,15 @@ public class SuppressWithPlainTextCommentFilterExamplesTest
         final String targetFile = getPath("Example2.properties");
 
         final String[] expectedWithoutFilter = {
-            "2: Duplicated property 'keyB' (2 occurrence(s)).",
-            "6: Duplicated property 'keyC' (2 occurrence(s)).",
+            "2: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "keyB", 2),
+            "6: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "keyC", 2),
         };
 
         final String[] expectedWithFilter = {
-            "6: Duplicated property 'keyC' (2 occurrence(s)).",
+            "6: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "keyC", 2),
         };
 
         verifyFilterWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile,
@@ -76,14 +85,19 @@ public class SuppressWithPlainTextCommentFilterExamplesTest
         final String targetFile = getPath("Example3.properties");
 
         final String[] expectedWithoutFilter = {
-            "3: Duplicated property 'keyB' (2 occurrence(s)).",
-            "6: Property key 'keyA' is not in the right order with previous property 'keyB'.",
-            "9: Duplicated property 'keyC' (2 occurrence(s)).",
+            "3: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "keyB", 2),
+            "6: " + getCheckMessage(OrderedPropertiesCheck.class, OrderedPropertiesCheck.MSG_KEY,
+                    "keyA", "keyB"),
+            "9: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "keyC", 2),
         };
 
         final String[] expectedWithFilter = {
-            "6: Property key 'keyA' is not in the right order with previous property 'keyB'.",
-            "9: Duplicated property 'keyC' (2 occurrence(s)).",
+            "6: " + getCheckMessage(OrderedPropertiesCheck.class, OrderedPropertiesCheck.MSG_KEY,
+                    "keyA", "keyB"),
+            "9: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "keyC", 2),
         };
 
         verifyFilterWithInlineConfigParserSeparateConfigAndTarget(fileWithConfig, targetFile,
@@ -174,7 +188,7 @@ public class SuppressWithPlainTextCommentFilterExamplesTest
         final String targetFile = getPath("Example8.sql");
 
         final String[] expectedWithoutFilter = {
-            "7: Line is longer than 60 characters (found 66).",
+            "7: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 60, 66),
         };
 
         final String[] expectedWithFilter = CommonUtil.EMPTY_STRING_ARRAY;
@@ -188,14 +202,14 @@ public class SuppressWithPlainTextCommentFilterExamplesTest
     public void testUseCase1() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "23: Line is longer than 100 characters (found 147).",
-            "24: Line is longer than 100 characters (found 133).",
-            "25: Line is longer than 100 characters (found 116).",
-            "32: Line is longer than 100 characters (found 183).",
+            "23: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 100, 147),
+            "24: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 100, 133),
+            "25: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 100, 116),
+            "32: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 100, 183),
         };
 
         final String[] expectedWithFilter = {
-            "32: Line is longer than 100 characters (found 183).",
+            "32: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 100, 183),
         };
 
         verifyFilterWithInlineConfigParser(getPath("UseCase1.java"),

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterExamplesTest.java
@@ -19,9 +19,18 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck;
+import com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck;
+import com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck;
+import com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck;
 
 public class SuppressionFilterExamplesTest extends AbstractExamplesModuleTestSupport {
 
@@ -34,14 +43,17 @@ public class SuppressionFilterExamplesTest extends AbstractExamplesModuleTestSup
     public void testExample1() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "20:7: Name 'MyVariable' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "22:11: '10' is a magic number.",
-            "26:15: '100' is a magic number.",
-            "28:15: Must have at least one statement.",
+            "20:7: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN,
+                    "MyVariable", "^[a-z][a-zA-Z0-9]*$"),
+            "22:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "10"),
+            "26:15: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "100"),
+            "28:15: " + getCheckMessage(EmptyBlockCheck.class,
+                    EmptyBlockCheck.MSG_KEY_BLOCK_NO_STATEMENT),
         };
 
         final String[] expectedWithFilter = {
-            "28:15: Must have at least one statement.",
+            "28:15: " + getCheckMessage(EmptyBlockCheck.class,
+                    EmptyBlockCheck.MSG_KEY_BLOCK_NO_STATEMENT),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example1.java"),
@@ -53,14 +65,15 @@ public class SuppressionFilterExamplesTest extends AbstractExamplesModuleTestSup
     public void testUseCase1() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "24: Line is longer than 80 characters (found 84).",
-            "31:22: String literal expressions should be on the left side of an equals comparison.",
-            "35:32: String literal expressions should be on the left side of "
-                    + "an equalsIgnoreCase comparison.",
+            "24: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 80, 84),
+            "31:22: " + getCheckMessage(EqualsAvoidNullCheck.class,
+                    EqualsAvoidNullCheck.MSG_EQUALS_AVOID_NULL),
+            "35:32: " + getCheckMessage(EqualsAvoidNullCheck.class,
+                    EqualsAvoidNullCheck.MSG_EQUALS_IGNORE_CASE_AVOID_NULL),
         };
 
         final String[] expectedWithFilter = {
-            "24: Line is longer than 80 characters (found 84).",
+            "24: " + getCheckMessage(LineLengthCheck.class, LineLengthCheck.MSG_KEY, 80, 84),
         };
 
         verifyFilterWithInlineConfigParser(getPath("UseCase1.java"),
@@ -72,8 +85,10 @@ public class SuppressionFilterExamplesTest extends AbstractExamplesModuleTestSup
     public void testUseCase2() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "1: Duplicated property 'keyB' (2 occurrence(s)).",
-            "4: Duplicated property 'keyC' (2 occurrence(s)).",
+            "1: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "keyB", 2),
+            "4: " + getCheckMessage(UniquePropertiesCheck.class, UniquePropertiesCheck.MSG_KEY,
+                    "keyC", 2),
         };
 
         final String[] expectedWithFilter = {};
@@ -87,17 +102,25 @@ public class SuppressionFilterExamplesTest extends AbstractExamplesModuleTestSup
 
     @Test
     public void testUseCase3() throws Exception {
+        final String memberPattern = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
+        final String constantPattern = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
 
         final String[] expectedWithoutFilter = {
-            "20:14: Name 'log' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "23:14: Name 'constant' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "29:27: Name 'log' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "32:30: Name 'line' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "20:14: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN,
+                    "log", memberPattern),
+            "23:14: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN,
+                    "constant", memberPattern),
+            "29:27: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "log", constantPattern),
+            "32:30: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "line", constantPattern),
         };
 
         final String[] expectedWithFilter = {
-            "23:14: Name 'constant' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
-            "32:30: Name 'line' must match pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'.",
+            "23:14: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN,
+                    "constant", memberPattern),
+            "32:30: " + getCheckMessage(ConstantNameCheck.class, MSG_INVALID_PATTERN,
+                    "line", constantPattern),
         };
 
         verifyFilterWithInlineConfigParser(getPath("UseCase3.java"),

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterExamplesTest.java
@@ -19,9 +19,20 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck;
+import com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck;
+import com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck;
+import com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck;
+import com.puppycrawl.tools.checkstyle.checks.metrics.CyclomaticComplexityCheck;
+import com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck;
 
 public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTestSupport {
 
@@ -34,11 +45,13 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     public void testExample1() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "41:3: Cyclomatic Complexity is 4 (max allowed is 3).",
+            "41:3: " + getCheckMessage(CyclomaticComplexityCheck.class,
+                    CyclomaticComplexityCheck.MSG_KEY, 4, 3),
         };
 
         final String[] expectedWithFilter = {
-            "41:3: Cyclomatic Complexity is 4 (max allowed is 3).",
+            "41:3: " + getCheckMessage(CyclomaticComplexityCheck.class,
+                    CyclomaticComplexityCheck.MSG_KEY, 4, 3),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -52,11 +65,13 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     public void testExample2() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "41:3: Cyclomatic Complexity is 4 (max allowed is 3).",
+            "41:3: " + getCheckMessage(CyclomaticComplexityCheck.class,
+                    CyclomaticComplexityCheck.MSG_KEY, 4, 3),
         };
 
         final String[] expectedWithFilter = {
-            "41:3: Cyclomatic Complexity is 4 (max allowed is 3).",
+            "41:3: " + getCheckMessage(CyclomaticComplexityCheck.class,
+                    CyclomaticComplexityCheck.MSG_KEY, 4, 3),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -70,11 +85,13 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     public void testExample3() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "40:3: Cyclomatic Complexity is 4 (max allowed is 3).",
+            "40:3: " + getCheckMessage(CyclomaticComplexityCheck.class,
+                    CyclomaticComplexityCheck.MSG_KEY, 4, 3),
         };
 
         final String[] expectedWithFilter = {
-            "40:3: Cyclomatic Complexity is 4 (max allowed is 3).",
+            "40:3: " + getCheckMessage(CyclomaticComplexityCheck.class,
+                    CyclomaticComplexityCheck.MSG_KEY, 4, 3),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -88,16 +105,23 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     public void testUseCase4() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "13:1: 'package' should be separated from previous line.",
-            "21:3: 'VARIABLE_DEF' should be separated from previous line.",
-            "22:3: 'METHOD_DEF' should be separated from previous line.",
-            "23:3: 'METHOD_DEF' should be separated from previous line.",
+            "13:1: " + getCheckMessage(EmptyLineSeparatorCheck.class,
+                    EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED, "package"),
+            "21:3: " + getCheckMessage(EmptyLineSeparatorCheck.class,
+                    EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
+            "22:3: " + getCheckMessage(EmptyLineSeparatorCheck.class,
+                    EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "23:3: " + getCheckMessage(EmptyLineSeparatorCheck.class,
+                    EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
         };
 
         final String[] expectedWithFilter = {
-            "21:3: 'VARIABLE_DEF' should be separated from previous line.",
-            "22:3: 'METHOD_DEF' should be separated from previous line.",
-            "23:3: 'METHOD_DEF' should be separated from previous line.",
+            "21:3: " + getCheckMessage(EmptyLineSeparatorCheck.class,
+                    EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
+            "22:3: " + getCheckMessage(EmptyLineSeparatorCheck.class,
+                    EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "23:3: " + getCheckMessage(EmptyLineSeparatorCheck.class,
+                    EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -111,22 +135,35 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     public void testUseCase5() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "19:23: '{' at column 23 should be on a new line.",
-            "27:36: '{' at column 36 should be on a new line.",
-            "31:27: '{' at column 27 should be on a new line.",
-            "35:28: '{' at column 28 should be on a new line.",
-            "40:31: '{' at column 31 should be on a new line.",
-            "41:35: '{' at column 35 should be on a new line.",
-            "44:23: '{' at column 23 should be on a new line.",
+            "19:23: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 23),
+            "27:36: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 36),
+            "31:27: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 27),
+            "35:28: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 28),
+            "40:31: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 31),
+            "41:35: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 35),
+            "44:23: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 23),
         };
 
         final String[] expectedWithFilter = {
-            "27:36: '{' at column 36 should be on a new line.",
-            "31:27: '{' at column 27 should be on a new line.",
-            "35:28: '{' at column 28 should be on a new line.",
-            "40:31: '{' at column 31 should be on a new line.",
-            "41:35: '{' at column 35 should be on a new line.",
-            "44:23: '{' at column 23 should be on a new line.",
+            "27:36: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 36),
+            "31:27: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 27),
+            "35:28: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 28),
+            "40:31: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 31),
+            "41:35: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 35),
+            "44:23: " + getCheckMessage(LeftCurlyCheck.class,
+                    LeftCurlyCheck.MSG_KEY_LINE_NEW, "{", 23),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -140,13 +177,17 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     public void testUseCase6() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "20:3: 'VARIABLE_DEF' should be separated from previous line.",
-            "21:3: 'METHOD_DEF' should be separated from previous line.",
-            "22:3: 'METHOD_DEF' should be separated from previous line.",
+            "20:3: " + getCheckMessage(EmptyLineSeparatorCheck.class,
+                    EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
+            "21:3: " + getCheckMessage(EmptyLineSeparatorCheck.class,
+                    EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "22:3: " + getCheckMessage(EmptyLineSeparatorCheck.class,
+                    EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
         };
 
         final String[] expectedWithFilter = {
-            "20:3: 'VARIABLE_DEF' should be separated from previous line.",
+            "20:3: " + getCheckMessage(EmptyLineSeparatorCheck.class,
+                    EmptyLineSeparatorCheck.MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -159,17 +200,26 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testUseCase7() throws Exception {
 
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+
         final String[] expectedWithoutFilter = {
-            "20:15: Name 'SetSomeVar' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "21:15: Name 'DoMATH' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "48:15: Name 'Test1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "51:15: Name 'Test2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "20:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "SetSomeVar", pattern),
+            "21:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "DoMATH", pattern),
+            "48:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test1", pattern),
+            "51:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test2", pattern),
         };
 
         final String[] expectedWithFilter = {
-            "21:15: Name 'DoMATH' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "48:15: Name 'Test1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "51:15: Name 'Test2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "21:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "DoMATH", pattern),
+            "48:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test1", pattern),
+            "51:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test2", pattern),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -182,13 +232,18 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testUseCase8() throws Exception {
 
+        final String pattern = "^([a-z][a-zA-Z0-9]*|_)$";
+
         final String[] expectedWithoutFilter = {
-            "34:9: Name 'TestVariable' must match pattern '^([a-z][a-zA-Z0-9]*|_)$'.",
-            "35:9: Name 'WeirdName' must match pattern '^([a-z][a-zA-Z0-9]*|_)$'.",
+            "34:9: " + getCheckMessage(LocalVariableNameCheck.class, MSG_INVALID_PATTERN,
+                    "TestVariable", pattern),
+            "35:9: " + getCheckMessage(LocalVariableNameCheck.class, MSG_INVALID_PATTERN,
+                    "WeirdName", pattern),
         };
 
         final String[] expectedWithFilter = {
-            "35:9: Name 'WeirdName' must match pattern '^([a-z][a-zA-Z0-9]*|_)$'.",
+            "35:9: " + getCheckMessage(LocalVariableNameCheck.class, MSG_INVALID_PATTERN,
+                    "WeirdName", pattern),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -201,26 +256,36 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testUseCase9() throws Exception {
 
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+
         final String[] expectedWithoutFilter = {
-            "19:13: '23' is a magic number.",
-            "20:27: '11' is a magic number.",
-            "21:15: Name 'SetSomeVar' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "22:15: Name 'DoMATH' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "31:11: '24' is a magic number.",
-            "49:15: Name 'Test1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "52:15: Name 'Test2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "56:19: '11' is a magic number.",
-            "57:8: Name 'FOO' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "19:13: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "23"),
+            "20:27: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "11"),
+            "21:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "SetSomeVar", pattern),
+            "22:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "DoMATH", pattern),
+            "31:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "24"),
+            "49:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test1", pattern),
+            "52:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test2", pattern),
+            "56:19: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "11"),
+            "57:8: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "FOO", pattern),
         };
 
         final String[] expectedWithFilter = {
-            "19:13: '23' is a magic number.",
-            "20:27: '11' is a magic number.",
-            "21:15: Name 'SetSomeVar' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "31:11: '24' is a magic number.",
-            "49:15: Name 'Test1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "52:15: Name 'Test2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "56:19: '11' is a magic number.",
+            "19:13: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "23"),
+            "20:27: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "11"),
+            "21:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "SetSomeVar", pattern),
+            "31:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "24"),
+            "49:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test1", pattern),
+            "52:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test2", pattern),
+            "56:19: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "11"),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -234,16 +299,23 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     public void testUseCase10() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "32:5: Reference to instance variable 'age' needs \"this.\".",
-            "41:9: Reference to instance variable 'age' needs \"this.\".",
-            "41:20: Reference to instance variable 'wordCount' needs \"this.\".",
-            "44:14: Reference to instance variable 'age' needs \"this.\".",
+            "32:5: " + getCheckMessage(RequireThisCheck.class, RequireThisCheck.MSG_VARIABLE,
+                    "age", ""),
+            "41:9: " + getCheckMessage(RequireThisCheck.class, RequireThisCheck.MSG_VARIABLE,
+                    "age", ""),
+            "41:20: " + getCheckMessage(RequireThisCheck.class, RequireThisCheck.MSG_VARIABLE,
+                    "wordCount", ""),
+            "44:14: " + getCheckMessage(RequireThisCheck.class, RequireThisCheck.MSG_VARIABLE,
+                    "age", ""),
         };
 
         final String[] expectedWithFilter = {
-            "41:9: Reference to instance variable 'age' needs \"this.\".",
-            "41:20: Reference to instance variable 'wordCount' needs \"this.\".",
-            "44:14: Reference to instance variable 'age' needs \"this.\".",
+            "41:9: " + getCheckMessage(RequireThisCheck.class, RequireThisCheck.MSG_VARIABLE,
+                    "age", ""),
+            "41:20: " + getCheckMessage(RequireThisCheck.class, RequireThisCheck.MSG_VARIABLE,
+                    "wordCount", ""),
+            "44:14: " + getCheckMessage(RequireThisCheck.class, RequireThisCheck.MSG_VARIABLE,
+                    "age", ""),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -257,7 +329,8 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     public void testUseCase11() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "23:37: Throwing 'RuntimeException' is not allowed.",
+            "23:37: " + getCheckMessage(IllegalThrowsCheck.class, IllegalThrowsCheck.MSG_KEY,
+                    "RuntimeException"),
         };
 
         final String[] expectedWithFilter = {};
@@ -273,8 +346,10 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     public void testUseCase12() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "25:9: 'public' modifier out of order with the JLS suggestions.",
-            "26:14: 'abstract' modifier out of order with the JLS suggestions.",
+            "25:9: " + getCheckMessage(ModifierOrderCheck.class,
+                    ModifierOrderCheck.MSG_MODIFIER_ORDER, "public"),
+            "26:14: " + getCheckMessage(ModifierOrderCheck.class,
+                    ModifierOrderCheck.MSG_MODIFIER_ORDER, "abstract"),
         };
 
         final String[] expectedWithFilter = {};
@@ -289,14 +364,14 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testUseCase13() throws Exception {
         final String[] expectedWithoutFilter = {
-            "18:13: '23' is a magic number.",
-            "19:27: '11' is a magic number.",
-            "30:11: '24' is a magic number.",
+            "18:13: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "23"),
+            "19:27: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "11"),
+            "30:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "24"),
         };
 
         final String[] expectedWithFilter = {
-            "18:13: '23' is a magic number.",
-            "30:11: '24' is a magic number.",
+            "18:13: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "23"),
+            "30:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "24"),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -310,14 +385,14 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     public void testUseCase1() throws Exception {
 
         final String[] expectedWithoutFilter = {
-            "18:13: '23' is a magic number.",
-            "19:27: '11' is a magic number.",
-            "30:11: '24' is a magic number.",
+            "18:13: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "23"),
+            "19:27: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "11"),
+            "30:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "24"),
         };
 
         final String[] expectedWithFilter = {
-            "18:13: '23' is a magic number.",
-            "30:11: '24' is a magic number.",
+            "18:13: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "23"),
+            "30:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "24"),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -330,16 +405,24 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testUseCase2() throws Exception {
 
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+
         final String[] expectedWithoutFilter = {
-            "19:15: Name 'SetSomeVar' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "20:15: Name 'DoMATH' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "47:15: Name 'Test1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "50:15: Name 'Test2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "19:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "SetSomeVar", pattern),
+            "20:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "DoMATH", pattern),
+            "47:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test1", pattern),
+            "50:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test2", pattern),
         };
 
         final String[] expectedWithFilter = {
-            "19:15: Name 'SetSomeVar' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "20:15: Name 'DoMATH' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "19:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "SetSomeVar", pattern),
+            "20:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "DoMATH", pattern),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"
@@ -352,17 +435,26 @@ public class SuppressionXpathFilterExamplesTest extends AbstractExamplesModuleTe
     @Test
     public void testUseCase3() throws Exception {
 
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+
         final String[] expectedWithoutFilter = {
-            "19:15: Name 'SetSomeVar' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "20:15: Name 'DoMATH' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "47:15: Name 'Test1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "50:15: Name 'Test2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "19:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "SetSomeVar", pattern),
+            "20:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "DoMATH", pattern),
+            "47:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test1", pattern),
+            "50:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test2", pattern),
         };
 
         final String[] expectedWithFilter = {
-            "19:15: Name 'SetSomeVar' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "20:15: Name 'DoMATH' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
-            "47:15: Name 'Test1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "19:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "SetSomeVar", pattern),
+            "20:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "DoMATH", pattern),
+            "47:15: " + getCheckMessage(MethodNameCheck.class, MSG_INVALID_PATTERN,
+                    "Test1", pattern),
         };
 
         System.setProperty("config.folder", "src/xdocs-examples/resources/"


### PR DESCRIPTION
Resolves #20793

Replaces hardcoded `"line:col: message"` literals with `getCheckMessage(SomeCheck.class, MSG_KEY, args...)` calls in the remaining `filters` xdocs-example tests, following the pattern established in #20941 and #20846.

Files updated:
- `SuppressWithNearbyCommentFilterExamplesTest.java`
- `SuppressWithNearbyTextFilterExamplesTest.java`
- `SuppressWithPlainTextCommentFilterExamplesTest.java` (the `RegexpSingleline` examples that set a custom `message` property were intentionally left as literals, since that text is not sourced from the check's message bundle)
- `SuppressionFilterExamplesTest.java`
- `SuppressionXpathFilterExamplesTest.java`

All 52 affected tests pass locally (JDK 21).