### PR TITLE
Issue #20954: Quote RecordComponentName example violation messages

### DIFF
--- a/src/site/xdoc/checks/naming/recordcomponentname.xml
+++ b/src/site/xdoc/checks/naming/recordcomponentname.xml
@@ -51,7 +51,7 @@
 class Example1 {
   record Rec1(int other) {}
 
-  record Rec2(String Values) {} // violation, Name must match '^[a-z][a-zA-Z0-9]*$'
+  record Rec2(String Values) {} // violation 'Name 'Values' must match pattern'
 
   record Rec3(double myNumber) {}
 }
@@ -74,9 +74,9 @@ class Example1 {
 class Example2 {
   record Rec1(int other) {}
 
-  record Rec2(String Values) {} // violation, Name must match '^[a-z]+$'
+  record Rec2(String Values) {} // violation 'Name 'Values' must match pattern'
 
-  record Rec3(double myNumber) {} // violation, Name must match '^[a-z]+$'
+  record Rec3(double myNumber) {} // violation 'Name 'myNumber' must match pattern'
 }
 </code></pre></div>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -390,8 +390,6 @@ public final class InlineConfigParser {
             "checks/imports/importorder/Example10.java",
             "checks/metrics/npathcomplexity/Example1.java",
             "checks/metrics/npathcomplexity/Example2.java",
-            "checks/naming/recordcomponentname/Example1.java",
-            "checks/naming/recordcomponentname/Example2.java",
             "checks/naming/recordtypeparametername/Example1.java",
             "checks/naming/recordtypeparametername/Example2.java",
             "checks/regexp/regexpmultiline/InputRegexpMultilineSemantic8.java",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/Example1.java
@@ -12,7 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming.recordcomponentname;
 class Example1 {
   record Rec1(int other) {}
 
-  record Rec2(String Values) {} // violation, Name must match '^[a-z][a-zA-Z0-9]*$'
+  record Rec2(String Values) {} // violation 'Name 'Values' must match pattern'
 
   record Rec3(double myNumber) {}
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/recordcomponentname/Example2.java
@@ -14,8 +14,8 @@ package com.puppycrawl.tools.checkstyle.checks.naming.recordcomponentname;
 class Example2 {
   record Rec1(int other) {}
 
-  record Rec2(String Values) {} // violation, Name must match '^[a-z]+$'
+  record Rec2(String Values) {} // violation 'Name 'Values' must match pattern'
 
-  record Rec3(double myNumber) {} // violation, Name must match '^[a-z]+$'
+  record Rec3(double myNumber) {} // violation 'Name 'myNumber' must match pattern'
 }
 // xdoc section - end


### PR DESCRIPTION
Issue: #20954

Quotes the real violation message substring in the RecordComponentName
example files instead of a paraphrase, and removes the two corresponding
entries from SUPPRESSED_VALIDATE_MESSAGE_FILES.

Verified with:
- `./mvnw clean test -Dtest=RecordComponentNameCheckExamplesTest,RecordComponentNameCheckTest`
  → Tests run: 6, Failures: 0, Errors: 0, Skipped: 0