### PR TITLE
infra: Update Google Java Format version to 1.36.0 for CI

### DIFF
--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VERSION: 1.35.0
+  VERSION: 1.36.1
 
 jobs:
   test:


### PR DESCRIPTION
https://github.com/google/google-java-format/releases/tag/v1.36.0
