### PR TITLE
Issue #20970: JavadocLeadingAsteriskAlign: Add indentation property

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -122,6 +122,15 @@
   <suppress checks="FileLength"
             files="googlenonconstantfieldname/Example1.java"/>
 
+  <!-- Example needs extra header lines to demonstrate the indentation property -->
+  <suppress checks="FileLength"
+            files="javadocleadingasteriskalign/Example2.java"/>
+
+  <!-- Javadoc text must stay identical to Example1's for AST/comment consistency,
+       and the added trailing violation-marker comment pushes it over LineLength -->
+  <suppress checks="LineLength"
+            files="javadocleadingasteriskalign/Example2.java"/>
+
   <!-- Suppress forbidden regex messages for avoidstarimport examples -->
   <suppress id="forbiddenRegexpInViolationMessage"
     files="avoidstarimport/Example[1-6].java"/>

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputIncorrectJavadocLeadingAsteriskAlignment.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InputIncorrectJavadocLeadingAsteriskAlignment.java
@@ -3,39 +3,39 @@ package com.google.checkstyle.test.chapter7javadoc.rule711generalform;
 /**
 * Extra violations are kept in this file to cover edge cases.
  */
-// violation 2 lines above 'Leading asterisk has .* indentation .* 1, expected is 2.'
+// violation 2 lines above 'Leading asterisk has .* indentation .* 0, expected is 1.'
 public class InputIncorrectJavadocLeadingAsteriskAlignment {
   /**
     * Javadoc for instance variable.
    */
-  // violation 2 lines above 'Leading asterisk has .* indentation .* 5, expected is 4.'
+  // violation 2 lines above 'Leading asterisk has .* indentation .* 2, expected is 1.'
   private int age;
 
   /**
   *  Misaligned leading asterisk.
    */
-  // violation 2 lines above 'Leading asterisk has .* indentation .* 3, expected is 4.'
+  // violation 2 lines above 'Leading asterisk has .* indentation .* 0, expected is 1.'
   private String name;
 
   /**
    * Javadoc for foo.
     */
-  // violation above 'Leading asterisk has .* indentation .* 5, expected is 4.'
+  // violation above 'Leading asterisk has .* indentation .* 2, expected is 1.'
   public void foo() {}
 
   // violation below "Summary javadoc is missing."
   /**
   */
-  // violation above 'Leading asterisk has .* indentation .* 3, expected is 4.'
+  // violation above 'Leading asterisk has .* indentation .* 0, expected is 1.'
   public void foo2() {}
 
-  // violation 2 lines below 'Leading asterisk has .* indentation .* 7, expected is 4.'
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 4, expected is 1.'
   /**
       * Misaligned leading asterisk.
    */
   public void foo3() {}
 
-  // violation 2 lines below 'Leading asterisk has .* indentation .* 1, expected is 4.'
+  // violation 2 lines below 'Leading asterisk has .* indentation .* -2, expected is 1.'
   /**
 *   Misaligned leading asterisk.
    */
@@ -44,27 +44,27 @@ public class InputIncorrectJavadocLeadingAsteriskAlignment {
   /**
    * Default Constructor.
       */
-  // violation above 'Leading asterisk has .* indentation .* 7, expected is 4.'
+  // violation above 'Leading asterisk has .* indentation .* 4, expected is 1.'
   public InputIncorrectJavadocLeadingAsteriskAlignment() {}
 
   /**
    * Parameterized Constructor.
 */
-  // violation above 'Leading asterisk has .* indentation .* 1, expected is 4.'
+  // violation above 'Leading asterisk has .* indentation .* -2, expected is 1.'
   public InputIncorrectJavadocLeadingAsteriskAlignment(String a) {}
 
-  // violation 2 lines below 'Leading asterisk has .* indentation .* 7, expected is 4.'
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 4, expected is 1.'
   /**
       * Misaligned leading asterisk.
     * Inner Class. */
-  // violation above 'Leading asterisk has .* indentation .* 5, expected is 4.'
+  // violation above 'Leading asterisk has .* indentation .* 2, expected is 1.'
   private static class Inner {
     // violation 2 lines below "Summary javadoc is missing."
     // violation 2 lines below "Javadoc line should start with leading asterisk."
     /**
 
         */
-    // violation above 'Leading asterisk has .* indentation .* 9, expected is 6.'
+    // violation above 'Leading asterisk has .* indentation .* 4, expected is 1.'
     private Object obj;
 
     // violation below "Summary javadoc is missing."
@@ -73,7 +73,7 @@ public class InputIncorrectJavadocLeadingAsteriskAlignment {
        *         Testing......
      *
      */
-    // violation 3 lines above 'Leading asterisk has .* indentation .* 8, expected is 6.'
+    // violation 3 lines above 'Leading asterisk has .* indentation .* 3, expected is 1.'
     void foo(String testing) {}
   }
 
@@ -82,14 +82,14 @@ public class InputIncorrectJavadocLeadingAsteriskAlignment {
     // violation below "Summary javadoc is missing."
     /**
    */
-    // violation above 'Leading asterisk has .* indentation .* 4, expected is 6.'
+    // violation above 'Leading asterisk has .* indentation .* -1, expected is 1.'
     ONE,
 
 
     // Closing tag should be alone on line. False negative until #18273
     /**
       * Wrong Alignment. */
-    // violation above 'Leading asterisk has .* indentation .* 7, expected is 6'
+    // violation above 'Leading asterisk has .* indentation .* 2, expected is 1'
     TWO
   }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheck.java
@@ -34,7 +34,9 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Checks the alignment of
  * <a href="https://docs.oracle.com/en/java/javase/14/docs/specs/javadoc/doc-comment-spec.html#leading-asterisks">
  * leading asterisks</a> in a Javadoc comment. The Check ensures that leading asterisks
- * are aligned vertically under the first asterisk ( &#42; )
+ * are aligned vertically at the number of columns to the right of the slash ( / ) of the
+ * opening Javadoc tag that is specified by the {@code indentation} property. By default
+ * they are aligned under the first asterisk ( &#42; )
  * of opening Javadoc tag. The alignment of closing Javadoc tag ( &#42;/ ) is also checked.
  * If a closing Javadoc tag contains non-whitespace character before it
  * then it's alignment will be ignored.
@@ -58,20 +60,43 @@ public class JavadocLeadingAsteriskAlignCheck extends AbstractJavadocCheck {
      */
     public static final String MSG_KEY = "javadoc.asterisk.indentation";
 
+    /** Default indentation of leading asterisks. */
+    private static final int DEFAULT_INDENTATION = 1;
+
     /** Specifies the line number of starting block of the javadoc comment. */
     private int javadocStartLineNumber;
 
-    /** Specifies the column number of starting block of the javadoc comment with tabs expanded. */
+    /** Specifies the column number of the slash of the opening javadoc tag with tabs expanded. */
+    private int javadocStartColumnNumberTabsExpanded;
+
+    /** Specifies the expected column number of leading asterisks with tabs expanded. */
     private int expectedColumnNumberTabsExpanded;
 
     /** Specifies the lines of the file being processed. */
     private String[] fileLines;
 
     /**
+     * Specify the number of columns between the slash ( / ) of the opening javadoc tag
+     * and the leading asterisks.
+     */
+    private int indentation = DEFAULT_INDENTATION;
+
+    /**
      * Creates a new {@code JavadocLeadingAsteriskAlignCheck} instance.
      */
     public JavadocLeadingAsteriskAlignCheck() {
         // no code by default
+    }
+
+    /**
+     * Setter to specify the number of columns between the slash ( / ) of the opening
+     * javadoc tag and the leading asterisks.
+     *
+     * @param indentation number of columns
+     * @since 13.11.0
+     */
+    public void setIndentation(int indentation) {
+        this.indentation = indentation;
     }
 
     @Override
@@ -93,8 +118,12 @@ public class JavadocLeadingAsteriskAlignCheck extends AbstractJavadocCheck {
         fileLines = getLines();
         final String startLine = fileLines[rootAst.getLineNumber() - 1];
         javadocStartLineNumber = rootAst.getLineNumber();
-        expectedColumnNumberTabsExpanded = CommonUtil.lengthExpandedTabs(
+        javadocStartColumnNumberTabsExpanded = 1 + CommonUtil.lengthExpandedTabs(
+            startLine, getBlockCommentAst().getColumnNo(), getTabWidth());
+        final int defaultColumnNumberTabsExpanded = CommonUtil.lengthExpandedTabs(
             startLine, rootAst.getColumnNumber() - 1, getTabWidth());
+        expectedColumnNumberTabsExpanded =
+            defaultColumnNumberTabsExpanded + indentation - DEFAULT_INDENTATION;
     }
 
     @Override
@@ -115,7 +144,8 @@ public class JavadocLeadingAsteriskAlignCheck extends AbstractJavadocCheck {
             final int columnNumberTabsExpanded = getColumnNumberTabsExpanded(ast);
 
             if (!hasValidAlignment(expectedColumnNumberTabsExpanded, columnNumberTabsExpanded)) {
-                log(ast, MSG_KEY, columnNumberTabsExpanded, expectedColumnNumberTabsExpanded);
+                log(ast, MSG_KEY, getIndentationLevel(columnNumberTabsExpanded),
+                        getIndentationLevel(expectedColumnNumberTabsExpanded));
             }
         }
     }
@@ -132,11 +162,11 @@ public class JavadocLeadingAsteriskAlignCheck extends AbstractJavadocCheck {
                 .ifPresent(columnNumber -> {
                     final int columnNumberTabsExpanded = CommonUtil.lengthExpandedTabs(
                             lastLine, columnNumber, getTabWidth());
-
                     if (!hasValidAlignment(
                             expectedColumnNumberTabsExpanded, columnNumberTabsExpanded)) {
                         log(javadocEndToken, MSG_KEY,
-                                columnNumberTabsExpanded, expectedColumnNumberTabsExpanded);
+                                getIndentationLevel(columnNumberTabsExpanded),
+                                getIndentationLevel(expectedColumnNumberTabsExpanded));
                     }
                 });
     }
@@ -172,6 +202,18 @@ public class JavadocLeadingAsteriskAlignCheck extends AbstractJavadocCheck {
                 fileLines[ast.getLineNumber() - 1],
                 ast.getColumnNumber(),
                 getTabWidth());
+    }
+
+    /**
+     * Converts a tab-expanded column number into an indentation level, which is
+     * the number of columns between the slash ( / ) of the opening javadoc tag
+     * and the given column.
+     *
+     * @param columnNumberTabsExpanded tab-expanded column number
+     * @return indentation level
+     */
+    private int getIndentationLevel(int columnNumberTabsExpanded) {
+        return columnNumberTabsExpanded - javadocStartColumnNumberTabsExpanded;
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocLeadingAsteriskAlignCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocLeadingAsteriskAlignCheck.xml
@@ -8,7 +8,9 @@
  Checks the alignment of
  &lt;a href="https://docs.oracle.com/en/java/javase/14/docs/specs/javadoc/doc-comment-spec.html#leading-asterisks"&gt;
  leading asterisks&lt;/a&gt; in a Javadoc comment. The Check ensures that leading asterisks
- are aligned vertically under the first asterisk ( &amp;#42; )
+ are aligned vertically at the number of columns to the right of the slash ( / ) of the
+ opening Javadoc tag that is specified by the &lt;code&gt;indentation&lt;/code&gt; property. By default
+ they are aligned under the first asterisk ( &amp;#42; )
  of opening Javadoc tag. The alignment of closing Javadoc tag ( &amp;#42;/ ) is also checked.
  If a closing Javadoc tag contains non-whitespace character before it
  then it's alignment will be ignored.
@@ -21,6 +23,9 @@
  &lt;a href="https://checkstyle.org/config.html#tabWidth"&gt;tabWidth&lt;/a&gt; property.
  &lt;/p&gt;</description>
          <properties>
+            <property default-value="1" name="indentation" type="int">
+               <description>Specify the number of columns between the slash ( / ) of the opening javadoc tag and the leading asterisks.</description>
+            </property>
             <property default-value="false"
                       name="violateExecutionOnNonTightHtml"
                       type="boolean">

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml
@@ -21,6 +21,7 @@
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#JavadocLeadingAsteriskAlign_Examples">Examples</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
               <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
+              <li><a href="#Example2-config" class="toc-sublink">Align leading asterisks under the slash ( / ) of the opening javadoc tag</a></li>
             </ul>
           </li>
           <li><a href="#JavadocLeadingAsteriskAlign_Example_of_Usage">Example of Usage</a></li>
@@ -35,7 +36,9 @@
           Checks the alignment of
           <a href="https://docs.oracle.com/en/java/javase/14/docs/specs/javadoc/doc-comment-spec.html#leading-asterisks">
           leading asterisks</a> in a Javadoc comment. The Check ensures that leading asterisks
-          are aligned vertically under the first asterisk ( &#42; )
+          are aligned vertically at the number of columns to the right of the slash ( / ) of the
+          opening Javadoc tag that is specified by the <code>indentation</code> property. By default
+          they are aligned under the first asterisk ( &#42; )
           of opening Javadoc tag. The alignment of closing Javadoc tag ( &#42;/ ) is also checked.
           If a closing Javadoc tag contains non-whitespace character before it
           then it's alignment will be ignored.
@@ -58,6 +61,13 @@
               <th>type</th>
               <th>default value</th>
               <th>since</th>
+            </tr>
+            <tr>
+              <td><a id="indentation"/><a href="#indentation">indentation</a></td>
+              <td>Specify the number of columns between the slash ( / ) of the opening javadoc tag and the leading asterisks.</td>
+              <td><a href="../../property_types.html#int">int</a></td>
+              <td><code>1</code></td>
+              <td>13.11.0</td>
             </tr>
             <tr>
               <td><a id="violateExecutionOnNonTightHtml"/><a href="#violateExecutionOnNonTightHtml">violateExecutionOnNonTightHtml</a></td>
@@ -85,12 +95,12 @@
           Example:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-// violation 2 lines below '1, expected is 2.'
+// violation 2 lines below '0, expected is 1.'
 /**
 * Javadoc for class.
  */
 public class Example1 {
-  // violation 2 lines below '5, expected is 4.'
+  // violation 2 lines below '2, expected is 1.'
   /**
     * Javadoc for instance variable, over-indented.
    */
@@ -100,17 +110,17 @@ public class Example1 {
    * Javadoc for instance variable, correctly aligned.
    */
   private int goodIndentField;
-  // violation 2 lines below '3, expected is 4.'
+  // violation 2 lines below '0, expected is 1.'
   /**
   *  Javadoc for method, under-indented.
   */
   private void wrongIndentMethod() {}
-  // violation 2 lines above '3, expected is 4.'
+  // violation 2 lines above '0, expected is 1.'
   /**
    * Javadoc for method, correctly aligned.
    */
   private void goodIndentMethod() {}
-  // violation 3 lines below '1, expected is 4.'
+  // violation 3 lines below '-2, expected is 1.'
   /**
    Javadoc for constructor, missing leading asterisk alignment on closing tag.
 */
@@ -122,7 +132,7 @@ public class Example1 {
   public Example1(int value) {}
 
   private enum indentedEnum {
-    // violation 2 lines below '5, expected is 6.'
+    // violation 2 lines below '0, expected is 1.'
     /**
     *  Wrong alignment for enum constant.
      */
@@ -131,6 +141,72 @@ public class Example1 {
     /**
      * Correct alignment for enum constant.
      */
+    GOOD
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example2-config">
+          To configure the check to align leading asterisks under the slash ( / )
+          of the opening javadoc tag:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocLeadingAsteriskAlign"&gt;
+      &lt;property name="indentation" value="0"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example2-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+/**
+* Javadoc for class.
+ */ // violation '1, expected is 0.'
+public class Example2 {
+
+  /**
+    * Javadoc for instance variable, over-indented. // violation '2, expected is 0.'
+   */ // violation '1, expected is 0.'
+  private int wrongIndentField;
+
+  /**
+   * Javadoc for instance variable, correctly aligned. // violation '1, expected is 0.'
+   */ // violation '1, expected is 0.'
+  private int goodIndentField;
+
+  /**
+  *  Javadoc for method, under-indented.
+  */
+  private void wrongIndentMethod() {}
+
+  /**
+   * Javadoc for method, correctly aligned. // violation '1, expected is 0.'
+   */ // violation '1, expected is 0.'
+  private void goodIndentMethod() {}
+
+  /**
+   Javadoc for constructor, missing leading asterisk alignment on closing tag.
+*/ // violation '-2, expected is 0.'
+  private Example2() {}
+
+  /**
+   * Javadoc for constructor, correctly aligned. // violation '1, expected is 0.'
+   */ // violation '1, expected is 0.'
+  public Example2(int value) {}
+
+  private enum indentedEnum {
+
+    /**
+    *  Wrong alignment for enum constant.
+     */ // violation '1, expected is 0.'
+    WRONG,
+
+    /**
+     * Correct alignment for enum constant. // violation '1, expected is 0.'
+     */ // violation '1, expected is 0.'
     GOOD
   }
 }

--- a/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocleadingasteriskalign.xml.template
@@ -47,6 +47,23 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example1.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example2-config">
+          To configure the check to align leading asterisks under the slash ( / )
+          of the opening javadoc tag:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example2.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignCheckTest.java
@@ -44,21 +44,21 @@ public class JavadocLeadingAsteriskAlignCheckTest extends AbstractModuleTestSupp
     @Test
     public void testIncorrectJavadoc() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 2),
-            "19:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
-            "26:3: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 3, 4),
-            "33:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
-            "38:3: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 3, 4),
-            "43:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 4),
-            "49:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 4),
-            "56:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 4),
-            "62:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 4),
-            "68:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 4),
-            "69:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
-            "74:9: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 9, 6),
-            "80:8: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 8, 6),
-            "90:4: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 4, 6),
-            "96:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 6),
+            "13:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 0, 1),
+            "19:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 2, 1),
+            "26:3: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 0, 1),
+            "33:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 2, 1),
+            "38:3: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 0, 1),
+            "43:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 4, 1),
+            "49:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, -2, 1),
+            "56:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 4, 1),
+            "62:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, -2, 1),
+            "68:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 4, 1),
+            "69:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 2, 1),
+            "74:9: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 4, 1),
+            "80:8: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 3, 1),
+            "90:4: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, -1, 1),
+            "96:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 2, 1),
         };
 
         final String filePath = getPath("InputJavadocLeadingAsteriskAlignIncorrect.java");
@@ -68,11 +68,11 @@ public class JavadocLeadingAsteriskAlignCheckTest extends AbstractModuleTestSupp
     @Test
     public void testTabs() throws Exception {
         final String[] expected = {
-            "50:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
-            "62:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 6),
-            "63:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 6),
-            "74:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 7, 6),
-            "75:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 6),
+            "50:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 2, 1),
+            "62:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 0, 1),
+            "63:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 2, 1),
+            "74:7: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 2, 1),
+            "75:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 0, 1),
         };
 
         final String filePath = getPath("InputJavadocLeadingAsteriskAlignTabs.java");
@@ -82,7 +82,7 @@ public class JavadocLeadingAsteriskAlignCheckTest extends AbstractModuleTestSupp
     @Test
     public void testMultipleLeadingAsterisks() throws Exception {
         final String[] expected = {
-            "20:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 4),
+            "20:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 2, 1),
         };
 
         final String filePath = getPath("InputJavadocLeadingAsteriskAlignMultipleAsterisks.java");
@@ -92,12 +92,39 @@ public class JavadocLeadingAsteriskAlignCheckTest extends AbstractModuleTestSupp
     @Test
     public void testLeadingAsteriskOnOpeningLine() throws Exception {
         final String[] expected = {
-            "18:6: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 6, 11),
-            "19:6: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 6, 11),
-            "20:6: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 6, 11),
+            "18:6: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 6),
+            "19:6: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 6),
+            "20:6: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 6),
         };
 
         final String filePath = getPath("InputJavadocLeadingAsteriskAlignOpeningLine.java");
+        verifyWithInlineConfigParser(filePath, expected);
+    }
+
+    @Test
+    public void testIndentationZero() throws Exception {
+        final String[] expected = {
+            "25:4: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 0),
+            "26:4: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 0),
+            "32:5: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 2, 0),
+            "38:1: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, -2, 0),
+            "49:3: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 0, 6),
+            "50:3: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 0, 6),
+        };
+
+        final String filePath = getPath("InputJavadocLeadingAsteriskAlignIndentationZero.java");
+        verifyWithInlineConfigParser(filePath, expected);
+    }
+
+    @Test
+    public void testIndentationTwo() throws Exception {
+        final String[] expected = {
+            "20:4: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 2),
+            "21:4: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 1, 2),
+            "32:8: " + getCheckMessage(JavadocLeadingAsteriskAlignCheck.class, MSG_KEY, 5, 2),
+        };
+
+        final String filePath = getPath("InputJavadocLeadingAsteriskAlignIndentationTwo.java");
         verifyWithInlineConfigParser(filePath, expected);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignIncorrect.java
@@ -8,73 +8,73 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocleadingasteriskalign;
 
-// violation 2 lines below 'Leading asterisk has .* indentation .* 1, expected is 2.'
+// violation 2 lines below 'Leading asterisk has .* indentation .* 0, expected is 1.'
 /**
 * This is the class level javadoc.
  *
  */
 public class InputJavadocLeadingAsteriskAlignIncorrect {
-  // violation 2 lines below 'Leading asterisk has .* indentation .* 5, expected is 4.'
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 2, expected is 1.'
   /**
     * Javadoc for instance variable
    *
    */
   private int age;
 
-  // violation 2 lines below 'Leading asterisk has .* indentation .* 3, expected is 4.'
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 0, expected is 1.'
   /**
   *
    */
   private String name;
 
-  // violation 3 lines below 'Leading asterisk has .* indentation .* 5, expected is 4.'
+  // violation 3 lines below 'Leading asterisk has .* indentation .* 2, expected is 1.'
   /**
    * Javadoc for foo.
     */
   public void foo() {}
 
-  // violation 2 lines below 'Leading asterisk has .* indentation .* 3, expected is 4.'
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 0, expected is 1.'
   /**
   */
   public void foo2() {}
 
-  // violation 2 lines below 'Leading asterisk has .* indentation .* 7, expected is 4.'
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 4, expected is 1.'
   /**
       *
    */
   public void foo3() {}
 
-  // violation 2 lines below 'Leading asterisk has .* indentation .* 1, expected is 4.'
+  // violation 2 lines below 'Leading asterisk has .* indentation .* -2, expected is 1.'
   /**
 *
    */
   public void foo4() {}
 
-  // violation 3 lines below 'Leading asterisk has .* indentation .* 7, expected is 4.'
+  // violation 3 lines below 'Leading asterisk has .* indentation .* 4, expected is 1.'
   /**
    * Default Constructor.
       */
   public InputJavadocLeadingAsteriskAlignIncorrect() {}
 
-  // violation 3 lines below 'Leading asterisk has .* indentation .* 1, expected is 4.'
+  // violation 3 lines below 'Leading asterisk has .* indentation .* -2, expected is 1.'
   /**
    * Parameterized Constructor.
 */
   public InputJavadocLeadingAsteriskAlignIncorrect(String a) {}
 
-  // violation 3 lines below 'Leading asterisk has .* indentation .* 7, expected is 4.'
-  // violation 3 lines below 'Leading asterisk has .* indentation .* 5, expected is 4.'
+  // violation 3 lines below 'Leading asterisk has .* indentation .* 4, expected is 1.'
+  // violation 3 lines below 'Leading asterisk has .* indentation .* 2, expected is 1.'
   /**
       *
     * Inner Class. */
   private static class Inner {
-    // violation 3 lines below 'Leading asterisk has .* indentation .* 9, expected is 6.'
+    // violation 3 lines below 'Leading asterisk has .* indentation .* 4, expected is 1.'
     /**
 
         */
     private Object obj;
 
-    // violation 3 lines below 'Leading asterisk has .* indentation .* 8, expected is 6.'
+    // violation 3 lines below 'Leading asterisk has .* indentation .* 3, expected is 1.'
     /**
      * @param testing
        *         Testing......
@@ -85,13 +85,13 @@ public class InputJavadocLeadingAsteriskAlignIncorrect {
 
   private enum incorrectJavadocEnum {
 
-    // violation 2 lines below 'Leading asterisk has .* indentation .* 4, expected is 6.'
+    // violation 2 lines below 'Leading asterisk has .* indentation .* -1, expected is 1.'
     /**
    */
     ONE,
 
 
-    // violation 2 lines below 'Leading asterisk has .* indentation .* 7, expected is 6.'
+    // violation 2 lines below 'Leading asterisk has .* indentation .* 2, expected is 1.'
     /**
       * Wrong Alignment */
     TWO

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignIndentationTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignIndentationTwo.java
@@ -1,0 +1,35 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocLeadingAsteriskAlign">
+      <property name="indentation" value="2"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocleadingasteriskalign;
+
+/**
+  * Javadoc indented by two columns from the slash.
+  */
+public class InputJavadocLeadingAsteriskAlignIndentationTwo {
+
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 1, expected is 2.'
+  /**
+   * Javadoc aligned under the first asterisk of opening tag.
+   */
+  private int wrongField;
+  // violation 2 lines above 'Leading asterisk has .* indentation .* 1, expected is 2.'
+
+  /**
+    * Correctly indented javadoc.
+    */
+  private void correctMethod() {}
+
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 5, expected is 2.'
+  /**
+       * Over indented javadoc.
+    */
+  private void wrongMethod() {}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignIndentationZero.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignIndentationZero.java
@@ -1,0 +1,52 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocLeadingAsteriskAlign">
+      <property name="indentation" value="0"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocleadingasteriskalign;
+
+/**
+* Left aligned javadoc for class.
+*/
+public class InputJavadocLeadingAsteriskAlignIndentationZero {
+
+  /**
+  * Left aligned javadoc for field.
+  */
+  private int correctField;
+
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 1, expected is 0.'
+  /**
+   * Javadoc aligned under the first asterisk of opening tag.
+   */
+  private int wrongField;
+  // violation 2 lines above 'Leading asterisk has .* indentation .* 1, expected is 0.'
+
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 2, expected is 0.'
+  /**
+    * Over indented javadoc.
+  */
+  private void wrongMethod() {}
+
+  // violation 2 lines below 'Leading asterisk has .* indentation .* -2, expected is 0.'
+  /**
+*/
+  private void closingTagOnTheLeft() {}
+
+  /**
+  * Left aligned javadoc for method.
+  */
+  private void correctMethod() {}
+
+  // violation 3 lines below 'Leading asterisk has .* indentation .* 0, expected is 6.'
+  // violation 3 lines below 'Leading asterisk has .* indentation .* 0, expected is 6.'
+  /**   *
+  * opening line asterisk defines the alignment, indentation is not applied
+  */
+  private void openingLineAsterisk() {}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignMultipleAsterisks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignMultipleAsterisks.java
@@ -15,7 +15,7 @@ public class InputJavadocLeadingAsteriskAlignMultipleAsterisks {
    */
   void valid() {}
 
-  // violation 2 lines below 'Leading asterisk has .* indentation .* 5, expected is 4.'
+  // violation 2 lines below 'Leading asterisk has .* indentation .* 2, expected is 1.'
   /****
     ** Misaligned multiple asterisks.
    */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignOpeningLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignOpeningLine.java
@@ -10,9 +10,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocleadingasteriskali
 
 public interface InputJavadocLeadingAsteriskAlignOpeningLine {
 
-    // violation 5 lines below 'Leading asterisk has incorrect indentation level 6, expected is 11.'
-    // violation 5 lines below 'Leading asterisk has incorrect indentation level 6, expected is 11.'
-    // violation 5 lines below 'Leading asterisk has incorrect indentation level 6, expected is 11.'
+    // violation 5 lines below 'Leading asterisk has incorrect indentation level 1, expected is 6.'
+    // violation 5 lines below 'Leading asterisk has incorrect indentation level 1, expected is 6.'
+    // violation 5 lines below 'Leading asterisk has incorrect indentation level 1, expected is 6.'
 
     /**   *  ***
      * There is a space, then a leading asterisk, then a space,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignTabs.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignTabs.java
@@ -45,7 +45,7 @@ public class InputJavadocLeadingAsteriskAlignTabs {
 		 */
 	public InputJavadocLeadingAsteriskAlignTabs() {}
 
-	// violation 2 lines below 'Leading asterisk has .* indentation .* 5, expected is 4.'
+	// violation 2 lines below 'Leading asterisk has .* indentation .* 2, expected is 1.'
 	/***
 	  * @param x testing..... */
 	public InputJavadocLeadingAsteriskAlignTabs(int x) {}
@@ -56,8 +56,8 @@ public class InputJavadocLeadingAsteriskAlignTabs {
 
 	private enum enumWithTabs {
 
-	  // violation 3 lines below 'Leading asterisk has .* indentation .* 5, expected is 6.'
-	  // violation 3 lines below 'Leading asterisk has .* indentation .* 7, expected is 6.'
+	  // violation 3 lines below 'Leading asterisk has .* indentation .* 0, expected is 1.'
+	  // violation 3 lines below 'Leading asterisk has .* indentation .* 2, expected is 1.'
 	  /**
 		*
 		  */
@@ -68,8 +68,8 @@ public class InputJavadocLeadingAsteriskAlignTabs {
 		 */
 		TWO,
 
-		// violation 3 lines below 'Leading asterisk has .* indentation .* 7, expected is 6.'
-		// violation 3 lines below 'Leading asterisk has .* indentation .* 5, expected is 6.'
+		// violation 3 lines below 'Leading asterisk has .* indentation .* 2, expected is 1.'
+		// violation 3 lines below 'Leading asterisk has .* indentation .* 0, expected is 1.'
 		/**
 			*
 		*/

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocLeadingAsteriskAlignExamplesTest.java
@@ -35,15 +35,36 @@ public class JavadocLeadingAsteriskAlignExamplesTest extends AbstractExamplesMod
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_KEY, 1, 2),
-            "18:5: " + getCheckMessage(MSG_KEY, 5, 4),
-            "28:3: " + getCheckMessage(MSG_KEY, 3, 4),
-            "29:3: " + getCheckMessage(MSG_KEY, 3, 4),
-            "39:1: " + getCheckMessage(MSG_KEY, 1, 4),
-            "50:5: " + getCheckMessage(MSG_KEY, 5, 6),
+            "13:1: " + getCheckMessage(MSG_KEY, 0, 1),
+            "18:5: " + getCheckMessage(MSG_KEY, 2, 1),
+            "28:3: " + getCheckMessage(MSG_KEY, 0, 1),
+            "29:3: " + getCheckMessage(MSG_KEY, 0, 1),
+            "39:1: " + getCheckMessage(MSG_KEY, -2, 1),
+            "50:5: " + getCheckMessage(MSG_KEY, 0, 1),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+    }
+
+    @Test
+    public void testExample2() throws Exception {
+        final String[] expected = {
+            "16:2: " + getCheckMessage(MSG_KEY, 1, 0),
+            "20:5: " + getCheckMessage(MSG_KEY, 2, 0),
+            "21:4: " + getCheckMessage(MSG_KEY, 1, 0),
+            "25:4: " + getCheckMessage(MSG_KEY, 1, 0),
+            "26:4: " + getCheckMessage(MSG_KEY, 1, 0),
+            "35:4: " + getCheckMessage(MSG_KEY, 1, 0),
+            "36:4: " + getCheckMessage(MSG_KEY, 1, 0),
+            "41:1: " + getCheckMessage(MSG_KEY, -2, 0),
+            "45:4: " + getCheckMessage(MSG_KEY, 1, 0),
+            "46:4: " + getCheckMessage(MSG_KEY, 1, 0),
+            "53:6: " + getCheckMessage(MSG_KEY, 1, 0),
+            "57:6: " + getCheckMessage(MSG_KEY, 1, 0),
+            "58:6: " + getCheckMessage(MSG_KEY, 1, 0),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example1.java
@@ -8,12 +8,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocleadingasteriskalign;
 // xdoc section - start
-// violation 2 lines below '1, expected is 2.'
+// violation 2 lines below '0, expected is 1.'
 /**
 * Javadoc for class.
  */
 public class Example1 {
-  // violation 2 lines below '5, expected is 4.'
+  // violation 2 lines below '2, expected is 1.'
   /**
     * Javadoc for instance variable, over-indented.
    */
@@ -23,17 +23,17 @@ public class Example1 {
    * Javadoc for instance variable, correctly aligned.
    */
   private int goodIndentField;
-  // violation 2 lines below '3, expected is 4.'
+  // violation 2 lines below '0, expected is 1.'
   /**
   *  Javadoc for method, under-indented.
   */
   private void wrongIndentMethod() {}
-  // violation 2 lines above '3, expected is 4.'
+  // violation 2 lines above '0, expected is 1.'
   /**
    * Javadoc for method, correctly aligned.
    */
   private void goodIndentMethod() {}
-  // violation 3 lines below '1, expected is 4.'
+  // violation 3 lines below '-2, expected is 1.'
   /**
    Javadoc for constructor, missing leading asterisk alignment on closing tag.
 */
@@ -45,7 +45,7 @@ public class Example1 {
   public Example1(int value) {}
 
   private enum indentedEnum {
-    // violation 2 lines below '5, expected is 6.'
+    // violation 2 lines below '0, expected is 1.'
     /**
     *  Wrong alignment for enum constant.
      */

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/Example2.java
@@ -1,0 +1,62 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocLeadingAsteriskAlign">
+      <property name="indentation" value="0"/>
+    </module>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocleadingasteriskalign;
+// xdoc section - start
+
+/**
+* Javadoc for class.
+ */ // violation '1, expected is 0.'
+public class Example2 {
+
+  /**
+    * Javadoc for instance variable, over-indented. // violation '2, expected is 0.'
+   */ // violation '1, expected is 0.'
+  private int wrongIndentField;
+
+  /**
+   * Javadoc for instance variable, correctly aligned. // violation '1, expected is 0.'
+   */ // violation '1, expected is 0.'
+  private int goodIndentField;
+
+  /**
+  *  Javadoc for method, under-indented.
+  */
+  private void wrongIndentMethod() {}
+
+  /**
+   * Javadoc for method, correctly aligned. // violation '1, expected is 0.'
+   */ // violation '1, expected is 0.'
+  private void goodIndentMethod() {}
+
+  /**
+   Javadoc for constructor, missing leading asterisk alignment on closing tag.
+*/ // violation '-2, expected is 0.'
+  private Example2() {}
+
+  /**
+   * Javadoc for constructor, correctly aligned. // violation '1, expected is 0.'
+   */ // violation '1, expected is 0.'
+  public Example2(int value) {}
+
+  private enum indentedEnum {
+
+    /**
+    *  Wrong alignment for enum constant.
+     */ // violation '1, expected is 0.'
+    WRONG,
+
+    /**
+     * Correct alignment for enum constant. // violation '1, expected is 0.'
+     */ // violation '1, expected is 0.'
+    GOOD
+  }
+}
+// xdoc section - end


### PR DESCRIPTION
## Summary
- Add an `indentation` property (`int`, default `1`) to `JavadocLeadingAsteriskAlign` that sets the expected number of columns between the slash of the opening javadoc tag and the leading asterisks. `indentation=1` preserves the existing under-first-asterisk style; `indentation=0` allows the left-aligned style discussed in #19808.
- The same expected column is used to validate the closing javadoc tag.
- The violation message arguments now report offsets from the slash instead of absolute columns, so the reported "expected" value matches the configured `indentation`.

## Notes
- Resolves #20970.
- One pre-existing edge case is unchanged and worth flagging: when the opening line already carries a leading asterisk (e.g. `/**   * text`), that asterisk's own column defines the expected alignment for the rest of the comment, overriding `indentation`. This keeps default behavior unchanged and is covered by `InputJavadocLeadingAsteriskAlignIndentationZero` (`openingLineAsterisk` case).

## Test plan
- [x] `JavadocLeadingAsteriskAlignCheckTest` (7/7, including new `testIndentationZero` / `testIndentationTwo`)
- [x] `JavadocLeadingAsteriskAlignExamplesTest` (2/2, new `Example2`)
- [x] `GeneralFormTest` (Google style `it` suite, 14/14)
- [x] `XdocsPagesTest` (20/20)