### PR TITLE
Issue #19764 : Move violation comments out of Javadoc for rule713atclauses inputs

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -78,16 +78,6 @@
   <suppress id="noViolationCommentsInJavadoc"
             files="/chapter7javadoc/rule711generalform/InputFormattedCorrectJavadocLeadingAsteriskAlignment.java"/>
   <suppress id="noViolationCommentsInJavadoc"
-            files="/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck1.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityRemoveIncorrectAnnotationToken.java"/>
 
 

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck1.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck1.java
@@ -33,6 +33,7 @@ class InputIncorrectAtClauseOrderCheck1 implements Serializable {
    */
   private String thirdName;
 
+  // violation 8 lines below 'Block tags have to appear in the order .*'
   /**
    * Some text.
    *
@@ -40,18 +41,19 @@ class InputIncorrectAtClauseOrderCheck1 implements Serializable {
    * @return Some text.
    * @serialData Some javadoc.
    * @deprecated Some text.
-   * @throws Exception Some text. // violation 'Block tags have to appear in the order .*'
+   * @throws Exception Some text.
    */
   String method(String str) throws Exception {
     return "null";
   }
 
+  // violation 6 lines below 'Block tags have to appear in the order .*'
   /**
    * Some text.
    *
    * @serialData Some javadoc.
    * @return Some text.
-   * @param str Some text. // violation 'Block tags have to appear in the order .*'
+   * @param str Some text.
    * @throws Exception Some text.
    */
   String method1(String str) throws Exception {
@@ -67,24 +69,28 @@ class InputIncorrectAtClauseOrderCheck1 implements Serializable {
    * @author max
    */
   class InnerClassWithAnnotations1 {
+    // violation 7 lines below 'Block tags have to appear in the order .*'
+    // violation 7 lines below 'Block tags have to appear in the order .*'
     /**
      * Some text.
      *
      * @return Some text.
      * @deprecated Some text.
-     * @param str Some text. // violation 'Block tags have to appear in the order .*'
-     * @throws Exception Some text. // violation 'Block tags have to appear in the order .*'
+     * @param str Some text.
+     * @throws Exception Some text.
      */
     String method(String str) throws Exception {
       return "null";
     }
 
+    // violation 6 lines below 'Block tags have to appear in the order .*'
+    // violation 6 lines below 'Block tags have to appear in the order .*'
     /**
      * Some text.
      *
      * @throws Exception Some text.
-     * @return Some text. // violation 'Block tags have to appear in the order .*'
-     * @param str Some text. // violation 'Block tags have to appear in the order .*'
+     * @return Some text.
+     * @param str Some text.
      */
     String method1(String str) throws Exception {
       return "null";
@@ -93,25 +99,28 @@ class InputIncorrectAtClauseOrderCheck1 implements Serializable {
 
   InnerClassWithAnnotations1 anon =
       new InnerClassWithAnnotations1() {
+        // violation 6 lines below 'Block tags have to appear in the order .*'
+        // violation 8 lines below 'Block tags have to appear in the order .*'
         /**
          * Some text.
          *
          * @throws Exception Some text.
-         * @param str Some text. // violation 'Block tags have to appear in the order .*'
+         * @param str Some text.
          * @serialData Some javadoc.
          * @deprecated Some text.
-         * @return Some text. // violation 'Block tags have to appear in the order .*'
+         * @return Some text.
          */
         String method(String str) throws Exception {
           return "null";
         }
 
+        // violation 6 lines below 'Block tags have to appear in the order .*'
         /**
          * Some text.
          *
          * @param str Some text.
          * @throws Exception Some text.
-         * @return Some text. // violation 'Block tags have to appear in the order .*'
+         * @return Some text.
          */
         String method1(String str) throws Exception {
           return "null";

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2.java
@@ -12,19 +12,21 @@ import java.io.Serializable;
  * @author max
  */
 class InputIncorrectAtClauseOrderCheck2 implements Serializable {
+  // violation 5 lines below 'Block tags have to appear in the order .*'
   /**
    * Some text.
    *
    * @throws Exception Some text.
-   * @param str Some text. // violation 'Block tags have to appear in the order .*'
+   * @param str Some text.
    */
   void method2(String str) throws Exception {}
 
+  // violation 5 lines below 'Block tags have to appear in the order .*'
   /**
    * Some text.
    *
    * @deprecated Some text.
-   * @throws Exception Some text. // violation 'Block tags have to appear in the order .*'
+   * @throws Exception Some text.
    */
   void method3() throws Exception {}
 
@@ -56,20 +58,22 @@ class InputIncorrectAtClauseOrderCheck2 implements Serializable {
      */
     void method2(String str) throws Exception {}
 
+    // violation 5 lines below 'Block tags have to appear in the order .*'
     /**
      * Some text.
      *
      * @deprecated Some text.
-     * @throws Exception Some text. // violation 'Block tags have to appear in the order .*'
+     * @throws Exception Some text.
      */
     void method3() throws Exception {}
 
+    // violation 6 lines below 'Block tags have to appear in the order .*'
     /**
      * Some text.
      *
      * @throws Exception Some text.
      * @serialData Some javadoc.
-     * @return Some text. // violation 'Block tags have to appear in the order .*'
+     * @return Some text.
      */
     String method4() throws Exception {
       return "null";
@@ -78,27 +82,30 @@ class InputIncorrectAtClauseOrderCheck2 implements Serializable {
 
   InnerClassWithAnnotations2 anon =
       new InnerClassWithAnnotations2() {
+        // violation 5 lines below 'Block tags have to appear in the order .*'
         /**
          * Some text.
          *
          * @throws Exception Some text.
-         * @param str Some text. // violation 'Block tags have to appear in the order .*'
+         * @param str Some text.
          */
         void method2(String str) throws Exception {}
 
+        // violation 5 lines below 'Block tags have to appear in the order .*'
         /**
          * Some text.
          *
          * @deprecated Some text.
-         * @throws Exception Some text. // violation 'Block tags have to appear in the order .*'
+         * @throws Exception Some text.
          */
         void method3() throws Exception {}
 
+        // violation 5 lines below 'Block tags have to appear in the order .*'
         /**
          * Some text.
          *
          * @throws Exception Some text.
-         * @return Some text. // violation 'Block tags have to appear in the order .*'
+         * @return Some text.
          */
         String method4() throws Exception {
           return "null";

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java
@@ -13,26 +13,30 @@ import java.io.Serializable;
  */
 class InputIncorrectAtClauseOrderCheck3 implements Serializable {
 
+  // violation 6 lines below 'Block tags have to appear in the order .*'
+  // violation 6 lines below 'Block tags have to appear in the order .*'
   /**
    * Some text.
    *
    * @deprecated Some text.
-   * @return Some text. // violation 'Block tags have to appear in the order .*'
-   * @param str Some text. // violation 'Block tags have to appear in the order .*'
+   * @return Some text.
+   * @param str Some text.
    */
   String method5(String str) {
     return "null";
   }
 
+  // violation 8 lines below 'Block tags have to appear in the order .*'
+  // violation 9 lines below 'Block tags have to appear in the order .*'
   /**
    * Some text.
    *
    * @param str Some text.
    * @return Some text.
    * @serialData Some javadoc.
-   * @param number Some text. // violation 'Block tags have to appear in the order .*'
+   * @param number Some text.
    * @throws Exception Some text.
-   * @param bool Some text. // violation 'Block tags have to appear in the order .*'
+   * @param bool Some text.
    * @deprecated Some text.
    */
   String method6(String str, int number, boolean bool) throws Exception {
@@ -49,25 +53,28 @@ class InputIncorrectAtClauseOrderCheck3 implements Serializable {
    */
   class InnerClassWithAnnotations3 {
 
+    // violation 6 lines below 'Block tags have to appear in the order .*'
     /**
      * Some text.
      *
      * @param str Some text.
      * @deprecated Some text.
-     * @return Some text. // violation 'Block tags have to appear in the order .*'
+     * @return Some text.
      */
     String method5(String str) {
       return "null";
     }
 
+    // violation 7 lines below 'Block tags have to appear in the order .*'
+    // violation 8 lines below 'Block tags have to appear in the order .*'
     /**
      * Some text.
      *
      * @param str Some text.
      * @return Some text.
-     * @param number Some text. // violation 'Block tags have to appear in the order .*'
+     * @param number Some text.
      * @throws Exception Some text.
-     * @param bool Some text. // violation 'Block tags have to appear in the order .*'
+     * @param bool Some text.
      * @deprecated Some text.
      */
     String method6(String str, int number, boolean bool) throws Exception {
@@ -78,25 +85,29 @@ class InputIncorrectAtClauseOrderCheck3 implements Serializable {
   InnerClassWithAnnotations3 anon =
       new InnerClassWithAnnotations3() {
 
+        // violation 6 lines below 'Block tags have to appear in the order .*'
+        // violation 6 lines below 'Block tags have to appear in the order .*'
         /**
          * Some text.
          *
          * @deprecated Some text.
-         * @return Some text. // violation 'Block tags have to appear in the order .*'
-         * @param str Some text. // violation 'Block tags have to appear in the order .*'
+         * @return Some text.
+         * @param str Some text.
          */
         String method5(String str) {
           return "null";
         }
 
+        // violation 7 lines below 'Block tags have to appear in the order .*'
+        // violation 8 lines below 'Block tags have to appear in the order .*'
         /**
          * Some text.
          *
          * @param str Some text.
          * @return Some text.
-         * @param number Some text. // violation 'Block tags have to appear in the order .*'
+         * @param number Some text.
          * @throws Exception Some text.
-         * @param bool Some text. // violation 'Block tags have to appear in the order .*'
+         * @param bool Some text.
          * @deprecated Some text.
          */
         String method6(String str, int number, boolean bool) throws Exception {

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor.java
@@ -1,31 +1,37 @@
 package com.google.checkstyle.test.chapter7javadoc.rule713atclauses;
 
+// violation 6 lines below 'Block tags have to appear in the order'
+// violation 6 lines below 'Block tags have to appear in the order'
 /**
  * Record with wrong tag order.
  *
  * @deprecated use NewPoint
- * @param x the x coordinate // violation 'Block tags have to appear in the order'
- * @param y the y coordinate // violation 'Block tags have to appear in the order'
+ * @param x the x coordinate
+ * @param y the y coordinate
  */
 record InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor(int x, int y) {
 
+  // violation 6 lines below 'Block tags have to appear in the order'
+  // violation 6 lines below 'Block tags have to appear in the order'
   /**
    * Some text.
    *
    * @deprecated old method
-   * @param val some text // violation 'Block tags have to appear in the order'
-   * @return some text // violation 'Block tags have to appear in the order'
+   * @param val some text
+   * @return some text
    */
   static String method(String val) {
     return val;
   }
 
+  // violation 6 lines below 'Block tags have to appear in the order'
+  // violation 6 lines below 'Block tags have to appear in the order'
   /**
    * Generic record with wrong tag order.
    *
    * @deprecated use other record
-   * @param <T> the type // violation 'Block tags have to appear in the order'
-   * @param name the name // violation 'Block tags have to appear in the order'
+   * @param <T> the type
+   * @param name the name
    */
   record InnerGenericRecord<T>(String name) {}
 
@@ -36,13 +42,16 @@ record InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor(int x, int y) {
    * @param hi the upper bound
    */
   record InnerRecordWithCompactCtor(int lo, int hi) {
+    // violation 7 lines below 'Block tags have to appear in the order'
+    // violation 7 lines below 'Block tags have to appear in the order'
+    // violation 7 lines below 'Block tags have to appear in the order'
     /**
      * Validates range.
      *
      * @deprecated use factory method
-     * @param lo the lower bound // violation 'Block tags have to appear in the order'
-     * @param hi the upper bound // violation 'Block tags have to appear in the order'
-     * @throws Exception if error // violation 'Block tags have to appear in the order'
+     * @param lo the lower bound
+     * @param hi the upper bound
+     * @throws Exception if error
      */
     InnerRecordWithCompactCtor {
       if (lo > hi) {

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java
@@ -39,6 +39,7 @@ class InputJavaDocTagContinuationIndentation implements Serializable {
    */
   private String thirdName;
 
+  // violation 9 lines below '.* incorrect indentation level, expected level should be 4.'
   /**
    * Some text.
    *
@@ -47,7 +48,7 @@ class InputJavaDocTagContinuationIndentation implements Serializable {
    * @return Some text.
    * @serialData Some javadoc.
    * @throws Exception Some text.
-   *    Some javadoc. // violation '.* incorrect indentation level, expected level should be 4.'
+   *    Some javadoc.
    * @deprecated Some text.
    */
   String method(String str) throws Exception {
@@ -106,15 +107,17 @@ class InputJavaDocTagContinuationIndentation implements Serializable {
     return "null";
   }
 
+  // violation 8 lines below '.* incorrect indentation level, expected level should be 4.'
+  // violation 9 lines below '.* incorrect indentation level, expected level should be 4.'
   /**
    * Some text.
    *
    * @param str Some text.
    * @param bool Some text.
    * @param number Some text.
-   *    Some javadoc. // violation '.* incorrect indentation level, expected level should be 4.'
+   *    Some javadoc.
    * @return Some text.
-   *    Some javadoc. // violation '.* incorrect indentation level, expected level should be 4.'
+   *    Some javadoc.
    * @serialData Some javadoc.
    * @throws Exception Some text.
    * @deprecated Some text.
@@ -287,16 +290,16 @@ class InputJavaDocTagContinuationIndentation implements Serializable {
       return "null";
     }
 
+    // violation 7 lines below '.* incorrect indentation level, expected level should be 4.'
+    // violation 8 lines below '.* incorrect indentation level, expected level should be 4.'
     /**
      * Some text.
      *
      * @param str Some text.
      * @param number Some text.
      *    Some javadoc.
-     *     // violation above '.* incorrect indentation level, expected level should be 4.'
      * @param bool Some text.
      *    Some javadoc.
-     *     // violation above '.* incorrect indentation level, expected level should be 4.'
      * @return Some text.
      * @throws Exception Some text.
      * @deprecated Some text.
@@ -308,17 +311,17 @@ class InputJavaDocTagContinuationIndentation implements Serializable {
 
   InnerClassWithAnnotations anon =
       new InnerClassWithAnnotations() {
+        // violation 6 lines below '.* incorrect indentation level, expected level should be 4.'
+        // violation 9 lines below '.* incorrect indentation level, expected level should be 4.'
         /**
          * Some text.
          *
          * @param str Some text.
          *   Some javadoc.
-         *     // violation above '.* incorrect indentation level, expected level should be 4.'
          * @return Some text.
          * @throws Exception Some text.
          * @serialData Some javadoc.
          *    Some javadoc.
-         *     // violation above '.* incorrect indentation level, expected level should be 4.'
          * @deprecated Some text.
          */
         String method(String str) throws Exception {
@@ -376,21 +379,21 @@ class InputJavaDocTagContinuationIndentation implements Serializable {
           return "null";
         }
 
+        // violation 8 lines below '.* incorrect indentation level, expected level should be 4.'
+        // violation 9 lines below '.* incorrect indentation level, expected level should be 4.'
+        // violation 12 lines below '.* incorrect indentation level, expected level should be 4.'
         /**
          * Some text.
          *       Some javadoc.
          *
          * @param str Some text.
          *    Some javadoc.
-         *     // violation above '.* incorrect indentation level, expected level should be 4.'
          * @param number Some text.
          *    Some javadoc.
-         *     // violation above '.* incorrect indentation level, expected level should be 4.'
          * @param bool Some text.
          * @return Some text.
          * @throws Exception Some text.
          *    Some javadoc.
-         *     // violation above '.* incorrect indentation level, expected level should be 4.'
          * @deprecated Some text.
          */
         String method6(String str, int number, boolean bool) throws Exception {
@@ -398,6 +401,7 @@ class InputJavaDocTagContinuationIndentation implements Serializable {
         }
       };
 
+  // violation 10 lines below '.* incorrect indentation level, expected level should be 4.'
   /**
    * Some javadoc.
    *
@@ -407,11 +411,12 @@ class InputJavaDocTagContinuationIndentation implements Serializable {
    *     Some javadoc.
    *     Some javadoc.
    * @see Some javadoc.
-   *    Some javadoc. // violation '.* incorrect indentation level, expected level should be 4.'
+   *    Some javadoc.
    * @author max
    */
   enum Foo3 {}
 
+  // violation 8 lines below '.* incorrect indentation level, expected level should be 4.'
   /**
    * Some javadoc.
    *
@@ -419,7 +424,7 @@ class InputJavaDocTagContinuationIndentation implements Serializable {
    * @since Some javadoc.
    *     Some javadoc.
    * @serialData Some javadoc.
-   *   Some javadoc. // violation '.* incorrect indentation level, expected level should be 4.'
+   *   Some javadoc.
    * @author max
    */
   interface FooIn5 {}


### PR DESCRIPTION
Issue: #19764

Summary:
Moved violation comments out of Javadoc for the following input files under rule713atclauses:

- InputIncorrectAtClauseOrderCheck1.java
- InputIncorrectAtClauseOrderCheck2.java
- InputIncorrectAtClauseOrderCheck3.java
- InputIncorrectAtClauseOrderCheckOnRecordAndCompactCtor.java
- InputJavaDocTagContinuationIndentation.java

Also removed the corresponding noViolationCommentsInJavadoc suppressions from
config/checkstyle-input-suppressions.xml.

Verification:
- Ran `./mvnw verify`
- BUILD SUCCESS