### PR TITLE
Issue #21137: Add default SeverityMatchFilter example

### DIFF
--- a/src/site/xdoc/filters/severitymatchfilter.xml
+++ b/src/site/xdoc/filters/severitymatchfilter.xml
@@ -48,7 +48,7 @@
       </subsection>
       <subsection name="Examples" id="SeverityMatchFilter_Examples">
         <p id="Example1-config">
-          For example, the following configuration fragment directs the
+          For example, the following default configuration fragment directs the
           Checker to not report audit events with severity
           level <code>info</code>:
         </p>
@@ -60,10 +60,7 @@
     &lt;/module&gt;
     &lt;module name="MethodName"/&gt;
   &lt;/module&gt;
-  &lt;module name="SeverityMatchFilter"&gt;
-    &lt;property name="severity" value="info"/&gt;
-    &lt;property name="acceptOnMatch" value="false"/&gt;
-  &lt;/module&gt;
+  &lt;module name="SeverityMatchFilter"/&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example1-code">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -160,7 +160,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/coding/returncount",
             "checks/descendanttoken",
             "checks/imports/importcontrol",
-            "filters/severitymatchfilter",
             "filters/suppressionfilter",
             "filters/suppressionsinglefilter",
             "filters/suppressionxpathfilter",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/severitymatchfilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/severitymatchfilter/Example1.java
@@ -6,10 +6,7 @@
     </module>
     <module name="MethodName"/>
   </module>
-  <module name="SeverityMatchFilter">
-    <property name="severity" value="info"/>
-    <property name="acceptOnMatch" value="false"/>
-  </module>
+  <module name="SeverityMatchFilter"/>
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.severitymatchfilter;


### PR DESCRIPTION
addresses #21137 by replacing the explicit `SeverityMatchFilter` properties with the equivalent default configuration.

this also removes the example from the ast-consistency exclusion list, so the documented configuration is exercised by the xdocs example checks.

checks:
- focused xdocs example suite: 5 tests passed
- xml formatting validation passed
- `git diff --check`