### PR TITLE
Issue #20954: Fix IllegalType generics violation messages

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -303,7 +303,6 @@ public final class InlineConfigParser {
      */
     private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of(
             "checks/coding/equalshashcode/Example1.java",
-            "checks/coding/illegaltype/InputIllegalTypeTestGenerics.java",
             "checks/coding/illegaltype/InputIllegalTypeTestIgnoreMethodNames.java",
             "checks/coding/illegaltype/InputIllegalTypeTestEnhancedInstanceof.java",
             "checks/coding/illegaltype/InputIllegalTypeTestLegalAbstractClassNames.java",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestGenerics.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestGenerics.java
@@ -25,44 +25,44 @@ public abstract class InputIllegalTypeTestGenerics {
 
     private Set<Boolean> privateSet;
     private java.util.List<Map<Boolean, Foo>> privateList;
-    public Set<Boolean> set; // violation 'Usage of type Set is not allowed'.
+    public Set<Boolean> set; // violation "Usage of type 'Boolean' is not allowed."
     public java.util.List<Map<Boolean, Foo>> list;
         // 2 violations above:
-        //                    'Usage of type 'Boolean' is not allowed.'
-        //                    'Usage of type 'Foo' is not allowed'
+        //                    "Usage of type 'Boolean' is not allowed."
+        //                    "Usage of type 'Foo' is not allowed."
 
     private void methodCall() {
-        Bounded.<Boolean>foo(); // violation 'Usage of type Boolean is not allowed'.
+        Bounded.<Boolean>foo(); // violation "Usage of type 'Boolean' is not allowed."
         final Consumer<Foo> consumer = Foo<Boolean>::foo;
         // 2 violations above:
-        //                    'Usage of type 'Foo' is not allowed.'
-        //                    'Usage of type 'Boolean' is not allowed'
+        //                    "Usage of type 'Foo' is not allowed."
+        //                    "Usage of type 'Boolean' is not allowed."
     }
 
     public <T extends Boolean, U extends Serializable> void typeParameter(T a) {}
         // 2 violations above:
-        //                    'Usage of type 'Boolean' is not allowed.'
-        //                    'Usage of type 'Serializable' is not allowed'
+        //                    "Usage of type 'Boolean' is not allowed."
+        //                    "Usage of type 'Serializable' is not allowed."
 
     public void fullName(java.util.ArrayList<? super Boolean> a) {}
-        // violation above 'Usage of type 'Boolean' is not allowed'
+        // violation above "Usage of type 'Boolean' is not allowed."
 
     public abstract Set<Boolean> shortName(Set<? super Set<Boolean>> a);
         // 2 violations above:
-        //                    'Usage of type 'Boolean' is not allowed.'
-        //                    'Usage of type 'Boolean' is not allowed'
+        //                    "Usage of type 'Boolean' is not allowed."
+        //                    "Usage of type 'Boolean' is not allowed."
 
     public Set<? extends Foo<Boolean>> typeArgument() {
         // 2 violations above:
-        //                    'Usage of type 'Foo' is not allowed.'
-        //                    'Usage of type 'Boolean' is not allowed'
+        //                    "Usage of type 'Foo' is not allowed."
+        //                    "Usage of type 'Boolean' is not allowed."
         return new TreeSet<Foo<Boolean>>();
     }
 
     public class MyClass<Foo extends Boolean> {}
     // 2 violations above:
-    //                    'Usage of type 'Foo' is not allowed.'
-    //                    'Usage of type 'Boolean' is not allowed'
+    //                    "Usage of type 'Foo' is not allowed."
+    //                    "Usage of type 'Boolean' is not allowed."
 
 }
 
@@ -71,7 +71,7 @@ class Bounded {
     public boolean match = new TreeSet<Integer>().stream()
             .allMatch(new TreeSet<>()::add);
 
-    public static <Boolean> void foo() {} // violation 'Usage of type Boolean is not allowed'.
+    public static <Boolean> void foo() {} // violation "Usage of type 'Boolean' is not allowed."
 
 }
 
@@ -84,6 +84,7 @@ class Foo<T extends Boolean & Serializable> {
 @interface Annotation {
 
     Class<? extends Boolean>[] nonPublic();
-    public Class<? extends Boolean>[] value(); // violation 'Usage of type Boolean is not allowed'.
+    public Class<? extends Boolean>[] value();
+    // violation above "Usage of type 'Boolean' is not allowed."
 
 }


### PR DESCRIPTION
Issue: #20954

Updated violation message comments in
`InputIllegalTypeTestGenerics.java` to use the actual quoted
IllegalType messages.

Removed `InputIllegalTypeTestGenerics.java` from
`SUPPRESSED_VALIDATE_MESSAGE_FILES` so violation messages are now
validated.

Validation:
- `IllegalTypeCheckTest#testGenerics` passes
- `mvn verify` passes