### PR TITLE
Issue #20625: Added example to remove suppression for : regexponfilename

### DIFF
--- a/src/site/xdoc/checks/regexp/regexponfilename.xml
+++ b/src/site/xdoc/checks/regexp/regexponfilename.xml
@@ -111,11 +111,15 @@
 </code></pre></div>
         <p id="Example1-code">Example1:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/*
 .../checkstyle.xml
 .../Test Example1.xml // violation 'File match folder pattern '' and file pattern '\s'.'
 .../TestExample2.xml
 .../TestExample3.md
 .../TestExample4.xml
+.../Example1.java
+*/
+class Example1{}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
           To configure the check to forbid 'xml' files in folders:
@@ -131,11 +135,15 @@
 </code></pre></div>
         <p id="Example2-code">Example2:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/*
 .../checkstyle.xml
 .../Test Example1.xml
 .../TestExample2.xml // violation 'xml files should not match '^TestExample\d+\.xml$''
 .../TestExample3.md
 .../TestExample4.xml // violation 'xml files should not match '^TestExample\d+\.xml$''
+.../Example1.java
+*/
+class Example2 {}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
           To configure the check to forbid 'md' files except 'README.md file' in folders,
@@ -154,11 +162,15 @@
 </code></pre></div>
         <p id="Example3-code">Example3:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/*
 .../checkstyle.xml
 .../Test Example1.xml
 .../TestExample2.xml
 .../TestExample3.md  // violation 'No *.md files other than README.md'
 .../TestExample4.xml
+.../Example1.java
+*/
+class Example3{}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
           To configure the check to only allow property and xml files to be located
@@ -176,11 +188,15 @@
 </code></pre></div>
         <p id="Example4-code">Example4:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/*
 .../checkstyle.xml
 .../Test Example1.xml
 .../TestExample2.xml
 .../TestExample3.md  // violation 'Only property and xml files to be located in the resource folder'
 .../TestExample4.xml
+.../Example1.java
+*/
+class Example4 {}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example5-config">
           To configure the check to only allow only camelcase
@@ -198,11 +214,15 @@
 </code></pre></div>
         <p id="Example5-code">Example5:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/*
 .../checkstyle.xml    // violation 'only filenames in camelcase is allowed'
 .../Test Example1.xml // violation 'only filenames in camelcase is allowed'
 .../TestExample2.xml
 .../TestExample3.md
 .../TestExample4.xml
+.../Example1.java
+*/
+class Example5 {}
 </code></pre></div><hr class="example-separator"/>
         <p id="Example6-config">
           To configure the check to forbid files that do not start with 'Test' in folders
@@ -219,8 +239,15 @@
 </code></pre></div>
         <p id="Example6-code">Example6:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/*
+.../checkstyle.xml
+.../Test Example1.xml
 .../TestExample2.xml
+.../TestExample3.md
+.../TestExample4.xml
 .../Example1.java // violation 'File match folder pattern'
+*/
+class Example6 {}
 </code></pre></div>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -119,7 +119,6 @@ public class XdocsExamplesAstConsistencyTest {
      *
      */
     private static final Set<String> UNPARSEABLE_EXAMPLES = Set.of(
-            "checks/regexp/regexponfilename/Example1",
             "checks/translation/Example1",
             "filters/suppressionxpathsinglefilter/Example14"
     );
@@ -155,7 +154,6 @@ public class XdocsExamplesAstConsistencyTest {
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
             // until https://github.com/checkstyle/checkstyle/issues/20625
-            "checks/regexp/regexponfilename",
             "checks/translation"
     );
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example1.java
@@ -4,13 +4,14 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
+/*
 .../checkstyle.xml
 .../Test Example1.xml // violation 'File match folder pattern '' and file pattern '\s'.'
 .../TestExample2.xml
 .../TestExample3.md
 .../TestExample4.xml
-// xdoc section -- end
+.../Example1.java
 */
 class Example1{}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example2.java
@@ -8,13 +8,14 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
+/*
 .../checkstyle.xml
 .../Test Example1.xml
 .../TestExample2.xml // violation 'xml files should not match '^TestExample\d+\.xml$''
 .../TestExample3.md
 .../TestExample4.xml // violation 'xml files should not match '^TestExample\d+\.xml$''
-// xdoc section -- end
+.../Example1.java
 */
 class Example2 {}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example3.java
@@ -10,13 +10,14 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
+/*
 .../checkstyle.xml
 .../Test Example1.xml
 .../TestExample2.xml
 .../TestExample3.md  // violation 'No *.md files other than README.md'
 .../TestExample4.xml
-// xdoc section -- end
+.../Example1.java
 */
 class Example3{}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example4.java
@@ -9,13 +9,14 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
+/*
 .../checkstyle.xml
 .../Test Example1.xml
 .../TestExample2.xml
 .../TestExample3.md  // violation 'Only property and xml files to be located in the resource folder'
 .../TestExample4.xml
-// xdoc section -- end
+.../Example1.java
 */
 class Example4 {}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example5.java
@@ -10,13 +10,14 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
+/*
 .../checkstyle.xml    // violation 'only filenames in camelcase is allowed'
 .../Test Example1.xml // violation 'only filenames in camelcase is allowed'
 .../TestExample2.xml
 .../TestExample3.md
 .../TestExample4.xml
-// xdoc section -- end
+.../Example1.java
 */
 class Example5 {}
+// xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexponfilename/Example6.java
@@ -8,10 +8,14 @@
 </module>
 */
 package com.puppycrawl.tools.checkstyle.checks.regexp.regexponfilename;
-/*
 // xdoc section -- start
+/*
+.../checkstyle.xml
+.../Test Example1.xml
 .../TestExample2.xml
+.../TestExample3.md
+.../TestExample4.xml
 .../Example1.java // violation 'File match folder pattern'
-// xdoc section -- end
 */
 class Example6 {}
+// xdoc section -- end


### PR DESCRIPTION
#20625 

### Change

Moved the `class ExampleN{}` declaration inside the xdoc section, after the closing `*/` of the pseudo-path comment, in each of the 6 example files. This gives every example a minimal but real, parseable AST instead of an unparseable dangling comment, letting testExampleCountMatchesPropertyCount group and count them correctly (6 matching examples = 5 properties + 1). No test code changes needed.