### PR TITLE
Issue #12226: Add nl_or_singleline option to LeftCurly check

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -298,10 +298,46 @@ public class LeftCurlyCheck
             else if (option == LeftCurlyOption.EOL) {
                 validateEol(brace, braceLine);
             }
+            else if (option == LeftCurlyOption.NL_OR_SINGLELINE) {
+                validateNlOrSingleline(brace, braceLine);
+            }
             else if (!TokenUtil.areOnSameLine(startToken, brace)) {
                 validateNewLinePosition(brace, startToken, braceLine);
             }
         }
+    }
+
+    /**
+     * Validate NL_OR_SINGLELINE case. A brace that opens a block which ends on
+     * the same line is allowed to stay at the end of that line, otherwise the
+     * NL rule is applied.
+     *
+     * @param brace brace AST
+     * @param braceLine line content
+     */
+    private void validateNlOrSingleline(DetailAST brace, String braceLine) {
+        if (!isSingleLineBlock(brace)
+                && !CommonUtil.hasWhitespaceBefore(brace.getColumnNo(), braceLine)) {
+            log(brace, MSG_KEY_LINE_NEW, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
+        }
+    }
+
+    /**
+     * Checks whether the block opened by the given left curly brace ends on the
+     * same line, that is, its matching right curly brace is on that same line.
+     *
+     * @param brace token for left curly brace
+     * @return true if the whole block fits on a single line
+     */
+    private static boolean isSingleLineBlock(DetailAST brace) {
+        final DetailAST block;
+        if (brace.getType() == TokenTypes.LCURLY) {
+            block = brace.getParent();
+        }
+        else {
+            block = brace;
+        }
+        return TokenUtil.areOnSameLine(brace, block.getLastChild());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyOption.java
@@ -71,4 +71,27 @@ public enum LeftCurlyOption {
      */
     NL,
 
+    /**
+     * Represents the policy that if the whole block fits on a single line,
+     * then apply the {@code EOL} rule.
+     * Otherwise apply the {@code NL} rule.
+     *
+     * <p>Checkstyle will allow a block that opens and closes on one line:
+     *
+     * <pre>
+     * if (condition) { doSomething(); }
+     * </pre>
+     *
+     * <p>But for a block spanning multiple lines, Checkstyle will enforce:
+     *
+     * <pre>
+     * if (condition)
+     * {
+     *     ...
+     * }
+     * </pre>
+     *
+     **/
+    NL_OR_SINGLELINE,
+
 }

--- a/src/site/xdoc/checks/blocks/leftcurly.xml
+++ b/src/site/xdoc/checks/blocks/leftcurly.xml
@@ -313,6 +313,38 @@ class UseCase1
     GREEN;
   }
 }
+</code></pre></div><hr class="example-separator"/>
+        <p id="UseCase2-config">
+          To configure the check to apply the <code>nl_or_singleline</code>
+          policy, allowing blocks that open and close on one line:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="LeftCurly"&gt;
+      &lt;property name="option" value="nl_or_singleline"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="UseCase2-code">Example: </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class UseCase2
+{
+  void singleLine() { doNothing(); }
+
+  void multiLine()
+  {
+    doNothing();
+  }
+
+  // violation below ''{' at column 28 should be on a new line.'
+  void trailingLeftCurly() {
+    doNothing();
+  }
+
+  void doNothing() { }
+}
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/blocks/leftcurly.xml.template
+++ b/src/site/xdoc/checks/blocks/leftcurly.xml.template
@@ -92,6 +92,19 @@
         <macro name="example">
             <param name="path" value="/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/UseCase1.java"/>
             <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="UseCase2-config">
+          To configure the check to apply the <code>nl_or_singleline</code>
+          policy, allowing blocks that open and close on one line:
+        </p>
+        <macro name="example">
+            <param name="path" value="/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/UseCase2.java"/>
+            <param name="type" value="config"/>
+        </macro>
+        <p id="UseCase2-code">Example: </p>
+        <macro name="example">
+            <param name="path" value="/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/UseCase2.java"/>
+            <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/site/xdoc/property_types.xml
+++ b/src/site/xdoc/property_types.xml
@@ -654,6 +654,33 @@
               </div>
             </td>
           </tr>
