### PR TITLE
Issue #17530: Update NestedIfDepth examples to new violation format

### DIFF
--- a/src/site/xdoc/checks/coding/nestedifdepth.xml
+++ b/src/site/xdoc/checks/coding/nestedifdepth.xml
@@ -57,15 +57,15 @@ class Example1 {
 
     if (true) {
       if (true) {
-        if (true) {} // violation, nested if-else depth is 2 (max allowed is 1)
+        if (true) {} // violation above, "Nested if-else depth is 2 (max allowed is 1)."
         else{}
       }
     }
 
     if (true) {
       if (true) {
-        if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-          if (true) {} // violation, nested if-else depth is 2 (max allowed is 1)
+        if (true) { //  violation above, "Nested if-else depth is 2 (max allowed is 1)."
+          if (true) {} //  violation above, "Nested if-else depth is 2 (max allowed is 1)."
           else {}
         }
       }
@@ -73,10 +73,10 @@ class Example1 {
 
     if (true) {
       if (true) {
-        if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-          if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-            if (true) { // violation, nested if-else depth is 4 (max allowed is 1)
-              if (true) {} // violation, nested if-else depth is 5 (max allowed is 1)
+        if (true) { //  violation above, "Nested if-else depth is 2 (max allowed is 1)."
+          if (true) { //  violation above, "Nested if-else depth is 2 (max allowed is 1)."
+            if (true) { //  violation above, "Nested if-else depth is 4 (max allowed is 1)."
+              if (true) {} //  violation above, "Nested if-else depth is 2 (max allowed is 1)."
               else {}
             }
           }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/Example1.java
@@ -14,29 +14,40 @@ class Example1 {
       if (true) {}
       else {}
     }
-
     if (true) {
       if (true) {
-        if (true) {} // violation, nested if-else depth is 2 (max allowed is 1)
-        else{}
+        // violation above, """Nested if-else depth is
+        //  2 (max allowed is 1)."""
+        if (true) {}
+        else {}
       }
     }
-
     if (true) {
       if (true) {
-        if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-          if (true) {} // violation, nested if-else depth is 2 (max allowed is 1)
+        // violation above, """Nested if-else depth is
+        //  2 (max allowed is 1)."""
+        if (true) {
+          // violation above, """Nested if-else depth is
+          //  2 (max allowed is 1)."""
+          if (true) {}
           else {}
         }
       }
     }
-
     if (true) {
       if (true) {
-        if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-          if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-            if (true) { // violation, nested if-else depth is 4 (max allowed is 1)
-              if (true) {} // violation, nested if-else depth is 5 (max allowed is 1)
+        // violation above, """Nested if-else depth is
+        //  2 (max allowed is 1)."""
+        if (true) {
+          // violation above, """Nested if-else depth is
+          //  2 (max allowed is 1)."""
+          if (true) {
+            // violation above, """Nested if-else depth is
+            //  4 (max allowed is 1)."""
+            if (true) {
+              // violation above, """Nested if-else depth is
+              //  5 (max allowed is 1)."""
+              if (true) {}
               else {}
             }
           }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/Example2.java
@@ -20,7 +20,7 @@ class Example2 {
     if (true) {
       if (true) {
         if (true) {}
-        else{}
+        else {}
       }
     }
 
@@ -37,8 +37,12 @@ class Example2 {
       if (true) {
         if (true) {
           if (true) {
-            if (true) { // violation, nested if-else depth is 4 (max allowed is 3)
-              if (true) {} // violation, nested if-else depth is 5 (max allowed is 3)
+            // violation above, """Nested if-else depth is
+            //  4 (max allowed is 3)."""
+            if (true) {
+              // violation above, """Nested if-else depth is
+              //  5 (max allowed is 3)."""
+              if (true) {}
               else {}
             }
           }


### PR DESCRIPTION

Fixes #17530

Updated NestedIfDepth documentation examples to use the new
"violation above" comment format.

Changes made in:
- src/site/xdoc/checks/coding/nestedifdepth.xml
- src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/Example1.java
- src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/Example2.java