### PR TITLE
Issue #15456: Fix violation message for RightCurlyCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -270,7 +270,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.arraytypestyle.ArrayTypeStyleCheck",
             "com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck",
             "com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck",
-            "com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.CovariantEqualsCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -117,19 +117,19 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "86:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
-            "122:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "122:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
-            "136:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "136:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
-            "144:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
-            "149:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
-            "152:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
-            "154:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
-            "197:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "202:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
-            "205:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
-            "211:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "211:10: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 10),
+            "125:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "125:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
+            "142:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "142:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
+            "153:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "158:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
+            "161:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+            "163:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
+            "206:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "211:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
+            "214:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
+            "220:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "220:10: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 10),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyLeftTestNewLine.java"), expected);
@@ -141,14 +141,14 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "86:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "111:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
-            "122:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "122:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
-            "136:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
-            "136:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
-            "197:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "202:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
-            "211:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "211:10: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 10),
+            "125:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "125:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
+            "142:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "142:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
+            "206:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "211:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
+            "220:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "220:10: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 10),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyLeftTestShouldStartLine2.java"), expected);
@@ -284,26 +284,26 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "161:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
             "173:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "173:10: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 10),
-            "177:54: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 54),
-            "177:55: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 55),
-            "183:75: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 75),
-            "183:76: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 76),
-            "183:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 77),
-            "199:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
-            "205:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "180:54: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 54),
+            "180:55: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 55),
+            "186:75: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 75),
+            "186:76: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 76),
+            "186:77: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 77),
+            "202:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
             "208:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
             "211:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
-            "217:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "219:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "221:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "214:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "220:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "222:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "227:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "232:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "233:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
-            "241:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
-            "253:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
-            "259:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
-            "259:38: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 38),
+            "224:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "225:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "230:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "235:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "236:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
+            "244:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "256:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
+            "262:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
+            "262:38: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 38),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestAloneOrSingleline.java"), expected);
@@ -447,15 +447,15 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "60:53: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 53),
             "62:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
             "62:52: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 52),
-            "75:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "75:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
-            "79:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
-            "81:56: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 56),
-            "84:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
-            "96:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
-            "99:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
-            "105:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "105:10: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 10),
+            "78:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "78:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
+            "85:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
+            "87:56: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 56),
+            "90:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "102:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
+            "105:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
+            "111:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "111:10: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 10),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestOptionAlone.java"),
@@ -495,7 +495,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "65:30: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 30),
             "74:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "74:11: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 11),
-            "78:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "81:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestOptSameBlocksWithSemi.java"), expected);
@@ -523,7 +523,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "65:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
             "71:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "71:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
-            "75:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "78:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestOptAloneBlocksWithSemi.java"), expected);
@@ -544,7 +544,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "65:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
             "74:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "74:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
-            "78:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "81:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi.java"), expected);
@@ -611,10 +611,10 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "23:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "23:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
-            "27:21: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 21),
-            "32:23: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 23),
-            "34:37: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 37),
-            "41:68: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 68),
+            "30:21: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 21),
+            "35:23: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 23),
+            "37:37: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 37),
+            "44:68: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 68),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestRecordsAndCompactCtors.java"), expected);
@@ -705,13 +705,13 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "29:22: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 22),
             "37:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
             "37:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
-            "43:40: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 40),
-            "43:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
-            "48:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
-            "50:32: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 32),
-            "50:33: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 33),
-            "52:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "52:14: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 14),
+            "46:40: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 40),
+            "46:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
+            "54:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
+            "56:32: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 32),
+            "56:33: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 33),
+            "61:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "61:14: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 14),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestSwitchCase3.java"), expected);
@@ -727,8 +727,8 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "28:22: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 22),
             "35:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
             "35:42: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 42),
-            "40:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
-            "42:32: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 32),
+            "43:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
+            "45:32: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 32),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestSwitchCase4.java"), expected);
@@ -744,9 +744,9 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "28:22: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 22),
             "35:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
             "35:42: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 42),
