### PR TITLE
Issue #20954: Fix violation message comments for FinalParameters check

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -333,17 +333,9 @@ public final class InlineConfigParser {
      * <a href="https://github.com/checkstyle/checkstyle/issues/20954">#20954</a>
      */
     private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of(
-            "checks/finalparameters/InputFinalParameters9.java",
-            "checks/finalparameters/InputFinalParameters2.java",
             "checks/finalparameters/InputFinalParameters.java",
-            "checks/finalparameters/InputFinalParameters6.java",
-            "checks/finalparameters/InputFinalParameters10.java",
-            "checks/finalparameters/InputFinalParametersPrimitiveTypes.java",
             "checks/finalparameters/InputFinalParameters3.java",
-            "checks/finalparameters/InputFinalParametersInterfaceMethod.java",
-            "checks/finalparameters/InputFinalParameters8.java",
             "checks/finalparameters/InputFinalParametersPatternVariables.java",
-            "checks/finalparameters/InputFinalParametersPrimitiveTypes2.java",
             "checks/finalparameters/"
                     + "InputFinalParametersRecordForLoopPatternVariables.java",
             "checks/coding/declarationorder/Example1.java",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters.java
@@ -25,7 +25,7 @@ class InputFinalParameters
     }
 
     /** non final param constructor */
-    InputFinalParameters(String s) // violation 's' should be final
+    InputFinalParameters(String s) // violation 'Parameter s should be final.'
     {
     }
 
@@ -40,12 +40,12 @@ class InputFinalParameters
     }
 
     /** non-final param constructor with annotation*/
-    InputFinalParameters(@MyAnnotation33 Boolean i) // violation 'i' should be final
+    InputFinalParameters(@MyAnnotation33 Boolean i) // violation 'Parameter i should be final.'
     {
     }
 
     /** mixed */
-    InputFinalParameters(String s, final Integer i) // violation 's' should be final
+    InputFinalParameters(String s, final Integer i) // violation 'Parameter s should be final.'
     {
     }
 
@@ -55,7 +55,7 @@ class InputFinalParameters
     }
 
     /** non final param method */
-    void method(String s) // violation 's' should be final
+    void method(String s) // violation 'Parameter s should be final.'
     {
     }
 
@@ -71,13 +71,13 @@ class InputFinalParameters
     }
 
     /** non-final param method with annotation **/
-    void method(@MyAnnotation33 Class<Object> s) // violation 's' should be final
+    void method(@MyAnnotation33 Class<Object> s) // violation 'Parameter s should be final.'
     {
 
     }
 
     /** mixed */
-    void method(String s, final Integer i) // violation 's' should be final
+    void method(String s, final Integer i) // violation 'Parameter s should be final.'
     {
     }
 
@@ -92,10 +92,10 @@ class InputFinalParameters
     {
         Action a = new AbstractAction()
             {
-                public void actionPerformed(ActionEvent e) // violation 'e' should be final
+                public void actionPerformed(ActionEvent e) // violation 'Parameter e should be final.'
                 {
                 }
-                void somethingElse(@MyAnnotation33 ActionEvent e) // violation 'e' should be final
+                void somethingElse(@MyAnnotation33 ActionEvent e) // violation 'Parameter e should be final.'
                 {
                 }
             };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters10.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters10.java
@@ -57,7 +57,7 @@ class Foo10
     /* Some for-each clauses */
     public void Bar()
     {
-        for(String s : someExpression()) // violation 's' should be final
+        for(String s : someExpression()) // violation  'Parameter s should be final.'
         {
 
         }
@@ -65,7 +65,7 @@ class Foo10
         {
 
         }
-        for(@MyAnnotation33 String s : someExpression()) // violation 's' should be final
+        for(@MyAnnotation33 String s : someExpression()) // violation 'Parameter s should be final.'
         {
 
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters2.java
@@ -26,7 +26,7 @@ class InputFinalParameters2
     }
 
     /** non final param constructor */
-    InputFinalParameters2(String s) // violation 's' should be final
+    InputFinalParameters2(String s) // violation 'Parameter s should be final.'
     {
     }
 
@@ -41,12 +41,12 @@ class InputFinalParameters2
     }
 
     /** non-final param constructor with annotation*/
-    InputFinalParameters2(@MyAnnotation33 Boolean i) // violation 'i' should be final
+    InputFinalParameters2(@MyAnnotation33 Boolean i) // violation 'Parameter i should be final.'
     {
     }
 
     /** mixed */
-    InputFinalParameters2(String s, final Integer i) // violation 's' should be final
+    InputFinalParameters2(String s, final Integer i) // violation 'Parameter s should be final.'
     {
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters3.java
@@ -56,7 +56,7 @@ class InputFinalParameters3
     }
 
     /** non final param method */
-    void method(String s) // violation 's' should be final
+    void method(String s) // violation "Parameter s should be final.'
     {
     }
 
@@ -72,13 +72,13 @@ class InputFinalParameters3
     }
 
     /** non-final param method with annotation **/
