### PR TITLE
Issue #11163: Enforce file size on ParameterNumber inputs

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -289,12 +289,6 @@
   <suppress checks="FileLength"
     files="/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharacters3\.java"/>
   <suppress checks="FileLength"
-    files="/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple4\.java"/>
-  <suppress checks="FileLength"
-    files="/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple2\.java"/>
-  <suppress checks="FileLength"
-    files="/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple3\.java"/>
-  <suppress checks="FileLength"
     files="/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/InputFileLength2\.java"/>
   <suppress checks="FileLength"
     files="/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/InputFileLength\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
@@ -90,8 +90,8 @@ public class ParameterNumberCheckTest
     public void testNum()
             throws Exception {
         final String[] expected = {
-            "76:9: " + getCheckMessage(MSG_KEY, 2, 3),
-            "199:10: " + getCheckMessage(MSG_KEY, 2, 9),
+            "22:9: " + getCheckMessage(MSG_KEY, 2, 3),
+            "32:10: " + getCheckMessage(MSG_KEY, 2, 9),
         };
         verifyWithInlineConfigParser(
                 getPath("InputParameterNumberSimple2.java"), expected);
@@ -109,7 +109,7 @@ public class ParameterNumberCheckTest
     public void shouldLogActualParameterNumber()
             throws Exception {
         final String[] expected = {
-            "199:10: " + getCheckMessage(MSG_KEY, 7, 9),
+            "32:10: " + getCheckMessage(MSG_KEY, 7, 9),
         };
         verifyWithInlineConfigParser(
                 getPath("InputParameterNumberSimple4.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple2.java
@@ -9,222 +9,28 @@ tokens = (default)METHOD_DEF, CTOR_DEF
 */
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
-import java.io.*;
-/**
- * Contains simple mistakes:
- * - Long lines
- * - Tabs
- * - Format of variables and parameters
- * - Order of modifiers
- * @author Oliver Burn
- **/
+
+/** Test input for ParameterNumberCheck default configuration. */
 final class InputParameterNumberSimple2
 {
-    // Long line ----------------------------------------------------------------
-    // Contains a tab ->        <-
-    // Contains trailing whitespace ->
-
-    // Name format tests
-    //
-    /** Invalid format **/
-    public static final int badConstant = 2;
-    /** Valid format **/
-    public static final int MAX_ROWS = 2;
-
-    /** Invalid format **/
-    private static int badStatic = 2;
-    /** Valid format **/
-    private static int sNumCreated = 0;
-
-    /** Invalid format **/
-    private int badMember = 2;
-    /** Valid format **/
-    private int mNumCreated1 = 0;
-    /** Valid format **/
-    protected int mNumCreated2 = 0;
-
-    /** commas are wrong **/
-    private int[] mInts = new int[] {1,2, 3,
-                                     4};
-
-    //
-    // Accessor tests
-    //
-    /** should be private **/
-    public static int sTest1;
-    /** should be private **/
-    protected static int sTest3;
-    /** should be private **/
-    static int sTest2;
-
-    /** should be private **/
-    int mTest1;
-    /** should be private **/
-    public int mTest2;
-
-    //
-    // Parameter name format tests
-    //
-
     /**
-     * @return hack
-     * @param badFormat1 bad format
-     * @param badFormat2 bad format
-     * @param badFormat3 bad format
+     * @param badFormat1 first param
+     * @param badFormat2 second param
+     * @param badFormat3 third param
      * @throws java.lang.Exception abc
      **/
-    int test1(int badFormat1,int badFormat2,
+    int test1(int badFormat1, int badFormat2,
               final int badFormat3) // violation above 'More than 2 parameters (found 3).'
         throws java.lang.Exception
     {
         return 0;
     }
 
-    /** method that is 20 lines long **/
-    private void longMethod()
-    {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-    }
-
-    /** constructor that is 10 lines long **/
-    private InputParameterNumberSimple2()
-    {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-    }
-
-    /** test local variables */
-    private void localVariables()
-    {
-        // normal decl
-        int abc = 0;
-        int ABC = 0;
-
-        // final decls
-        final int cde = 0;
-        final int CDE = 0;
-
-        // decl in for loop init statement
-        for (int k = 0; k < 1; k++)
-        {
-            String innerBlockVariable = "";
-        }
-        for (int I = 0; I < 1; I++)
-        {
-            String InnerBlockVariable = "";
-        }
-    }
-
-    /** test method pattern */
-    void ALL_UPPERCASE_METHOD()
-    {
-    }
-
-    /** test illegal constant **/
-    private static final int BAD__NAME = 3;
-
-    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
-    // long line that has a tab ->        <- and would be OK if tab counted as 1 char
-    // tabs that count as one char because of their position ->        <-   ->        <-, OK
-
-    /** some lines to test the violation column after tabs */
-    void errorColumnAfterTabs()
-    {
-        // with tab-width 8 all statements below start at the same column,
-        // with different combinations of ' ' and '\t' before the statement
-                int tab0 =1;
-                int tab1 =1;
-                 int tab2 =1;
-                int tab3 =1;
-                    int tab4 =1;
-                  int tab5 =1;
-    }
-
-    // MEMME:
-    /* MEMME: a
-     * MEMME:
-     * OOOO
-     */
-    /* NOTHING */
-    /* YES */ /* MEMME: x */ /* YES!! */
-
-    /** test long comments **/
-    void veryLong()
-    {
-        /*
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          enough talk */
-    }
-
     /**
-     * @see to lazy to document all args. Testing excessive # args
+     * @see too lazy to document all args. Testing excessive number of args
      **/
     void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
                     int aArg6, int aArg7, int aArg8, int aArg9)
     {
     } // violation 3 lines above 'More than 2 parameters (found 9).'
-}
-
-/** Test class for variable naming in for each clause. */
-class InputSimple22
-{
-    /** Some more Javadoc. */
-    public void doSomething()
-    {
-        //"O" should be named "o"
-        for (Object O : new java.util.ArrayList())
-        {
-
-        }
-    }
-}
-
-/** Test enum for member naming check */
-enum MyEnum12
-{
-    /** ABC constant */
-    ABC,
-
-    /** XYZ constant */
-    XYZ;
-
-    /** Should be mSomeMember */
-    private int someMember;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple3.java
@@ -9,222 +9,28 @@ tokens = (default)METHOD_DEF, CTOR_DEF
 */
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
-import java.io.*;
-/**
- * Contains simple mistakes:
- * - Long lines
- * - Tabs
- * - Format of variables and parameters
- * - Order of modifiers
- * @author Oliver Burn
- **/
+
+/** Test input for ParameterNumberCheck with a raised max. */
 final class InputParameterNumberSimple3
 {
-    // Long line ----------------------------------------------------------------
-    // Contains a tab ->        <-
-    // Contains trailing whitespace ->
-
-    // Name format tests
-    //
-    /** Invalid format **/
-    public static final int badConstant = 2;
-    /** Valid format **/
-    public static final int MAX_ROWS = 2;
-
-    /** Invalid format **/
-    private static int badStatic = 2;
-    /** Valid format **/
-    private static int sNumCreated = 0;
-
-    /** Invalid format **/
-    private int badMember = 2;
-    /** Valid format **/
-    private int mNumCreated1 = 0;
-    /** Valid format **/
-    protected int mNumCreated2 = 0;
-
-    /** commas are wrong **/
-    private int[] mInts = new int[] {1,2, 3,
-                                     4};
-
-    //
-    // Accessor tests
-    //
-    /** should be private **/
-    public static int sTest1;
-    /** should be private **/
-    protected static int sTest3;
-    /** should be private **/
-    static int sTest2;
-
-    /** should be private **/
-    int mTest1;
-    /** should be private **/
-    public int mTest2;
-
-    //
-    // Parameter name format tests
-    //
-
     /**
-     * @return hack
-     * @param badFormat1 bad format
-     * @param badFormat2 bad format
-     * @param badFormat3 bad format
+     * @param badFormat1 first param
+     * @param badFormat2 second param
+     * @param badFormat3 third param
      * @throws java.lang.Exception abc
      **/
-    int test1(int badFormat1,int badFormat2,
+    int test1(int badFormat1, int badFormat2,
               final int badFormat3)
         throws java.lang.Exception
     {
         return 0;
     }
 
-    /** method that is 20 lines long **/
-    private void longMethod()
-    {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-    }
-
-    /** constructor that is 10 lines long **/
-    private InputParameterNumberSimple3()
-    {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-    }
-
-    /** test local variables */
-    private void localVariables()
-    {
-        // normal decl
-        int abc = 0;
-        int ABC = 0;
-
-        // final decls
-        final int cde = 0;
-        final int CDE = 0;
-
-        // decl in for loop init statement
-        for (int k = 0; k < 1; k++)
-        {
-            String innerBlockVariable = "";
-        }
-        for (int I = 0; I < 1; I++)
-        {
-            String InnerBlockVariable = "";
-        }
-    }
-
-    /** test method pattern */
-    void ALL_UPPERCASE_METHOD()
-    {
-    }
-
-    /** test illegal constant **/
-    private static final int BAD__NAME = 3;
-
-    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
-    // long line that has a tab ->        <- and would be OK if tab counted as 1 char
-    // tabs that count as one char because of their position ->        <-   ->        <-, OK
-
-    /** some lines to test the violation column after tabs */
-    void errorColumnAfterTabs()
-    {
-        // with tab-width 8 all statements below start at the same column,
-        // with different combinations of ' ' and '\t' before the statement
-                int tab0 =1;
-                int tab1 =1;
-                 int tab2 =1;
-                int tab3 =1;
-                    int tab4 =1;
-                  int tab5 =1;
-    }
-
-    // MEMME:
-    /* MEMME: a
-     * MEMME:
-     * OOOO
-     */
-    /* NOTHING */
-    /* YES */ /* MEMME: x */ /* YES!! */
-
-    /** test long comments **/
-    void veryLong()
-    {
-        /*
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          enough talk */
-    }
-
     /**
-     * @see to lazy to document all args. Testing excessive # args
+     * @see too lazy to document all args. Testing excessive number of args
      **/
     void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
                     int aArg6, int aArg7, int aArg8, int aArg9)
     {
     }
-}
-
-/** Test class for variable naming in for each clause. */
-class InputSimple23
-{
-    /** Some more Javadoc. */
-    public void doSomething()
-    {
-        //"O" should be named "o"
-        for (Object O : new java.util.ArrayList())
-        {
-
-        }
-    }
-}
-
-/** Test enum for member naming check */
-enum MyEnum13
-{
-    /** ABC constant */
-    ABC,
-
-    /** XYZ constant */
-    XYZ;
-
-    /** Should be mSomeMember */
-    private int someMember;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberSimple4.java
@@ -9,222 +9,28 @@ tokens = (default)METHOD_DEF, CTOR_DEF
 */
 
 package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
-import java.io.*;
-/**
- * Contains simple mistakes:
- * - Long lines
- * - Tabs
- * - Format of variables and parameters
- * - Order of modifiers
- * @author Oliver Burn
- **/
+
+/** Test input for ParameterNumberCheck default max. */
 final class InputParameterNumberSimple4
 {
-    // Long line ----------------------------------------------------------------
-    // Contains a tab ->        <-
-    // Contains trailing whitespace ->
-
-    // Name format tests
-    //
-    /** Invalid format **/
-    public static final int badConstant = 2;
-    /** Valid format **/
-    public static final int MAX_ROWS = 2;
-
-    /** Invalid format **/
-    private static int badStatic = 2;
-    /** Valid format **/
-    private static int sNumCreated = 0;
-
-    /** Invalid format **/
-    private int badMember = 2;
-    /** Valid format **/
-    private int mNumCreated1 = 0;
-    /** Valid format **/
-    protected int mNumCreated2 = 0;
-
-    /** commas are wrong **/
-    private int[] mInts = new int[] {1,2, 3,
-                                     4};
-
-    //
-    // Accessor tests
-    //
-    /** should be private **/
-    public static int sTest1;
-    /** should be private **/
-    protected static int sTest3;
-    /** should be private **/
-    static int sTest2;
-
-    /** should be private **/
-    int mTest1;
-    /** should be private **/
-    public int mTest2;
-
-    //
-    // Parameter name format tests
-    //
-
     /**
-     * @return hack
-     * @param badFormat1 bad format
-     * @param badFormat2 bad format
-     * @param badFormat3 bad format
+     * @param badFormat1 first param
+     * @param badFormat2 second param
+     * @param badFormat3 third param
      * @throws java.lang.Exception abc
      **/
-    int test1(int badFormat1,int badFormat2,
+    int test1(int badFormat1, int badFormat2,
               final int badFormat3)
         throws java.lang.Exception
     {
         return 0;
     }
 
-    /** method that is 20 lines long **/
-    private void longMethod()
-    {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-    }
-
-    /** constructor that is 10 lines long **/
-    private InputParameterNumberSimple4()
-    {
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-        // a line
-    }
-
-    /** test local variables */
-    private void localVariables()
-    {
-        // normal decl
-        int abc = 0;
-        int ABC = 0;
-
-        // final decls
-        final int cde = 0;
-        final int CDE = 0;
-
-        // decl in for loop init statement
-        for (int k = 0; k < 1; k++)
-        {
-            String innerBlockVariable = "";
-        }
-        for (int I = 0; I < 1; I++)
-        {
-            String InnerBlockVariable = "";
-        }
-    }
-
-    /** test method pattern */
-    void ALL_UPPERCASE_METHOD()
-    {
-    }
-
-    /** test illegal constant **/
-    private static final int BAD__NAME = 3;
-
-    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
-    // long line that has a tab ->        <- and would be OK if tab counted as 1 char
-    // tabs that count as one char because of their position ->        <-   ->        <-, OK
-
-    /** some lines to test the violation column after tabs */
-    void errorColumnAfterTabs()
-    {
-        // with tab-width 8 all statements below start at the same column,
-        // with different combinations of ' ' and '\t' before the statement
-                int tab0 =1;
-                int tab1 =1;
-                 int tab2 =1;
-                int tab3 =1;
-                    int tab4 =1;
-                  int tab5 =1;
-    }
-
-    // MEMME:
-    /* MEMME: a
-     * MEMME:
-     * OOOO
-     */
-    /* NOTHING */
-    /* YES */ /* MEMME: x */ /* YES!! */
-
-    /** test long comments **/
-    void veryLong()
-    {
-        /*
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          blah blah blah blah
-          enough talk */
-    }
-
     /**
-     * @see to lazy to document all args. Testing excessive # args
+     * @see too lazy to document all args. Testing excessive number of args
      **/
     void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
                     int aArg6, int aArg7, int aArg8, int aArg9)
     {
     } // violation 3 lines above 'More than 7 parameters (found 9).'
-}
-
-/** Test class for variable naming in for each clause. */
-class InputSimple24
-{
-    /** Some more Javadoc. */
-    public void doSomething()
-    {
-        //"O" should be named "o"
-        for (Object O : new java.util.ArrayList())
-        {
-
-        }
-    }
-}
-
-/** Test enum for member naming check */
-enum MyEnum14
-{
-    /** ABC constant */
-    ABC,
-
-    /** XYZ constant */
-    XYZ;
-
-    /** Should be mSomeMember */
-    private int someMember;
 }


### PR DESCRIPTION
Issue #11163

### Description
Trim `ParameterNumber` test inputs that were over the 120-line FileLength limit and drop the matching suppressions.

### Changes
- Reduce `InputParameterNumberSimple2/3/4.java` to focused fixtures (36 lines each)
- Update expected violation line numbers in `ParameterNumberCheckTest`
- Remove three `FileLength` suppressions from `config/checkstyle-resources-suppressions.xml`

### Testing
```
./mvnw -Dcheckstyle.skipCompileInputResources=true -Djacoco.skip=true \
  -Dtest=ParameterNumberCheckTest test
```
All 12 tests passed (JDK 21).