### PR TITLE
Issue #21097: Website search: remove release notes from index

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGenerator.java
@@ -518,7 +518,8 @@ public final class SearchIndexGenerator {
         final File[] xmlFiles = xdocsDir.listFiles(file -> {
             final String name = file.getName();
             return file.isFile()
-                    && PLAIN_XML.matcher(name).find();
+                    && PLAIN_XML.matcher(name).find()
+                    && !name.startsWith("releasenotes");
         });
 
         if (xmlFiles != null) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/site/SearchIndexGeneratorTest.java
@@ -23,6 +23,8 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -32,6 +34,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -65,6 +68,19 @@ public class SearchIndexGeneratorTest {
 
     /** Name of the field under test on {@link SearchIndexGenerator}. */
     private static final String CATEGORY_FIELD_NAME = "CHECKS_CATEGORY_DISPLAY_NAMES";
+
+    private static String minimalXdoc(String sectionName) {
+        return "<?xml version=\"1.0\"?>\n"
+                + "<document>\n"
+                + "  <body>\n"
+                + "    <section name=\"" + sectionName + "\">\n"
+                + "      <subsection name=\"Description\">\n"
+                + "        <p>Description of " + sectionName + ".</p>\n"
+                + "      </subsection>\n"
+                + "    </section>\n"
+                + "  </body>\n"
+                + "</document>\n";
+    }
 
     @Test
     public void checksCategoryDisplayNamesMatchSidebarNavigation() throws Exception {
@@ -128,6 +144,40 @@ public class SearchIndexGeneratorTest {
             }
         }
         return result;
+    }
+
+    /**
+     * Release note pages ({@code releasenotes.xml},
+     * {@code releasenotes_old_*.xml}) must not appear in the search index.
+     * Before the fix, all plain {@code .xml} files in the xdocs root were
+     * processed without exclusion, causing release note entries to pollute
+     * search results. The fix adds a
+     * {@code !name.startsWith("releasenotes")} predicate in
+     * This test ensures that predicate is never accidentally removed.
+     */
+    @Test
+    public void testReleaseNotesAreExcludedFromSearchIndex(@TempDir Path tempDir) throws Exception {
+        final Path xdocsDir = tempDir.resolve("xdocs");
+        Files.createDirectories(xdocsDir);
+
+        Files.writeString(xdocsDir.resolve("releasenotes.xml"),
+                minimalXdoc("Release 10.21.0"));
+        Files.writeString(xdocsDir.resolve("releasenotes_old_8-0_8-34.xml"),
+                minimalXdoc("Release 8.0 to 8.34"));
+
+        final Path outputFile = tempDir.resolve("search-index.json");
+
+        SearchIndexGenerator.main(
+                xdocsDir.toString(),
+                outputFile.toString()
+        );
+
+        final String output = Files.readString(outputFile);
+
+        assertWithMessage(
+                "Release note pages must not produce entries in the search index")
+                .that(output)
+                .doesNotContain("releasenotes");
     }
 
 }


### PR DESCRIPTION
#21097 

### Fix

Added `!name.startsWith("releasenotes")` predicate to the file filter in `SearchIndexGenerator.processGeneralPages()` so all release note files are excluded during index generation.

### Regression test

Added `testReleaseNotesAreExcludedFromSearchIndex` to `SearchIndexGeneratorTest`.

The test:
- Creates a temp xdocs directory containing both `releasenotes.xml` and `releasenotes_old_*.xml` (covering both naming patterns)
- Runs `SearchIndexGenerator.main()` against that directory
- Asserts the generated JSON contains no entry whose URL or title references "releasenotes"