### PR TITLE
Issue #20946: Resolve Failsafe discovery warning

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputUnderscoreUsedInNames.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputUnderscoreUsedInNames.java
@@ -127,7 +127,7 @@ public class InputUnderscoreUsedInNames {
     void testCount3() {}
   }
 
-  class UnderscoreInTestMethodNames {
+  static class UnderscoreInTestMethodNames {
 
     @Test
     void testSetCount_zeroToZero_addSupported() {}


### PR DESCRIPTION
Issue: #20946

Makes `UnderscoreInTestMethodNames` static so JUnit can discover and execute its test methods without warning.

Validation:

- Focused Failsafe run: 14 tests, no discovery warning
- `CamelCaseDefinedTest`: 3 tests, 0 failures
- Full unit and integration suites: 0 failures
- `mvnw antrun:run@ant-phase-verify`: `BUILD SUCCESS`
