### PR TITLE
Test #21006: Verify closed PR cancellation

### DIFF
--- a/.github/auto-cancel-test.txt
+++ b/.github/auto-cancel-test.txt
@@ -1,0 +1,4 @@
+Temporary post-merge validation for issue #21006.
+
+This file exists only to create a pull request with active workflow runs.
+The pull request will be closed without merging.


### PR DESCRIPTION
Post-merge validation requested in #21025.

This PR adds only a temporary marker so workflows begin. It will be closed without merging once runs are active. After closing, I will verify that active runs are cancelled and the closed-event replacement jobs are skipped.