-            "40:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
-            "42:32: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 32),
-            "65:49: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 49),
+            "43:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
+            "45:32: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 32),
+            "68:49: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 49),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestSwitchCase5.java"), expected);
@@ -846,18 +846,18 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testCaseBlocksInSwitchStatementAlone2() throws Exception {
         final String[] expected = {
             "17:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
-            "26:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "38:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "41:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "49:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
-            "49:45: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 45),
-            "57:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "68:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "68:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
-            "75:34: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 34),
-            "75:47: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 47),
-            "82:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
-            "102:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "25:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "37:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "40:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "48:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "48:45: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 45),
+            "59:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "70:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "70:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
+            "79:34: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 34),
+            "79:47: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 47),
+            "88:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
+            "105:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyCaseBlocksInSwitchStatementAlone2.java"), expected);
@@ -909,16 +909,16 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testCaseBlocksInSwitchStatementSame2() throws Exception {
         final String[] expected = {
-            "18:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "27:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "39:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "42:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "50:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "70:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
-            "77:34: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 34),
-            "77:47: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 47),
-            "85:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
-            "103:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "17:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "26:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "38:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "41:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "49:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "69:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "75:34: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 34),
+            "75:47: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 47),
+            "86:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
+            "104:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyCaseBlocksInSwitchStatementSame2.java"), expected);
@@ -935,8 +935,8 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "74:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
             "83:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
             "83:36: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 36),
-            "93:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
-            "94:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+            "96:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
+            "97:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyCaseBlocksWithSwitchRuleAlone.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementAlone2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementAlone2.java
@@ -17,7 +17,6 @@ public class InputRightCurlyCaseBlocksInSwitchStatementAlone2 {
             1;} default : x = 5;         // violation '}' at column 15 should be alone on a line'
         }
     }
