### PR TITLE
Issue #21137: Add default configuration example for ReturnCount

### DIFF
--- a/src/site/xdoc/checks/coding/returncount.xml
+++ b/src/site/xdoc/checks/coding/returncount.xml
@@ -94,16 +94,12 @@
 
       <subsection name="Examples" id="ReturnCount_Examples">
         <p id="Example1-config">
-          To configure the check so that it doesn't allow more than three
-          return statements per method (ignoring the <code>equals()</code>
-          method):
+          To configure the check:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-    &lt;module name="ReturnCount"&gt;
-      &lt;property name="max" value="3"/&gt;
-    &lt;/module&gt;
+    &lt;module name="ReturnCount"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -120,14 +116,14 @@ public class Example1 {
         if (x &lt; -2) { return -1; }
         return 0;
     }
-    // violation below 'max allowed for non-void methods/lambdas is 3'
+    // violation below 'max allowed for non-void methods/lambdas is 2'
     public int signB(int x) {
         if (x &lt; -2) { return -1; }
         if (x == 0) { return 0; }
         if (x &gt; 2) { return 2; }
         return 1;
     }
-    // ok below, because non-void restriction is 3
+    // ok below, because default non-void restriction is 2
     final Predicate&lt;Integer&gt; lambdaA = i -&gt; {
         if (i &gt; 5) { return true; }
         return false;

--- a/src/site/xdoc/checks/coding/returncount.xml.template
+++ b/src/site/xdoc/checks/coding/returncount.xml.template
@@ -29,9 +29,7 @@
 
       <subsection name="Examples" id="ReturnCount_Examples">
         <p id="Example1-config">
-          To configure the check so that it doesn't allow more than three
-          return statements per method (ignoring the <code>equals()</code>
-          method):
+          To configure the check:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -157,7 +157,6 @@ public class XdocsExamplesAstConsistencyTest {
      */
     private static final Set<String> EXAMPLE_DEFAULT_CONFIG_SUPPRESSED_MODULES = Set.of(
             "checks/coding/matchxpath",
-            "checks/coding/returncount",
             "checks/descendanttoken",
             "checks/imports/importcontrol",
             "filters/severitymatchfilter",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example1.java
@@ -1,9 +1,7 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="ReturnCount">
-      <property name="max" value="3"/>
-    </module>
+    <module name="ReturnCount"/>
   </module>
 </module>
 */
@@ -21,14 +19,14 @@ public class Example1 {
         if (x < -2) { return -1; }
         return 0;
     }
-    // violation below 'max allowed for non-void methods/lambdas is 3'
+    // violation below 'max allowed for non-void methods/lambdas is 2'
     public int signB(int x) {
         if (x < -2) { return -1; }
         if (x == 0) { return 0; }
         if (x > 2) { return 2; }
         return 1;
     }
-    // ok below, because non-void restriction is 3
+    // ok below, because default non-void restriction is 2
     final Predicate<Integer> lambdaA = i -> {
         if (i > 5) { return true; }
         return false;


### PR DESCRIPTION
Issue: #21137
Fixes #21137

### Rationale
`ReturnCount` was suppressed in `XdocsExamplesAstConsistencyTest` because `Example1.java` had a custom property set (`max=3`) instead of demonstrating the check's default configuration.

### Changes
- Updated `Example1.java` for `ReturnCount` to use the default `<module name="ReturnCount"/>` configuration without any properties.
- Updated comments and violation expectations in `Example1.java` to match the default thresholds (`max=2` for non-void methods, `maxForVoid=1` for void methods).
- Updated `returncount.xml` and `returncount.xml.template` to reflect the default configuration and updated description.
- Removed `"checks/coding/returncount"` from `EXAMPLE_DEFAULT_CONFIG_SUPPRESSED_MODULES` in `XdocsExamplesAstConsistencyTest.java`.