### PR TITLE
Issue #20625: Added example to remove suppression for : javadocblockt…

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
@@ -81,12 +81,27 @@
 </code></pre></div>
         <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-/**
- * Escaped tag &amp;#64;version (OK)
- * Plain text with {@code @see} (OK)
- * A @custom tag (OK)
- *
- */
+class Example1 {
+  /**
+   * Escaped tag &amp;#64;version (OK)
+   * Plain text with {@code @see} (OK)
+   * A @custom tag (OK)
+   * Some text with misplaced @version tag
+   */
+  void foo1() {}
+  // violation 3 lines above 'block tag '@version' should be placed at the beginning'
+  /**
+   * Another misplaced tag: text @noinspection here
+   */
+  void foo2() {}
+
+  /**
+   * @return properly placed tag (OK)
+   */
+  int foo3() {
+    return 0;
+  }
+}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
           To configure the check to verify tags from
@@ -100,6 +115,30 @@
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
+</code></pre></div>
+        <p id="Example2-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example2 {
+  /**
+   * Escaped tag &amp;#64;version (OK)
+   * Plain text with {@code @see} (OK)
+   * A @custom tag (OK)
+   * Some text with misplaced @version tag
+   */
+  void foo1() {}
+
+  /**
+   * Another misplaced tag: text @noinspection here
+   */
+  void foo2() {}
+
+  /**
+   * @return properly placed tag (OK)
+   */
+  int foo3() {
+    return 0;
+  }
+}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
           To configure the check to verify all default tags and some custom tags in addition:
@@ -118,6 +157,30 @@
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example3 {
+  /**
+   * Escaped tag &amp;#64;version (OK)
+   * Plain text with {@code @see} (OK)
+   * A @custom tag (OK)
+   * Some text with misplaced @version tag
+   */
+  void foo1() {}
+  // violation 3 lines above 'block tag '@version' should be placed at the beginning'
+  /**
+   * Another misplaced tag: text @noinspection here
+   */
+  void foo2() {}
+  // violation 3 lines above 'should be placed at the beginning'
+  /**
+   * @return properly placed tag (OK)
+   */
+  int foo3() {
+    return 0;
+  }
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
@@ -56,6 +56,12 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example2.java"/>
           <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example2.java"/>
+          <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example3-config">
           To configure the check to verify all default tags and some custom tags in addition:
@@ -64,6 +70,12 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example3.java"/>
           <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example3.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -155,7 +155,6 @@ public class XdocsExamplesAstConsistencyTest {
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
             // until https://github.com/checkstyle/checkstyle/issues/20625
-            "checks/javadoc/javadocblocktaglocation",
             "checks/regexp/regexponfilename",
             "checks/translation"
     );

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckExamplesTest.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.MSG_BLOCK_TAG_LOCATION;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
@@ -33,7 +35,7 @@ public class JavadocBlockTagLocationCheckExamplesTest extends AbstractExamplesMo
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-
+            "17: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "version"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -41,9 +43,7 @@ public class JavadocBlockTagLocationCheckExamplesTest extends AbstractExamplesMo
 
     @Test
     public void testExample2() throws Exception {
-        final String[] expected = {
-
-        };
+        final String[] expected = {};
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
@@ -51,7 +51,8 @@ public class JavadocBlockTagLocationCheckExamplesTest extends AbstractExamplesMo
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-
+            "25: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "version"),
+            "30: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "noinspection"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example1.java
@@ -8,14 +8,26 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
-class Example1 {
 // xdoc section -- start
-/**
- * Escaped tag &#64;version (OK)
- * Plain text with {@code @see} (OK)
- * A @custom tag (OK)
- *
- */
-// xdoc section -- end
+class Example1 {
+  /**
+   * Escaped tag &#64;version (OK)
+   * Plain text with {@code @see} (OK)
+   * A @custom tag (OK)
+   * Some text with misplaced @version tag
+   */
+  void foo1() {}
+  // violation 3 lines above 'block tag '@version' should be placed at the beginning'
+  /**
+   * Another misplaced tag: text @noinspection here
+   */
+  void foo2() {}
 
+  /**
+   * @return properly placed tag (OK)
+   */
+  int foo3() {
+    return 0;
+  }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example2.java
@@ -8,12 +8,28 @@
 </module>
 */
 
-
-
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
-class Example2 {
 // xdoc section -- start
-// xdoc section -- end
+class Example2 {
+  /**
+   * Escaped tag &#64;version (OK)
+   * Plain text with {@code @see} (OK)
+   * A @custom tag (OK)
+   * Some text with misplaced @version tag
+   */
+  void foo1() {}
+
+  /**
+   * Another misplaced tag: text @noinspection here
+   */
+  void foo2() {}
+
+  /**
+   * @return properly placed tag (OK)
+   */
+  int foo3() {
+    return 0;
+  }
 }
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example3.java
@@ -16,7 +16,26 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
-public class Example3 {
 // xdoc section -- start
-// xdoc section -- end
+class Example3 {
+  /**
+   * Escaped tag &#64;version (OK)
+   * Plain text with {@code @see} (OK)
+   * A @custom tag (OK)
+   * Some text with misplaced @version tag
+   */
+  void foo1() {}
+  // violation 3 lines above 'block tag '@version' should be placed at the beginning'
+  /**
+   * Another misplaced tag: text @noinspection here
+   */
+  void foo2() {}
+  // violation 3 lines above 'should be placed at the beginning'
+  /**
+   * @return properly placed tag (OK)
+   */
+  int foo3() {
+    return 0;
+  }
 }
+// xdoc section -- end


### PR DESCRIPTION
#20625 

`JavadocBlockTagLocation's `xdocs examples (Example1/Example2/Example3) didn't include any code that actually produces a violation. All three examples validated cleanly, and the xdocs page didn't show readers
what a violation looks like.

## Changes

- Kept the AST/code shape aligned across Example1/Example2/Example3 (per XdocsExamplesAstConsistencyTest) only the module config differs between them
- Added missing `Example2-code` / `Example3-code` `<p>` + `<macro>` blocks to JavadocBlockTagLocation.xml.vm, matching Example1's existing config+code pairing
- Updated JavadocBlockTagLocationCheckExamplesTest expected violation messages to match the actual check output
  ("The Javadoc block tag '{0}' should be placed at the beginning of
  the line.")