### PR TITLE
Issue #21119: Fix duplicate violation behavior in examples: constantname

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -96,8 +96,6 @@ public class XdocsExampleFileTest {
      * <a href="https://github.com/checkstyle/checkstyle/issues/21072">...</a>
      */
     private static final Set<String> SUPPRESSED_UNIQUENESS_CHECK_MODULES = Set.of(
-        "checks/javadoc/missingjavadocmethod/",
-        "checks/naming/constantname/",
         "checks/naming/methodname/",
         "checks/naming/typename/",
         "checks/nocodeinfile/",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckExamplesTest.java
@@ -65,9 +65,9 @@ public class ConstantNameCheckExamplesTest extends AbstractExamplesModuleTestSup
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "20:20: " + getCheckMessage(MSG_INVALID_PATTERN, "third_Constant3", DEFAULT_PATTERN),
-            "21:28: " + getCheckMessage(MSG_INVALID_PATTERN, "fourth_Const4", DEFAULT_PATTERN),
-            "24:20: " + getCheckMessage(MSG_INVALID_PATTERN, "loggerMYSELF", DEFAULT_PATTERN),
+            "18:20: " + getCheckMessage(MSG_INVALID_PATTERN, "third_Constant3", DEFAULT_PATTERN),
+            "19:28: " + getCheckMessage(MSG_INVALID_PATTERN, "fourth_Const4", DEFAULT_PATTERN),
+            "22:20: " + getCheckMessage(MSG_INVALID_PATTERN, "loggerMYSELF", DEFAULT_PATTERN),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example3.java
@@ -7,8 +7,6 @@
     </module>
   </module>
 </module>
-
-
 */
 
 package com.puppycrawl.tools.checkstyle.checks.naming.constantname;


### PR DESCRIPTION
#21119 

`testAllModuleExamplesAreBehaviorallyUnique` flagged `checks/naming/constantname/`:

```
Module 'constantname': examples [Example3.java, Example6.java] produce identical violations
(20:must match pattern|21:must match pattern|24:must match pattern).
```

This PR fixes the collision and removes `checks/naming/constantname/` from `SUPPRESSED_UNIQUENESS_CHECK_MODULES`.

## Root cause

Unlike other flagged modules, `Example3` and `Example6` are genuinely behaviorally distinct different properties (`applyToPublic`/`applyToProtected` vs `applyToPrivate`/`applyToPackage`), and different constants flagged (`third_Constant3`/`fourth_Const4`/`loggerMYSELF` vs `log`/`logger`/`myselfConstant`). The collision is a coincidence of formatting: `Example3`'s config block has two extra blank lines before the closing `*/` that its siblings don't have, shifting its violation line numbers down by exactly 2  landing them on the same absolute lines (20, 21, 24) that `Example6`'s unrelated violations happen to occupy.

## Fix

Removed the two superfluous blank lines from `Example3.java`'s config block. No code, comment, or config-value change  purely a whitespace fix that realigns `Example3`'s formatting with the rest of the module's examples (none of which have this extra padding) and moves its violations to lines 18, 19, 22.

## Files changed

- `src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/Example3.java`
- `src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java` — removed `"checks/naming/constantname/"` from `SUPPRESSED_UNIQUENESS_CHECK_MODULES`

## Testing

- Ran `testAllModuleExamplesAreBehaviorallyUnique` locally `constantname` no longer appears in the failure output.
- Manually re-verified all six examples (`Example1`–`Example6`) don't produce any other pairwise collision.
- No AST/behavior change confirmed `Example3.java`'s actual violations (which constants are flagged, under which config) are unchanged; only their absolute line numbers shifted.


removed `"checks/javadoc/missingjavadocmethod/",` suppression already fixed due to changes via https://github.com/checkstyle/checkstyle/issues/5744