### PR TITLE
Issue #19991: Update NonEmptyAtclauseDescription to validate @since tags

### DIFF
--- a/config/linkcheck-suppressions.txt
+++ b/config/linkcheck-suppressions.txt
@@ -87,6 +87,7 @@
 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_BLOCK_TAG">../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_BLOCK_TAG</a>: doesn't exist.
 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_BLOCK_TAG">../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_BLOCK_TAG</a>: doesn't exist.
 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_BLOCK_TAG">../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_BLOCK_TAG</a>: doesn't exist.
+<a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#SINCE_BLOCK_TAG">../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#SINCE_BLOCK_TAG</a>: doesn't exist.
 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/LineColumn.html#%3Cinit%3E(int,int)">#%3Cinit%3E(int,int)</a>: doesn't exist.
 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/Scope.html#%3Cinit%3E()">#%3Cinit%3E()</a>: doesn't exist.
 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/SeverityLevel.html#%3Cinit%3E()">#%3Cinit%3E()</a>: doesn't exist.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
@@ -55,6 +55,7 @@ public class NonEmptyAtclauseDescriptionCheck extends AbstractJavadocCheck {
             JavadocCommentsTokenTypes.THROWS_BLOCK_TAG,
             JavadocCommentsTokenTypes.EXCEPTION_BLOCK_TAG,
             JavadocCommentsTokenTypes.DEPRECATED_BLOCK_TAG,
+            JavadocCommentsTokenTypes.SINCE_BLOCK_TAG,
         };
     }
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/NonEmptyAtclauseDescriptionCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/NonEmptyAtclauseDescriptionCheck.xml
@@ -8,7 +8,7 @@
  Checks that the block tag is followed by description.
  &lt;/div&gt;</description>
          <properties>
-            <property default-value="PARAM_BLOCK_TAG,RETURN_BLOCK_TAG,THROWS_BLOCK_TAG,EXCEPTION_BLOCK_TAG,DEPRECATED_BLOCK_TAG"
+            <property default-value="PARAM_BLOCK_TAG,RETURN_BLOCK_TAG,THROWS_BLOCK_TAG,EXCEPTION_BLOCK_TAG,DEPRECATED_BLOCK_TAG,SINCE_BLOCK_TAG"
                       name="javadocTokens"
                       type="java.lang.String[]"
                       validation-type="tokenSet">

--- a/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml
+++ b/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml
@@ -45,6 +45,8 @@
                     EXCEPTION_BLOCK_TAG</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_BLOCK_TAG">
                     DEPRECATED_BLOCK_TAG</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#SINCE_BLOCK_TAG">
+                    SINCE_BLOCK_TAG</a>
                   .
               </td>
               <td>
@@ -58,6 +60,8 @@
                     EXCEPTION_BLOCK_TAG</a>
                 , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_BLOCK_TAG">
                     DEPRECATED_BLOCK_TAG</a>
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#SINCE_BLOCK_TAG">
+                    SINCE_BLOCK_TAG</a>
                   .
               </td>
               <td>7.3</td>
@@ -69,7 +73,8 @@
       <subsection name="Examples" id="NonEmptyAtclauseDescription_Examples">
         <p id="Example1-config">
           To configure the default check that will check <code>@param</code>,
-          <code>@deprecated</code>,<code>@throws</code>,<code>@return</code>:
+          <code>@deprecated</code>,<code>@throws</code>,<code>@return</code>,
+          <code>@since</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -92,12 +97,14 @@ class Example1 {
    * @deprecated
    * @throws Exception
    * @return
+   * @since
    */
   public void testMethod(){
-    // violation 6 lines above 'At-clause should have a non-empty description'
-    // violation 6 lines above 'At-clause should have a non-empty description'
-    // violation 6 lines above 'At-clause should have a non-empty description'
-    // violation 6 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
   }
 }
 </code></pre></div><hr class="example-separator"/>
@@ -128,12 +135,14 @@ class Example2 {
    * @deprecated
    * @throws Exception
    * @return
+   * @since
    */
   public void testMethod(){
-    // violation 6 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
     // @deprecated ignored as not mentioned in javadocTokens
-    // violation 6 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
     // @return ignored as not mentioned in javadocTokens
+    // @since ignored as not mentioned in javadocTokens
   }
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml.template
+++ b/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml.template
@@ -30,7 +30,8 @@
       <subsection name="Examples" id="NonEmptyAtclauseDescription_Examples">
         <p id="Example1-config">
           To configure the default check that will check <code>@param</code>,
-          <code>@deprecated</code>,<code>@throws</code>,<code>@return</code>:
+          <code>@deprecated</code>,<code>@throws</code>,<code>@return</code>,
+          <code>@since</code>:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
@@ -87,6 +87,15 @@ public class NonEmptyAtclauseDescriptionCheckTest
     }
 
     @Test
