### PR TITLE
Issue #21089: Search: exclude Example [code] results from index and a…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
@@ -181,18 +181,6 @@ public final class SearchIndexGenerator {
     /** Exception message prefix used when an XDoc file fails to parse. */
     private static final String PARSE_FAILURE_MSG = "Failed to parse XDoc file: ";
 
-    /**
-     * Suffix label appended to example titles for configuration snippets.
-     * Yields e.g. "AnnotationLocation: Example1 [config]".
-     */
-    private static final String EXAMPLE_LABEL_CONFIG = " [config]";
-
-    /**
-     * Suffix label appended to example titles for Java code examples.
-     * Yields e.g. "AnnotationLocation: Example1 [code]".
-     */
-    private static final String EXAMPLE_LABEL_CODE = " [code]";
-
     /** Magic number for minimum word length. */
     private static final int MIN_WORD_LENGTH = 2;
 
@@ -245,7 +233,7 @@ public final class SearchIndexGenerator {
      * </ul>
      */
     private static final Pattern EXAMPLE_PARAGRAPH_ID =
-            Pattern.compile("^(Example\\d+)-(config|code)$");
+            Pattern.compile("^(Example\\d+)-(config)$");
 
     /**
      * Generic section/subsection names that are structurally repeated across
@@ -686,20 +674,12 @@ public final class SearchIndexGenerator {
             final String exampleLabel = matcher.group(1);
             final String exampleType = matcher.group(2);
 
-            final String labelSuffix;
-            if ("config".equals(exampleType)) {
-                labelSuffix = EXAMPLE_LABEL_CONFIG;
-            }
-            else {
-                labelSuffix = EXAMPLE_LABEL_CODE;
-            }
-
             final String introText = WHITESPACE
                     .matcher(paragraph.getTextContent())
                     .replaceAll(SPACE).trim();
 
             final String title = checkName + TITLE_SEPARATOR
-                    + exampleLabel + labelSuffix;
+                    + exampleLabel;
             final String url = baseUrl + ANCHOR_SEPARATOR + id;
             final String description =
                     truncate(introText, MAX_DESCRIPTION_LENGTH);

--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -573,6 +573,35 @@ html {
     transition: background-color 0.15s ease;
 }
 
+#checkstyle-search-input {
+    padding-right: 56px;
+}
+
+#checkstyle-search-kbd {
+    box-sizing: border-box;
+    position: absolute;
+    right: 8px;
+    top: 40%;
+    margin-top: -10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    line-height: 1;
+    padding: 0;
+    font-size: 11px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-weight: 600;
+    color: #888;
+    background: #f2f2f2;
+    border: 1px solid #d8d8d8;
+    border-radius: 4px;
+    box-shadow: inset 0 -1px 0 rgba(0,0,0,0.04);
+    cursor: default;
+    user-select: none;
+}
+
 #checkstyle-search-clear:hover {
     background-color: #e0e0e0;
     color: #333;
@@ -713,7 +742,11 @@ html {
 #checkstyle-search-results::-webkit-scrollbar-thumb:hover { background: #bbb; }
 
 @media screen and (max-width: 823px) {
+    #checkstyle-search-kbd {
+        display: none !important;
+    }
     #checkstyle-search-input {
+        padding-right: 32px;
         font-size: 16px;
     }
     #checkstyle-search-results {

--- a/src/site/resources/js/search.js
+++ b/src/site/resources/js/search.js
@@ -6,6 +6,7 @@
     var focusedResultIndex = -1;
     var resultsContainer   = null;
     var searchInput        = null;
+    var kbdBadge            = null;
     var TYPE_COLORS = {
         "Check":       "#cc0000",
         "Filter":      "#2e7d32",
@@ -73,6 +74,12 @@
         searchInput.setAttribute("aria-expanded",    "false");
         searchInput.setAttribute("role",             "combobox");
 
+        kbdBadge = document.createElement("span");
+        kbdBadge.id = "checkstyle-search-kbd";
+        kbdBadge.textContent = "S";
+        kbdBadge.setAttribute("aria-hidden", "true");
+        kbdBadge.title = "Press S to search";
+
         var clearBtn = document.createElement("button");
         clearBtn.id = "checkstyle-search-clear";
         clearBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" '
@@ -94,9 +101,11 @@
             clearBtn.style.display = "none";
             hideResults();
             searchInput.focus();
+            updateKbdVisibility();
         });
 
         posWrap.appendChild(searchInput);
+        posWrap.appendChild(kbdBadge);
         posWrap.appendChild(clearBtn);
         posWrap.appendChild(resultsContainer);
         wrapper.appendChild(posWrap);
@@ -106,6 +115,7 @@
         searchInput.addEventListener("input",   onInput);
         searchInput.addEventListener("keydown", onKeyDown);
         searchInput.addEventListener("focus",   onFocus);
+        searchInput.addEventListener("blur",    updateKbdVisibility);
 
         document.addEventListener("click", function (e) {
             if (!wrapper.contains(e.target)) { hideResults(); }
@@ -120,6 +130,19 @@
                 searchInput.select();
             }
         });
+
+        updateKbdVisibility();
+    }
+
+    /**
+     * Shows the "S" keyboard-shortcut badge only when the field is empty and unfocused;
+     * hides it once the user focuses the input or has typed something (so it never
+     * collides with the clear button).
+     */
+    function updateKbdVisibility() {
+        if (!kbdBadge || !searchInput) { return; }
+        var show = document.activeElement !== searchInput && searchInput.value.length === 0;
+        kbdBadge.style.display = show ? "flex" : "none";
     }
 
     /**
@@ -421,6 +444,7 @@
         if (clearBtn) {
             clearBtn.style.display = query.length > 0 ? "flex" : "none";
         }
+        updateKbdVisibility();
 
         debounceTimer = setTimeout(function() {
             if (query.length < MIN_QUERY_LENGTH) {
@@ -442,6 +466,7 @@
      */
     function onFocus() {
         ensureIndexLoaded();
+        updateKbdVisibility();
         var query = searchInput.value.trim();
         if (query.length >= MIN_QUERY_LENGTH && resultsContainer.innerHTML !== "") {
             showResults();


### PR DESCRIPTION
#21089

### Fix
**SearchIndexGenerator.java:**
- `EXAMPLE_PARAGRAPH_ID` pattern changed to match only `-config` paragraphs, excluding `-code` paragraphs from the index entirely
- `EXAMPLE_LABEL_CONFIG` suffix removed  titles now read "AnnotationLocation: Example1" instead of "AnnotationLocation: Example1 [config]"
- `EXAMPLE_LABEL_CODE` constant removed (no longer referenced)

**search.js / CSS:**
- Added a small "S" key-shaped badge inside the search input (right-aligned, visible only when the field is empty and unfocused) to passively surface the keyboard shortcut without adding extra explanatory text to the placeholder

### Result
Before: Example [code] results appeared alongside Example [config] results, linking to raw Java with no explanatory context
After: Only Example [config] results appear each has a meaningful intro sentence explaining what configuration is being demonstrated

Before: "press s" shortcut was undiscoverable
After: A visible "S" badge inside the search box hints at the shortcut whenever the field is empty