### PR TITLE
Issue #20954: Fix validation message for IllegalType with arrays

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -350,7 +350,6 @@ public final class InlineConfigParser {
             "checks/coding/declarationorder/Example2.java",
             "checks/coding/declarationorder/Example3.java",
             "checks/coding/equalshashcode/Example1.java",
-            "checks/coding/illegaltype/InputIllegalTypeArrays.java",
             "checks/coding/illegaltype/InputIllegalTypeTestDefaults.java",
             "checks/coding/illegaltype/InputIllegalTypeEmptyStringMemberModifiers.java",
             "checks/coding/illegaltype/InputIllegalTypeTestExtendsImplements.java",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeArrays.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeArrays.java
@@ -17,22 +17,22 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 public class InputIllegalTypeArrays {
 
-    public Boolean[] array; // violation 'Usage of type Boolean[] is not allowed'.
+    public Boolean[] array; // violation "Usage of type 'Boolean\[\]' is not allowed."
 
-    public Boolean[][] matrix; // violation 'Usage of type Boolean[][] is not allowed'.
+    public Boolean[][] matrix; // violation "Usage of type 'Boolean\[\]\[\]' is not allowed."
 
-    public Boolean[] getArray() { // violation 'Usage of type Boolean[] is not allowed'.
+    public Boolean[] getArray() { // violation "Usage of type 'Boolean\[\]' is not allowed."
         Boolean[] value = array != null ? array : new Boolean[0];
-        // violation above 'Usage of type 'Boolean\[\]' is not allowed'
+        // violation above "Usage of type 'Boolean\[\]' is not allowed."
 
         return value;
     }
 
     public Boolean[][] getMatrix() {
-        // violation above 'Usage of type 'Boolean\[\]\[\]' is not allowed'
+        // violation above "Usage of type 'Boolean\[\]\[\]' is not allowed."
 
         Boolean[][] value = matrix != null ? matrix : new Boolean[0][0];
-        // violation above 'Usage of type 'Boolean\[\]\[\]' is not allowed'
+        // violation above "Usage of type 'Boolean\[\]\[\]' is not allowed."
 
         return value;
     }


### PR DESCRIPTION
Issue #20954

Fixed validation error messages for the `IllegalType` check when dealing with array types.

- - Fix validation error messages for IllegalType check when dealing with array types.