### PR TITLE
Issue #20954: Quote ImportOrder example violation message

### DIFF
--- a/src/site/xdoc/checks/imports/importorder.xml
+++ b/src/site/xdoc/checks/imports/importorder.xml
@@ -495,7 +495,7 @@ import static java.lang.Character.UnicodeBlock.BASIC_LATIN;
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 import static java.lang.Math.PI;
 import static java.io.File.createTempFile;
-import static javax.swing.WindowConstants.*;// violation, should be separated from previous imports
+import static javax.swing.WindowConstants.*;// violation 'should be separated from previous imports.'
 
 import java.net.URL;
 </code></pre></div><hr class="example-separator"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -344,7 +344,6 @@ public final class InlineConfigParser {
                     + "InputUnusedLocalVariablePatternVariablesCondition2.java",
             "checks/coding/unusedlocalvariable/InputUnusedLocalVariableUnnamedTryCatch.java",
             "checks/imports/avoidstarimport/InputAvoidStarImportExcludes.java",
-            "checks/imports/importorder/Example10.java",
             "checks/sizes/recordcomponentnumber/Example1.java",
             "checks/sizes/recordcomponentnumber/Example2.java",
             "checks/whitespace/separatorwrap/Example1.java",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/Example10.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/Example10.java
@@ -15,7 +15,7 @@ package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
 // xdoc section - start
 import static java.lang.Math.PI;
 import static java.io.File.createTempFile;
-import static javax.swing.WindowConstants.*;// violation, should be separated from previous imports
+import static javax.swing.WindowConstants.*;// violation 'should be separated from previous imports.'
 
 import java.net.URL;
 // xdoc section - end


### PR DESCRIPTION
Issue: #20954

## Summary

- replace the unchecked ImportOrder explanation in `Example10.java` with a quoted substring of the actual Checkstyle message
- remove `Example10.java` from the temporary message-validation suppression list
- synchronize the generated ImportOrder xdoc example

## Root cause

The violation comment used an unquoted explanatory phrase. `InlineConfigParser` therefore treated the violation as having no message to validate, and the file required a temporary suppression.

After this change, the parser validates `should be separated from previous imports.` against the message emitted by `ImportOrderCheck`.

## Validation

- `mvnw.cmd -Dtest=ImportOrderCheckExamplesTest test` using JDK 25: 12 tests passed
- `mvnw.cmd verify` using JDK 25: `BUILD SUCCESS`

