### PR TITLE
Issue #20954: Update NestedIfDepth examples to new violation format

### DIFF
--- a/src/site/xdoc/checks/coding/nestedifdepth.xml
+++ b/src/site/xdoc/checks/coding/nestedifdepth.xml
@@ -57,15 +57,15 @@ class Example1 {
 
     if (true) {
       if (true) {
-        if (true) {} // violation, nested if-else depth is 2 (max allowed is 1)
-        else{}
+        if (true) {} // violation 'Nested if-else depth is 2 (max allowed is 1).'
+        else {}
       }
     }
 
     if (true) {
       if (true) {
-        if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-          if (true) {} // violation, nested if-else depth is 2 (max allowed is 1)
+        if (true) { // violation 'Nested if-else depth is 2 (max allowed is 1).'
+          if (true) {} // violation 'Nested if-else depth is 3 (max allowed is 1).'
           else {}
         }
       }
@@ -73,10 +73,10 @@ class Example1 {
 
     if (true) {
       if (true) {
-        if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-          if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-            if (true) { // violation, nested if-else depth is 4 (max allowed is 1)
-              if (true) {} // violation, nested if-else depth is 5 (max allowed is 1)
+        if (true) { // violation 'Nested if-else depth is 2 (max allowed is 1).'
+          if (true) { // violation 'Nested if-else depth is 3 (max allowed is 1).'
+            if (true) { // violation 'Nested if-else depth is 4 (max allowed is 1).'
+              if (true) {} // violation 'Nested if-else depth is 5'
               else {}
             }
           }
@@ -110,7 +110,7 @@ class Example2 {
     if (true) {
       if (true) {
         if (true) {}
-        else{}
+        else {}
       }
     }
 
@@ -127,8 +127,8 @@ class Example2 {
       if (true) {
         if (true) {
           if (true) {
-            if (true) { // violation, nested if-else depth is 4 (max allowed is 3)
-              if (true) {} // violation, nested if-else depth is 5 (max allowed is 3)
+            if (true) { // violation 'Nested if-else depth is 4 (max allowed is 3).'
+              if (true) {} // violation 'Nested if-else depth is 5'
               else {}
             }
           }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -324,8 +324,6 @@ public final class InlineConfigParser {
             "checks/coding/illegaltype/InputIllegalTypeTestSameFileNameGeneral.java",
             "checks/coding/illegaltype/InputIllegalTypeTestStarImports.java",
             "checks/coding/illegaltype/InputIllegalTypeTestStaticImports.java",
-            "checks/coding/nestedifdepth/Example1.java",
-            "checks/coding/nestedifdepth/Example2.java",
             "checks/coding/noclone/Example1.java",
             "checks/coding/simplifybooleanreturn/Example1.java",
             "checks/coding/superfinalize/InputSuperFinalizeVariations.java",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/Example1.java
@@ -17,15 +17,15 @@ class Example1 {
 
     if (true) {
       if (true) {
-        if (true) {} // violation, nested if-else depth is 2 (max allowed is 1)
-        else{}
+        if (true) {} // violation 'Nested if-else depth is 2 (max allowed is 1).'
+        else {}
       }
     }
 
     if (true) {
       if (true) {
-        if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-          if (true) {} // violation, nested if-else depth is 2 (max allowed is 1)
+        if (true) { // violation 'Nested if-else depth is 2 (max allowed is 1).'
+          if (true) {} // violation 'Nested if-else depth is 3 (max allowed is 1).'
           else {}
         }
       }
@@ -33,10 +33,10 @@ class Example1 {
 
     if (true) {
       if (true) {
-        if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-          if (true) { // violation, nested if-else depth is 2 (max allowed is 1)
-            if (true) { // violation, nested if-else depth is 4 (max allowed is 1)
-              if (true) {} // violation, nested if-else depth is 5 (max allowed is 1)
+        if (true) { // violation 'Nested if-else depth is 2 (max allowed is 1).'
+          if (true) { // violation 'Nested if-else depth is 3 (max allowed is 1).'
+            if (true) { // violation 'Nested if-else depth is 4 (max allowed is 1).'
+              if (true) {} // violation 'Nested if-else depth is 5'
               else {}
             }
           }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/nestedifdepth/Example2.java
@@ -20,7 +20,7 @@ class Example2 {
     if (true) {
       if (true) {
         if (true) {}
-        else{}
+        else {}
       }
     }
 
@@ -37,8 +37,8 @@ class Example2 {
       if (true) {
         if (true) {
           if (true) {
-            if (true) { // violation, nested if-else depth is 4 (max allowed is 3)
-              if (true) {} // violation, nested if-else depth is 5 (max allowed is 3)
+            if (true) { // violation 'Nested if-else depth is 4 (max allowed is 3).'
+              if (true) {} // violation 'Nested if-else depth is 5'
               else {}
             }
           }


### PR DESCRIPTION
issue: https://github.com/checkstyle/checkstyle/issues/20954

Updated NestedIfDepth xdoc examples to use the new violation message format.

Changes:
- Updated NestedIfDepth Example1 and Example2 xdoc examples.
- Replaced outdated violation comments with the current expected violation message format.

Verification:
- ./mvnw clean verify