### PR TITLE
Issue #20954: Fix violation message comments for FinalParameters check inputs

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -333,10 +333,6 @@ public final class InlineConfigParser {
      * <a href="https://github.com/checkstyle/checkstyle/issues/20954">#20954</a>
      */
     private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of(
-            "checks/finalparameters/InputFinalParameters3.java",
-            "checks/finalparameters/InputFinalParametersPatternVariables.java",
-             "checks/finalparameters/"
-                     + "InputFinalParametersRecordForLoopPatternVariables.java",
             "checks/coding/equalshashcode/Example1.java",
             "checks/coding/illegaltype/InputIllegalTypeTestDefaults.java",
             "checks/coding/illegaltype/InputIllegalTypeEmptyStringMemberModifiers.java",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckTest.java
@@ -66,8 +66,8 @@ public class FinalParametersCheckTest extends AbstractModuleTestSupport {
             "59:17: " + getCheckMessage(MSG_KEY, "s"),
             "75:17: " + getCheckMessage(MSG_KEY, "s"),
             "81:17: " + getCheckMessage(MSG_KEY, "s"),
-            "96:45: " + getCheckMessage(MSG_KEY, "e"),
-            "99:36: " + getCheckMessage(MSG_KEY, "e"),
+            "97:45: " + getCheckMessage(MSG_KEY, "e"),
+            "101:36: " + getCheckMessage(MSG_KEY, "e"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFinalParameters3.java"), expected);
@@ -227,9 +227,9 @@ public class FinalParametersCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "17:47: " + getCheckMessage(MSG_KEY, "s"),
             "19:26: " + getCheckMessage(MSG_KEY, "i"),
-            "24:34: " + getCheckMessage(MSG_KEY, "name"),
-            "30:18: " + getCheckMessage(MSG_KEY, "s"),
-            "32:26: " + getCheckMessage(MSG_KEY, "name"),
+            "25:34: " + getCheckMessage(MSG_KEY, "name"),
+            "31:18: " + getCheckMessage(MSG_KEY, "s"),
+            "34:26: " + getCheckMessage(MSG_KEY, "name"),
         };
         verifyWithInlineConfigParser(
             getPath("InputFinalParametersPatternVariables.java"), expected);
@@ -238,7 +238,7 @@ public class FinalParametersCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testRecordForLoopPatternVariableDefinitions() throws Exception {
         final String[] expected = {
-            "17:22: " + getCheckMessage(MSG_KEY, "name"),
+            "18:22: " + getCheckMessage(MSG_KEY, "name"),
         };
         verifyWithInlineConfigParser(
             getNonCompilablePath("InputFinalParametersRecordForLoopPatternVariables.java"),

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersRecordForLoopPatternVariables.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersRecordForLoopPatternVariables.java
@@ -14,7 +14,8 @@ public class InputFinalParametersRecordForLoopPatternVariables {
     record ARecord(String name, int age) {
     }
     static void method(final ARecord[] records) {
-        for (ARecord(String name, final int age) : records) { // violation 'name' should be final
+        // violation below 'Parameter name should be final.'
+        for (ARecord(String name, final int age) : records) {
         }
         for (ARecord(final String name, final int age) : records) {
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParameters3.java
@@ -56,7 +56,7 @@ class InputFinalParameters3
     }
 
     /** non final param method */
-    void method(String s) // violation 's' should be final
+    void method(String s) // violation 'Parameter s should be final.'
     {
     }
 
@@ -72,13 +72,13 @@ class InputFinalParameters3
     }
 
     /** non-final param method with annotation **/
-    void method(@MyAnnotation33 Class<Object> s) // violation 's' should be final
+    void method(@MyAnnotation33 Class<Object> s) // violation 'Parameter s should be final.'
     {
 
     }
 
     /** mixed */
-    void method(String s, final Integer i) // violation 's' should be final
+    void method(String s, final Integer i) // violation 'Parameter s should be final.'
     {
     }
 
@@ -93,10 +93,12 @@ class InputFinalParameters3
     {
         Action a = new AbstractAction()
             {
-                public void actionPerformed(ActionEvent e) // violation 'e' should be final
+                // violation below 'Parameter e should be final.'
+                public void actionPerformed(ActionEvent e)
                 {
                 }
-                void somethingElse(@MyAnnotation33 ActionEvent e) // violation 'e' should be final
+                // violation below 'Parameter e should be final.'
+                void somethingElse(@MyAnnotation33 ActionEvent e)
                 {
                 }
             };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPatternVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/finalparameters/InputFinalParametersPatternVariables.java
@@ -14,22 +14,24 @@ public class InputFinalParametersPatternVariables {
     record ARecord(String name, int age) {
     }
     static void method(final Object o) {
-        final boolean isString = o instanceof String s; // violation 's' should be final
+        final boolean isString = o instanceof String s; // violation 'Parameter s should be final.'
         final boolean isStringCorrect = o instanceof final String correct;
-        if (o instanceof Integer i) { // violation 'i' should be final
+        if (o instanceof Integer i) { // violation 'Parameter i should be final.'
         }
         if (o instanceof final Integer i) {
         }
 
-        if (o instanceof ARecord(String name, final int age)) { // violation 'name' should be final
+       // violation below 'Parameter name should be final.'
+        if (o instanceof ARecord(String name, final int age)) {
         }
         if (o instanceof ARecord(final String name, final int age)) {
         }
 
         switch (o) {
-            case String s -> { // violation 's' should be final
+            case String s -> { // violation 'Parameter s should be final.'
             }
-            case ARecord(String name, final int age) -> { // violation 'name' should be final
+            // violation below 'Parameter name should be final.'
+            case ARecord(String name, final int age) -> {
             }
             default -> {}
         }


### PR DESCRIPTION
  
Issue #20954 
 
 Changes:
 Fixed violation message comments in FinalParameters check test input files.
 Fixed the expected line numbers in FinalParametersCheckTest.java to match the shifted line positions caused by multi-line violation comments.
 Removed fixed files from SUPPRESSED_VALIDATE_MESSAGE_FILES in InlineConfigParser.java
 
 File changed:
 InputFinalParameters3.java
 InputFinalParametersPatternVariables.java
 InputFinalParametersRecordForLoopPatternVariables.java
 
 validation steps to run:
 git status
 git log
 ./mvnw clean verify - BUILD SUCCESS (20:37 min)
 