### PR TITLE
Issue #20954: Quote NoClone example violation message

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -376,7 +376,6 @@ public final class InlineConfigParser {
             "checks/coding/nestedifdepth/Example2.java",
             "checks/coding/nestedtrydepth/Example1.java",
             "checks/coding/nestedtrydepth/Example2.java",
-            "checks/coding/noclone/Example1.java",
             "checks/coding/simplifybooleanreturn/Example1.java",
             "checks/coding/superfinalize/InputSuperFinalizeVariations.java",
             "checks/coding/unusedlocalvariable/Example1.java",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/noclone/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/noclone/Example1.java
@@ -9,7 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.noclone;
 
 // xdoc section -- start
 public class Example1 {
-  public Example1 clone() {return null;} // violation, overrides the clone method
+  public Example1 clone() {return null;} // violation 'Avoid using clone method.'
   public static Object clone(Object o) {return null;}
   public static Example1 clone(Example1 same) {return null;}
 }


### PR DESCRIPTION
Issue: #20954

## Summary

- replace the unchecked NoClone explanation with the real quoted Checkstyle message
- remove the NoClone example from the temporary message-validation suppression list
- allow InlineConfigParser to validate the violation text

This handles only the NoClone example and does not overlap the active FinalParameters work.

## Validation

- `mvn clean verify` using JDK 21

AI assistance was used to prepare the initial focused patch and automation. I reviewed the changes and ran the complete Maven verification.