### PR TITLE
Issue #19764: enable noViolationCommentsInJavadoc check for InputIncorrectAtClauseOrderCheck

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -78,20 +78,11 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="/chapter7javadoc/rule711generalform/InputFormattedCorrectJavadocLeadingAsteriskAlignment.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck1.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor.java"/>
+            files="/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2OnRecordAndCompactCtor.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityRemoveIncorrectAnnotationToken.java"/>
-
-
-
   <suppress id="noViolationCommentsInJavadoc"
             files="/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturn.java"/>
   <suppress id="noViolationCommentsInJavadoc"

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck1.java
@@ -2,6 +2,8 @@ package com.google.checkstyle.test.chapter7javadoc.rule713atclauses;
 
 import java.io.Serializable;
 
+import com.puppycrawl.tools.checkstyle.checks.metrics.javancss.InputJavaNCSSResolveMutation.Some;
+
 /**
  * Some javadoc.
  *
@@ -40,8 +42,9 @@ class InputIncorrectAtClauseOrderCheck1 implements Serializable {
    * @return Some text.
    * @serialData Some javadoc.
    * @deprecated Some text.
-   * @throws Exception Some text. // violation 'Block tags have to appear in the order .*'
+   * @throws Exception Some text. 
    */
+  // violation 'Block tags have to appear in the order .*'
   String method(String str) throws Exception {
     return "null";
   }