+
+          <tr>
+            <td>
+              <a id="LeftCurlyOption-nl_or_singleline"/>
+              <a href="#LeftCurlyOption-nl_or_singleline">nl_or_singleline</a>
+            </td>
+            <td>
+              If the whole block fits on a single line, then apply the
+              <code>eol</code> rule. Otherwise, apply the <code>nl</code> rule.
+              Checkstyle will allow:
+              <div class="wrapper">
+                <pre><code class="language-java">
+    if (condition) { doSomething(); }
+                </code></pre>
+              </div>
+              But for a block spanning multiple lines, Checkstyle will
+              enforce:
+              <div class="wrapper">
+                <pre><code class="language-java">
+    if (condition)
+    {
+        ...
+    }
+                </code></pre>
+              </div>
+            </td>
+          </tr>
         </table>
       </div>
     </section>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -616,6 +616,18 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testNlOrSingleline() throws Exception {
+        final String[] expected = {
+            "28:30: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 30),
+            "40:31: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 31),
+            "51:42: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 42),
+            "56:47: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 47),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestNlOrSingleline.java"), expected);
+    }
+
+    @Test
     public void commentBeforeLeftCurly() throws Exception {
         final String[] expected = {
             "32:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNlOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestNlOrSingleline.java
@@ -1,0 +1,69 @@
+/*
+LeftCurly
+option = NL_OR_SINGLELINE
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, \
+         INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT, \
+         LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, \
+         LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF, \
+         OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF, SWITCH_RULE
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+public class InputLeftCurlyTestNlOrSingleline
+{
+
+    class SingleLineOk { }
+
+    class SingleNextLineOk
+    { }
+
+    class MultiLineOk
+    {
+    }
+
+    class MultiLineViolation { // violation ''{' at column 30 should be on a new line'
+    }
+
+    void singleLineOk() { }
+
+    void singleNextLineOk()
+    { }
+
+    void multiLineOk()
+    {
+    }
+
+    void multiLineViolation() { // violation ''{' at column 31 should be on a new line'
+    }
+
+    boolean flag;
+
+    void singleLineStatementOk() { flag = true; }
+
+    void singleNextLineStatementOk()
+    { flag = true; }
+
+    // violation below ''{' at column 42 should be on a new line'
+    boolean statementsSplitAcrossLines() { flag = true;
+        return flag;
+    }
+
+    // violation below ''{' at column 47 should be on a new line'
+    boolean statementsWithTrailingLeftCurly() {
+        flag = true;
+        return flag;
+    }
+
+    void nestedSingleLineBlocks()
+    {
+        try { doNothing(); }
+        catch (Exception exc) { doNothing(); }
+        finally { doNothing(); }
+    }
+
+    void doNothing() { }
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckExamplesTest.java
@@ -65,6 +65,15 @@ public class LeftCurlyCheckExamplesTest extends AbstractExamplesModuleTestSuppor
     }
 
     @Test
+    public void testUseCase2() throws Exception {
+        final String[] expected = {
+            "24:28: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", "28"),
+        };
+
+        verifyWithInlineConfigParser(getPath("UseCase2.java"), expected);
+    }
+
+    @Test
     public void testExample3() throws Exception {
         final String[] expected = {
             "22:13: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", "13"),

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/UseCase2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/UseCase2.java
@@ -1,0 +1,30 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="LeftCurly">
+      <property name="option" value="nl_or_singleline"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+// xdoc section - start
+class UseCase2
+{
+  void singleLine() { doNothing(); }
+
+  void multiLine()
+  {
+    doNothing();
+  }
+
+  // violation below ''{' at column 28 should be on a new line.'
+  void trailingLeftCurly() {
+    doNothing();
+  }
+
+  void doNothing() { }
+}
+// xdoc section - end


### PR DESCRIPTION
Issue: #12226

Adds a new `LeftCurlyOption` value, `nl_or_singleline`.

## Problem

`LeftCurly` currently offers `eol`, `nl`, and `nlow`.
None of them allow a block that opens and closes on one line while still requiring the brace to sit alone on a new line for any block that spans multiple lines.
That combination is what an otherwise-Allman codebase needs in order to permit trivial single-line blocks, and there is no existing combination of options that expresses it.

## Solution

`nl_or_singleline`: if the whole block fits on a single line, the brace may stay at the end of that line (`eol` rule).
Otherwise, the `nl` rule applies, and the brace must be alone on a new line.

```java
class Example
{
  void singleLine() { doNothing(); }   // ok - opens and closes on one line

  void multiLine()
  {                                    // ok - brace alone on a new line
    doNothing();
  }

  void trailingLeftCurly() {           // violation - '{' should be on a new line
    doNothing();
  }
}
```

This matches the behaviour requested in the issue: the open and close braces must be either on the same line, or in the same column.

## Implementation

- `LeftCurlyOption.NL_OR_SINGLELINE` — a new enum value, marked `@since 14.2.0` and documented in the style of the existing `NLOW` value.
- `LeftCurlyCheck.validateNlOrSingleline(..)` — a new branch in `verifyBrace`, backed by `isSingleLineBlock(..)`, which compares the line of the left curly against the line of its matching right curly.
- The matching logic handles both block nodes and bare `LCURLY` tokens, including the switch-expression path.
- Documentation — `nl_or_singleline` was added to the `LeftCurlyOption` table in `property-types.xml`, and a new `UseCase2` was added to `leftcurly.xml.template`.
- `leftcurly.xml` was regenerated from the template by the build rather than hand-edited.

`UseCase2` is used instead of `Example5` because `XdocsExamplesAstConsistencyTest` requires the example count to equal the property count plus one, and `LeftCurly` already has exactly four examples for its three properties.

No metadata change is required because `LeftCurlyCheck.xml` records the property's type, not the enum's values.

## Testing

Added `LeftCurlyCheckTest#testNlOrSingleline` with `InputLeftCurlyTestNlOrSingleline.java`, covering the cases from the issue: empty blocks, single-statement blocks, multi-line blocks with either a trailing or wrapped left curly, nested single-line `try`/`catch`/`finally` blocks inside a multi-line method, and a single-line switch expression.

Added `LeftCurlyCheckExamplesTest#testUseCase2` for the documentation example.

Verified locally after rebasing on current `master`:

- `mvn clean verify` — BUILD SUCCESS: 6,812 unit tests and 1,363 integration tests passed, with PMD, SpotBugs, forbidden APIs, source checks, documentation checks, and commit validation all passing.
- JaCoCo — all coverage checks passed, including full line and branch coverage of the new `LeftCurly` logic.
- `mvn -Ppitest-blocks clean test-compile org.pitest:pitest-maven:mutationCoverage` — BUILD SUCCESS: 1,193 of 1,193 mutations killed, with no new surviving mutations.

## Diff regression

The option is additive and opt-in, so existing configurations retain their current behaviour.
The normal PR workflows provide the external-project regression checks.
