### PR TITLE
Issue #21006: Cancel PR workflows when closed

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,17 +6,19 @@ on:
     paths:
       - '.github/workflows/**'
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches:
       - '*'
     paths:
       - '.github/workflows/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   actionlint:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-performance-regression.yml
+++ b/.github/workflows/check-performance-regression.yml
@@ -13,15 +13,16 @@ on:
     branches:
       - master
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   test:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     strategy:
       matrix:
         target:

--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -2,14 +2,16 @@ name: "Check PR Description"
 
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: [ master ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   analyze:
+    if: github.event.action != 'closed'
     name: Analyze
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/checker-framework.yml
+++ b/.github/workflows/checker-framework.yml
@@ -5,15 +5,16 @@ on:
     branches:
       - master
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   check:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     # The branches below must be a subset of the branches above
     branches: [ master ]
   schedule:
@@ -15,12 +16,12 @@ permissions:
   security-events: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   analyze:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/error-prone.yml
+++ b/.github/workflows/error-prone.yml
@@ -5,15 +5,16 @@ on:
     branches:
       - master
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   error-prone:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 21

--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -13,10 +13,11 @@ on:
     branches:
       - master
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -24,7 +25,7 @@ env:
 
 jobs:
   test:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 21

--- a/.github/workflows/no-error-workflow.yml
+++ b/.github/workflows/no-error-workflow.yml
@@ -5,15 +5,16 @@ on:
     branches:
       - master
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   no-error-kafka:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -27,7 +28,7 @@ jobs:
         run: ./.ci/validation.sh no-error-kafka
 
   no-error-trino:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/no-exception-workflow.yml
+++ b/.github/workflows/no-exception-workflow.yml
@@ -5,16 +5,17 @@ on:
     branches:
       - master
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   # this execution should stay on GitHub actions due to time/ memory limits in other CI
   no-exception-openjdk17:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 21
@@ -37,7 +38,7 @@ jobs:
       - run: .ci/no-exception-test.sh openjdk17-with-checks-nonjavadoc-error
   # this execution should stay on GitHub actions due to time/ memory limits in other CI
   no-exception-openjdk19:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 21
@@ -60,7 +61,7 @@ jobs:
       - run: .ci/no-exception-test.sh openjdk19-with-checks-nonjavadoc-error
   # this execution should stay on GitHub actions due to time/ memory limits in other CI
   no-exception-openjdk20:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 21
@@ -83,7 +84,7 @@ jobs:
       - run: .ci/no-exception-test.sh openjdk20-with-checks-nonjavadoc-error
   # this execution should stay on GitHub actions due to time/ memory limits in other CI
   no-exception-openjdk25:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 21

--- a/.github/workflows/no-old-refs.yml
+++ b/.github/workflows/no-old-refs.yml
@@ -12,15 +12,16 @@ on:
   push:
     branches: [ master ]
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   check_issues:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-24.04
     steps:
       - name: Download checkstyle

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -5,15 +5,16 @@ on:
     branches:
       - master
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   test:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     strategy:
       matrix:
         profile:

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -1,14 +1,16 @@
 name: IDEA inspections
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: [ master ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   qodana:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,16 +5,17 @@ on:
     branches:
       - master
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   # this execution should stay on GitHub actions due to time/ memory limits in other CI
   shellcheck:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies

--- a/.github/workflows/verify-no-exception-configs.yml
+++ b/.github/workflows/verify-no-exception-configs.yml
@@ -2,15 +2,16 @@ name: 'verify-no-exception-configs'
 
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: '*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   verify-no-exception-configs:
-    if: github.repository == 'checkstyle/checkstyle'
+    if: github.event.action != 'closed' && github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies


### PR DESCRIPTION
Issue: #21006

This updates all 14 workflows triggered by `pull_request` so closing or merging a PR cancels its in-progress workflow runs.

Each workflow now subscribes to the `closed` event, uses the stable `${{ github.workflow }}-${{ github.event.number || github.ref }}` concurrency group, and skips every job for the closed-event replacement run.

I tested the mechanism on the fork before applying it to all workflows:

- [The original in-progress run was cancelled](https://github.com/arturict/checkstyle/actions/runs/30427085787)
- [The closed-event replacement run was created with its job skipped](https://github.com/arturict/checkstyle/actions/runs/30427107384)

Local validation:

- `actionlint`
- `yamllint -f parsable -c config/yamllint.yaml .`
- `./mvnw clean verify`
- `./.ci/test-spelling-unknown-words.sh`