### PR TITLE
Issue #20636: Fix false negatives regarding LeftCurly in openjdk_chec…

### DIFF
--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulebraces/InputBracesLeftCurlyInValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulebraces/InputBracesLeftCurlyInValid.java
@@ -90,4 +90,9 @@ public class InputBracesLeftCurlyInValid {
         } // violation 'should be on the same line'
         while (i > 0);
     }
+
+    public boolean method4()
+    { // violation ''{' at column 5 should be on the previous line.'
+        return true;
+    }
 }

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulebraces/InputBracesLeftCurlyValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulebraces/InputBracesLeftCurlyValid.java
@@ -76,4 +76,6 @@ public class InputBracesLeftCurlyValid {
             System.out.println("hello");
         } while (i > 0);
     }
+
+    public boolean method4() { return true; }
 }

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -326,6 +326,7 @@
       <property name="query"
                 value="//METHOD_DEF/SLIST[LITERAL_RETURN
                         or EXPR[following-sibling::SEMI[following-sibling::*[self::RCURLY]]]]"/>
+      <property name="message" value=".*should have line break after.*"/>
     </module>
     <module name="RightCurly">
       <property name="id" value="RightCurlySame"/>


### PR DESCRIPTION
Fixes #20636

## Summary

Restrict the `LeftCurly` suppression in `openjdk_checks.xml` so that it suppresses only the intended
`should have line break after` message.

This prevents the suppression from hiding the
`should be on the previous line` violation for invalid multi-line methods while preserving the intended
suppression for valid OpenJDK short-form methods.

## Verification

- Reproduced the original false negative using the example from the issue.
- Verified that the invalid multi-line method reports the expected `LeftCurly` violation.
- Verified that valid OpenJDK short-form methods remain suppressed.
- Added regression test cases covering both scenarios.