### PR TITLE
Issue #20995: Add MultilineCommentLeadingAsteriskPresence to google_checks

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/BlockCommentStyleTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/BlockCommentStyleTest.java
@@ -76,4 +76,9 @@ public class BlockCommentStyleTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputBoxComments.java"));
     }
 
+    @Test
+    public void testMultilineCommentLeadingAsterisk() throws Exception {
+        verifyWithWholeConfig(getPath("InputMultilineCommentLeadingAsterisk.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputFormattedOneStatementPerLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputFormattedOneStatementPerLine.java
@@ -176,6 +176,7 @@ public class InputFormattedOneStatementPerLine {
       one = 5;
     } // legal
 
+    // violation below 'Multiline comment line(s) 181, 182, 183 should start with leading asterisk'
     /*
      One statement inside for block where
      increment and conditional expressions are empty

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLine.java
@@ -301,6 +301,7 @@ public class InputOneStatementPerLine {
     //  ''{' at column 30 should have line break after.'
     //  ''}' at column 41 should be alone on a line.'
 
+    // violation below 'Multiline comment line(s) 306, 307, 308 should start with leading asterisk'
     /*
       One statement inside for block where
       increment and conditional expressions are empty

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputMultilineCommentLeadingAsterisk.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/InputMultilineCommentLeadingAsterisk.java
@@ -1,0 +1,74 @@
+package com.google.checkstyle.test.chapter4formatting.rule4861blockcommentstyle;
+
+/** Some javadoc. */
+public class InputMultilineCommentLeadingAsterisk {
+
+  // violation below 'Multiline comment line(s) 8, 9 should start with leading asterisk'
+  /*
+    Some Comment
+    Some Comment2
+  */
+
+  // violation below 'Multiline comment line(s) 14, 15 should start with leading asterisk'
+  /*
+    This is
+    okay.
+  */
+
+  // violation below 'Multiline comment line(s) 20, 22, 24 should start with leading asterisk'
+  /* Line 1
+    Line 2
+  * Line 3
+    Line 4
+  * Line 5
+    Line 6
+  */
+
+  // violation below 'Multiline comment line(s) 29 should start with leading asterisk'
+  /*
+  Some Comment */
+
+  /** Bad Examples. */
+  public void missingLeadingAsterisk() {}
+
+  /*
+   * Some Comment
+   * Some Comment2
+   */
+
+  /*
+   * This is
+   * okay.
+   */
+
+  /* Line 1
+   * Line 2
+   * Line 3
+   * Line 4
+   * Line 5
+   * Line 6
+   */
+
+  /*
+   * Some Comment */
+
+  /** Good Examples. */
+  public void presentLeadingAsterisk() {}
+
+  /** Some javadoc. */
+  public native void doSomething() /*-{
+    console.log("hello from JS");
+    this.@com.example.MyClass::someJavaMethod()();
+  }-*/;
+
+  /** Some javadoc. */
+  public native void logName() /*-{
+    var name = this.@com.example.MyClass::name;
+    console.log(name);
+  }-*/;
+
+  /** Some javadoc. */
+  public native String getProperty() /*-{
+    return "value";
+  }-*/;
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -498,6 +498,13 @@
     <module name="CommentsIndentation">
       <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
     </module>
+    <module name="MultilineCommentLeadingAsteriskPresence"/>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MultilineCommentLeadingAsteriskPresence"/>
+      <property name="query"
+                value="//BLOCK_COMMENT_BEGIN[preceding-sibling::RPAREN
+                and following-sibling::SEMI]"/>
+    </module>
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"

--- a/src/site/xdoc/checks/misc/multilinecommentleadingasteriskpresence.xml
+++ b/src/site/xdoc/checks/misc/multilinecommentleadingasteriskpresence.xml
@@ -57,8 +57,13 @@ public class Example1 {
         id="MultilineCommentLeadingAsteriskPresence_Example_of_Usage">
         <ul>
           <li>
-           <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultilineCommentLeadingAsteriskPresence">
-           Checkstyle Style
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultilineCommentLeadingAsteriskPresence">
+            Google Style
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultilineCommentLeadingAsteriskPresence">
+            Checkstyle Style
             </a>
           </li>
         </ul>

--- a/src/site/xdoc/checks/misc/multilinecommentleadingasteriskpresence.xml.template
+++ b/src/site/xdoc/checks/misc/multilinecommentleadingasteriskpresence.xml.template
@@ -38,8 +38,13 @@
         id="MultilineCommentLeadingAsteriskPresence_Example_of_Usage">
         <ul>
           <li>
-           <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultilineCommentLeadingAsteriskPresence">
-           Checkstyle Style
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultilineCommentLeadingAsteriskPresence">
+            Google Style
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultilineCommentLeadingAsteriskPresence">
+            Checkstyle Style
             </a>
           </li>
         </ul>

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -1621,6 +1621,15 @@
                     TodoComment</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TodoComment+BoxComments">
                   config</a>)
+                  <br/>
+                  <br/>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/misc/multilinecommentleadingasteriskpresence.html#MultilineCommentLeadingAsteriskPresence">
+                    MultilineCommentLeadingAsteriskPresence</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultilineCommentLeadingAsteriskPresence">
+                  config</a>)
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle">


### PR DESCRIPTION
Issue: #20995

Adds MultilineCommentLeadingAsteriskPresence to google_checks.xml to cover  [4.8.6.1 Block comment style](https://google.github.io/styleguide/javaguide.html#s4.8.6-comments)
For multi-line /* ... */ comments, subsequent lines must start with *

Diff Regression config: https://gist.githubusercontent.com/Atharv3221/c162e1d69675d807876a47103a56be2a/raw/50058e816d1b09af8cad8fa3eeba8b5cc4663ac3/MultilineCommentLeadingAsteriskPresence.xml

Diff Regression patch config: https://gist.githubusercontent.com/Atharv3221/7be5a82933831937660b9fec07b808e3/raw/125f6a3333b018655c9c23ececd0a4e070ae1aab/MultilineCommentLeadingAsteriskPresenceJSNI.xml

Diff Regression projects: https://gist.githubusercontent.com/Atharv3221/b506d5a9f935594fc37e0e2fa59193ec/raw/c54253b6af5a810800fb9815eb9f52e3fc5627b1/projects.properties
