### PR TITLE
Issue #20940: Updates StringTokenizer usage with String.split()

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -239,6 +239,7 @@ cson
 css
 cstyle
 csv
+csvfilterelement
 ctc
 ctor
 ctx

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -211,6 +210,9 @@ public class CustomImportOrderCheck extends AbstractCheck {
 
     /** Pattern used to separate groups of imports. */
     private static final Pattern GROUP_SEPARATOR_PATTERN = Pattern.compile("\\s*###\\s*");
+
+    /** Domain Separator. */
+    private static final String DOMAIN_SEPARATOR = "\\.";
 
     /** Specify ordered list of import groups. */
     private final List<String> customImportOrderRules = new ArrayList<>();
@@ -657,7 +659,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
      */
     private static int compareImports(String import1, String import2) {
         int result = 0;
-        final String separator = "\\.";
+        final String separator = DOMAIN_SEPARATOR;
         final String[] import1Tokens = import1.split(separator, -1);
         final String[] import2Tokens = import2.split(separator, -1);
         for (int i = 0; i != import1Tokens.length && i != import2Tokens.length; i++) {
@@ -770,11 +772,14 @@ public class CustomImportOrderCheck extends AbstractCheck {
     private static String getFirstDomainsFromIdent(
             final int firstPackageDomainsCount, final String packageFullPath) {
         final StringBuilder builder = new StringBuilder(256);
-        final StringTokenizer tokens = new StringTokenizer(packageFullPath, ".");
+        final String[] tokens = packageFullPath.split(DOMAIN_SEPARATOR, -1);
         int count = firstPackageDomainsCount;
 
-        while (count > 0 && tokens.hasMoreTokens()) {
-            builder.append(tokens.nextToken());
+        for (String token : tokens) {
+            if (count <= 0) {
+                break;
+            }
+            builder.append(token);
             count--;
         }
         return builder.toString();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.StringTokenizer;
 
 /**
  * <div>
@@ -47,19 +46,21 @@ final class CsvFilterElement implements IntFilterElement {
      *     contain a parsable integer.
      */
     /* package */ CsvFilterElement(String pattern) {
-        final StringTokenizer tokenizer = new StringTokenizer(pattern, ",");
-        while (tokenizer.hasMoreTokens()) {
-            final String token = tokenizer.nextToken().trim();
-            final int index = token.indexOf('-');
+        for (String token : pattern.split(",", -1)) {
+            if (token.isEmpty()) {
+                continue;
+            }
+            final String trimmedToken = token.trim();
+            final int index = trimmedToken.indexOf('-');
             if (index == -1) {
-                final int matchValue = Integer.parseInt(token);
+                final int matchValue = Integer.parseInt(trimmedToken);
                 addFilter(new IntMatchFilterElement(matchValue));
             }
             else {
                 final int lowerBound =
-                    Integer.parseInt(token.substring(0, index));
+                    Integer.parseInt(trimmedToken.substring(0, index));
                 final int upperBound =
-                    Integer.parseInt(token.substring(index + 1));
+                    Integer.parseInt(trimmedToken.substring(index + 1));
                 addFilter(new IntRangeFilterElement(lowerBound, upperBound));
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElementTest.java
@@ -20,13 +20,22 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck.MSG_REGEXP_EXCEEDED;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
 import org.junit.jupiter.api.Test;
 
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
 
-public class CsvFilterElementTest {
+public class CsvFilterElementTest extends AbstractModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/filters/csvfilterelement";
+    }
 
     @Test
     public void testDecideSingle() {
@@ -137,6 +146,52 @@ public class CsvFilterElementTest {
         assertWithMessage("Error: %s", ev.getMessage())
                 .that(ev.isSuccessful())
                 .isTrue();
+    }
+
+    @Test
+    public void testEmptyTokens() throws Exception {
+        final String[] expectedUnfiltered = {
+            "26: "
+                + getCheckMessage(RegexpSinglelineCheck.class,
+                    MSG_REGEXP_EXCEEDED, "TODO$"),
+            "28: "
+                + getCheckMessage(RegexpSinglelineCheck.class,
+                    MSG_REGEXP_EXCEEDED, "TODO$"),
+            "30: "
+                + getCheckMessage(RegexpSinglelineCheck.class,
+                    MSG_REGEXP_EXCEEDED, "TODO$"),
+        };
+        final String[] expectedFiltered = {
+            "28: "
+                + getCheckMessage(RegexpSinglelineCheck.class,
+                    MSG_REGEXP_EXCEEDED, "TODO$"),
+        };
+
+        verifyFilterWithInlineConfigParser(
+                getPath("InputCsvFilterElementEmptyTokens.java"),
+                expectedUnfiltered,
+                expectedFiltered);
+    }
+
+    @Test
+    public void testBlankToken() {
+        final String[] expectedViolation = {
+            "26: "
+                + getCheckMessage(RegexpSinglelineCheck.class,
+                    MSG_REGEXP_EXCEEDED, "TODO$"),
+            "28: "
+                + getCheckMessage(RegexpSinglelineCheck.class,
+                    MSG_REGEXP_EXCEEDED, "TODO$"),
+        };
+
+        final NumberFormatException ex = getExpectedThrowable(NumberFormatException.class, () -> {
+            verifyFilterWithInlineConfigParser(
+                    getPath("InputCsvFilterElementBlankToken.java"),
+                    expectedViolation);
+        });
+        assertWithMessage("Invalid exception message")
+                .that(ex.getMessage())
+                .isEqualTo("For input string: \"\"");
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/csvfilterelement/InputCsvFilterElementBlankToken.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/csvfilterelement/InputCsvFilterElementBlankToken.java
@@ -1,0 +1,29 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck
+format = TODO$
+message = (default)(null)
+ignoreCase = (default)false
+minimum = (default)0
+maximum = (default)0
+fileExtensions = (default)(null)
+
+
+com.puppycrawl.tools.checkstyle.filters.SuppressionSingleFilter
+files = InputCsvFilterElementBlankToken
+checks = RegexpSingleline
+message = (default)(null)
+id = (default)(null)
+lines = 26, ,28
+columns = (default)(null)
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.filters.csvfilterelement;
+
+public class InputCsvFilterElementBlankToken {
+    // violation below 'illegal pattern'
+    // TODO
+    // violation below 'illegal pattern'
+    // TODO
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/csvfilterelement/InputCsvFilterElementEmptyTokens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/csvfilterelement/InputCsvFilterElementEmptyTokens.java
@@ -1,0 +1,31 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck
+format = TODO$
+message = (default)(null)
+ignoreCase = (default)false
+minimum = (default)0
+maximum = (default)0
+fileExtensions = (default)(null)
+
+
+com.puppycrawl.tools.checkstyle.filters.SuppressionSingleFilter
+files = InputCsvFilterElementEmptyTokens
+checks = RegexpSingleline
+message = (default)(null)
+id = (default)(null)
+lines = 26,,30
+columns = (default)(null)
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.filters.csvfilterelement;
+
+public class InputCsvFilterElementEmptyTokens {
+    // filtered violation below 'illegal pattern'
+    // TODO
+    // violation below 'illegal pattern'
+    // TODO
+    // filtered violation below 'illegal pattern'
+    // TODO
+}


### PR DESCRIPTION
Issue #20940 

### Summary

- Updates StringTokenizer usage with String.split() in an attempt to bump modernizer-maven to 3.5.0
- add focussed tests to CsvFilterElement
- Zero domain test for getFirstDomainsFromIdent
