### PR TITLE
Issue #21119: Fix duplicate violation behavior in examples: methodname

### DIFF
--- a/src/site/xdoc/checks/naming/methodname.xml
+++ b/src/site/xdoc/checks/naming/methodname.xml
@@ -101,13 +101,13 @@ class Example1 {
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
           An example of how to configure the check for names that begin with a lower case letter,
-          followed by letters, digits, and underscores is:
+          followed by at least 7 letters or digits is:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodName"&gt;
-       &lt;property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
+       &lt;property name="format" value="^[a-z][a-zA-Z0-9]{7,}$"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -115,10 +115,10 @@ class Example1 {
         <p id="Example2-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example2 {
-  public void method1() {}
+  public void method1() {}    // violation 'Name 'method1' must match pattern'
   protected void Method2() {} // violation 'Name 'Method2' must match pattern'
-  private void Method3() {} // violation 'Name 'Method3' must match pattern'
-  public void Example3() {} // violation 'Name 'Example3' must match pattern'
+  private void Method3() {}   // violation 'Name 'Method3' must match pattern'
+  public void Example3() {}   // violation 'Name 'Example3' must match pattern'
   void Method5() {} // violation 'Name 'Method5' must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>

--- a/src/site/xdoc/checks/naming/methodname.xml.template
+++ b/src/site/xdoc/checks/naming/methodname.xml.template
@@ -44,7 +44,7 @@
         </macro><hr class="example-separator"/>
         <p id="Example2-config">
           An example of how to configure the check for names that begin with a lower case letter,
-          followed by letters, digits, and underscores is:
+          followed by at least 7 letters or digits is:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -98,7 +98,6 @@ public class XdocsExampleFileTest {
     private static final Set<String> SUPPRESSED_UNIQUENESS_CHECK_MODULES = Set.of(
         "checks/javadoc/missingjavadocmethod/",
         "checks/naming/constantname/",
-        "checks/naming/methodname/",
         "checks/nocodeinfile/",
         "checks/outertypefilename/"
     );

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
@@ -41,20 +41,20 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
 
     @Test
     public void test() {
-        assertThat(XmlMetaReader.readAllModulesIncludingThirdPartyIfAny()).hasSize(226);
+        assertThat(XmlMetaReader.readAllModulesIncludingThirdPartyIfAny()).hasSize(228);
     }
 
     @Test
     public void testDuplicatePackage() {
         assertThat(XmlMetaReader
                 .readAllModulesIncludingThirdPartyIfAny("com.puppycrawl.tools.checkstyle.meta"))
-                .hasSize(226);
+                .hasSize(228);
     }
 
     @Test
     public void testBadPackage() {
         assertThat(XmlMetaReader.readAllModulesIncludingThirdPartyIfAny("DOES.NOT.EXIST"))
-                .hasSize(226);
+                .hasSize(228);
     }
 
     @Test

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckExamplesTest.java
@@ -48,11 +48,12 @@ public class MethodNameCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "18:18: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", "^[a-z](_?[a-zA-Z0-9]+)*$"),
-            "19:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Method3", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "17:15: " + getCheckMessage(MSG_INVALID_PATTERN, "method1", "^[a-z][a-zA-Z0-9]{7,}$"),
+            "18:18: " + getCheckMessage(MSG_INVALID_PATTERN, "Method2", "^[a-z][a-zA-Z0-9]{7,}$"),
+            "19:16: " + getCheckMessage(MSG_INVALID_PATTERN, "Method3", "^[a-z][a-zA-Z0-9]{7,}$"),
             "20:15: " + getCheckMessage(MSG_INVALID_PATTERN, "Example3",
-                    "^[a-z](_?[a-zA-Z0-9]+)*$"),
-            "21:8: " + getCheckMessage(MSG_INVALID_PATTERN, "Method5", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+                    "^[a-z][a-zA-Z0-9]{7,}$"),
+            "21:8: " + getCheckMessage(MSG_INVALID_PATTERN, "Method5", "^[a-z][a-zA-Z0-9]{7,}$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example2.java
@@ -2,7 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="MethodName">
-       <property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/>
+       <property name="format" value="^[a-z][a-zA-Z0-9]{7,}$"/>
     </module>
   </module>
 </module>
@@ -14,10 +14,10 @@ package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 
 // xdoc section - start
 class Example2 {
-  public void method1() {}
+  public void method1() {}    // violation 'Name 'method1' must match pattern'
   protected void Method2() {} // violation 'Name 'Method2' must match pattern'
-  private void Method3() {} // violation 'Name 'Method3' must match pattern'
-  public void Example3() {} // violation 'Name 'Example3' must match pattern'
+  private void Method3() {}   // violation 'Name 'Method3' must match pattern'
+  public void Example3() {}   // violation 'Name 'Example3' must match pattern'
   void Method5() {} // violation 'Name 'Method5' must match pattern'
 }
 // xdoc section - end


### PR DESCRIPTION
#21119

```
Module 'methodname': examples [Example1.java, Example2.java] produce identical violations
(18:Name 'Method2' must match pattern|19:Name 'Method3' must match pattern|
20:Name 'Example3' must match pattern|21:Name 'Method5' must match pattern).
```

Fixes the collision and removes `checks/naming/methodname/` from `SUPPRESSED_UNIQUENESS_CHECK_MODULES`.

## Root cause

`Example2`'s `format="^[a-z](_?[a-zA-Z0-9]+)*$"` is `MethodName`'s own default pattern  setting it explicitly changes nothing versus `Example1`'s implicit default, so both examples flag the exact same four uppercase-starting method names on the exact same lines.

## Fix

Changed `Example2`'s `format` to `^[a-z][a-zA-Z0-9]{7,}$`, requiring lowercase start plus a minimum 8-character length. This additionally rejects `method1` (7 characters, previously the only compliant method in the shared source), producing a 5th violation and diverging from `Example1`'s 4-violation signature  while still being a coherent standalone demonstration of the `format` property (a length-constrained naming convention). No structural/code change.

## Files changed

- `src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/Example2.java`
- `src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java` — removed `"checks/naming/methodname/"` from `SUPPRESSED_UNIQUENESS_CHECK_MODULES`
