### PR TITLE
Issue #20954: Quote RegexpSingleline example violation messages

### DIFF
--- a/src/site/xdoc/checks/regexp/regexpsingleline.xml
+++ b/src/site/xdoc/checks/regexp/regexpsingleline.xml
@@ -131,7 +131,7 @@ public class Example2 {
       doSomething();
       System.exit(0);
     } catch (Exception e) {
-      System.exit(1); // violation, as there are more than one occurrence.
+      System.exit(1); // violation 'Line matches the illegal pattern'
     }
   }
 
@@ -358,7 +358,7 @@ public class UseCase1 {
       doSomething();
       System.exit(0);
     } catch (Exception e) {
-      System.exit(1); // violation, as there are more than one occurrence.
+      System.exit(1); // violation 'Line matches the illegal pattern'
     }
   }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -345,8 +345,6 @@ public final class InlineConfigParser {
             "checks/coding/unusedlocalvariable/InputUnusedLocalVariableUnnamedTryCatch.java",
             "checks/imports/avoidstarimport/InputAvoidStarImportExcludes.java",
             "checks/imports/importorder/Example10.java",
-            "checks/regexp/regexpsingleline/Example2.java",
-            "checks/regexp/regexpsingleline/UseCase1.java",
             "checks/sizes/recordcomponentnumber/Example1.java",
             "checks/sizes/recordcomponentnumber/Example2.java",
             "checks/whitespace/separatorwrap/Example1.java",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/Example2.java
@@ -20,7 +20,7 @@ public class Example2 {
       doSomething();
       System.exit(0);
     } catch (Exception e) {
-      System.exit(1); // violation, as there are more than one occurrence.
+      System.exit(1); // violation 'Line matches the illegal pattern'
     }
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/regexp/regexpsingleline/UseCase1.java
@@ -20,7 +20,7 @@ public class UseCase1 {
       doSomething();
       System.exit(0);
     } catch (Exception e) {
-      System.exit(1); // violation, as there are more than one occurrence.
+      System.exit(1); // violation 'Line matches the illegal pattern'
     }
   }
 


### PR DESCRIPTION
Issue: #20954

Quotes the actual RegexpSingleline violation message in Example2 and UseCase1,
then removes both files from `SUPPRESSED_VALIDATE_MESSAGE_FILES`.

Verified with `mvn clean test -Dtest=RegexpSinglelineCheckExamplesTest,RegexpSinglelineCheckTest`
and `mvn clean verify`.