+    public void testCheckSince() throws Exception {
+        final String[] expected = {
+            "28: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputNonEmptyAtclauseDescriptionSince.java"), expected);
+    }
+
+    @Test
     public void testCheckTwo() throws Exception {
         final String[] expected = {
             "16: " + getCheckMessage(MSG_KEY),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionOne.java
@@ -2,7 +2,7 @@
 NonEmptyAtclauseDescription
 violateExecutionOnNonTightHtml = (default)false
 javadocTokens = (default)PARAM_BLOCK_TAG, RETURN_BLOCK_TAG, THROWS_BLOCK_TAG, \
-         EXCEPTION_BLOCK_TAG, DEPRECATED_BLOCK_TAG
+         EXCEPTION_BLOCK_TAG, DEPRECATED_BLOCK_TAG, SINCE_BLOCK_TAG
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionSince.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionSince.java
@@ -1,0 +1,34 @@
+/*
+NonEmptyAtclauseDescription
+violateExecutionOnNonTightHtml = (default)false
+javadocTokens = (default)PARAM_BLOCK_TAG, RETURN_BLOCK_TAG, THROWS_BLOCK_TAG, \
+         EXCEPTION_BLOCK_TAG, DEPRECATED_BLOCK_TAG, SINCE_BLOCK_TAG
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.nonemptyatclausedescription;
+
+class InputNonEmptyAtclauseDescriptionSince
+{
+        /**
+         * Some javadoc
+         * @param a Some javadoc
+         * @since 1.0
+         */
+        public void fooWithSince(String a)
+        {
+
+        }
+
+        // violation 4 lines below 'At-clause should have a non-empty description'
+        /**
+         * Some javadoc
+         * @param a Some javadoc
+         * @since
+         */
+        public void fooWithEmptySince(String a)
+        {
+
+        }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescriptionTwo.java
@@ -2,7 +2,7 @@
 NonEmptyAtclauseDescription
 violateExecutionOnNonTightHtml = (default)false
 javadocTokens = (default)PARAM_BLOCK_TAG, RETURN_BLOCK_TAG, THROWS_BLOCK_TAG, \
-                EXCEPTION_BLOCK_TAG, DEPRECATED_BLOCK_TAG
+                EXCEPTION_BLOCK_TAG, DEPRECATED_BLOCK_TAG, SINCE_BLOCK_TAG
 
 
 */

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckExamplesTest.java
@@ -41,6 +41,7 @@ public class NonEmptyAtclauseDescriptionCheckExamplesTest
             "18: " + getCheckMessage(MSG_KEY),
             "19: " + getCheckMessage(MSG_KEY),
             "20: " + getCheckMessage(MSG_KEY),
+            "21: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/Example1.java
@@ -18,12 +18,14 @@ class Example1 {
    * @deprecated
    * @throws Exception
    * @return
+   * @since
    */
   public void testMethod(){
-    // violation 6 lines above 'At-clause should have a non-empty description'
-    // violation 6 lines above 'At-clause should have a non-empty description'
-    // violation 6 lines above 'At-clause should have a non-empty description'
-    // violation 6 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
   }
 }
 // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/Example2.java
@@ -20,12 +20,14 @@ class Example2 {
    * @deprecated
    * @throws Exception
    * @return
+   * @since
    */
   public void testMethod(){
-    // violation 6 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
     // @deprecated ignored as not mentioned in javadocTokens
-    // violation 6 lines above 'At-clause should have a non-empty description'
+    // violation 7 lines above 'At-clause should have a non-empty description'
     // @return ignored as not mentioned in javadocTokens
+    // @since ignored as not mentioned in javadocTokens
   }
 }
 // xdoc section -- end


### PR DESCRIPTION
Closes #19991

### Description
Extend `NonEmptyAtclauseDescriptionCheck` defaults so `@since` (`SINCE_BLOCK_TAG`) requires a non-empty description, matching the other default block tags.

### Changes
- Add `SINCE_BLOCK_TAG` to `getDefaultJavadocTokens()`
- Update module meta defaults and xdocs (properties + examples)
- Cover empty and non-empty `@since` in unit + example tests

### Testing
```
./mvnw -Dcheckstyle.skipCompileInputResources=true -Djacoco.skip=true \
  -Dtest=NonEmptyAtclauseDescriptionCheckTest,NonEmptyAtclauseDescriptionCheckExamplesTest,AllChecksTest,XdocsPagesTest,CommitValidationTest test
```
All passed (JDK 21).