-    void method(@MyAnnotation33 Class<Object> s) // violation 's' should be final
+    void method(@MyAnnotation33 Class<Object> s) // violation 'Parameter s should be final.'
     {
 
     }
 
     /** mixed */
-    void method(String s, final Integer i) // violation 's' should be final
+    void method(String s, final Integer i) // violation 'Parameter s should be final.'
     {
     }
 
@@ -93,10 +93,10 @@ class InputFinalParameters3
     {
         Action a = new AbstractAction()
             {
-                public void actionPerformed(ActionEvent e) // violation 'e' should be final
+                public void actionPerformed(ActionEvent e) // violation 'Parameter e should be final.'
                 {
                 }
-                void somethingElse(@MyAnnotation33 ActionEvent e) // violation 'e' should be final
+                void somethingElse(@MyAnnotation33 ActionEvent e) // violation 'Parameter e should be final.'
                 {
                 }
             };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters6.java
@@ -15,13 +15,13 @@ package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 class InputFinalParameters6
 {
     /** methods with complicated types of the parameters. */
-    void methodA(java.lang.String aParam) { // violation 'aParam' should be final
+    void methodA(java.lang.String aParam) { // violation 'Parameter aParam should be final.'
     }
 
-    void methodB(String[] args) { // violation 'args' should be final
+    void methodB(String[] args) { // violation 'Parameter args should be final.'
     }
 
-    void methodC(java.lang.String[] args) { // violation 'args' should be final
+    void methodC(java.lang.String[] args) { // violation 'Parameter args should be final.'
     }
 
     /** some catch blocks */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters8.java
@@ -15,13 +15,13 @@ package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 class InputFinalParameters8
 {
     /** methods with complicated types of the parameters. */
-    void methodA(String aParam) { // violation 'aParam' should be final
+    void methodA(String aParam) { // violation 'Parameter aParam should be final.'
     }
 
-    void methodB(String[] args) { // violation 'args' should be final
+    void methodB(String[] args) { // violation 'Parameter args should be final.'
     }
 
-    void methodC(String[] args) { // violation 'args' should be final
+    void methodC(String[] args) { // violation 'Parameter args should be final.'
     }
 
     /** some catch blocks */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters9.java
@@ -30,16 +30,16 @@ class InputFinalParameters9
         try {
             String.CASE_INSENSITIVE_ORDER.equals("");
         }
-        catch (NullPointerException npe) { // violation 'npe' should be fina;
+        catch (NullPointerException npe) { // violation 'Parameter npe should be final.'
             npe.getMessage();
         }
         catch (@MyAnnotation33 final ClassCastException e) {
             e.getMessage();
         }
-        catch (RuntimeException e) { // violation 'e' should be final
+        catch (RuntimeException e) { // violation 'Parameter e should be final.'
             e.getMessage();
         }
-        catch (@MyAnnotation33 NoClassDefFoundError e) { // violation 'e' should be final
+        catch (@MyAnnotation33 NoClassDefFoundError e) { // violation 'Parameter e should be final.'
             e.getMessage();
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersInterfaceMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersInterfaceMethod.java
@@ -13,19 +13,19 @@ package com.puppycrawl.tools.checkstyle.checks.finalparameters;
  * Test cases for detecting missing final parameters in interface methods.
  */
 public interface InputFinalParametersInterfaceMethod {
-    static void method1B(Object param1) { // violation 'param1' should be final
+    static void method1B(Object param1) { // violation 'Parameter param1 should be final.'
     }
 
     static void method1G(final Object param1) {
     }
 
-    private void method2B(Object param1) { // violation 'param1' should be final
+    private void method2B(Object param1) { // violation 'Parameter param1 should be final.'
     }
 
     private void method2G(final Object param1) {
     }
 
-    default void method3B(Object param1) { // violation 'param1' should be final
+    default void method3B(Object param1) { // violation 'Parameter param1 should be final.'
     }
 
     default void method3G(final Object param1) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPatternVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPatternVariables.java
@@ -14,22 +14,22 @@ public class InputFinalParametersPatternVariables {
     record ARecord(String name, int age) {
     }
     static void method(final Object o) {
-        final boolean isString = o instanceof String s; // violation 's' should be final
+        final boolean isString = o instanceof String s; // violation 'Parameter s should be final.'
         final boolean isStringCorrect = o instanceof final String correct;
-        if (o instanceof Integer i) { // violation 'i' should be final
+        if (o instanceof Integer i) { // violation 'Parameter i should be final.'
         }
         if (o instanceof final Integer i) {
         }
 
-        if (o instanceof ARecord(String name, final int age)) { // violation 'name' should be final
+        if (o instanceof ARecord(String name, final int age)) { // violation 'Parameter name should be final.'
         }
         if (o instanceof ARecord(final String name, final int age)) {
         }
 
         switch (o) {
-            case String s -> { // violation 's' should be final
+            case String s -> { // violation 'Parameter s should be final.'
             }
-            case ARecord(String name, final int age) -> { // violation 'name' should be final
+            case ARecord(String name, final int age) -> { // violation 'Parameter name should be final.'
             }
             default -> {}
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPrimitiveTypes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPrimitiveTypes.java
@@ -12,13 +12,13 @@ package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 public class InputFinalParametersPrimitiveTypes
 {
     void foo(int i) {} //no warning
-    void foo1(int i, String k, float s) {}  // violation 'k' should be final
+    void foo1(int i, String k, float s) {}  // violation 'Parameter k should be final.'
     void foo2(String s, Object o, long l) {}
     // 2 violations above:
     //    'Parameter s should be final.'
     //    'Parameter o should be final.'
-    void foo3(int[] array) {}  // violation 'array' should be final
-    void foo4(int i, float x, int[] s) {}  // violation 's' should be final
+    void foo3(int[] array) {}  // violation 'Parameter array should be final.'
+    void foo4(int i, float x, int[] s) {}  // violation 'Parameter s should be final.'
     void foo5(int x, long[] l, String s) {}
     // 2 violations above:
     //    'Parameter l should be final.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPrimitiveTypes2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPrimitiveTypes2.java
@@ -11,7 +11,7 @@ package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 
 public class InputFinalParametersPrimitiveTypes2
 {
-    void foo(int i) {}  // violation 'i' should be final
+    void foo(int i) {}  // violation 'Parameter i should be final.'
     void foo1(int i, String k, float s) {}
     // 3 violations above:
     //    'Parameter i should be final.'
@@ -22,7 +22,7 @@ public class InputFinalParametersPrimitiveTypes2
     //    'Parameter s should be final.'
     //    'Parameter o should be final.'
     //    'Parameter l should be final.'
-    void foo3(int[] array) {} // violation 'array' should be final
+    void foo3(int[] array) {} // violation 'Parameter array should be final.'
     void foo4(int i, float x, int[] s) {}
     // 3 violations above:
     //    'Parameter i should be final.'


### PR DESCRIPTION
 Issue: #20954

### Description
This pull request fixes the violation message comments across test inputs for the `FinalParameters` check to match the actual expected format (`Parameter <name> should be final .`). It also updates `InlineConfigParser.java` to clean up the suppressed validate message files list for `finalparameters`.

### Summary of Changes
* **`InlineConfigParser.java`**: Cleaned up and updated the list of suppressed validate message files for `finalparameters`.
* **Test Input Files**: Fixed violation message comments across multiple test input files (including `InputFinalParameters.java`, `InputFinalParameters2.java`, `InputFinalParameters3.java`, `InputFinalParameters6.java`, `InputFinalParameters8.java`, `InputFinalParameters9.java`, `InputFinalParameters10.java`, `InputFinalParametersInterfaceMethod.java`, `InputFinalParametersPatternVariables.java`, `InputFinalParametersPrimitiveTypes.java`, and `InputFinalParametersPrimitiveTypes2.java`) to properly expect `Parameter <name> should be final .`.