### PR TITLE
Issue #20794: Make examples of WhitespaceAround compact

### DIFF
--- a/src/site/xdoc/checks/whitespace/whitespacearound.xml
+++ b/src/site/xdoc/checks/whitespace/whitespacearound.xml
@@ -380,51 +380,32 @@ try {
         <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example1() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example1(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () -&gt;{};
-    // 4 violations above:
+    Runnable noop = () -&gt;{ };
+    // 2 violations above:
     //  ''-&gt;' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i &lt; 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i &lt; 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
@@ -443,51 +424,32 @@ class Example1 {
         <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example2() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example2(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () -&gt;{};
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    Runnable noop = () -&gt;{ };
+    // violation above ''{' is not preceded with whitespace'
+
     // ok '-&gt;', '(' and ')' not configured
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i &lt; 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i &lt; 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
@@ -505,51 +467,32 @@ class Example2 {
         <p id="Example3-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example3() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
   //  ''}' is not preceded with whitespace'
-  public Example3(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
-  //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () -&gt;{};
-    // 4 violations above:
+    Runnable noop = () -&gt;{ };
+    // 2 violations above:
     //  ''-&gt;' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i &lt; 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i &lt; 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-
+  void myFunction(){ }
   // ok, allowEmptyMethods is true
-
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
@@ -567,51 +510,32 @@ class Example3 {
         <p id="Example4-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example4 {
-  interface Empty {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example4(){}
-  // violation above ''{' is not preceded with whitespace.
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example4() {}
 
   // ok, allowEmptyConstructors is true
 
   int y = 0;
   void example() {
-    Runnable noop = () -&gt;{};
-    // 4 violations above:
+    Runnable noop = () -&gt;{ };
+    // 2 violations above:
     //  ''-&gt;' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i &lt; 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i &lt; 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example5-config">
@@ -629,51 +553,32 @@ class Example4 {
         <p id="Example5-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example5 {
-  interface Empty {}
-
+  interface Empty{ }
   // ok, allowEmptyTypes is true
-
-  public Example5(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
-  //  ''}' is not preceded with whitespace'
-  int y = 0;
-  void example() {
-    Runnable noop = () -&gt;{};
-    // 4 violations above:
-    //  ''-&gt;' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
-    for (char item: vowels) { }
-    for (int i = 0; i &lt; 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
-    switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
-    }
-  }
-  void myFunction() {}
+  public Example5() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
   //  ''}' is not preceded with whitespace'
+  int y = 0;
+  void example() {
+    Runnable noop = () -&gt;{ };
+    // 2 violations above:
+    //  ''-&gt;' is not followed by whitespace'
+    //  ''{' is not preceded with whitespace'
+    try { }
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 0; i &lt; 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
+    switch (y) {
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
+    }
+  }
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example6-config">
@@ -691,51 +596,32 @@ class Example5 {
         <p id="Example6-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example6 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example6() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example6(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () -&gt;{};
-    // 4 violations above:
+    Runnable noop = () -&gt;{ };
+    // 2 violations above:
     //  ''-&gt;' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i &lt; 10; i++){}
-
-    // ok, allowEmptyLoops
-    // is true above
-
-    do {} while (y == 1);
-
+    for (int i = 0; i &lt; 10; i++){ }
     // ok, allowEmptyLoops is true
-
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example7-config">
@@ -753,51 +639,32 @@ class Example6 {
         <p id="Example7-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example7 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example7() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example7(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () -&gt;{};
-    // violation above '-&gt;' is not followed by whitespace.
-
+    Runnable noop = () -&gt;{ };
+    // violation above ''-&gt;' is not followed by whitespace'
     // ok, allowEmptyLambdas
     // is true above
-
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i &lt; 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i &lt; 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example8-config">
@@ -815,51 +682,32 @@ class Example7 {
         <p id="Example8-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example8 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example8() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example8(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () -&gt;{};
-    // 4 violations above:
+    Runnable noop = () -&gt;{ };
+    // 2 violations above:
     //  ''-&gt;' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-
-    // ok, allowEmptyCatches
-    // is true above
-
+    catch (Exception e){ }
+    // ok, allowEmptyCatches is true above
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i &lt; 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i &lt; 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 </code></pre></div>
         <p>
@@ -882,51 +730,32 @@ class Example8 {
         <p id="Example9-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example9 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example9() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example9(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () -&gt;{};
-    // 4 violations above:
+    Runnable noop = () -&gt;{ };
+    // 2 violations above:
     //  ''-&gt;' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { } // violation '':' is not preceded with whitespace'
-    for (int i = 0; i &lt; 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i &lt; 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 </code></pre></div>
         <hr class="example-separator"/>
@@ -945,51 +774,32 @@ class Example9 {
         <p id="Example10-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example10 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example10() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example10(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () -&gt;{};
-    // 4 violations above:
+    Runnable noop = () -&gt;{ };
+    // 2 violations above:
     //  ''-&gt;' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i &lt; 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i &lt; 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-
+      case 1:{ }
       // ok, allowEmptySwitchBlockStatements is true
-
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 </code></pre></div>
       </subsection>

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundExamplesTest.java
@@ -36,27 +36,15 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "11:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "11:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "15:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "15:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "15:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "22:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
-            "22:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "22:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "22:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "29:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "29:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "29:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "36:33: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "36:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "36:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "41:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "41:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "46:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "46:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "52:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "52:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "11:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "13:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "13:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "19:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "19:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "24:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "28:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "31:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "35:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -65,26 +53,14 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "13:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "13:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "24:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "31:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "38:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "43:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "43:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "48:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "48:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "54:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "54:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "13:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "15:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "15:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "33:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "37:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -93,25 +69,14 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "13:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "13:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "24:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "24:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "31:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "38:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "43:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "43:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "48:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "48:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "13:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "15:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "15:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "21:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "33:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -120,25 +85,13 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "13:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "13:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "24:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "24:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "31:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "38:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "43:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "43:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "48:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "48:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "54:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "54:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "13:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "21:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "33:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "37:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
@@ -147,25 +100,14 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "24:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "24:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "31:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "38:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "43:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "43:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "48:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "48:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "54:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "54:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "15:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "15:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "21:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "33:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "37:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);
@@ -174,22 +116,14 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample6() throws Exception {
         final String[] expected = {
-            "13:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "13:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "24:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "24:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "31:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "48:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "48:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "54:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "54:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "13:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "15:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "15:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "21:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "33:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "37:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
 
         verifyWithInlineConfigParser(getPath("Example6.java"), expected);
@@ -198,24 +132,14 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample7() throws Exception {
         final String[] expected = {
-            "13:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "13:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "24:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "31:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "38:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "43:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "43:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "48:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "48:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "54:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "54:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "13:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "15:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "15:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "21:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "33:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "37:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
 
         verifyWithInlineConfigParser(getPath("Example7.java"), expected);
@@ -224,24 +148,14 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample8() throws Exception {
         final String[] expected = {
-            "13:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "13:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "24:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "24:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "38:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "43:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "43:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "48:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "48:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "54:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "54:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "13:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "15:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "15:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "21:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "33:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "37:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
 
         verifyWithInlineConfigParser(getPath("Example8.java"), expected);
@@ -250,28 +164,16 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample9() throws Exception {
         final String[] expected = {
-            "13:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "13:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "17:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "24:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "24:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "31:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "37:19: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "38:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "43:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "43:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "48:15: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "48:16: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "54:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "54:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "13:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "15:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "15:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "21:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "29:19: " + getCheckMessage(MSG_WS_NOT_PRECEDED, ":"),
+            "30:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "33:14: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "37:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
 
         verifyWithInlineConfigParser(getPath("Example9.java"), expected);
@@ -280,25 +182,14 @@ public class WhitespaceAroundExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample10() throws Exception {
         final String[] expected = {
-            "13:19: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "13:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "17:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "17:21: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "17:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "24:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "24:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "24:27: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "31:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "31:25: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "38:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
-            "38:34: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "43:8: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "43:9: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
-            "54:21: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
-            "54:22: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "13:18: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "15:22: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "{"),
+            "15:23: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "}"),
+            "21:24: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, "->"),
+            "21:26: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "26:24: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "30:33: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
+            "37:20: " + getCheckMessage(MSG_WS_NOT_PRECEDED, "{"),
         };
 
         verifyWithInlineConfigParser(getPath("Example10.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example1.java
@@ -8,50 +8,31 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 // xdoc section - start
 class Example1 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example1() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example1(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () ->{};
-    // 4 violations above:
+    Runnable noop = () ->{ };
+    // 2 violations above:
     //  ''->' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i < 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i < 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example10.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example10.java
@@ -10,50 +10,31 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 // xdoc section - start
 class Example10 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example10() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example10(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () ->{};
-    // 4 violations above:
+    Runnable noop = () ->{ };
+    // 2 violations above:
     //  ''->' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i < 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i < 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-
+      case 1:{ }
       // ok, allowEmptySwitchBlockStatements is true
-
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example2.java
@@ -10,50 +10,31 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 // xdoc section - start
 class Example2 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example2() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example2(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () ->{};
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    Runnable noop = () ->{ };
+    // violation above ''{' is not preceded with whitespace'
+
     // ok '->', '(' and ')' not configured
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i < 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i < 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example3.java
@@ -10,50 +10,31 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 // xdoc section - start
 class Example3 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example3() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
   //  ''}' is not preceded with whitespace'
-  public Example3(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
-  //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () ->{};
-    // 4 violations above:
+    Runnable noop = () ->{ };
+    // 2 violations above:
     //  ''->' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i < 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i < 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-
+  void myFunction(){ }
   // ok, allowEmptyMethods is true
-
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example4.java
@@ -10,50 +10,31 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 // xdoc section - start
 class Example4 {
-  interface Empty {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example4(){}
-  // violation above ''{' is not preceded with whitespace.
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example4() {}
 
   // ok, allowEmptyConstructors is true
 
   int y = 0;
   void example() {
-    Runnable noop = () ->{};
-    // 4 violations above:
+    Runnable noop = () ->{ };
+    // 2 violations above:
     //  ''->' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i < 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i < 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example5.java
@@ -10,50 +10,31 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 // xdoc section - start
 class Example5 {
-  interface Empty {}
-
+  interface Empty{ }
   // ok, allowEmptyTypes is true
-
-  public Example5(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
-  //  ''}' is not preceded with whitespace'
-  int y = 0;
-  void example() {
-    Runnable noop = () ->{};
-    // 4 violations above:
-    //  ''->' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
-    for (char item: vowels) { }
-    for (int i = 0; i < 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
-    switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
-    }
-  }
-  void myFunction() {}
+  public Example5() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
   //  ''}' is not preceded with whitespace'
+  int y = 0;
+  void example() {
+    Runnable noop = () ->{ };
+    // 2 violations above:
+    //  ''->' is not followed by whitespace'
+    //  ''{' is not preceded with whitespace'
+    try { }
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
+    char[] vowels = {'a', 'e', 'i', 'o', 'u'};
+    for (char item: vowels) { }
+    for (int i = 0; i < 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
+    switch (y) {
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
+    }
+  }
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example6.java
@@ -10,50 +10,31 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 // xdoc section - start
 class Example6 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example6() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example6(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () ->{};
-    // 4 violations above:
+    Runnable noop = () ->{ };
+    // 2 violations above:
     //  ''->' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i < 10; i++){}
-
-    // ok, allowEmptyLoops
-    // is true above
-
-    do {} while (y == 1);
-
+    for (int i = 0; i < 10; i++){ }
     // ok, allowEmptyLoops is true
-
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example7.java
@@ -10,50 +10,31 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 // xdoc section - start
 class Example7 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example7() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example7(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () ->{};
-    // violation above '->' is not followed by whitespace.
-
+    Runnable noop = () ->{ };
+    // violation above ''->' is not followed by whitespace'
     // ok, allowEmptyLambdas
     // is true above
-
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i < 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i < 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example8.java
@@ -10,50 +10,31 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 // xdoc section - start
 class Example8 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example8() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example8(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () ->{};
-    // 4 violations above:
+    Runnable noop = () ->{ };
+    // 2 violations above:
     //  ''->' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-
-    // ok, allowEmptyCatches
-    // is true above
-
+    catch (Exception e){ }
+    // ok, allowEmptyCatches is true above
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { }
-    for (int i = 0; i < 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i < 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/whitespacearound/Example9.java
@@ -10,50 +10,31 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound;
 // xdoc section - start
 class Example9 {
-  interface Empty {}
+  interface Empty{ }
+  // violation above ''{' is not preceded with whitespace'
+  public Example9() {}
   // 2 violations above:
   //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
-  public Example9(){}
-  // 3 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''{' is not preceded with whitespace'
   //  ''}' is not preceded with whitespace'
   int y = 0;
   void example() {
-    Runnable noop = () ->{};
-    // 4 violations above:
+    Runnable noop = () ->{ };
+    // 2 violations above:
     //  ''->' is not followed by whitespace'
-    //  ''{' is not followed by whitespace'
     //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
     try { }
-    catch (Exception e){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
+    catch (Exception e){ }
+    // violation above ''{' is not preceded with whitespace'
     char[] vowels = {'a', 'e', 'i', 'o', 'u'};
     for (char item: vowels) { } // violation '':' is not preceded with whitespace'
-    for (int i = 0; i < 10; i++){}
-    // 3 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''{' is not preceded with whitespace'
-    //  ''}' is not preceded with whitespace'
-    do {} while (y == 1);
-    // 2 violations above:
-    //  ''{' is not followed by whitespace'
-    //  ''}' is not preceded with whitespace'
+    for (int i = 0; i < 10; i++){ }
+    // violation above ''{' is not preceded with whitespace'
     switch (y) {
-      case 1: {}
-      // 2 violations above:
-      //  ''{' is not followed by whitespace'
-      //  ''}' is not preceded with whitespace'
+      case 1:{ }
+      // violation above ''{' is not preceded with whitespace'
     }
   }
-  void myFunction() {}
-  // 2 violations above:
-  //  ''{' is not followed by whitespace'
-  //  ''}' is not preceded with whitespace'
+  void myFunction(){ }
+  // violation above ''{' is not preceded with whitespace'
 }
 // xdoc section - end


### PR DESCRIPTION
Issue: #20794

- Removed redundant violations and made `WhitespaceAround` examples more compact.
- Updated `WhitespaceAroundExamplesTest` and replaced expected results with `CommonUtil.EMPTY_STRING_ARRAY` in some tests because those example files no longer contain violation comments.
- Added suppressions for `XdocsExamplesAstConsistencyTest` because examples now have a different format.