@@ -51,9 +54,10 @@ class InputIncorrectAtClauseOrderCheck1 implements Serializable {
    *
    * @serialData Some javadoc.
    * @return Some text.
-   * @param str Some text. // violation 'Block tags have to appear in the order .*'
+   * @param str Some text. 
    * @throws Exception Some text.
    */
+  // violation 'Block tags have to appear in the order .*'
   String method1(String str) throws Exception {
     return "null";
   }
@@ -72,9 +76,11 @@ class InputIncorrectAtClauseOrderCheck1 implements Serializable {
      *
      * @return Some text.
      * @deprecated Some text.
-     * @param str Some text. // violation 'Block tags have to appear in the order .*'
-     * @throws Exception Some text. // violation 'Block tags have to appear in the order .*'
+     * @param str Some text. 
+     * @throws Exception Some text. 
      */
+    // violation 'Block tags have to appear in the order .*'
+    // violation 'Block tags have to appear in the order .*'
     String method(String str) throws Exception {
       return "null";
     }
@@ -83,9 +89,11 @@ class InputIncorrectAtClauseOrderCheck1 implements Serializable {
      * Some text.
      *
      * @throws Exception Some text.
-     * @return Some text. // violation 'Block tags have to appear in the order .*'
-     * @param str Some text. // violation 'Block tags have to appear in the order .*'
+     * @return Some text. 
+     * @param str Some text. 
      */
+    // violation 'Block tags have to appear in the order .*'
+    // violation 'Block tags have to appear in the order .*'
     String method1(String str) throws Exception {
       return "null";
     }
@@ -97,11 +105,13 @@ class InputIncorrectAtClauseOrderCheck1 implements Serializable {
          * Some text.
          *
          * @throws Exception Some text.
-         * @param str Some text. // violation 'Block tags have to appear in the order .*'
+         * @param str Some text. 
          * @serialData Some javadoc.
          * @deprecated Some text.
-         * @return Some text. // violation 'Block tags have to appear in the order .*'
+         * @return Some text. 
          */
+        // violation 'Block tags have to appear in the order .*'
+        // violation 'Block tags have to appear in the order .*'
         String method(String str) throws Exception {
           return "null";
         }
@@ -111,8 +121,9 @@ class InputIncorrectAtClauseOrderCheck1 implements Serializable {
          *
          * @param str Some text.
          * @throws Exception Some text.
-         * @return Some text. // violation 'Block tags have to appear in the order .*'
+         * @return Some text. 
          */
+        // violation 'Block tags have to appear in the order .*'
         String method1(String str) throws Exception {
           return "null";
         }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2.java
@@ -2,6 +2,8 @@ package com.google.checkstyle.test.chapter7javadoc.rule713atclauses;
 
 import java.io.Serializable;
 
+import com.puppycrawl.tools.checkstyle.checks.metrics.javancss.InputJavaNCSSResolveMutation.Some;
+
 /**
  * Some javadoc.
  *
@@ -16,16 +18,18 @@ class InputIncorrectAtClauseOrderCheck2 implements Serializable {
    * Some text.
    *
    * @throws Exception Some text.
-   * @param str Some text. // violation 'Block tags have to appear in the order .*'
+   * @param str Some text. 
    */
+  // violation 'Block tags have to appear in the order .*'
   void method2(String str) throws Exception {}
 
   /**
    * Some text.
    *
    * @deprecated Some text.
-   * @throws Exception Some text. // violation 'Block tags have to appear in the order .*'
+   * @throws Exception Some text. 
    */
+  // violation 'Block tags have to appear in the order .*'
   void method3() throws Exception {}
 
   /**
@@ -54,14 +58,16 @@ class InputIncorrectAtClauseOrderCheck2 implements Serializable {
      * @param str Some text.
      * @throws Exception Some text.
      */
+    // violation 'Block tags have to appear in the order .*'
     void method2(String str) throws Exception {}
 
     /**
      * Some text.
      *
      * @deprecated Some text.
-     * @throws Exception Some text. // violation 'Block tags have to appear in the order .*'
+     * @throws Exception Some text. 
      */
+    // violation 'Block tags have to appear in the order .*'
     void method3() throws Exception {}
 
     /**
@@ -69,8 +75,9 @@ class InputIncorrectAtClauseOrderCheck2 implements Serializable {
      *
      * @throws Exception Some text.
      * @serialData Some javadoc.
-     * @return Some text. // violation 'Block tags have to appear in the order .*'
+     * @return Some text. 
      */
+    // violation 'Block tags have to appear in the order .*'
     String method4() throws Exception {
       return "null";
     }
@@ -82,24 +89,27 @@ class InputIncorrectAtClauseOrderCheck2 implements Serializable {
          * Some text.
          *
          * @throws Exception Some text.
-         * @param str Some text. // violation 'Block tags have to appear in the order .*'
+         * @param str Some text. 
          */
+        // violation 'Block tags have to appear in the order .*'
         void method2(String str) throws Exception {}
 
         /**
          * Some text.
          *
          * @deprecated Some text.
-         * @throws Exception Some text. // violation 'Block tags have to appear in the order .*'
+         * @throws Exception Some text. 
          */
+        // violation 'Block tags have to appear in the order .*'
         void method3() throws Exception {}
 
         /**
          * Some text.
          *
          * @throws Exception Some text.
-         * @return Some text. // violation 'Block tags have to appear in the order .*'
-         */
+         * @return Some text. 
+        */
+        // violation 'Block tags have to appear in the order .*'
         String method4() throws Exception {
           return "null";
         }

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java
@@ -2,6 +2,8 @@ package com.google.checkstyle.test.chapter7javadoc.rule713atclauses;
 
 import java.io.Serializable;
 
+import com.puppycrawl.tools.checkstyle.checks.metrics.javancss.InputJavaNCSSResolveMutation.Some;
+
 /**
  * Some javadoc.
  *
@@ -17,9 +19,11 @@ class InputIncorrectAtClauseOrderCheck3 implements Serializable {
    * Some text.
    *
    * @deprecated Some text.
-   * @return Some text. // violation 'Block tags have to appear in the order .*'
-   * @param str Some text. // violation 'Block tags have to appear in the order .*'
+   * @return Some text. 
+   * @param str Some text. 
    */
+  // violation 'Block tags have to appear in the order .*'
+  // violation 'Block tags have to appear in the order .*'
   String method5(String str) {
     return "null";
   }
@@ -30,11 +34,13 @@ class InputIncorrectAtClauseOrderCheck3 implements Serializable {
    * @param str Some text.
    * @return Some text.
    * @serialData Some javadoc.
-   * @param number Some text. // violation 'Block tags have to appear in the order .*'
+   * @param number Some text. 
    * @throws Exception Some text.
-   * @param bool Some text. // violation 'Block tags have to appear in the order .*'
+   * @param bool Some text. 
    * @deprecated Some text.
    */
+  // violation 'Block tags have to appear in the order .*'
+  // violation 'Block tags have to appear in the order .*'
   String method6(String str, int number, boolean bool) throws Exception {
     return "null";
   }
@@ -54,8 +60,9 @@ class InputIncorrectAtClauseOrderCheck3 implements Serializable {
      *
      * @param str Some text.
      * @deprecated Some text.
-     * @return Some text. // violation 'Block tags have to appear in the order .*'
+     * @return Some text. 
      */
+    // violation 'Block tags have to appear in the order .*'
     String method5(String str) {
       return "null";
     }
@@ -65,11 +72,13 @@ class InputIncorrectAtClauseOrderCheck3 implements Serializable {
      *
      * @param str Some text.
      * @return Some text.
-     * @param number Some text. // violation 'Block tags have to appear in the order .*'
+     * @param number Some text. 
      * @throws Exception Some text.
-     * @param bool Some text. // violation 'Block tags have to appear in the order .*'
+     * @param bool Some text. 
      * @deprecated Some text.
      */
+    // violation 'Block tags have to appear in the order .*'
+    // violation 'Block tags have to appear in the order .*'
     String method6(String str, int number, boolean bool) throws Exception {
       return "null";
     }
@@ -82,9 +91,11 @@ class InputIncorrectAtClauseOrderCheck3 implements Serializable {
          * Some text.
          *
          * @deprecated Some text.
-         * @return Some text. // violation 'Block tags have to appear in the order .*'
-         * @param str Some text. // violation 'Block tags have to appear in the order .*'
+         * @return Some text. 
+         * @param str Some text. 
          */
+        // violation 'Block tags have to appear in the order .*'
+        // violation 'Block tags have to appear in the order .*'
         String method5(String str) {
           return "null";
         }
@@ -94,11 +105,13 @@ class InputIncorrectAtClauseOrderCheck3 implements Serializable {
          *
          * @param str Some text.
          * @return Some text.
-         * @param number Some text. // violation 'Block tags have to appear in the order .*'
+         * @param number Some text. 
          * @throws Exception Some text.
-         * @param bool Some text. // violation 'Block tags have to appear in the order .*'
+         * @param bool Some text. 
          * @deprecated Some text.
          */
+        // violation 'Block tags have to appear in the order .*'
+        // violation 'Block tags have to appear in the order .*'
         String method6(String str, int number, boolean bool) throws Exception {
           return "null";
         }


### PR DESCRIPTION
Issue: #19764

Removed `InputIncorrectAtClauseOrderCheck` test files from `checkstyle-input-suppressions.xml` and moved `// violation` comments out of Javadoc blocks in the corresponding test input files.