### PR TITLE
Fix validation message for IllegalType in InputIllegalType tests

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -303,8 +303,6 @@ public final class InlineConfigParser {
      */
     private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of(
             "checks/coding/equalshashcode/Example1.java",
-            "checks/coding/illegaltype/InputIllegalTypeTestDefaults.java",
-            "checks/coding/illegaltype/InputIllegalTypeEmptyStringMemberModifiers.java",
             "checks/coding/illegaltype/InputIllegalTypeTestExtendsImplements.java",
             "checks/coding/illegaltype/InputIllegalTypeTestFormat.java",
             "checks/coding/illegaltype/InputIllegalTypeTestGenerics.java",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeEmptyStringMemberModifiers.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeEmptyStringMemberModifiers.java
@@ -32,8 +32,8 @@ public class InputIllegalTypeEmptyStringMemberModifiers implements InputIllegalT
     private class NotAnAbstractClass {}
 
     private java.util.TreeSet table1() { return null; }
-    // violation above 'Usage of type 'java.util.TreeSet' is not allowed'
-    private TreeSet table2() { return null; } // violation 'Usage of type TreeSet is not allowed'.
+    // violation above "Usage of type 'java.util.TreeSet' is not allowed."
+    private TreeSet table2() { return null; } // violation "Usage of type 'TreeSet' is not allowed."
     static class SomeStaticClass {
 
     }
@@ -58,9 +58,9 @@ public class InputIllegalTypeEmptyStringMemberModifiers implements InputIllegalT
 }
 
 interface InputIllegalTypeSuperEmptyStringMemberModifiers {
-    void foo(HashMap<?, ?> buffer); // violation 'Usage of type TreeSet is not allowed'.
+    void foo(HashMap<?, ?> buffer); // violation "Usage of type 'HashMap' is not allowed."
 
-    HashMap<?, ?> foo(); // violation 'Usage of type TreeSet is not allowed'.
+    HashMap<?, ?> foo(); // violation "Usage of type 'HashMap' is not allowed."
 
     Object bar();
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestDefaults.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestDefaults.java
@@ -32,9 +32,9 @@ public class InputIllegalTypeTestDefaults implements InputIllegalTypeSuper {
     private class NotAnAbstractClass {}
 
     private java.util.TreeSet table1() { return null; }
-    // violation above 'Usage of type 'java.util.TreeSet' is not allowed'
+    // violation above "Usage of type 'java.util.TreeSet' is not allowed."
     private TreeSet table2() { return null; }
-    // violation above 'Usage of type 'TreeSet' is not allowed'
+    // violation above "Usage of type 'TreeSet' is not allowed."
     static class SomeStaticClass {
 
     }
@@ -59,9 +59,9 @@ public class InputIllegalTypeTestDefaults implements InputIllegalTypeSuper {
 }
 
 interface InputIllegalTypeSuperTestDefaults {
-    void foo(HashMap<?, ?> buffer); // violation 'Usage of type HashMap is not allowed'.
+    void foo(HashMap<?, ?> buffer); // violation "Usage of type 'HashMap' is not allowed."
 
-    HashMap<?, ?> foo(); // violation 'Usage of type HashMap is not allowed'.
+    HashMap<?, ?> foo(); // violation "Usage of type 'HashMap' is not allowed."
 
     Object bar();
 }


### PR DESCRIPTION
Issue #20954: Fix test expectation for InputIllegalTypeEmptyStringMemberModifiers and InputIllegalTypeTestDefaults