### PR TITLE
Issue #19764: Move SummaryJavadoc violation comments

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -95,12 +95,6 @@
 
 
   <suppress id="noViolationCommentsInJavadoc"
-            files="/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturn.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturn2.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
-            files="/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnForbidden.java"/>
-  <suppress id="noViolationCommentsInJavadoc"
             files="/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEmptyLineAfterPackageForPackageAst.java"/>
   <suppress id="noViolationCommentsInJavadoc"
             files="/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorJavadocCommentAfterPackage.java"/>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturn.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturn.java
@@ -69,8 +69,8 @@ class InputSummaryJavadocInlineReturn {
     }
 
     // the return tag is empty, which is not allowed
+    // violation 2 lines below 'Summary javadoc is missing.'
     /**
-     // violation below 'Summary javadoc is missing.'
      * {@return}
      */
     int returnNothing() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturn2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturn2.java
@@ -10,8 +10,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
 
 class InputSummaryJavadocInlineReturn2 {
 
+    // violation 2 lines below 'Summary javadoc is missing.'
     /**
-     * // violation below 'Summary javadoc is missing.'
      * {@return <p></p>}
      */
     int returnNothing() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnForbidden.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnForbidden.java
@@ -9,22 +9,22 @@ period = (default).
 package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
 
 public class InputSummaryJavadocInlineReturnForbidden {
+    // violation 2 lines below 'Forbidden summary fragment.'
     /**
-     // violation below 'Forbidden summary fragment.'
      * {@return the nothing}
      */
     int returnNothing() {
         return 0;
     }
+    // violation 2 lines below 'Forbidden summary fragment.'
     /**
-     // violation below 'Forbidden summary fragment.'
      * {@return This method returns something}
      */
     int returnSomething() {
         return 0;
     }
+    // violation 2 lines below 'Forbidden summary fragment.'
     /**
-     // violation below 'Forbidden summary fragment.'
      * {@return This method returns something.}
      */
     int returnSomethingElse() {


### PR DESCRIPTION
Issue: #19764

Moves violation comments outside Javadocs in the three suppressed SummaryJavadoc inputs and removes their matching suppressions.

Validation:
- `./mvnw -Dtest=SummaryJavadocCheckTest test`: 38 tests passed
- `./mvnw clean verify`: BUILD SUCCESS
- `./.ci/test-spelling-unknown-words.sh`: no new words or misspellings