### PR TITLE
Issue #21054: Rename Doc to Prop for properties in Search Bar

### DIFF
--- a/src/site/resources/js/search.js
+++ b/src/site/resources/js/search.js
@@ -7,16 +7,18 @@
     var resultsContainer   = null;
     var searchInput        = null;
     var TYPE_COLORS = {
-        "Check":       "#c00",
+        "Check":       "#cc0000",
         "Filter":      "#2e7d32",
         "File Filter": "#1565c0",
-        "General":     "#555"
+        "Property":    "#7b5ea7",
+        "General":     "#555555"
     };
 
     var TYPE_LABELS = {
         "Check":       "Check",
         "Filter":      "Filter",
         "File Filter": "File Filter",
+        "Property":    "Prop",
         "General":     "Doc"
     };
     var debounceTimer = null;


### PR DESCRIPTION
#21054 

Property entries in the search bar showed "Doc" badge instead of "Prop". `TYPE_LABELS` in `search.js` had no explicit entry for `"Property"` type, so it fell through to the `"General"` default "Doc".

Additionally, "Check" and "Doc" badge boxes were invisible caused by 3-digit hex colors (`#c00`, `#555`) having opacity suffixes appended (`#c0018`, `#55518`), producing invalid CSS. Only 6-digit hex colors (`#2e7d32`, `#1565c0`) rendered the badge box correctly.

## Fix
`search.js` — two changes:

1. Added explicit `"Property": "Prop"` entry to `TYPE_LABELS`
2. Expanded 3-digit hex to 6-digit in `TYPE_COLORS`:
   - `#c00` → `#cc0000`
   - `#555` → `#555555`
   
   
## Result

<img width="551" height="472" alt="image" src="https://github.com/user-attachments/assets/49cc0dab-64bf-4485-af3c-51d45c4a3916" />