-
     public static void test10() {
         int mode = 0;
         switch (mode) {
@@ -46,7 +45,10 @@ public class InputRightCurlyCaseBlocksInSwitchStatementAlone2 {
         switch (mode) {
             case 0: {
 
-            int x = 1; } case 1: {int x = 1;} break;  // 2 violations
+            int x = 1; } case 1: {int x = 1;} break;
+            // 2 violations above:
+            // ''}' at column 24 should be alone on a line.'
+            // ''}' at column 45 should be alone on a line.'
         }
     }
     public static void test13() {
@@ -65,16 +67,20 @@ public class InputRightCurlyCaseBlocksInSwitchStatementAlone2 {
         switch (mode) {
             case 0: {
 
-            } case 1: {  }         // 2 violations
+            } case 1: {  }
+            // 2 violations above:
+            // ''}' at column 13 should be alone on a line.'
+            // ''}' at column 26 should be alone on a line.'
             default : {break;}
         }
     }
-
     public static void test15() {
         int mode = 0;
-        switch (mode) {case 0: { } case 1: {  } } // 2 violations
+        switch (mode) {case 0: { } case 1: {  } }
+        // 2 violations above:
+        // ''}' at column 34 should be alone on a line.'
+        // ''}' at column 47 should be alone on a line.'
     }
-
     public static void test16() {
         int mode = 0;
         switch (mode) {
@@ -84,7 +90,6 @@ public class InputRightCurlyCaseBlocksInSwitchStatementAlone2 {
             case 2: int t = 1; { };
         }
     }
-
     public static void test17() {
         int mode = 0;
         switch (mode) {
@@ -94,15 +99,12 @@ public class InputRightCurlyCaseBlocksInSwitchStatementAlone2 {
             case 1:
             mode++;
             {
-
             } int y; // ok, the braces is not a first child of case
             case 3:
             {
-
             } int z = 1;  // violation '}' at column 13 should be alone on a line'
         }
     }
-
     public static void test18() {
         int mode = 0;
         switch (mode) {
@@ -112,9 +114,7 @@ public class InputRightCurlyCaseBlocksInSwitchStatementAlone2 {
             case 1:
             int z;
             {
-
             }break; default: break; // ok, the braces is not a first child of case
         }
     }
 }
-

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementSame2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksInSwitchStatementSame2.java
@@ -7,7 +7,6 @@ tokens = LITERAL_CASE
 package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyCaseBlocksInSwitchStatementSame2 {
-
      public static void test9() {
         int mode = 0;
         switch (mode) {
@@ -71,10 +70,12 @@ public class InputRightCurlyCaseBlocksInSwitchStatementSame2 {
             default : {break;}
         }
     }
-
     public static void test15() {
         int mode = 0;
-        switch (mode) {case 0: { } case 1: {  } } // 2 violations
+        switch (mode) {case 0: { } case 1: {  } }
+        // 2 violations above:
+        // ''}' at column 34 should be alone on a line.'
+        // ''}' at column 47 should be alone on a line.'
 
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchRuleAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyCaseBlocksWithSwitchRuleAlone.java
@@ -80,7 +80,10 @@ public class InputRightCurlyCaseBlocksWithSwitchRuleAlone {
         switch (mode) {
             case 0 -> {
                 int x = 1;
-            } case 1 -> {int x = 2;}  // 2 violations
+            } case 1 -> {int x = 2;}
+            // 2 violations above:
+            // ''}' at column 13 should be alone on a line.'
+            // ''}' at column 36 should be alone on a line.'
         }
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestNewLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestNewLine.java
@@ -108,7 +108,10 @@ class FooCtorTestNewLine
         public void FooCtor()
     {
                 i = 1;
-    }} // 2 violations
+    }}
+// 2 violations above:
+// ''}' at column 5 should be alone on a line.'
+// ''}' at column 6 should be alone on a line.'
 
 /**
 * Test input for closing brace if that brace terminates
@@ -119,7 +122,10 @@ class FooMethodTestNewLine
         public void fooMethod()
     {
                 int i = 1;
-    }} // 2 violations
+    }}
+// 2 violations above:
+// ''}' at column 5 should be alone on a line.'
+// ''}' at column 6 should be alone on a line.'
 
 /**
 * Test input for closing brace if that brace terminates
@@ -133,7 +139,10 @@ class FooInnerTestNewLine
         {
 
                 }
-    }} // 2 violations
+    }}
+// 2 violations above:
+// ''}' at column 5 should be alone on a line.'
+// ''}' at column 6 should be alone on a line.'
 
 /**
  * False positive
@@ -208,5 +217,8 @@ class ClassWithStaticInitializersTestNewLine
         void display();
         interface Interface4 {
             void myMethod();
-        }} // 2 violations
+        }}
+    // 2 violations above:
+    // ''}' at column 9 should be alone on a line.'
+    // ''}' at column 10 should be alone on a line.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestShouldStartLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestShouldStartLine2.java
@@ -108,7 +108,10 @@ class FooCtorTestShouldStartLine2
         public void FooCtor()
     {
                 i = 1;
-    }} // 2 violations
+    }}
+// 2 violations above:
+// ''}' at column 5 should be alone on a line.'
+// ''}' at column 6 should be alone on a line.'
 
 /**
 * Test input for closing brace if that brace terminates
@@ -119,7 +122,10 @@ class FooMethodTestShouldStartLine2
         public void fooMethod()
     {
                 int i = 1;
-    }} // 2 violations
+    }}
+// 2 violations above:
+// ''}' at column 5 should be alone on a line.'
+// ''}' at column 6 should be alone on a line.'
 
 /**
 * Test input for closing brace if that brace terminates
@@ -133,7 +139,10 @@ class FooInnerTestShouldStartLine2
         {
 
                 }
-    }} // 2 violations
+    }}
+// 2 violations above:
+// ''}' at column 5 should be alone on a line.'
+// ''}' at column 6 should be alone on a line.'
 
 /**
  * False positive
@@ -208,5 +217,8 @@ class ClassWithStaticInitializersTestShouldStartLine2
         void display();
         interface Interface4 {
             void myMethod();
-        }} // 2 violations
+        }}
+    // 2 violations above:
+    // ''}' at column 9 should be alone on a line.'
+    // ''}' at column 10 should be alone on a line.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestAloneOrSingleline.java
@@ -170,7 +170,10 @@ public class InputRightCurlyTestAloneOrSingleline {
     void foo25() {
         for (int i = 0; i < 10; i++) {
             System.identityHashCode("Hello, world!");
-        }} // 2 violations
+        }}
+    // 2 violations above:
+    // ''}' at column 9 should be alone on a line.'
+    // ''}' at column 10 should be alone on a line.'
 
     void foo26() {
         for (int i = 0; i < 10; i++) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestDoubleBrace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestDoubleBrace.java
@@ -11,4 +11,7 @@ package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 class InputRightCurlyTestDoubleBrace {{
 
-}} // 2 violations
+}}
+// 2 violations above:
+// ''}' at column 1 should be alone on a line.'
+// ''}' at column 2 should be alone on a line.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestEndOfFile.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestEndOfFile.java
@@ -13,4 +13,7 @@ public class InputRightCurlyTestEndOfFile
     public static void main(String[] arg)
     {
 
- }} // 2 violations
+ }}
+// 2 violations above:
+// ''}' at column 2 should be alone on a line.'
+// ''}' at column 3 should be alone on a line.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneBlocksWithSemi.java
@@ -68,7 +68,10 @@ public class InputRightCurlyTestOptAloneBlocksWithSemi {
         void display();
         interface Interface4 {
             void myMethod();
-        };}; // 2 violations
+        };};
+    // 2 violations above:
+    // ''}' at column 9 should be alone on a line.'
+    // ''}' at column 11 should be alone on a line.'
 
     interface InterfaceEndingWithSemiColon2 {
         public void fooEmpty();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi.java
@@ -71,7 +71,10 @@ public class InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi {
         void display();
         interface Interface4 {
             void myMethod();
-        };}; // 2 violations
+        };};
+    // 2 violations above:
+    // ''}' at column 9 should be alone on a line.'
+    // ''}' at column 11 should be alone on a line.'
 
     interface InterfaceEndingWithSemiColon2 {
         public void fooEmpty();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptSameBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptSameBlocksWithSemi.java
@@ -71,7 +71,10 @@ public class InputRightCurlyTestOptSameBlocksWithSemi {
         void display();
         interface Interface4 {
             void myMethod();
-        };}; // 2 violations
+        };};
+    // 2 violations above:
+    // ''}' at column 9 should be alone on a line.'
+    // ''}' at column 11 should have line break before.'
 
     interface InterfaceEndingWithSemiColon2 {
         public void fooEmpty();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptionAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptionAlone.java
@@ -59,7 +59,10 @@ public class InputRightCurlyTestOptionAlone {
         // violation below ''}' at column 53 should be alone on a line'
         for (int i = 1; i < 10; i++) { byte b = 10; }
 
-        if (a < 2) { --a; } else if (a > 3) { a++; } // 2 violations
+        if (a < 2) { --a; } else if (a > 3) { a++; }
+        // 2 violations above:
+        // ''}' at column 27 should be alone on a line.'
+        // ''}' at column 52 should be alone on a line.'
 
         java.util.List<String> list = new java.util.ArrayList<>();
         list.stream()
@@ -72,7 +75,10 @@ public class InputRightCurlyTestOptionAlone {
             put("Hello", "World");
             put("first", "second");
             put("polygene", "lubricants");
-        }{}; // 2 violations
+        }{};
+        // 2 violations above:
+        // ''}' at column 9 should be alone on a line.'
+        // ''}' at column 11 should be alone on a line.'
         };
     }
 
@@ -102,5 +108,8 @@ public class InputRightCurlyTestOptionAlone {
         void display();
         interface Interface4 {
             void myMethod();
-        }} // 2 violations
+        }}
+    // 2 violations above:
+    // ''}' at column 9 should be alone on a line.'
+    // ''}' at column 10 should be alone on a line.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptionAloneOrSingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptionAloneOrSingleLine.java
@@ -83,5 +83,8 @@ public class InputRightCurlyTestOptionAloneOrSingleLine {
         void display();
         interface Interface4 {
             void myMethod();
-        }} // 2 violations
+        }}
+    // 2 violations above:
+    // ''}' at column 9 should be alone on a line.'
+    // ''}' at column 10 should be alone on a line.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestRecordsAndCompactCtors.java
@@ -20,7 +20,10 @@ public class InputRightCurlyTestRecordsAndCompactCtors {
                 value = i;
             }
             return value > 10;
-        } } // 2 violations
+        } }
+    // 2 violations above:
+    // ''}' at column 9 should be alone on a line.'
+    // ''}' at column 11 should be alone on a line.'
 
     record MyTestRecord2() {
         MyTestRecord2(String one, String two, String three) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSinglelineIfBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSinglelineIfBlocks.java
@@ -12,6 +12,9 @@ public class InputRightCurlyTestSinglelineIfBlocks {
     void foo1() {
         if (true) { int a = 5; } // violation ''}' at column 32 should be alone on a line'
 
-        if (true) { if (false) { int b = 6; } } // 2 violations
+        if (true) { if (false) { int b = 6; } }
+        // 2 violations above:
+        // ''}' at column 45 should be alone on a line.'
+        // ''}' at column 47 should be alone on a line.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase3.java
@@ -34,22 +34,34 @@ public class InputRightCurlyTestSwitchCase3 {
         if (7>x) {
            switch (x) {
                case(1):
-                   break;}} // 2 violations
+                   break;}}
+        // 2 violations above:
+        // ''}' at column 26 should be alone on a line.'
+        // ''}' at column 27 should be alone on a line.'
     }
 
     public void someMethod2() {
         int x = 90;
         if (7>x) {
-           switch (x) { case(1): break;}} // 2 violations
+           switch (x) { case(1): break;}}
+        // 2 violations above:
+        // ''}' at column 40 should be alone on a line.'
+        // ''}' at column 41 should be alone on a line.'
     }
 
     public void someMethod3() {
         int x = 90;
         if (7>x) {switch (x) {case(1): break;}
         } // violation above ''}' at column 46 should be alone on a line'
-        if (7>x) {switch (x) { }} // 2 violations
+        if (7>x) {switch (x) { }}
+        // 2 violations above:
+        // ''}' at column 32 should be alone on a line.'
+        // ''}' at column 33 should be alone on a line.'
         if (7>x) {switch (x) {
-            }} // 2 violations
+            }}
+        // 2 violations above:
+        // ''}' at column 13 should be alone on a line.'
+        // ''}' at column 14 should be alone on a line.'
         if (7>x) {switch (x) {
             }
        }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase4.java
@@ -32,7 +32,10 @@ public class InputRightCurlyTestSwitchCase4 {
     public void someMethod2() {
         int x = 90;
         if (7>x) {
-            switch (x) { case(1): break;}} // 2 violations
+            switch (x) { case(1): break;}}
+        // 2 violations above:
+        // ''}' at column 41 should be alone on a line.'
+        // ''}' at column 42 should be alone on a line.'
     }
 
     public void someMethod3() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase5.java
@@ -32,7 +32,10 @@ public class InputRightCurlyTestSwitchCase5 {
     public void someMethod2() {
         int x = 90;
         if (7>x) {
-            switch (x) { case(1): break;}} // 2 violations
+            switch (x) { case(1): break;}}
+        // 2 violations above:
+        // ''}' at column 41 should be alone on a line.'
+        // ''}' at column 42 should have line break before.'
     }
 
     public void someMethod3() {


### PR DESCRIPTION
Issue: #15456

- Fixed violation message for `RightCurlyCheck`.
- Refactored `InputRightCurlyCaseBlocksInSwitchStatementAlone2` and `InputRightCurlyCaseBlocksInSwitchStatementSame2` to meet the 120-row limit (removed spaces between classes and between brackets in several places).

### Notes:
I'm not sure about this refactoring, maybe I should add these classes to `checkstyle-resources-suppressions.xml` to be handled as part of [issue 11163](https://github.com/checkstyle/checkstyle/issues/11163) instead?

Also, I found several unused suppressions in `SUPPRESSED_CHECKS`. If I remove these suppressions, the `./mvnw clean verify` command runs successfully. May I submit a PR to remove these unused suppressions?