### PR TITLE
Issue #21071: Dedicated WriteTag missing/format message keys

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
@@ -55,7 +55,7 @@ public class WriteTagCheck extends AbstractJavadocCheck {
      * A key is pointing to the warning message text in "messages.properties"
      * file.
      */
-    public static final String MSG_MISSING_TAG = "type.missingTag";
+    public static final String MSG_MISSING_TAG = "writetag.missingTag";
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -67,7 +67,7 @@ public class WriteTagCheck extends AbstractJavadocCheck {
      * A key is pointing to the warning message text in "messages.properties"
      * file.
      */
-    public static final String MSG_TAG_FORMAT = "type.tagFormat";
+    public static final String MSG_TAG_FORMAT = "writetag.tagFormat";
 
     /** Specify the regexp to match tag content. */
     private Pattern tagFormat;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -37,3 +37,5 @@ tag.continuation.indent=Line continuation have incorrect indentation level, expe
 type.missingTag=Type Javadoc comment is missing {0} tag.
 type.missingTagWithQuotes=Type Javadoc comment is missing {0} ''{1}'' tag.
 type.tagFormat=Type Javadoc tag {0} must match pattern ''{1}''.
+writetag.missingTag=Javadoc comment is missing {0} tag.
+writetag.tagFormat=Javadoc tag {0} must match pattern ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -37,3 +37,5 @@ tag.continuation.indent=Fortsetzung der Zeile hat falsche Einrückungstiefe (erw
 type.missingTag=Im Javadoc des Typs fehlt das Tag {0}.
 type.missingTagWithQuotes=Im Javadoc des Typs fehlt das Tag {0} ''{1}''.
 type.tagFormat=Das Tag {0} im Javadoc des Typs muss dem Muster ''{1}'' entsprechen.
+writetag.missingTag=Im Javadoc fehlt das Tag {0}.
+writetag.tagFormat=Das Tag {0} im Javadoc muss dem Muster ''{1}'' entsprechen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -37,3 +37,5 @@ tag.continuation.indent=La continuación de la línea tiene un nivel de sangría
 type.missingTag=El comentario Javadoc del tipo falta una etiqueta ''{0}''.
 type.missingTagWithQuotes=El comentario Javadoc del tipo falta una etiqueta ''{0}'' ''{1}''.
 type.tagFormat=El formato de la etiqueta Javadoc ''{0}'' debería coincidir con el patrón ''{1}''.
+writetag.missingTag=El comentario Javadoc falta una etiqueta ''{0}''.
+writetag.tagFormat=El formato de la etiqueta Javadoc ''{0}'' debería coincidir con el patrón ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -37,3 +37,5 @@ tag.continuation.indent=Jatkorivin on väärä sisennystason, odotettu taso olis
 type.missingTag=Javadoc-kommentista puuttuu {0}-tagi.
 type.missingTagWithQuotes=Javadoc-kommentista puuttuu {0} ''{1}'' -tagi.
 type.tagFormat=Javadoc-tagin {0} pitää olla mallin ''{1}'' mukainen.
+writetag.missingTag=Javadoc-kommentista puuttuu {0}-tagi.
+writetag.tagFormat=Javadoc-tagin {0} pitää olla mallin ''{1}'' mukainen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -37,3 +37,5 @@ tag.continuation.indent=La continuation de la ligne a un niveau d''indentation i
 type.missingTag=Dans le commentaire Javadoc de la classe, il manque une balise {0}.
 type.missingTagWithQuotes=Dans le commentaire Javadoc de la classe, il manque une balise {0} ''{1}''.
 type.tagFormat=La balise Javadoc {0} doit correspondre au motif ''{1}''.
+writetag.missingTag=Dans le commentaire Javadoc, il manque une balise {0}.
+writetag.tagFormat=La balise Javadoc {0} doit correspondre au motif ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -37,3 +37,5 @@ tag.continuation.indent=行継続のインデントのレベルが間違って�
 type.missingTag=クラスの Javadoc コメントに {0} タグがありません。
 type.missingTagWithQuotes=クラスの Javadoc コメントに {0} ''{1}'' タグがありません。
 type.tagFormat=クラスの Javadoc タグ {0} はパターン ''{1}'' に合致しなければなりません。
+writetag.missingTag=Javadoc コメントに {0} タグがありません。
+writetag.tagFormat=Javadoc タグ {0} はパターン ''{1}'' に合致しなければなりません。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -37,3 +37,5 @@ tag.continuation.indent=Continuação de linha têm um nível de indentação in
 type.missingTag=O comentário Javadoc do tipo está com uma tag {0} faltando.
 type.missingTagWithQuotes=O comentário Javadoc do tipo está com uma tag {0} ''{1}'' faltando.
 type.tagFormat=O formato da tag Javadoc {0} deveria condizer com o padrão ''{1}''
+writetag.missingTag=O comentário Javadoc está com uma tag {0} faltando.
+writetag.tagFormat=O formato da tag Javadoc {0} deveria condizer com o padrão ''{1}''

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ru.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ru.properties
@@ -37,3 +37,5 @@ tag.continuation.indent=Неправильный уровень отступа �
 type.missingTag=Отсутствует тег {0}.
 type.missingTagWithQuotes=Отсутствует тег {0} ''{1}''.
 type.tagFormat=Тег {0} должен соответствовать ''{1}''.
+writetag.missingTag=Отсутствует тег {0}.
+writetag.tagFormat=Тег {0} должен соответствовать ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -37,3 +37,5 @@ tag.continuation.indent=Çizgi devamı yanlış girinti düzeyine sahip, beklene
 type.missingTag=Tür için yazılan Javadoc açıklamasında {0} etiketi eksik.
 type.missingTagWithQuotes=Tür için yazılan Javadoc açıklamasında {0} ''{1}'' etiketi eksik.
 type.tagFormat=Tür için yazılan {0} Javadoc etiketi şu kalıpta olmalı: ''{1}''.
+writetag.missingTag=Javadoc açıklamasında {0} etiketi eksik.
+writetag.tagFormat={0} Javadoc etiketi şu kalıpta olmalı: ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -37,3 +37,5 @@ tag.continuation.indent=Javadoc 缩进级别错误，应为 {0} 个缩进符。
 type.missingTag=缺少 {0} 标签。
 type.missingTagWithQuotes=缺少 {0} ''{1}'' 标签。
 type.tagFormat=标签 {0} 必须匹配： ''{1}'' 。
+writetag.missingTag=缺少 {0} 标签。
+writetag.tagFormat=标签 {0} 必须匹配： ''{1}'' 。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/WriteTagCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/WriteTagCheck.xml
@@ -41,8 +41,8 @@
             <message-key key="javadoc.parse.rule.error"/>
             <message-key key="javadoc.unclosedHtml"/>
             <message-key key="javadoc.writeTag"/>
-            <message-key key="type.missingTag"/>
-            <message-key key="type.tagFormat"/>
+            <message-key key="writetag.missingTag"/>
+            <message-key key="writetag.tagFormat"/>
          </message-keys>
       </check>
    </module>

--- a/src/site/xdoc/checks/javadoc/writetag.xml
+++ b/src/site/xdoc/checks/javadoc/writetag.xml
@@ -169,7 +169,7 @@ public class Example1 {
  *
  */
 public class Example2 {
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
   /**
    * some doc
    * @since
@@ -219,7 +219,7 @@ public class Example2 {
  *
  */
 public class Example3 {
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
   /**
    * some doc
    * @since
@@ -240,7 +240,7 @@ public class Example3 {
   // violation 3 lines above 'Javadoc tag @since=1.1-beta'
   /** some doc */
   public void testMethod2() {}
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -274,13 +274,13 @@ public class Example3 {
  *
  */
 public class Example4 {
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
   /**
    * some doc
    * @since
    */
   void testMethod1() {}
-  // violation 3 lines above 'Type Javadoc tag @since'
+  // violation 3 lines above 'Javadoc tag @since must match pattern'
   /**
    * some doc
    * @since 1.6
@@ -292,10 +292,10 @@ public class Example4 {
    * @since 1.1-beta
    */
   void testMethod1WithAlphaSince() {}
-  // violation 3 lines above 'Type Javadoc tag @since'
+  // violation 3 lines above 'Javadoc tag @since must match pattern'
   /** some doc */
   public void testMethod2() {}
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example5-config">
@@ -327,13 +327,13 @@ public class Example4 {
  *
  */
 public class Example5 {
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
   /**
    * some doc
    * @since
    */
   void testMethod1() {}
-  // violation 3 lines above 'Type Javadoc tag @since must match pattern'
+  // violation 3 lines above 'Javadoc tag @since must match pattern'
   /**
    * some doc
    * @since 1.6
@@ -345,10 +345,10 @@ public class Example5 {
    * @since 1.1-beta
    */
   void testMethod1WithAlphaSince() {}
-  // violation 3 lines above 'Type Javadoc tag @since must match pattern'
+  // violation 3 lines above 'Javadoc tag @since must match pattern'
   /** some doc */
   public void testMethod2() {}
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
 }
 </code></pre></div>
       </subsection>
@@ -365,7 +365,7 @@ public class Example5 {
       "com.puppycrawl.tools.checkstyle.filters.SuppressionSingleFilter"&gt;
     &lt;property name="checks" value="WriteTag"/&gt;
     &lt;property name="message"
-              value="^Type Javadoc comment is missing @author tag\.$"/&gt;
+              value="^Javadoc comment is missing @author tag\.$"/&gt;
   &lt;/module&gt;
 
   &lt;module name="TreeWalker"&gt;
@@ -429,13 +429,13 @@ public class UseCase1 {
             </a>
           </li>
           <li>
-            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22type.missingTag%22">
-              type.missingTag
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22writetag.missingTag%22">
+              writetag.missingTag
             </a>
           </li>
           <li>
-            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22type.tagFormat%22">
-              type.tagFormat
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22writetag.tagFormat%22">
+              writetag.tagFormat
             </a>
           </li>
         </ul>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -115,6 +115,15 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testMissingTagOnMethod() throws Exception {
+        final String[] expected = {
+            "17: " + getCheckMessage(MSG_MISSING_TAG, "@since"),
+        };
+        verifyWithInlineConfigParserTwice(
+                getPath("InputWriteTagMissingTagMethod.java"), expected);
+    }
+
+    @Test
     public void testInterface() throws Exception {
         final String[] expected = {
             "16: " + getCheckMessage(MSG_WRITE_TAG, "@author", "Daniel Grenner"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/ExpectedWriteTagResetSeverity.txt
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/ExpectedWriteTagResetSeverity.txt
@@ -1,4 +1,4 @@
 Starting audit...
 [WARN] src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagResetSeverity.java:16: Javadoc tag @author=Mohanad [WriteTag]
-[ERROR] src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagResetSeverity.java:17: Type Javadoc tag @author must match pattern 'Mohanad'. [WriteTag]
+[ERROR] src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagResetSeverity.java:17: Javadoc tag @author must match pattern 'Mohanad'. [WriteTag]
 Audit done.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMissingTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMissingTag.java
@@ -18,7 +18,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
  * @doubletag second text
  * @emptytag
  */
-class InputWriteTagMissingTag // violation 'Type Javadoc comment is missing @missingtag tag.*'
+class InputWriteTagMissingTag // violation 'Javadoc comment is missing @missingtag tag.*'
 {
     /**
      * @todo Add a constructor comment

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMissingTagMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagMissingTagMethod.java
@@ -1,0 +1,26 @@
+/*
+WriteTag
+tag = @since
+tagFormat = (default)null
+tagSeverity = ignore
+tokens = METHOD_DEF
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
+
+class InputWriteTagMissingTagMethod {
+    // violation 2 lines below 'Javadoc comment is missing @since tag.'
+    /** some doc */
+    void methodWithoutSince() {
+    }
+
+    /**
+     * some doc
+     * @since 1.0
+     */
+    void methodWithSince() {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagRecordsAndCompactCtors.java
@@ -15,7 +15,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 
 public class InputWriteTagRecordsAndCompactCtors {
 
-    // violation 2 lines below 'Type Javadoc tag @incomplete must match pattern '\\S''
+    // violation 2 lines below 'Javadoc tag @incomplete must match pattern '\\S''
     /**
      * @incomplete
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTwoClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/InputWriteTagTwoClasses.java
@@ -18,7 +18,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
 class InputWriteTagTwoClasses {
 }
 
-// violation 4 lines below 'Type Javadoc comment is missing @incomplete tag.'
+// violation 4 lines below 'Javadoc comment is missing @incomplete tag.'
 /**
  * No incomplete tag here.
  */

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example2.java
@@ -16,7 +16,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
  *
  */
 public class Example2 {
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
   /**
    * some doc
    * @since

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example3.java
@@ -19,7 +19,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
  *
  */
 public class Example3 {
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
   /**
    * some doc
    * @since
@@ -40,6 +40,6 @@ public class Example3 {
   // violation 3 lines above 'Javadoc tag @since=1.1-beta'
   /** some doc */
   public void testMethod2() {}
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example4.java
@@ -21,13 +21,13 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
  *
  */
 public class Example4 {
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
   /**
    * some doc
    * @since
    */
   void testMethod1() {}
-  // violation 3 lines above 'Type Javadoc tag @since'
+  // violation 3 lines above 'Javadoc tag @since must match pattern'
   /**
    * some doc
    * @since 1.6
@@ -39,9 +39,9 @@ public class Example4 {
    * @since 1.1-beta
    */
   void testMethod1WithAlphaSince() {}
-  // violation 3 lines above 'Type Javadoc tag @since'
+  // violation 3 lines above 'Javadoc tag @since must match pattern'
   /** some doc */
   public void testMethod2() {}
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/Example5.java
@@ -21,13 +21,13 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.writetag;
  *
  */
 public class Example5 {
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
   /**
    * some doc
    * @since
    */
   void testMethod1() {}
-  // violation 3 lines above 'Type Javadoc tag @since must match pattern'
+  // violation 3 lines above 'Javadoc tag @since must match pattern'
   /**
    * some doc
    * @since 1.6
@@ -39,9 +39,9 @@ public class Example5 {
    * @since 1.1-beta
    */
   void testMethod1WithAlphaSince() {}
-  // violation 3 lines above 'Type Javadoc tag @since must match pattern'
+  // violation 3 lines above 'Javadoc tag @since must match pattern'
   /** some doc */
   public void testMethod2() {}
-  // violation 1 lines above 'Type Javadoc comment is missing @since tag.'
+  // violation 1 lines above 'Javadoc comment is missing @since tag.'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/writetag/UseCase1.java
@@ -4,7 +4,7 @@
       "com.puppycrawl.tools.checkstyle.filters.SuppressionSingleFilter">
     <property name="checks" value="WriteTag"/>
     <property name="message"
-              value="^Type Javadoc comment is missing @author tag\.$"/>
+              value="^Javadoc comment is missing @author tag\.$"/>
   </module>
 
   <module name="TreeWalker">


### PR DESCRIPTION
Issue: #21071

WriteTag accepts non-type tokens (`METHOD_DEF`, `CTOR_DEF`, ...), but missing-tag /
tag-format messages said "Type Javadoc ...", which is misleading on methods and
other members.

## Summary
- WriteTag uses dedicated keys: `writetag.missingTag` / `writetag.tagFormat` (token-agnostic wording)
- Leave `type.missingTag` / `type.tagFormat` unchanged for JavadocType only (no shared message reuse)
- Meta, site xdoc, examples, and method missing-tag coverage updated for WriteTag

## Test plan
- [x] `mvn -Dtest=WriteTagCheckTest,WriteTagCheckExamplesTest,JavadocTypeCheckTest,JavadocTypeCheckExamplesTest,CommitValidationTest test`