### PR TITLE
Issue #20954: Quote NPathComplexity example violation messages

### DIFF
--- a/src/site/xdoc/checks/metrics/npathcomplexity.xml
+++ b/src/site/xdoc/checks/metrics/npathcomplexity.xml
@@ -147,7 +147,7 @@ public abstract class Example1 {
     print(m &gt; n ? baz() : bar());
   }
 
-  public void boo() { // violation, NPath complexity is 217 (max allowed is 200)
+  public void boo() { // violation 'NPath Complexity is 217 (max allowed is 200).'
     // looping through 3 switch statements produces 6^3 + 1 (217) possible outcomes
     for(int i = 0; i &lt; b; i++) { // for statement adds 1 to final complexity
       switch(i) { // each independent switch statement multiplies complexity by 6
@@ -196,7 +196,7 @@ public abstract class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public abstract class Example2 {
   int b = 0;
-  public void foo() { // violation, NPath complexity is 128 (max allowed is 100)
+  public void foo() { // violation 'NPath Complexity is 128 (max allowed is 100).'
     int a,b,t,m,n;
     a=b=t=m=n = 0;
 
@@ -209,7 +209,7 @@ public abstract class Example2 {
     print(m &gt; n ? baz() : bar());
   }
 
-  public void boo() { // violation, NPath complexity is 217 (max allowed is 100)
+  public void boo() { // violation 'NPath Complexity is 217 (max allowed is 100).'
     // looping through 3 switch statements produces 6^3 + 1 (217) possible outcomes
     for(int i = 0; i &lt; b; i++) { // for statement adds 1 to final complexity
       switch(i) { // each independent switch statement multiplies complexity by 6

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -388,8 +388,6 @@ public final class InlineConfigParser {
             "checks/coding/unusedlocalvariable/InputUnusedLocalVariableUnnamedTryCatch.java",
             "checks/imports/avoidstarimport/InputAvoidStarImportExcludes.java",
             "checks/imports/importorder/Example10.java",
-            "checks/metrics/npathcomplexity/Example1.java",
-            "checks/metrics/npathcomplexity/Example2.java",
             "checks/naming/recordtypeparametername/Example1.java",
             "checks/naming/recordtypeparametername/Example2.java",
             "checks/regexp/regexpmultiline/InputRegexpMultilineSemantic8.java",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/Example1.java
@@ -23,7 +23,7 @@ public abstract class Example1 {
     print(m > n ? baz() : bar());
   }
 
-  public void boo() { // violation, NPath complexity is 217 (max allowed is 200)
+  public void boo() { // violation 'NPath Complexity is 217 (max allowed is 200).'
     // looping through 3 switch statements produces 6^3 + 1 (217) possible outcomes
     for(int i = 0; i < b; i++) { // for statement adds 1 to final complexity
       switch(i) { // each independent switch statement multiplies complexity by 6

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/metrics/npathcomplexity/Example2.java
@@ -12,7 +12,7 @@ package com.puppycrawl.tools.checkstyle.checks.metrics.npathcomplexity;
 // xdoc section - start
 public abstract class Example2 {
   int b = 0;
-  public void foo() { // violation, NPath complexity is 128 (max allowed is 100)
+  public void foo() { // violation 'NPath Complexity is 128 (max allowed is 100).'
     int a,b,t,m,n;
     a=b=t=m=n = 0;
 
@@ -25,7 +25,7 @@ public abstract class Example2 {
     print(m > n ? baz() : bar());
   }
 
-  public void boo() { // violation, NPath complexity is 217 (max allowed is 100)
+  public void boo() { // violation 'NPath Complexity is 217 (max allowed is 100).'
     // looping through 3 switch statements produces 6^3 + 1 (217) possible outcomes
     for(int i = 0; i < b; i++) { // for statement adds 1 to final complexity
       switch(i) { // each independent switch statement multiplies complexity by 6


### PR DESCRIPTION
Issue: #20954

Quotes the real violation messages in the NPathComplexity example files
instead of a paraphrase, and removes the two corresponding entries
from `SUPPRESSED_VALIDATE_MESSAGE_FILES`.

Verified with `mvn clean test -Dtest=NPathComplexityCheckExamplesTest,NPathComplexityCheckTest`
and `mvn clean verify`.