### PR TITLE
Issue #20978: Add OpenjdkAnnotationLocation to OpenJDK style

### DIFF
--- a/src/it/java/com/openjdk/checkstyle/test/chapterformatting/ruleannotations/AnnotationsTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapterformatting/ruleannotations/AnnotationsTest.java
@@ -31,8 +31,18 @@ public class AnnotationsTest extends AbstractOpenJdkModuleTestSupport {
     }
 
     @Test
-    public void testAnnotationsOne() throws Exception {
+    public void testAnnotationsDoAndDonts() throws Exception {
         verifyWithWholeConfig(getPath("InputAnnotationsDoAndDonts.java"));
+    }
+
+    @Test
+    public void testAnnotationsValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputAnnotationsValid.java"));
+    }
+
+    @Test
+    public void testAnnotationsInvalid() throws Exception {
+        verifyWithWholeConfig(getPath("InputAnnotationsInvalid.java"));
     }
 
 }

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleannotations/InputAnnotationsDoAndDonts.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleannotations/InputAnnotationsDoAndDonts.java
@@ -56,12 +56,14 @@ public class InputAnnotationsDoAndDonts {
         }
     }
 
-    // ok until https://github.com/checkstyle/checkstyle/issues/20978
     class Donts extends Temp {
 
+        // violation below 'Annotations must be on a separate line from 'foo'.'
         @Override @Deprecated public void foo() {
         }
 
+        // violation 4 lines below """Annotations on 'foo2' must be all on one line or all on
+        // separate lines."""
         @Override @Deprecated
         @SafeVarargs
         public final void foo2(String... arg) {

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleannotations/InputAnnotationsInvalid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleannotations/InputAnnotationsInvalid.java
@@ -1,0 +1,26 @@
+package com.openjdk.checkstyle.test.chapterformatting.ruleannotations;
+
+// violation first line 'Header mismatch'
+
+// violation below 'Annotations must be on a separate line from 'InputAnnotationsInvalid'.'
+@Deprecated public class InputAnnotationsInvalid {
+
+    // violation below 'Annotations must be on a separate line from 'InputAnnotationsInvalid'.'
+    @Deprecated InputAnnotationsInvalid() {
+    }
+
+    // violation below 'Annotations must be on a separate line from 'annotationOnMultilineMethod'.'
+    @Deprecated public void annotationOnMultilineMethod() {
+    }
+
+    // violation 4 lines below """Annotations on 'annotationsOnMixedLines' must be all on one
+    // line or all on separate lines."""
+    @Deprecated @SuppressWarnings("unused")
+    @SafeVarargs
+    public final void annotationsOnMixedLines(String... arguments) {
+    }
+
+    @Deprecated
+    public void annotationOnSeparateLine() {
+    }
+}

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleannotations/InputAnnotationsValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleannotations/InputAnnotationsValid.java
@@ -1,0 +1,23 @@
+package com.openjdk.checkstyle.test.chapterformatting.ruleannotations;
+
+// violation first line 'Header mismatch'
+
+@Deprecated
+@SuppressWarnings("unused")
+public class InputAnnotationsValid {
+
+    @Deprecated @SuppressWarnings("unused")
+    public InputAnnotationsValid() {
+    }
+
+    @Deprecated
+    @SuppressWarnings("unused")
+    public void annotationsOnSeparateLines() {
+    }
+
+    @Deprecated @SuppressWarnings("unused")
+    public void annotationsOnSameLine() {
+    }
+
+    @Deprecated public void annotationOnSingleLineMethod() { }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/OpenjdkAnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/OpenjdkAnnotationLocationCheck.java
@@ -35,8 +35,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-annotations">
  * OpenJDK Style</a>.
  * Declaration annotations must either reside entirely on a single line or
- * have each annotation placed on its own separate line. Annotations should
- * not share a line with the target declaration, except for single-line methods and fields.
+ * have each annotation placed on its own separate line. Annotations may share
+ * a line with the target declaration only when all annotations and the complete
+ * target declaration are on that same line.
  * </div>
  *
  * <p>
@@ -100,31 +101,19 @@ public class OpenjdkAnnotationLocationCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (!isLocalVariable(ast)) {
-            final DetailAST annotationParentNode = getAnnotationsNode(ast);
-            final DetailAST startOfTargetNode = getStartingAst(annotationParentNode);
-            final List<DetailAST> annotationList = getAnnotations(annotationParentNode);
+        final DetailAST annotationParentNode = getAnnotationsNode(ast);
+        final DetailAST startOfTargetNode = getStartingAst(annotationParentNode);
+        final List<DetailAST> annotationList = getAnnotations(annotationParentNode);
 
-            if (!areAllOnSameLine(annotationList) && !areAllOnSeparateLines(annotationList)) {
-                log(startOfTargetNode, MSG_KEY_ANNOTATION_ALONE_OR_SAME, getTargetName(ast));
-            }
-            if (isAnyOnTargetLine(annotationList, startOfTargetNode)
-                    && !isSingleLineMethodOrField(ast)) {
-                log(startOfTargetNode, MSG_KEY_ANNOTATION_ON_TARGET_LINE, getTargetName(ast));
-            }
+        final boolean areAnnotationsOnSameLine = areAllOnSameLine(annotationList);
+        if (!areAnnotationsOnSameLine && !areAllOnSeparateLines(annotationList)) {
+            log(startOfTargetNode, MSG_KEY_ANNOTATION_ALONE_OR_SAME, getTargetName(ast));
         }
-    }
-
-    /**
-     * Checks whether the variable is local or not.
-     *
-     * @param ast variable.
-     * @return true if local variable.
-     */
-    private static boolean isLocalVariable(DetailAST ast) {
-        return ast.getType() == TokenTypes.VARIABLE_DEF
-                && ast.getParent().getType() != TokenTypes.OBJBLOCK
-                && ast.getParent().getType() != TokenTypes.COMPACT_COMPILATION_UNIT;
+        if (isAnyOnTargetLine(annotationList, startOfTargetNode)
+                && !(areAnnotationsOnSameLine
+                        && isSingleLineTarget(startOfTargetNode, ast))) {
+            log(startOfTargetNode, MSG_KEY_ANNOTATION_ON_TARGET_LINE, getTargetName(ast));
+        }
     }
 
     /**
@@ -226,27 +215,19 @@ public class OpenjdkAnnotationLocationCheck extends AbstractCheck {
     }
 
     /**
-     * Checks whether a method or field is single line or not.
+     * Checks whether a target is single line or not.
      *
-     * @param targetNode ast of target node
-     * @return true if the method or field is single line.
+     * @param startOfTargetNode first node of the target after annotations.
+     * @param targetNode ast of target node.
+     * @return true if the target is single line.
      */
-    private static boolean isSingleLineMethodOrField(DetailAST targetNode) {
-        boolean result = false;
-        if (targetNode.getType() == TokenTypes.METHOD_DEF
-                || targetNode.getType() == TokenTypes.ANNOTATION_FIELD_DEF
-                || targetNode.getType() == TokenTypes.VARIABLE_DEF) {
-            final DetailAST lastToken = targetNode.getLastChild();
-            if (lastToken.getType() == TokenTypes.SLIST) {
-                final DetailAST rightCurly = lastToken.getLastChild();
-                result = TokenUtil.areOnSameLine(targetNode, rightCurly);
-            }
-            else {
-                result = TokenUtil.areOnSameLine(targetNode, lastToken);
-            }
+    private static boolean isSingleLineTarget(DetailAST startOfTargetNode,
+            DetailAST targetNode) {
+        DetailAST lastToken = targetNode;
+        while (lastToken.hasChildren()) {
+            lastToken = lastToken.getLastChild();
         }
-
-        return result;
+        return TokenUtil.areOnSameLine(startOfTargetNode, lastToken);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/OpenjdkAnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/OpenjdkAnnotationLocationCheck.java
@@ -35,8 +35,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-annotations">
  * OpenJDK Style</a>.
  * Declaration annotations must either reside entirely on a single line or
- * have each annotation placed on its own separate line. Annotations should
- * not share a line with the target declaration, except for single-line methods and fields.
+ * have each annotation placed on its own separate line. Annotations may share
+ * a line with the target declaration only when all annotations and the complete
+ * target declaration are on that same line.
  * </div>
  *
  * <p>
@@ -99,31 +100,19 @@ public class OpenjdkAnnotationLocationCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (!isLocalVariable(ast)) {
-            final DetailAST annotationParentNode = getAnnotationsNode(ast);
-            final DetailAST startOfTargetNode = getStartingAst(annotationParentNode);
-            final List<DetailAST> annotationList = getAnnotations(annotationParentNode);
+        final DetailAST annotationParentNode = getAnnotationsNode(ast);
+        final DetailAST startOfTargetNode = getStartingAst(annotationParentNode);
+        final List<DetailAST> annotationList = getAnnotations(annotationParentNode);
 
-            if (!areAllOnSameLine(annotationList) && !areAllOnSeparateLines(annotationList)) {
-                log(startOfTargetNode, MSG_KEY_ANNOTATION_ALONE_OR_SAME, getTargetName(ast));
-            }
-            if (isAnyOnTargetLine(annotationList, startOfTargetNode)
-                    && !isSingleLineMethodOrField(ast)) {
-                log(startOfTargetNode, MSG_KEY_ANNOTATION_ON_TARGET_LINE, getTargetName(ast));
-            }
+        final boolean areAnnotationsOnSameLine = areAllOnSameLine(annotationList);
+        if (!areAnnotationsOnSameLine && !areAllOnSeparateLines(annotationList)) {
+            log(startOfTargetNode, MSG_KEY_ANNOTATION_ALONE_OR_SAME, getTargetName(ast));
         }
-    }
-
-    /**
-     * Checks whether the variable is local or not.
-     *
-     * @param ast variable.
-     * @return true if local variable.
-     */
-    private static boolean isLocalVariable(DetailAST ast) {
-        return ast.getType() == TokenTypes.VARIABLE_DEF
-                && ast.getParent().getType() != TokenTypes.OBJBLOCK
-                && ast.getParent().getType() != TokenTypes.COMPACT_COMPILATION_UNIT;
+        if (isAnyOnTargetLine(annotationList, startOfTargetNode)
+                && !(areAnnotationsOnSameLine
+                        && isSingleLineTarget(startOfTargetNode, ast))) {
+            log(startOfTargetNode, MSG_KEY_ANNOTATION_ON_TARGET_LINE, getTargetName(ast));
+        }
     }
 
     /**
@@ -225,27 +214,19 @@ public class OpenjdkAnnotationLocationCheck extends AbstractCheck {
     }
 
     /**
-     * Checks whether a method or field is single line or not.
+     * Checks whether a target is single line or not.
      *
-     * @param targetNode ast of target node
-     * @return true if the method or field is single line.
+     * @param startOfTargetNode first node of the target after annotations.
+     * @param targetNode ast of target node.
+     * @return true if the target is single line.
      */
-    private static boolean isSingleLineMethodOrField(DetailAST targetNode) {
-        boolean result = false;
-        if (targetNode.getType() == TokenTypes.METHOD_DEF
-                || targetNode.getType() == TokenTypes.ANNOTATION_FIELD_DEF
-                || targetNode.getType() == TokenTypes.VARIABLE_DEF) {
-            final DetailAST lastToken = targetNode.getLastChild();
-            if (lastToken.getType() == TokenTypes.SLIST) {
-                final DetailAST rightCurly = lastToken.getLastChild();
-                result = TokenUtil.areOnSameLine(targetNode, rightCurly);
-            }
-            else {
-                result = TokenUtil.areOnSameLine(targetNode, lastToken);
-            }
+    private static boolean isSingleLineTarget(DetailAST startOfTargetNode,
+            DetailAST targetNode) {
+        DetailAST lastToken = targetNode;
+        while (lastToken.hasChildren()) {
+            lastToken = lastToken.getLastChild();
         }
-
-        return result;
+        return TokenUtil.areOnSameLine(startOfTargetNode, lastToken);
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/OpenjdkAnnotationLocationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/OpenjdkAnnotationLocationCheck.xml
@@ -9,8 +9,9 @@
  &lt;a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-annotations"&gt;
  OpenJDK Style&lt;/a&gt;.
  Declaration annotations must either reside entirely on a single line or
- have each annotation placed on its own separate line. Annotations should
- not share a line with the target declaration, except for single-line methods and fields.
+ have each annotation placed on its own separate line. Annotations may share
+ a line with the target declaration only when all annotations and the complete
+ target declaration are on that same line.
  &lt;/div&gt;
 
  &lt;p&gt;

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -167,6 +167,7 @@
     <module name="MultipleVariableDeclarations"/>
     <module name="ArrayTypeStyle"/>
     <module name="VariableDeclarationUsageDistance"/>
+    <module name="OpenjdkAnnotationLocation"/>
 
     <module name="MethodName">
       <property name="format" value="^[a-z]{2,}[a-zA-Z0-9]*$"/>

--- a/src/site/xdoc/checks/annotation/openjdkannotationlocation.xml
+++ b/src/site/xdoc/checks/annotation/openjdkannotationlocation.xml
@@ -37,8 +37,9 @@
           <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-annotations">
           OpenJDK Style</a>.
           Declaration annotations must either reside entirely on a single line or
-          have each annotation placed on its own separate line. Annotations should
-          not share a line with the target declaration, except for single-line methods and fields.
+          have each annotation placed on its own separate line. Annotations may share
+          a line with the target declaration only when all annotations and the complete
+          target declaration are on that same line.
         </div>
 
         <p>
@@ -183,6 +184,10 @@ class Example1 {
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OpenjdkAnnotationLocation">
             Checkstyle Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OpenjdkAnnotationLocation">
+            OpenJDK Style</a>
           </li>
         </ul>
       </subsection>

--- a/src/site/xdoc/checks/annotation/openjdkannotationlocation.xml
+++ b/src/site/xdoc/checks/annotation/openjdkannotationlocation.xml
@@ -15,8 +15,9 @@
           <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-annotations">
           OpenJDK Style</a>.
           Declaration annotations must either reside entirely on a single line or
-          have each annotation placed on its own separate line. Annotations should
-          not share a line with the target declaration, except for single-line methods and fields.
+          have each annotation placed on its own separate line. Annotations may share
+          a line with the target declaration only when all annotations and the complete
+          target declaration are on that same line.
         </div>
 
         <p>
@@ -157,6 +158,10 @@ class Example1 {
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OpenjdkAnnotationLocation">
             Checkstyle Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OpenjdkAnnotationLocation">
+            OpenJDK Style</a>
           </li>
         </ul>
       </subsection>

--- a/src/site/xdoc/checks/annotation/openjdkannotationlocation.xml.template
+++ b/src/site/xdoc/checks/annotation/openjdkannotationlocation.xml.template
@@ -55,6 +55,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OpenjdkAnnotationLocation">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OpenjdkAnnotationLocation">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/annotation/openjdkannotationlocation.xml.template
+++ b/src/site/xdoc/checks/annotation/openjdkannotationlocation.xml.template
@@ -51,6 +51,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OpenjdkAnnotationLocation">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OpenjdkAnnotationLocation">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -1006,14 +1006,18 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img src="images/ban_red.png" alt="" />
+                    <img src="images/ok_green.png" alt="" />
                   </span>
-                  This section can not be covered until:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/20209">
-                    #20209
+                  <a href="checks/annotation/openjdkannotationlocation.html#OpenjdkAnnotationLocation">
+                    OpenjdkAnnotationLocation</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OpenjdkAnnotationLocation">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleannotations">
+                    samples
                   </a>
                 </td>
-                <td/>
               </tr>
               <tr>
                 <td>

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -991,14 +991,18 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img src="images/ban_red.png" alt="" />
+                    <img src="images/ok_green.png" alt="" />
                   </span>
-                  This section can not be covered until:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/20209">
-                    #20209
+                  <a href="checks/annotation/openjdkannotationlocation.html#OpenjdkAnnotationLocation">
+                    OpenjdkAnnotationLocation</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OpenjdkAnnotationLocation">
+                  config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/ruleannotations">
+                    samples
                   </a>
                 </td>
-                <td/>
               </tr>
               <tr>
                 <td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/OpenjdkAnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/OpenjdkAnnotationLocationCheckTest.java
@@ -97,6 +97,8 @@ public class OpenjdkAnnotationLocationCheckTest extends AbstractModuleTestSuppor
             "65:21: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "e"),
             "69:21: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
                     "methodNotSingleLineBad"),
+            "84:25: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "multilineLocalVariable"),
         };
 
         verifyWithInlineConfigParser(
@@ -122,7 +124,7 @@ public class OpenjdkAnnotationLocationCheckTest extends AbstractModuleTestSuppor
         final String[] expected = {
             "20:17: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "method"),
             "27:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ALONE_OR_SAME, "badMethod"),
-            "36:29: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "Temp"),
+            "42:21: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "temp1"),
         };
 
         verifyWithInlineConfigParser(
@@ -134,7 +136,8 @@ public class OpenjdkAnnotationLocationCheckTest extends AbstractModuleTestSuppor
         final String[] expected = {
             "22:29: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "badField6"),
             "32:13: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "badField7"),
-            "53:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ALONE_OR_SAME, "helperMethodThree"),
+            "37:17: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "local1"),
+            "54:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ALONE_OR_SAME, "helperMethodThree"),
         };
 
         verifyWithInlineConfigParser(
@@ -151,6 +154,29 @@ public class OpenjdkAnnotationLocationCheckTest extends AbstractModuleTestSuppor
 
         verifyWithInlineConfigParser(
                 getPath("InputOpenjdkAnnotationLocation5.java"), expected);
+    }
+
+    @Test
+    public void testSingleLineTypesAndConstructor() throws Exception {
+        final String[] expected = {
+            "20:46: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "MultilineC"),
+            "27:48: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "MultilineRat"),
+            "39:38: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "GenericMethods2"),
+            "46:34: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "MultilineInterface"),
+            "52:34: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "MultilineEnum"),
+            "59:38: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "VALUE_WITH_BODY"),
+            "66:34: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "MultilineRecord"),
+            "75:38: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "MultilineCompactConstructor"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputOpenjdkAnnotationLocation6.java"), expected);
     }
 
     @Test
@@ -187,6 +213,13 @@ public class OpenjdkAnnotationLocationCheckTest extends AbstractModuleTestSuppor
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
                 getNonCompilablePath("module-info/open/module-info.java"), expected);
+    }
+
+    @Test
+    public void testSingleLinePackage() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("inputs/singleline/package-info.java"), expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/OpenjdkAnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/OpenjdkAnnotationLocationCheckTest.java
@@ -96,6 +96,8 @@ public class OpenjdkAnnotationLocationCheckTest extends AbstractModuleTestSuppor
             "65:21: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "e"),
             "69:21: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
                     "methodNotSingleLineBad"),
+            "84:25: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "multilineLocalVariable"),
         };
 
         verifyWithInlineConfigParser(
@@ -121,7 +123,7 @@ public class OpenjdkAnnotationLocationCheckTest extends AbstractModuleTestSuppor
         final String[] expected = {
             "20:17: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "method"),
             "27:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ALONE_OR_SAME, "badMethod"),
-            "36:29: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "Temp"),
+            "42:21: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "temp1"),
         };
 
         verifyWithInlineConfigParser(
@@ -133,7 +135,8 @@ public class OpenjdkAnnotationLocationCheckTest extends AbstractModuleTestSuppor
         final String[] expected = {
             "22:29: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "badField6"),
             "32:13: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "badField7"),
-            "53:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ALONE_OR_SAME, "helperMethodThree"),
+            "37:17: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "local1"),
+            "54:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ALONE_OR_SAME, "helperMethodThree"),
         };
 
         verifyWithInlineConfigParser(
@@ -153,12 +156,42 @@ public class OpenjdkAnnotationLocationCheckTest extends AbstractModuleTestSuppor
     }
 
     @Test
+    public void testSingleLineTypesAndConstructor() throws Exception {
+        final String[] expected = {
+            "20:46: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "MultilineC"),
+            "27:48: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE, "MultilineRat"),
+            "39:38: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "GenericMethods2"),
+            "46:34: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "MultilineInterface"),
+            "52:34: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "MultilineEnum"),
+            "59:38: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "VALUE_WITH_BODY"),
+            "66:34: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "MultilineRecord"),
+            "75:38: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_TARGET_LINE,
+                    "MultilineCompactConstructor"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputOpenjdkAnnotationLocation6.java"), expected);
+    }
+
+    @Test
     public void testPackage() throws Exception {
         final String[] expected = {
             "10:84: " + getCheckMessage(MSG_KEY_ANNOTATION_ALONE_OR_SAME, "inputs"),
         };
         verifyWithInlineConfigParser(
                 getPath("inputs/package-info.java"), expected);
+    }
+
+    @Test
+    public void testSingleLinePackage() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("inputs/singleline/package-info.java"), expected);
     }
 
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/compact/InputOpenjdkAnnotationLocationCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/compact/InputOpenjdkAnnotationLocationCompactSourceFile.java
@@ -35,6 +35,7 @@ int good;
 void main() {
     @SuppressWarnings("unused")
     @Deprecated int local1 = 0;
+    // violation above 'Annotations must be on a separate line from 'local1'.'
     @Deprecated int local2 = 0;
     System.out.println(local1 + local2 + field1);
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/InputOpenjdkAnnotationLocation2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/InputOpenjdkAnnotationLocation2.java
@@ -76,6 +76,14 @@ class TestClassBad {
     }
 
     @MyAnnotation15(value = "") public void method7() {};
+
+    void methodWithLocalVariables() {
+        @MyAnnotation11 int singleLineLocalVariable;
+
+        // violation below 'Annotations must be on a separate line from 'multilineLocalVariable'.'
+        @MyAnnotation11 int
+                multilineLocalVariable;
+    }
 }
 
 @interface MyAnnotation11 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/InputOpenjdkAnnotationLocation3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/InputOpenjdkAnnotationLocation3.java
@@ -41,4 +41,3 @@ import java.lang.annotation.Target;
     EnumAnnotation[] value();
 
 }
-

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/InputOpenjdkAnnotationLocation4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/InputOpenjdkAnnotationLocation4.java
@@ -34,13 +34,13 @@ public class InputOpenjdkAnnotationLocation4 {
     }
 
     @Annotation @Annotation class Temp {}
-    // violation above, 'Annotations must be on a separate line from 'Temp'.'
 
     void methodNoAnnotation() {}
 
     void parameterlessSamelineInForEach() {
         @Annotation
         @Annotation int temp1;
+        // violation above 'Annotations must be on a separate line from 'temp1'.'
         for (@Annotation Object o : new Object[0]) break;
         for (@Annotation @Annotation Object o : new Object[0]) break;
         for (@Annotation Object o;;) break;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/InputOpenjdkAnnotationLocation6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/InputOpenjdkAnnotationLocation6.java
@@ -1,0 +1,78 @@
+/*
+OpenjdkAnnotationLocation
+tokens = (default)CLASS_DEF, INTERFACE_DEF, PACKAGE_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
+         RECORD_DEF, COMPACT_CTOR_DEF, MODULE_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.annotation.openjdkannotationlocation;
+
+@interface InputOpenjdkAnnotationLocation6 {
+    String value() default "";
+}
+
+@interface Annotation17 { }
+
+// Taken from OpenJDK 25: AnnotationTest.java.
+@InputOpenjdkAnnotationLocation6(value = "") class C { }
+
+@InputOpenjdkAnnotationLocation6(value = "") class MultilineC {
+// violation above 'Annotations must be on a separate line from 'MultilineC'.'
+}
+
+// Taken from OpenJDK 25: RecursiveAnnotation.java.
+@InputOpenjdkAnnotationLocation6 @Annotation17 @interface Rat { }
+
+@InputOpenjdkAnnotationLocation6 @Annotation17 @interface MultilineRat {
+// violation above 'Annotations must be on a separate line from 'MultilineRat'.'
+}
+
+class GenericMethods1 {
+
+    // Taken from OpenJDK 25: AnnotatedTypeVariableTest.java.
+    @InputOpenjdkAnnotationLocation6 <M extends Error> GenericMethods1() throws M { }
+}
+
+class GenericMethods2 {
+
+    @InputOpenjdkAnnotationLocation6 GenericMethods2() {
+    // violation above 'Annotations must be on a separate line from 'GenericMethods2'.'
+    }
+}
+
+@InputOpenjdkAnnotationLocation6 interface SingleLineInterface { }
+
+@InputOpenjdkAnnotationLocation6 interface MultilineInterface {
+// violation above 'Annotations must be on a separate line from 'MultilineInterface'.'
+}
+
+@InputOpenjdkAnnotationLocation6 enum SingleLineEnum { VALUE }
+
+@InputOpenjdkAnnotationLocation6 enum MultilineEnum {
+// violation above 'Annotations must be on a separate line from 'MultilineEnum'.'
+    VALUE
+}
+
+enum EnumConstants {
+    @InputOpenjdkAnnotationLocation6 VALUE,
+    @InputOpenjdkAnnotationLocation6 VALUE_WITH_BODY {
+    // violation above 'Annotations must be on a separate line from 'VALUE_WITH_BODY'.'
+    };
+}
+
+@InputOpenjdkAnnotationLocation6 record SingleLineRecord(int value) { }
+
+@InputOpenjdkAnnotationLocation6 record MultilineRecord(int value) {
+// violation above 'Annotations must be on a separate line from 'MultilineRecord'.'
+}
+
+record CompactConstructors(int value) {
+    @InputOpenjdkAnnotationLocation6 CompactConstructors { }
+}
+
+record MultilineCompactConstructor(int value) {
+    @InputOpenjdkAnnotationLocation6 MultilineCompactConstructor {
+    // violation above 'Annotations must be on a separate line from 'MultilineCompactConstructor'.'
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/InputOpenjdkAnnotationLocation6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/InputOpenjdkAnnotationLocation6.java
@@ -1,0 +1,78 @@
+/*
+OpenjdkAnnotationLocation
+tokens = (default)CLASS_DEF, INTERFACE_DEF, PACKAGE_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF, \
+         RECORD_DEF, COMPACT_CTOR_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.annotation.openjdkannotationlocation;
+
+@interface InputOpenjdkAnnotationLocation6 {
+    String value() default "";
+}
+
+@interface Annotation17 { }
+
+// Taken from OpenJDK 25: AnnotationTest.java.
+@InputOpenjdkAnnotationLocation6(value = "") class C { }
+
+@InputOpenjdkAnnotationLocation6(value = "") class MultilineC {
+// violation above 'Annotations must be on a separate line from 'MultilineC'.'
+}
+
+// Taken from OpenJDK 25: RecursiveAnnotation.java.
+@InputOpenjdkAnnotationLocation6 @Annotation17 @interface Rat { }
+
+@InputOpenjdkAnnotationLocation6 @Annotation17 @interface MultilineRat {
+// violation above 'Annotations must be on a separate line from 'MultilineRat'.'
+}
+
+class GenericMethods1 {
+
+    // Taken from OpenJDK 25: AnnotatedTypeVariableTest.java.
+    @InputOpenjdkAnnotationLocation6 <M extends Error> GenericMethods1() throws M { }
+}
+
+class GenericMethods2 {
+
+    @InputOpenjdkAnnotationLocation6 GenericMethods2() {
+    // violation above 'Annotations must be on a separate line from 'GenericMethods2'.'
+    }
+}
+
+@InputOpenjdkAnnotationLocation6 interface SingleLineInterface { }
+
+@InputOpenjdkAnnotationLocation6 interface MultilineInterface {
+// violation above 'Annotations must be on a separate line from 'MultilineInterface'.'
+}
+
+@InputOpenjdkAnnotationLocation6 enum SingleLineEnum { VALUE }
+
+@InputOpenjdkAnnotationLocation6 enum MultilineEnum {
+// violation above 'Annotations must be on a separate line from 'MultilineEnum'.'
+    VALUE
+}
+
+enum EnumConstants {
+    @InputOpenjdkAnnotationLocation6 VALUE,
+    @InputOpenjdkAnnotationLocation6 VALUE_WITH_BODY {
+    // violation above 'Annotations must be on a separate line from 'VALUE_WITH_BODY'.'
+    };
+}
+
+@InputOpenjdkAnnotationLocation6 record SingleLineRecord(int value) { }
+
+@InputOpenjdkAnnotationLocation6 record MultilineRecord(int value) {
+// violation above 'Annotations must be on a separate line from 'MultilineRecord'.'
+}
+
+record CompactConstructors(int value) {
+    @InputOpenjdkAnnotationLocation6 CompactConstructors { }
+}
+
+record MultilineCompactConstructor(int value) {
+    @InputOpenjdkAnnotationLocation6 MultilineCompactConstructor {
+    // violation above 'Annotations must be on a separate line from 'MultilineCompactConstructor'.'
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/inputs/singleline/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/openjdkannotationlocation/inputs/singleline/package-info.java
@@ -1,0 +1,7 @@
+/*
+OpenjdkAnnotationLocation
+tokens = PACKAGE_DEF
+
+*/
+
+@Deprecated package com.puppycrawl.tools.checkstyle.checks.annotation.openjdkannotationlocation.inputs.singleline;


### PR DESCRIPTION
Issue: #20978

Adds `OpenjdkAnnotationLocation` to `openjdk_checks.xml` so the published OpenJDK configuration enforces the annotation rules.

Extends the same-line allowance to every acceptable target when all annotations and the complete target are on one physical line. Local variables now follow the same rule instead of being skipped.

Adds unit and integration coverage for classes, annotation definitions, constructors, records, enum constants, methods, fields, packages, compact source files, and local variables, including paired multiline invalid cases.

Validation:

- focused tests
- `./mvnw clean verify`
- spelling
- annotation Pitest
- real-project comparison across 29 projects; 368 new warnings in 77 files across eight projects, all expected local multiline or split-annotation declarations