### PR TITLE
Issue #11163: Move EscapedUnicodeCharacters array from suppressions that should be fixed

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -258,6 +258,8 @@
     files="/it/resources/com/google/checkstyle/test/.*/.*/.*\.java"/>
   <suppress checks="FileLength"
     files="/it/resources-noncompilable/com/google/checkstyle/test/.*/.*/.*\.java"/>
+  <suppress checks="FileLength"
+    files="/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersAllEscapedUnicodeCharacters\.java"/>
 
   <!-- Until https://github.com/checkstyle/checkstyle/issues/11163 -->
   <suppress checks="FileLength"
@@ -278,8 +280,6 @@
     files="/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeJavadoc\.java"/>
   <suppress checks="FileLength"
     files="/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeJavadoc_3\.java"/>
-  <suppress checks="FileLength"
-    files="/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersAllEscapedUnicodeCharacters\.java"/>
   <suppress checks="FileLength"
     files="/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/filelength/InputFileLength2\.java"/>
   <suppress checks="FileLength"


### PR DESCRIPTION
Issue: #11163

Moved `InputAvoidEscapedUnicodeCharactersAllEscapedUnicodeCharacters` to `intentional problem for testing` from suppressions that should be fixed