### PR TITLE
Issue #5573: cover unmatched influence group

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -352,6 +352,33 @@ public class SuppressWithNearbyCommentFilterTest
     }
 
     @Test
+    public void testUnmatchedInfluenceGroup() {
+        final String[] violationAndSuppressedMessages = {
+            "33:17: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "InvalidIfName", "^[a-z][a-zA-Z0-9]*$"),
+            "34:16: "
+                + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "InvalidElseName", "^[a-z][a-zA-Z0-9]*$"),
+        };
+
+        final CheckstyleException exc = getExpectedThrowable(
+                CheckstyleException.class,
+                () -> {
+                    verifyFilterWithInlineConfigParser(
+                        getPath("InputSuppressWithNearbyCommentFilterUnmatchedInfluenceGroup.java"),
+                        violationAndSuppressedMessages
+                    );
+                });
+        assertWithMessage("Invalid exception message")
+            .that(exc)
+            .hasCauseThat()
+            .hasMessageThat()
+            .isEqualTo("unable to parse influence from "
+                    + "'-@csoff[MoveVariableInside(If|Else)](5) my comment text' using $3");
+    }
+
+    @Test
     public void testEqualsAndHashCodeOfTagClass() {
         final SuppressWithNearbyCommentFilter filter = new SuppressWithNearbyCommentFilter();
         final Object tag =

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/InputSuppressWithNearbyCommentFilterUnmatchedInfluenceGroup.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithnearbycommentfilter/InputSuppressWithNearbyCommentFilterUnmatchedInfluenceGroup.java
@@ -1,0 +1,35 @@
+/*
+SuppressWithNearbyCommentFilter
+commentFormat = -@csoff\\[(MoveVariableInside\\((If\\|Else)\\))(?:\\|(\\w+))?\\]\\((\\d+)\\) .{10,}
+checkFormat = (default).*
+messageFormat = (default)(null)
+idFormat = on(If|Else)
+influenceFormat = $3
+checkCPP = (default)true
+checkC = (default)true
+
+com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck
+id = onIf
+format = (default)^[a-z][a-zA-Z0-9]*$
+applyToPublic = false
+applyToProtected = false
+applyToPackage = false
+applyToPrivate = (default)true
+
+com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck
+id = onElse
+format = (default)^[a-z][a-zA-Z0-9]*$
+applyToPublic = (default)true
+applyToProtected = false
+applyToPackage = false
+applyToPrivate = false
+
+*/
+
+package com.puppycrawl.tools.checkstyle.filters.suppresswithnearbycommentfilter;
+
+public class InputSuppressWithNearbyCommentFilterUnmatchedInfluenceGroup {
+    // -@csoff[MoveVariableInside(If|Else)](5) my comment text
+    private int InvalidIfName; // violation 'Name 'InvalidIfName' must match pattern'
+    public int InvalidElseName; // violation 'Name 'InvalidElseName' must match pattern'
+}


### PR DESCRIPTION
Issue: #5573

Adds regression coverage for an unresolved optional capture group in `influenceFormat`. Current behavior is unchanged: the invalid influence is rejected with an exception that identifies the comment and influence format. There are no production code changes.

Validation:
- `./mvnw clean verify`
- `./mvnw -Dtest=SuppressWithNearbyCommentFilterTest#testUnmatchedInfluenceGroup test`