### PR TITLE
Issue #20940: bump modernizer-maven to 3.5.0

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -74,6 +74,7 @@
 
   <file name="AbstractAutomaticBean">
     <allow class="java.beans.PropertyDescriptor" local-only="true"/>
+    <allow class="com.google.common.base.Splitter"/>
   </file>
 
   <subpackage name="site">
@@ -206,6 +207,7 @@
     </file>
     <subpackage name="imports">
       <allow class="com.puppycrawl.tools.checkstyle.XmlLoader" local-only="true"/>
+      <allow class="com.google.common.base.Splitter"/>
     </subpackage>
     <subpackage name="indentation">
       <allow pkg="java.lang.reflect"/>
@@ -245,6 +247,7 @@
 
   <subpackage name="filters">
     <disallow pkg="com\.puppycrawl\.tools\.checkstyle\.checks\.[^.]+" regex="true"/>
+    <allow class="com.google.common.base.Splitter"/>
 
     <allow pkg="net.sf.saxon"/>
     <allow class="java.lang.ref.WeakReference" local-only="true"/>

--- a/pom.xml
+++ b/pom.xml
@@ -904,7 +904,7 @@
       <plugin>
         <groupId>org.gaul</groupId>
         <artifactId>modernizer-maven-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
         <configuration>
           <javaVersion>${java.version}</javaVersion>
           <includeTestClasses>false</includeTestClasses>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
@@ -46,6 +45,7 @@ import org.apache.commons.beanutils.converters.IntegerConverter;
 import org.apache.commons.beanutils.converters.LongConverter;
 import org.apache.commons.beanutils.converters.ShortConverter;
 
+import com.google.common.base.Splitter;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configurable;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
@@ -80,7 +80,7 @@ public abstract class AbstractAutomaticBean
 
     }
 
-    /** Comma separator for StringTokenizer. */
+    /** Comma separator. */
     private static final String COMMA_SEPARATOR = ",";
 
     /** The configuration of this bean. */
