### PR TITLE
Issue #21119: Fix duplicate violation behavior in examples: localvari…

### DIFF
--- a/src/site/xdoc/checks/coding/finallocalvariable.xml
+++ b/src/site/xdoc/checks/coding/finallocalvariable.xml
@@ -180,15 +180,15 @@ class Example3
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
-          An example of how to configure check on local variables and parameters
-          but do not validate loop variables:
+          An example of how to configure the check to validate unnamed variables
+          declared with VARIABLE_DEF:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="FinalLocalVariable"&gt;
-      &lt;property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/&gt;
-      &lt;property name="validateEnhancedForLoopVariable" value="false"/&gt;
+      &lt;property name="tokens" value="VARIABLE_DEF"/&gt;
+      &lt;property name="validateUnnamedVariables" value="true"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -198,15 +198,15 @@ class Example3
 class Example4
 {
   static int foo(int x, int y) {
-    // 2 violations above:
-    // 'Variable 'x' should be declared final'
-    // 'Variable 'y' should be declared final'
-    int _  = 1;
+
+    // ok above, because PARAMETER_DEF is not configured in tokens
+
+    int _  = 1; // violation 'Variable '_' should be declared final'
 
     return x+y;
   }
   public static void main (String []args) {
-    // violation above 'Variable 'args' should be declared final'
+    // ok above, because PARAMETER_DEF is not configured in tokens
     // ok below, because validateEnhancedForLoopVariable is false by default
     for (String i : args) {
       System.out.println(i);

--- a/src/site/xdoc/checks/coding/finallocalvariable.xml.template
+++ b/src/site/xdoc/checks/coding/finallocalvariable.xml.template
@@ -90,8 +90,8 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example4-config">
-          An example of how to configure check on local variables and parameters
-          but do not validate loop variables:
+          An example of how to configure the check to validate unnamed variables
+          declared with VARIABLE_DEF:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -104,8 +104,7 @@ public class XdocsExampleFileTest {
         "checks/naming/methodname/",
         "checks/naming/typename/",
         "checks/nocodeinfile/",
-        "checks/outertypefilename/",
-        "checks/coding/finallocalvariable/"
+        "checks/outertypefilename/"
     );
 
     @Test

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckExamplesTest.java
@@ -66,9 +66,7 @@ public class FinalLocalVariableCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample4() throws Exception {
         final String[] expected = {
-            "18:22: " + getCheckMessage(MSG_KEY, "x"),
-            "18:29: " + getCheckMessage(MSG_KEY, "y"),
-            "26:37: " + getCheckMessage(MSG_KEY, "args"),
+            "22:9: " + getCheckMessage(MSG_KEY, "_"),
             "32:9: " + getCheckMessage(MSG_KEY, "result"),
         };
 

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example4.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/Example4.java
@@ -2,8 +2,8 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="FinalLocalVariable">
-      <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
-      <property name="validateEnhancedForLoopVariable" value="false"/>
+      <property name="tokens" value="VARIABLE_DEF"/>
+      <property name="validateUnnamedVariables" value="true"/>
     </module>
   </module>
 </module>
@@ -16,15 +16,15 @@ package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
 class Example4
 {
   static int foo(int x, int y) {
-    // 2 violations above:
-    // 'Variable 'x' should be declared final'
-    // 'Variable 'y' should be declared final'
-    int _  = 1;
+
+    // ok above, because PARAMETER_DEF is not configured in tokens
+
+    int _  = 1; // violation 'Variable '_' should be declared final'
 
     return x+y;
   }
   public static void main (String []args) {
-    // violation above 'Variable 'args' should be declared final'
+    // ok above, because PARAMETER_DEF is not configured in tokens
     // ok below, because validateEnhancedForLoopVariable is false by default
     for (String i : args) {
       System.out.println(i);


### PR DESCRIPTION
#21119 

<html>
<body>

Example | tokens | validateEnhancedForLoopVariable | validateUnnamedVariables | Signature
-- | -- | -- | -- | --
1 | (default: VARIABLE_DEF) | (default: false) | (default: false) | 32:result
2 | VARIABLE_DEF,PARAMETER_DEF | (default: false) | (default: false) | 18:x\|18:y\|26:args\|32:result
3 | VARIABLE_DEF | true | (default: false) | 26:i\|32:result
4 | VARIABLE_DEF | false | (default: false) | 32:result ← collides with 1
5 | VARIABLE_DEF,PARAMETER_DEF | (default: false) | true | 18:x\|18:y\|20:_\|26:args\|32:result


<p><code>validateUnnamedVariables</code> only has one example (5), and it's paired with the widest <code>tokens</code> set. Nobody demonstrates <code>validateUnnamedVariables=true</code> on its own with the narrower <code>tokens=VARIABLE_DEF</code> scope that's an actual gap, and a natural fix for Example4.</p>
<h2>Fix</h2>
<pre><code class="language-java">/*xml
&lt;module name="Checker"&gt;
  &lt;module name="TreeWalker"&gt;
    &lt;module name="FinalLocalVariable"&gt;
      &lt;property name="tokens" value="VARIABLE_DEF"/&gt;
      &lt;property name="validateUnnamedVariables" value="true"/&gt;
    &lt;/module&gt;
  &lt;/module&gt;
&lt;/module&gt;
*/
// non-compiled with javac: Compilable with Java25

package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;

// xdoc section - start
class Example4
{
  static int foo(int x, int y) {
    // ok above, because PARAMETER_DEF is not configured in tokens
    int _  = 1; // violation 'Variable '_' should be declared final'

    return x+y;
  }
  public static void main (String []args) {
    // ok above, because PARAMETER_DEF is not configured in tokens
    // ok below, because validateEnhancedForLoopVariable is false by default
    for (String i : args) {
      System.out.println(i);
    }
    int result=foo(1,2); // violation 'Variable 'result' should be declared final'
  }
}
// xdoc section - end
</code></pre>
<h3>Resulting signature: <code>20:_|32:result</code></h3>
<p>Checked against all four siblings — no collision:</p>
<ul>
<li>vs Example1 (<code>32:result</code>) — different, extra <code>20:_</code></li>
<li>vs Example2 (<code>18:x|18:y|26:args|32:result</code>) — different</li>
<li>vs Example3 (<code>26:i|32:result</code>) — different</li>
<li>vs Example5 (<code>18:x|18:y|20:_|26:args|32:result</code>) — different (narrower tokens, so no <code>x</code>/<code>y</code>/<code>args</code>)</li>
</ul>
</body>
</html>