### PR TITLE
Issue #21059: Fix ANTLR report PR sources and add project argument

### DIFF
--- a/.github/workflows/antlr-report.yml
+++ b/.github/workflows/antlr-report.yml
@@ -2,8 +2,10 @@
 # GitHub Action to generate Checkstyle ANTLR Regression Report (AST diff).
 #
 # Workflow starts when:
-# 1) issue comment - created or edited - with body exactly:
-#    "GitHub, generate ANTLR report"
+# 1) issue comment - created or edited - with body:
+#    "GitHub, generate ANTLR report" - self-test, AST diff over Checkstyle sources
+#    "GitHub, generate ANTLR report for <project-name>" - AST diff over sources of
+#      a project from config/projects-to-test/*-projects-to-test-on.config
 #
 # Requirements:
 # 1) secrets.AWS_ACCESS_KEY_ID - access key for AWS S3 service user
@@ -31,7 +33,8 @@ concurrency:
 jobs:
   make_report:
     if: github.event.issue.pull_request != null
-        && github.event.comment.body == 'GitHub, generate ANTLR report'
+        && (github.event.comment.body == 'GitHub, generate ANTLR report'
+            || startsWith(github.event.comment.body, 'GitHub, generate ANTLR report for '))
     runs-on: ubuntu-latest
     outputs:
       message: ${{ steps.out.outputs.message }}
@@ -64,9 +67,26 @@ jobs:
               -o .ci-temp/info.json
 
           BRANCH=$(jq --raw-output .head.ref .ci-temp/info.json)
-          COMMIT_SHA=$(jq --raw-output .head.sha .ci-temp/info.json | cut -c 1-7)
+          FULL_SHA=$(jq --raw-output .head.sha .ci-temp/info.json)
           ./.ci/append-to-github-output.sh "ref" "$BRANCH"
-          ./.ci/append-to-github-output.sh "commit_sha" "$COMMIT_SHA"
+          ./.ci/append-to-github-output.sh "full_sha" "$FULL_SHA"
+          ./.ci/append-to-github-output.sh "commit_sha" "$(echo "$FULL_SHA" | cut -c 1-7)"
+
+      - name: Parse project from comment
+        id: project
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          PATTERN='^GitHub, generate ANTLR report for ([a-zA-Z0-9-]+)[[:space:]]*$'
+          if [ "$COMMENT_BODY" = 'GitHub, generate ANTLR report' ]; then
+            PROJECT=checkstyle
+          elif [[ "$COMMENT_BODY" =~ $PATTERN ]]; then
+            PROJECT=$(echo "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')
+          else
+            echo "Could not parse project name from comment"
+            exit 1
+          fi
+          ./.ci/append-to-github-output.sh "name" "$PROJECT"
 
       - name: Set upstream and forked remotes
         run: |
@@ -103,6 +123,8 @@ jobs:
       - name: Generate ANTLR report
         env:
           BRANCH: ${{ steps.branch.outputs.ref }}
+          FULL_SHA: ${{ steps.branch.outputs.full_sha }}
+          PROJECT_NAME: ${{ steps.project.outputs.name }}
         run: |
           cd .ci-temp/contribution/checkstyle-tester
 
@@ -129,8 +151,21 @@ jobs:
 
           mkdir -p "$RUNNER_TEMP/launch_diff"
 
-          echo "checkstyle|git|https://github.com/$USER_LOGIN/checkstyle.git|$BRANCH||" \
-            > projects-to-test-on.properties
+          if [ "$PROJECT_NAME" = "checkstyle" ]; then
+            echo "checkstyle|git|https://github.com/$USER_LOGIN/checkstyle.git|$FULL_SHA||" \
+              > projects-to-test-on.properties
+          else
+            CONFIGS_DIR="$GITHUB_WORKSPACE/config/projects-to-test"
+            ENTRY=$(grep -h --no-messages "^$PROJECT_NAME|" \
+              "$CONFIGS_DIR"/*-projects-to-test-on.config | head -n 1)
+            if [ -z "$ENTRY" ]; then
+              echo "Unknown project '$PROJECT_NAME'. Valid project names:"
+              grep -h --no-messages -v '^#' "$CONFIGS_DIR"/*-projects-to-test-on.config \
+                | cut -d '|' -f 1 | grep -v '^$' | sort -u
+              exit 1
+            fi
+            echo "$ENTRY" > projects-to-test-on.properties
+          fi
 
           export MAVEN_OPTS="-Xmx5g"
           bash ./launch_diff_antlr.sh "$BRANCH"


### PR DESCRIPTION
Issue #21059

Part 1: the 4th field of `projects-to-test-on.properties` is consumed by `launch_diff_antlr.sh` as `git reset --hard $COMMIT_ID` after a fresh clone, where a bare branch name does not resolve. The failed reset was silently ignored and the AST diff ran over the fork's default branch instead of the PR head. Writing the full head SHA makes the reset deterministic and pins the scanned sources to the exact commit being reported on.

Part 2: `GitHub, generate ANTLR report for <project-name>` runs the AST diff over an external project's sources, resolved from `config/projects-to-test/*-projects-to-test-on.config` (e.g. `openjdk25`). The bare command stays the default self-test. Unknown names fail with the list of valid projects in the job log.