### PR TITLE
Issue #20954:Fix violation message comments for FinalParameters check inputs

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -333,19 +333,11 @@ public final class InlineConfigParser {
      * <a href="https://github.com/checkstyle/checkstyle/issues/20954">#20954</a>
      */
     private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of(
-            "checks/finalparameters/InputFinalParameters9.java",
-            "checks/finalparameters/InputFinalParameters2.java",
             "checks/finalparameters/InputFinalParameters.java",
-            "checks/finalparameters/InputFinalParameters6.java",
-            "checks/finalparameters/InputFinalParameters10.java",
-            "checks/finalparameters/InputFinalParametersPrimitiveTypes.java",
             "checks/finalparameters/InputFinalParameters3.java",
-            "checks/finalparameters/InputFinalParametersInterfaceMethod.java",
-            "checks/finalparameters/InputFinalParameters8.java",
             "checks/finalparameters/InputFinalParametersPatternVariables.java",
-            "checks/finalparameters/InputFinalParametersPrimitiveTypes2.java",
-            "checks/finalparameters/"
-                    + "InputFinalParametersRecordForLoopPatternVariables.java",
+             "checks/finalparameters/"
+                     + "InputFinalParametersRecordForLoopPatternVariables.java",
             "checks/coding/declarationorder/Example1.java",
             "checks/coding/declarationorder/Example2.java",
             "checks/coding/declarationorder/Example3.java",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters10.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters10.java
@@ -57,7 +57,7 @@ class Foo10
     /* Some for-each clauses */
     public void Bar()
     {
-        for(String s : someExpression()) // violation 's' should be final
+        for(String s : someExpression()) // violation 'Parameter s should be final.'
         {
 
         }
@@ -65,7 +65,7 @@ class Foo10
         {
 
         }
-        for(@MyAnnotation33 String s : someExpression()) // violation 's' should be final
+        for(@MyAnnotation33 String s : someExpression()) // violation 'Parameter s should be final.'
         {
 
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters2.java
@@ -26,7 +26,7 @@ class InputFinalParameters2
     }
 
     /** non final param constructor */
-    InputFinalParameters2(String s) // violation 's' should be final
+    InputFinalParameters2(String s) // violation 'Parameter s should be final.'
     {
     }
 
@@ -41,12 +41,12 @@ class InputFinalParameters2
     }
 
     /** non-final param constructor with annotation*/
-    InputFinalParameters2(@MyAnnotation33 Boolean i) // violation 'i' should be final
+    InputFinalParameters2(@MyAnnotation33 Boolean i) // violation 'Parameter i should be final.'
     {
     }
 
     /** mixed */
-    InputFinalParameters2(String s, final Integer i) // violation 's' should be final
+    InputFinalParameters2(String s, final Integer i) // violation 'Parameter s should be final.'
     {
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters6.java
@@ -15,13 +15,13 @@ package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 class InputFinalParameters6
 {
     /** methods with complicated types of the parameters. */
-    void methodA(java.lang.String aParam) { // violation 'aParam' should be final
+    void methodA(java.lang.String aParam) { // violation 'Parameter aParam should be final.'
     }
 
-    void methodB(String[] args) { // violation 'args' should be final
+    void methodB(String[] args) { // violation 'Parameter args should be final.'
     }
 
-    void methodC(java.lang.String[] args) { // violation 'args' should be final
+    void methodC(java.lang.String[] args) { // violation 'Parameter args should be final.'
     }
 
     /** some catch blocks */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters8.java
@@ -15,13 +15,13 @@ package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 class InputFinalParameters8
 {
     /** methods with complicated types of the parameters. */
-    void methodA(String aParam) { // violation 'aParam' should be final
+    void methodA(String aParam) { // violation 'Parameter aParam should be final.'
     }
 
-    void methodB(String[] args) { // violation 'args' should be final
+    void methodB(String[] args) { // violation 'Parameter args should be final.'
     }
 
-    void methodC(String[] args) { // violation 'args' should be final
+    void methodC(String[] args) { // violation 'Parameter args should be final.'
     }
 
     /** some catch blocks */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters9.java
@@ -30,16 +30,16 @@ class InputFinalParameters9
         try {
             String.CASE_INSENSITIVE_ORDER.equals("");
         }
-        catch (NullPointerException npe) { // violation 'npe' should be fina;
+        catch (NullPointerException npe) { // violation 'Parameter npe should be final.'
             npe.getMessage();
         }
         catch (@MyAnnotation33 final ClassCastException e) {
             e.getMessage();
         }
-        catch (RuntimeException e) { // violation 'e' should be final
+        catch (RuntimeException e) { // violation 'Parameter e should be final.'
             e.getMessage();
         }
-        catch (@MyAnnotation33 NoClassDefFoundError e) { // violation 'e' should be final
+        catch (@MyAnnotation33 NoClassDefFoundError e) { // violation 'Parameter e should be final.'
             e.getMessage();
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersInterfaceMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersInterfaceMethod.java
@@ -13,19 +13,19 @@ package com.puppycrawl.tools.checkstyle.checks.finalparameters;
  * Test cases for detecting missing final parameters in interface methods.
  */
 public interface InputFinalParametersInterfaceMethod {
-    static void method1B(Object param1) { // violation 'param1' should be final
+    static void method1B(Object param1) { // violation 'Parameter param1 should be final.'
     }
 
     static void method1G(final Object param1) {
     }
 
-    private void method2B(Object param1) { // violation 'param1' should be final
+    private void method2B(Object param1) { // violation 'Parameter param1 should be final.'
     }
 
     private void method2G(final Object param1) {
     }
 
-    default void method3B(Object param1) { // violation 'param1' should be final
+    default void method3B(Object param1) { // violation 'Parameter param1 should be final.'
     }
 
     default void method3G(final Object param1) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPrimitiveTypes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPrimitiveTypes.java
@@ -12,13 +12,13 @@ package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 public class InputFinalParametersPrimitiveTypes
 {
     void foo(int i) {} //no warning
-    void foo1(int i, String k, float s) {}  // violation 'k' should be final
+    void foo1(int i, String k, float s) {}  // violation 'Parameter k should be final.'
     void foo2(String s, Object o, long l) {}
     // 2 violations above:
     //    'Parameter s should be final.'
     //    'Parameter o should be final.'
-    void foo3(int[] array) {}  // violation 'array' should be final
-    void foo4(int i, float x, int[] s) {}  // violation 's' should be final
+    void foo3(int[] array) {}  // violation 'Parameter array should be final.'
+    void foo4(int i, float x, int[] s) {}  // violation 'Parameter s should be final.'
     void foo5(int x, long[] l, String s) {}
     // 2 violations above:
     //    'Parameter l should be final.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPrimitiveTypes2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPrimitiveTypes2.java
@@ -11,7 +11,7 @@ package com.puppycrawl.tools.checkstyle.checks.finalparameters;
 
 public class InputFinalParametersPrimitiveTypes2
 {
-    void foo(int i) {}  // violation 'i' should be final
+    void foo(int i) {}  // violation 'Parameter i should be final.'
     void foo1(int i, String k, float s) {}
     // 3 violations above:
     //    'Parameter i should be final.'
@@ -22,7 +22,7 @@ public class InputFinalParametersPrimitiveTypes2
     //    'Parameter s should be final.'
     //    'Parameter o should be final.'
     //    'Parameter l should be final.'
-    void foo3(int[] array) {} // violation 'array' should be final
+    void foo3(int[] array) {} // violation 'Parameter array should be final.'
     void foo4(int i, float x, int[] s) {}
     // 3 violations above:
     //    'Parameter i should be final.'


### PR DESCRIPTION
 Issue #20954 

 Changes:
 Fixed violation message comments in FinalParameters check test input files
 Removed fixed files from SUPPRESSED_VALIDATE_MESSAGE_FILES  in InlineConfigParser.java
 
Files changed:
1- InputFinalParameters2.java
2- InputFinalParameters6.java
3- InputFinalParameters8.java
4- InputFinalParameters9.java
5- InputFinalParameters10.java
6- InputFinalParametersInterfaceMethod.java
7- InputFinalParametersPrimitiveTypes.java
8- InputFinalParametersPrimitiveTypes2.java
9- InlineConfigParser.java

Files NOT changed in this PR:
 InputFinalParameters.java, InputFinalParameters3.java, InputFinalParametersPatternVariables.java and InputFinalParametersRecordForLoopPatternVariables.java

Validation steps run locally:
- git status 
- git log 
- awk length check  
- ./mvnw clean test -Dtest=FinalParametersCheckTest -> 18/18 PASS
- ./mvnw clean verify -> BUILD SUCCESS (19 min)
- mvn clean verify -> BUILD SUCCESS (24:31 min)


