### PR TITLE
Issue #21119: Fix duplicate violation behavior in examples: atclauseo…

### DIFF
--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml
@@ -251,21 +251,28 @@ public class Example3 {
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
-            To configure the check such that it targets only methods:
+            To configure the check such that it targets only classes, with a
+            custom tag order:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AtclauseOrder"&gt;
-      &lt;property name="target" value="METHOD_DEF"/&gt;
+      &lt;property name="target" value="CLASS_DEF"/&gt;
+      &lt;property name="tagOrder"
+                value="@version, @author, @param, @return,
+                       @throws, @exception, @see, @since,
+                       @serial, @serialField, @serialData"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">
-          Example:
+          Results in the following violation, as only the class-level javadoc is
+          checked and its tags do not follow the custom order:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation 5 lines below 'Block tags have to appear in the order'
 /**
 * Some javadoc.
 *
@@ -284,7 +291,7 @@ public class Example3 {
 public class Example4 {
   class Valid implements Serializable {}
 
-  // ok below 'Block tags have to appear in the order'
+  // ok below, ENUM_DEF is not checked because target is CLASS_DEF
   /**
    * Some javadoc.
    *
@@ -304,7 +311,7 @@ public class Example4 {
   public int foo(int a) {
     return a;
   }
-  // violation 5 lines above 'Block tags have to appear in the order'
+  // ok above, METHOD_DEF is not checked because target is CLASS_DEF
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml.template
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml.template
@@ -77,7 +77,8 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example4-config">
-            To configure the check such that it targets only methods:
+            To configure the check such that it targets only classes, with a
+            custom tag order:
         </p>
         <macro name="example">
           <param name="path"
@@ -85,7 +86,8 @@
           <param name="type" value="config"/>
         </macro>
         <p id="Example4-code">
-          Example:
+          Results in the following violation, as only the class-level javadoc is
+          checked and its tags do not follow the custom order:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -98,7 +98,6 @@ public class XdocsExampleFileTest {
     private static final Set<String> SUPPRESSED_UNIQUENESS_CHECK_MODULES = Set.of(
         "checks/coding/magicnumber/",
         "checks/design/onetoplevelclass/",
-        "checks/javadoc/atclauseorder/",
         "checks/javadoc/missingjavadocmethod/",
         "checks/naming/constantname/",
         "checks/naming/methodname/",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckExamplesTest.java
@@ -77,12 +77,12 @@ public class AtclauseOrderCheckExamplesTest extends AbstractExamplesModuleTestSu
 
     @Test
     public void testExample4() throws Exception {
-        final String tagOrder = "[@author, @version, @param, @return"
+        final String tagOrder = "[@version, @author, @param, @return"
             + ", @throws, @exception,"
-            + " @see, @since, @serial, @serialField, @serialData, @deprecated]";
+            + " @see, @since, @serial, @serialField, @serialData]";
 
         final String[] expected = {
-            "48: " + getCheckMessage(MSG_KEY, tagOrder),
+            "23: " + getCheckMessage(MSG_KEY, tagOrder),
         };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example4.java
@@ -2,7 +2,11 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="AtclauseOrder">
-      <property name="target" value="METHOD_DEF"/>
+      <property name="target" value="CLASS_DEF"/>
+      <property name="tagOrder"
+                value="@version, @author, @param, @return,
+                       @throws, @exception, @see, @since,
+                       @serial, @serialField, @serialData"/>
     </module>
   </module>
 </module>
@@ -11,7 +15,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 
 import java.io.Serializable;
 // xdoc section - start
-
+// violation 5 lines below 'Block tags have to appear in the order'
 /**
 * Some javadoc.
 *
@@ -30,7 +34,7 @@ import java.io.Serializable;
 public class Example4 {
   class Valid implements Serializable {}
 
-  // ok below 'Block tags have to appear in the order'
+  // ok below, ENUM_DEF is not checked because target is CLASS_DEF
   /**
    * Some javadoc.
    *
@@ -50,7 +54,6 @@ public class Example4 {
   public int foo(int a) {
     return a;
   }
-  // violation 5 lines above 'Block tags have to appear in the order'
+  // ok above, METHOD_DEF is not checked because target is CLASS_DEF
 }
 // xdoc section - end
-


### PR DESCRIPTION
#21119 

### Summary

`testAllModuleExamplesAreBehaviorallyUnique` flagged `checks/javadoc/atclauseorder/`:

```
Module 'atclauseorder': examples [Example1.java, Example4.java] produce identical violations
(48:Block tags have to appear in the order).
```

This PR fixes the collision and removes `checks/javadoc/atclauseorder/` from `SUPPRESSED_UNIQUENESS_CHECK_MODULES`.

### Root cause

`Example1` uses default `AtclauseOrder` configuration. `Example4` previously set only `target="METHOD_DEF"`, intended to demonstrate that the property scopes the check to method-level javadoc.

Since all examples in this module must share identical code structure only config and `// violation`/`// ok` comments may differ, enforced separately by `XdocsExamplesAstConsistencyTest` and `foo()`'s javadoc (`@return` listed before `@param`) is the only block out of order under the default tag ordering in both configurations, restricting `target` to `METHOD_DEF` alone still landed on the exact same single violation, on the exact same line, as `Example1`. `Example4`'s config difference had no observable effect on output in this shared source.

### Fix

Changed `Example4`'s configuration to `target="CLASS_DEF"` combined with a custom `tagOrder` that lists `@version` before `@author` — the reverse of the order the class-level javadoc block actually uses (`@author` then `@version`). This makes the class-level doc block, which was previously compliant under default ordering, the violating block instead. Both `foo()` and the enum fall entirely out of scope under `target=CLASS_DEF`, so neither is evaluated at all. The result is one violation, on a different declaration and a different line than `Example1`'s.

Updated the `Example4-config`/`Example4-code` prose in `atclauseorder.xml.template` to describe the new configuration intent ("targets only classes, with a custom tag order") and outcome ("results in the following violation, as only the class-level javadoc is checked and its tags do not follow the custom order").

### Files changed

- `src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example4.java`
- `src/site/xdoc/checks/javadoc/atclauseorder.xml.template`
- `src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java` — removed `"checks/javadoc/atclauseorder/"` from `SUPPRESSED_UNIQUENESS_CHECK_MODULES`

### Testing

- Ran `testAllModuleExamplesAreBehaviorallyUnique` locally — `atclauseorder` no longer appears in the failure output.
- Confirmed `Example4.java` remains AST-identical to its siblings (`XdocsExamplesAstConsistencyTest` still passes) — the only diffs are property values and comment text.
- Manually re-verified all four examples (`Example1`–`Example4`) in the directory don't produce any other pairwise collision beyond the one being fixed.
- Rebuilt the site docs locally to confirm the updated `Example4-config`/`Example4-code` prose renders correctly against the new example content.