@@ -362,13 +362,13 @@ public abstract class AbstractAutomaticBean
         @Override
         @SuppressWarnings("unchecked")
         public Object convert(Class type, Object value) {
-            final StringTokenizer tokenizer = new StringTokenizer(
-                    value.toString(), COMMA_SEPARATOR);
             final List<Pattern> result = new ArrayList<>();
 
-            while (tokenizer.hasMoreTokens()) {
-                final String token = tokenizer.nextToken();
-                result.add(CommonUtil.createPattern(token.trim()));
+            for (String token : Splitter.on(COMMA_SEPARATOR)
+                    .trimResults()
+                    .omitEmptyStrings()
+                    .split(value.toString())) {
+                result.add(CommonUtil.createPattern(token));
             }
 
             return result.toArray(new Pattern[0]);
@@ -455,13 +455,13 @@ public abstract class AbstractAutomaticBean
         @Override
         @SuppressWarnings("unchecked")
         public Object convert(Class type, Object value) {
-            final StringTokenizer tokenizer = new StringTokenizer(
-                value.toString().trim(), COMMA_SEPARATOR);
             final List<String> result = new ArrayList<>();
 
-            while (tokenizer.hasMoreTokens()) {
-                final String token = tokenizer.nextToken();
-                result.add(token.trim());
+            for (String token : Splitter.on(COMMA_SEPARATOR)
+                    .trimResults()
+                    .omitEmptyStrings()
+                    .split(value.toString())) {
+                result.add(token);
             }
 
             return result.toArray(CommonUtil.EMPTY_STRING_ARRAY);
@@ -490,13 +490,12 @@ public abstract class AbstractAutomaticBean
         @Override
         @SuppressWarnings("unchecked")
         public Object convert(Class type, Object value) {
-            // Converts to a String and trims it for the tokenizer.
-            final StringTokenizer tokenizer = new StringTokenizer(
-                value.toString().trim(), COMMA_SEPARATOR);
             final List<AccessModifierOption> result = new ArrayList<>();
 
-            while (tokenizer.hasMoreTokens()) {
-                final String token = tokenizer.nextToken();
+            for (String token : Splitter.on(COMMA_SEPARATOR)
+                    .trimResults()
+                    .omitEmptyStrings()
+                    .split(value.toString())) {
                 result.add(AccessModifierOption.getInstance(token));
             }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -22,10 +22,10 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.base.Splitter;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -770,12 +770,12 @@ public class CustomImportOrderCheck extends AbstractCheck {
     private static String getFirstDomainsFromIdent(
             final int firstPackageDomainsCount, final String packageFullPath) {
         final StringBuilder builder = new StringBuilder(256);
-        final StringTokenizer tokens = new StringTokenizer(packageFullPath, ".");
-        int count = firstPackageDomainsCount;
+        final List<String> tokens = Splitter.on('.')
+                .splitToList(packageFullPath);
+        final int limit = Math.min(firstPackageDomainsCount, tokens.size());
 
-        while (count > 0 && tokens.hasMoreTokens()) {
-            builder.append(tokens.nextToken());
-            count--;
+        for (int tokenIndex = 0; tokenIndex < limit; tokenIndex++) {
+            builder.append(tokens.get(tokenIndex));
         }
         return builder.toString();
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java
@@ -23,7 +23,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.StringTokenizer;
+
+import com.google.common.base.Splitter;
 
 /**
  * <div>
@@ -47,19 +48,21 @@ final class CsvFilterElement implements IntFilterElement {
      *     contain a parsable integer.
      */
     /* package */ CsvFilterElement(String pattern) {
-        final StringTokenizer tokenizer = new StringTokenizer(pattern, ",");
-        while (tokenizer.hasMoreTokens()) {
-            final String token = tokenizer.nextToken().trim();
-            final int index = token.indexOf('-');
+        for (String token : Splitter.on(',').split(pattern)) {
+            final String trimmedToken = token.trim();
+            if (trimmedToken.isEmpty()) {
+                continue;
+            }
+            final int index = trimmedToken.indexOf('-');
             if (index == -1) {
-                final int matchValue = Integer.parseInt(token);
+                final int matchValue = Integer.parseInt(trimmedToken);
                 addFilter(new IntMatchFilterElement(matchValue));
             }
             else {
                 final int lowerBound =
-                    Integer.parseInt(token.substring(0, index));
+                    Integer.parseInt(trimmedToken.substring(0, index));
                 final int upperBound =
-                    Integer.parseInt(token.substring(index + 1));
+                    Integer.parseInt(trimmedToken.substring(index + 1));
                 addFilter(new IntRangeFilterElement(lowerBound, upperBound));
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AccessModifierOptionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AccessModifierOptionTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +56,38 @@ public class AccessModifierOptionTest {
         assertWithMessage("Case mismatch.")
                 .that(AccessModifierOption.PRIVATE.toString())
                 .isEqualTo("private");
+    }
+
+    @Test
+    public void testGetInstance() {
+        assertWithMessage("Invalid instance returned")
+                .that(AccessModifierOption.getInstance("public"))
+                .isEqualTo(AccessModifierOption.PUBLIC);
+        assertWithMessage("Invalid instance returned")
+                .that(AccessModifierOption.getInstance(" PUBLIC "))
+                .isEqualTo(AccessModifierOption.PUBLIC);
+        assertWithMessage("Invalid instance returned")
+                .that(AccessModifierOption.getInstance("private"))
+                .isEqualTo(AccessModifierOption.PRIVATE);
+        assertWithMessage("Invalid instance returned")
+                .that(AccessModifierOption.getInstance("package"))
+                .isEqualTo(AccessModifierOption.PACKAGE);
+        assertWithMessage("Invalid instance returned")
+                .that(AccessModifierOption.getInstance("protected"))
+                .isEqualTo(AccessModifierOption.PROTECTED);
+    }
+
+    @Test
+    public void testGetInstanceInvalid() {
+        final IllegalArgumentException expected =
+            getExpectedThrowable(IllegalArgumentException.class, () -> {
+                AccessModifierOption.getInstance("invalid");
+            });
+
+        assertWithMessage("Invalid exception message")
+                .that(expected.getMessage())
+                .isEqualTo("No enum constant com.puppycrawl.tools.checkstyle.checks.naming."
+                        + "AccessModifierOption.INVALID");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -26,6 +26,7 @@ import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsCla
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -390,4 +391,30 @@ public class TokenUtilTest {
                 .isFalse();
     }
 
+    @Test
+    public void testAsBitSet() {
+        final BitSet expected = new BitSet();
+        expected.set(TokenTypes.LITERAL_TRUE);
+        expected.set(TokenTypes.LITERAL_FALSE);
+
+        assertWithMessage("Result is not expected")
+                .that(TokenUtil.asBitSet(TokenTypes.LITERAL_TRUE, TokenTypes.LITERAL_FALSE))
+                .isEqualTo(expected);
+
+        assertWithMessage("Result is not expected")
+                .that(TokenUtil.asBitSet("LITERAL_TRUE", "  ", "LITERAL_FALSE", ""))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void testAsBitSetInvalid() {
+        final IllegalArgumentException expected =
+            getExpectedThrowable(IllegalArgumentException.class, () -> {
+                TokenUtil.asBitSet("UNKNOWN_TOKEN");
+            });
+
+        assertWithMessage("Invalid exception message")
+                .that(expected.getMessage())
+                .isEqualTo("unknown TokenTypes value 'UNKNOWN_TOKEN'");
+    }
 }


### PR DESCRIPTION
closes #20940 
### Summary 

- Bump modernizer-maven to 3.5.0
- remove StringTokenizer,  use Splitter
- add Splitter to allowed imports to import-control.xml