### PR TITLE
Issue #20958: align with parsed opening asterisk

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheck.java
@@ -100,9 +100,18 @@ public class JavadocLeadingAsteriskAlignCheck extends AbstractJavadocCheck {
     @Override
     public void visitJavadocToken(DetailNode ast) {
         // this method checks the alignment of leading asterisks.
-        final boolean isJavadocStartingLine = ast.getLineNumber() == javadocStartLineNumber;
+        final boolean isJavadocOpeningLine = ast.getLineNumber() == javadocStartLineNumber;
 
-        if (!isJavadocStartingLine) {
+        if (isJavadocOpeningLine) {
+            if (ast.getType() == JavadocCommentsTokenTypes.LEADING_ASTERISK) {
+                final int previousColumn = ast.getColumnNumber() - 1;
+                if (Character.isWhitespace(
+                        fileLines[ast.getLineNumber() - 1].charAt(previousColumn))) {
+                    expectedColumnNumberTabsExpanded = getColumnNumberTabsExpanded(ast);
+                }
+            }
+        }
+        else {
             final int columnNumberTabsExpanded = getColumnNumberTabsExpanded(ast);
 
             if (!hasValidAlignment(expectedColumnNumberTabsExpanded, columnNumberTabsExpanded)) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheckTest.java
@@ -89,4 +89,16 @@ public class JavadocLeadingAsteriskAlignCheckTest extends AbstractModuleTestSupp
         verifyWithInlineConfigParser(filePath, expected);
     }
 
+    @Test
+    public void testLeadingAsteriskOnOpeningLine() throws Exception {
+        final String[] expected = {
+            "18:6: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 6, 11),
+            "19:6: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 6, 11),
+            "20:6: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 6, 11),
+        };
+
+        final String filePath = getPath("InputJavadocLeadingAsteriskAlignOpeningLine.java");
+        verifyWithInlineConfigParser(filePath, expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignOpeningLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignOpeningLine.java
@@ -1,0 +1,27 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocLeadingAsteriskAlign" />
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocleadingasteriskalign;
+
+public interface InputJavadocLeadingAsteriskAlignOpeningLine {
+
+    // violation 5 lines below 'Leading asterisk has incorrect indentation level 6, expected is 11.'
+    // violation 5 lines below 'Leading asterisk has incorrect indentation level 6, expected is 11.'
+    // violation 5 lines below 'Leading asterisk has incorrect indentation level 6, expected is 11.'
+
+    /**   *  ***
+     * There is a space, then a leading asterisk, then a space,
+     * then asterisks in the first line
+     */
+    void test();
+
+    /**   ***
+        * Multiple opening-line asterisks do not change the expected column.
+        */
+    void multipleOpeningAsterisks();
+}


### PR DESCRIPTION
Issue: #20958

Keeps reporting the existing alignment violations, but uses the parser-recognized leading asterisk on the opening line as the expected column when whitespace separates it from the opening marker.

The regression fixture verifies all three reported messages with expected column 11 and distinguishes a single `LEADING_ASTERISK` from `LEADING_ASTERISKS` on the opening line.

Validation:
- `./mvnw.cmd clean verify`
- targeted Pitest: 101/101 mutations killed
- spelling scan: no new words from this change