### PR TITLE
Issue #20954: Quote UnusedLocalVariable messages in Example1

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -379,7 +379,6 @@ public final class InlineConfigParser {
             "checks/coding/noclone/Example1.java",
             "checks/coding/simplifybooleanreturn/Example1.java",
             "checks/coding/superfinalize/InputSuperFinalizeVariations.java",
-            "checks/coding/unusedlocalvariable/Example1.java",
             "checks/coding/unusedlocalvariable/Example2.java",
             "checks/coding/unusedlocalvariable/Example4.java",
             "checks/coding/unusedlocalvariable/InputUnusedLocalVariable3.java",

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example1.java
@@ -13,7 +13,7 @@ import java.util.function.Predicate;
 // xdoc section -- start
 public class Example1 {
   {
-    int k = 12; // violation, 'Unused local variable 'k'.'
+    int k = 12; // violation 'Unused local variable 'k'.'
     k++;
   }
 
@@ -23,20 +23,20 @@ public class Example1 {
   }
 
   void method(int b) {
-    int[] arr = {1, 2, 3};  // violation, 'Unused local variable 'arr'.'
+    int[] arr = {1, 2, 3};  // violation 'Unused local variable 'arr'.'
     int[] anotherArr = {1}; // ok, 'anotherArr' is accessed
     anotherArr[0] = 4;
   }
 
   String convertValue(String newValue) {
-    String s = newValue.toLowerCase(); // violation, 'Unused local variable 's'.'
+    String s = newValue.toLowerCase(); // violation 'Unused local variable 's'.'
     String _ = newValue.toLowerCase(); // ok, '_' is unnamed variable
     return newValue.toLowerCase();
   }
 
   void read() throws IOException {
     BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-    String s; // violation, 'Unused local variable 's'.'
+    String s; // violation 'Unused local variable 's'.'
     while ((s = reader.readLine()) != null) {}
     try (BufferedReader reader1 = // ok, 'reader1' is a resource
                  new BufferedReader(new FileReader("abc.txt"))) {}
@@ -46,7 +46,7 @@ public class Example1 {
 
   void loops() {
     int j = 12;
-    for (int i = 0; j < 11; i++)  // violation, 'Unused local variable 'i'.'
+    for (int i = 0; j < 11; i++)  // violation 'Unused local variable 'i'.'
       for (int p = 0; j < 11; p++) p /= 2;    // ok, 'p' is used
     for (Integer _ : new  int[0]) { } // ok, '_' is unnamed variable
   }

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example1.java
@@ -13,7 +13,7 @@ import java.util.function.Predicate;
 // xdoc section -- start
 public class Example1 {
   {
-    int k = 12; // violation, assign and update but never use 'k'
+    int k = 12; // violation, 'Unused local variable 'k'.'
     k++;
   }
 
@@ -23,20 +23,20 @@ public class Example1 {
   }
 
   void method(int b) {
-    int[] arr = {1, 2, 3};  // violation, unused named local variable 'arr'
+    int[] arr = {1, 2, 3};  // violation, 'Unused local variable 'arr'.'
     int[] anotherArr = {1}; // ok, 'anotherArr' is accessed
     anotherArr[0] = 4;
   }
 
   String convertValue(String newValue) {
-    String s = newValue.toLowerCase(); // violation, unused named local variable 's'
+    String s = newValue.toLowerCase(); // violation, 'Unused local variable 's'.'
     String _ = newValue.toLowerCase(); // ok, '_' is unnamed variable
     return newValue.toLowerCase();
   }
 
   void read() throws IOException {
     BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-    String s; // violation, unused named local variable 's'
+    String s; // violation, 'Unused local variable 's'.'
     while ((s = reader.readLine()) != null) {}
     try (BufferedReader reader1 = // ok, 'reader1' is a resource
                  new BufferedReader(new FileReader("abc.txt"))) {}
@@ -46,7 +46,7 @@ public class Example1 {
 
   void loops() {
     int j = 12;
-    for (int i = 0; j < 11; i++)  // violation, unused named local variable 'i'
+    for (int i = 0; j < 11; i++)  // violation, 'Unused local variable 'i'.'
       for (int p = 0; j < 11; p++) p /= 2;    // ok, 'p' is used
     for (Integer _ : new  int[0]) { } // ok, '_' is unnamed variable
   }


### PR DESCRIPTION
Issue #20954

This PR updates `checks/coding/unusedlocalvariable/Example1.java` by replacing explanatory violation comments with quoted substrings of the actual Checkstyle messages.

It also removes `checks/coding/unusedlocalvariable/Example1.java` from `SUPPRESSED_VALIDATE_MESSAGE_FILES`.
