### PR TITLE
Issue #20954: Quote violation messages in NestedTryDepth examples

### DIFF
--- a/src/site/xdoc/checks/coding/nestedtrydepth.xml
+++ b/src/site/xdoc/checks/coding/nestedtrydepth.xml
@@ -59,16 +59,16 @@ public class Example1 {
 
     try {
       try {
-        try { // violation, current depth is 2, default max allowed depth is 1
+        try { // violation 'Nested try depth is 2 (max allowed is 1).'
         } catch (Exception e) {}
       } catch (Exception e) {}
     } catch (Exception e) {}
 
     try {
       try {
-        try { // violation, current depth is 2, default max allowed depth is 1
-          try { // violation, current depth is 3, default max allowed depth is 1
-            try { // violation, current depth is 4, default max allowed depth is 1
+        try { // violation 'Nested try depth is 2 (max allowed is 1).'
+          try { // violation 'Nested try depth is 3 (max allowed is 1).'
+            try { // violation 'Nested try depth is 4 (max allowed is 1).'
             } catch (Exception e) {}
           } catch (Exception e) {}
         } catch (Exception e) {}
@@ -111,7 +111,7 @@ public class Example2 {
       try {
         try { // ok, current depth is 2, max allowed depth is 3
           try { // ok, current depth is 3, max allowed depth is 3
-            try { // violation, current depth is 4, max allowed depth is 3
+            try { // violation 'Nested try depth is 4 (max allowed is 3).'
             } catch (Exception e) {}
           } catch (Exception e) {}
         } catch (Exception e) {}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -365,8 +365,6 @@ public final class InlineConfigParser {
             "checks/coding/illegaltype/InputIllegalTypeTestStaticImports.java",
             "checks/coding/nestedifdepth/Example1.java",
             "checks/coding/nestedifdepth/Example2.java",
-            "checks/coding/nestedtrydepth/Example1.java",
-            "checks/coding/nestedtrydepth/Example2.java",
             "checks/coding/noclone/Example1.java",
             "checks/coding/simplifybooleanreturn/Example1.java",
             "checks/coding/superfinalize/InputSuperFinalizeVariations.java",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedtrydepth/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedtrydepth/Example1.java
@@ -17,16 +17,16 @@ public class Example1 {
 
     try {
       try {
-        try { // violation, current depth is 2, default max allowed depth is 1
+        try { // violation 'Nested try depth is 2 (max allowed is 1).'
         } catch (Exception e) {}
       } catch (Exception e) {}
     } catch (Exception e) {}
 
     try {
       try {
-        try { // violation, current depth is 2, default max allowed depth is 1
-          try { // violation, current depth is 3, default max allowed depth is 1
-            try { // violation, current depth is 4, default max allowed depth is 1
+        try { // violation 'Nested try depth is 2 (max allowed is 1).'
+          try { // violation 'Nested try depth is 3 (max allowed is 1).'
+            try { // violation 'Nested try depth is 4 (max allowed is 1).'
             } catch (Exception e) {}
           } catch (Exception e) {}
         } catch (Exception e) {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedtrydepth/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedtrydepth/Example2.java
@@ -28,7 +28,7 @@ public class Example2 {
       try {
         try { // ok, current depth is 2, max allowed depth is 3
           try { // ok, current depth is 3, max allowed depth is 3
-            try { // violation, current depth is 4, max allowed depth is 3
+            try { // violation 'Nested try depth is 4 (max allowed is 3).'
             } catch (Exception e) {}
           } catch (Exception e) {}
         } catch (Exception e) {}


### PR DESCRIPTION
Issue: #20954

Quotes the real violation message in the NestedTryDepth example files
instead of a paraphrase, and removes the two corresponding entries
from SUPPRESSED_VALIDATE_MESSAGE_FILES.

Verified with `mvn clean test -Dtest=NestedTryDepthCheckExamplesTest`
and `mvn clean verify`.