### PR TITLE
Issue #20977: skip input resource compilation in pitest profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3379,6 +3379,7 @@
       <id>pitest-misc</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -3499,6 +3500,7 @@
       <id>pitest-annotation</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -3563,6 +3565,7 @@
       <id>pitest-blocks</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -3627,6 +3630,7 @@
       <id>pitest-coding-1</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -3756,6 +3760,7 @@
       <id>pitest-coding-2</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -3889,6 +3894,7 @@
       <id>pitest-coding-require-this-check</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -3950,6 +3956,7 @@
       <id>pitest-design</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4011,6 +4018,7 @@
       <id>pitest-header</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4072,6 +4080,7 @@
       <id>pitest-imports</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4134,6 +4143,7 @@
       <id>pitest-indentation</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4183,6 +4193,7 @@
       <id>pitest-javadoc</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4257,6 +4268,7 @@
       <id>pitest-metrics</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4318,6 +4330,7 @@
       <id>pitest-modifier</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4382,6 +4395,7 @@
       <id>pitest-naming</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4446,6 +4460,7 @@
       <id>pitest-regexp</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4507,6 +4522,7 @@
       <id>pitest-sizes</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4568,6 +4584,7 @@
       <id>pitest-whitespace</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4633,6 +4650,7 @@
       <id>pitest-ant</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4698,6 +4716,7 @@
       <id>pitest-packagenamesloader</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4756,6 +4775,7 @@
       <id>pitest-common</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4903,6 +4923,7 @@
       <id>pitest-common-2</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -4991,6 +5012,7 @@
       <id>pitest-main</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -5054,6 +5076,7 @@
       <id>pitest-tree-walker</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -5172,6 +5195,7 @@
       <id>pitest-api</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -5260,6 +5284,7 @@
       <id>pitest-filters</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -5330,6 +5355,7 @@
       <id>pitest-utils</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -5510,6 +5536,7 @@
       <id>pitest-gui</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -5580,6 +5607,7 @@
       <id>pitest-xpath</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>
@@ -5652,6 +5680,7 @@
       <id>pitest-java-ast-visitor</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skipCompileInputResources>true</checkstyle.skipCompileInputResources>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Issue: #20977

### Description
Pitest CI compiles intentional Input/Example fixtures under `src/test/resources`, `src/it/resources`, and `src/xdocs-examples/resources`. Those fixtures intentionally use deprecated APIs (`Integer(int)`, `finalize()`), `strictfp`, internal `sun.misc.Signal`, and duplicate package-info layouts, which floods every pitest matrix job with compiler warnings.

Following maintainer guidance on #20977, set `checkstyle.skipCompileInputResources=true` on all 29 `pitest-*` Maven profiles (same property already used by `no-validations` and the pre-#20877 default). Pitest only needs production + real test sources; fixture sources are still compiled in the normal `mvn verify` path.

### Testing
Executed locally:
- RED: `./mvnw -e --no-transfer-progress -Dcheckstyle.skipCompileInputResources=false clean test-compile`
  - BUILD SUCCESS
  - 100 `[WARNING]` lines under `src/it/resources` / `src/xdocs-examples/resources` (includes Signal, Integer(int), strictfp, finalize, package-info duplicate, missing @Deprecated)
- GREEN: `./mvnw -e --no-transfer-progress -Ppitest-common clean test-compile`
  - BUILD SUCCESS
  - 0 warnings from those fixture roots
  - build-helper skipped `add-test-source`, `add-it-test-resource`, and `add-xdocs-examples-resource`
  - real sources still compiled (`src/main`, `src/test/java`, `src/it/java`, `src/xdocs-examples/java`)

### Notes
- No production check logic changed
- Default `checkstyle.skipCompileInputResources` remains `false` for regular builds/IDE parity from #20877