### PR TITLE
Issue #21119: Fix duplicate violation behavior in examples: typename

### DIFF
--- a/src/site/xdoc/checks/naming/typename.xml
+++ b/src/site/xdoc/checks/naming/typename.xml
@@ -222,15 +222,15 @@ class Example5 {
 </code></pre></div><hr class="example-separator"/>
         <p id="Example6-config">
           An example of how to configure the check for names that begin with a lower case letter,
-          followed by letters, digits, and underscores. Also, suppress the check from being
-          applied to package-private type:
+          followed by letters, digits, and underscores. Also, restrict the check to only apply
+          to enum definitions:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TypeName"&gt;
       &lt;property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
-      &lt;property name="applyToPackage" value="false"/&gt;
+      &lt;property name="tokens" value="ENUM_DEF"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -239,10 +239,10 @@ class Example5 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example6 {
   public interface firstName {}
-  public class SecondName {}     // violation 'Name 'SecondName' must match pattern'
-  protected class Third_Name {}  // violation 'Name 'Third_Name' must match pattern'
-  private class FourthName_ {}   // violation 'Name 'FourthName_' must match pattern'
-  enum Fifth_Name {}
+  public class SecondName {}
+  protected class Third_Name {}
+  private class FourthName_ {}
+  enum Fifth_Name {} // violation 'Name 'Fifth_Name' must match pattern'
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example7-config">

--- a/src/site/xdoc/checks/naming/typename.xml.template
+++ b/src/site/xdoc/checks/naming/typename.xml.template
@@ -109,8 +109,8 @@
         </macro><hr class="example-separator"/>
         <p id="Example6-config">
           An example of how to configure the check for names that begin with a lower case letter,
-          followed by letters, digits, and underscores. Also, suppress the check from being
-          applied to package-private type:
+          followed by letters, digits, and underscores. Also, restrict the check to only apply
+          to enum definitions:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -99,7 +99,6 @@ public class XdocsExampleFileTest {
         "checks/javadoc/missingjavadocmethod/",
         "checks/naming/constantname/",
         "checks/naming/methodname/",
-        "checks/naming/typename/",
         "checks/nocodeinfile/",
         "checks/outertypefilename/"
     );

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheckExamplesTest.java
@@ -95,12 +95,8 @@ public class TypeNameCheckExamplesTest extends AbstractExamplesModuleTestSupport
     @Test
     public void testExample6() throws Exception {
         final String[] expected = {
-            "17:16: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "SecondName", "^[a-z](_?[a-zA-Z0-9]+)*$"),
-            "18:19: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "Third_Name", "^[a-z](_?[a-zA-Z0-9]+)*$"),
-            "19:17: " + getCheckMessage(MSG_INVALID_PATTERN,
-                    "FourthName_", "^[a-z](_?[a-zA-Z0-9]+)*$"),
+            "20:8: " + getCheckMessage(MSG_INVALID_PATTERN,
+                    "Fifth_Name", "^[a-z](_?[a-zA-Z0-9]+)*$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example6.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/typename/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/typename/Example6.java
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="TypeName">
       <property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/>
-      <property name="applyToPackage" value="false"/>
+      <property name="tokens" value="ENUM_DEF"/>
     </module>
   </module>
 </module>
@@ -14,9 +14,9 @@ package com.puppycrawl.tools.checkstyle.checks.naming.typename;
 // xdoc section - start
 class Example6 {
   public interface firstName {}
-  public class SecondName {}     // violation 'Name 'SecondName' must match pattern'
-  protected class Third_Name {}  // violation 'Name 'Third_Name' must match pattern'
-  private class FourthName_ {}   // violation 'Name 'FourthName_' must match pattern'
-  enum Fifth_Name {}
+  public class SecondName {}
+  protected class Third_Name {}
+  private class FourthName_ {}
+  enum Fifth_Name {} // violation 'Name 'Fifth_Name' must match pattern'
 }
 // xdoc section - end


### PR DESCRIPTION
#21119 

```
Module 'typename': examples [Example5.java, Example6.java] produce identical violations
(17:Name 'SecondName' must match pattern|18:Name 'Third_Name' must match pattern|
19:Name 'FourthName_' must match pattern).
```

Fixes the collision and removes `checks/naming/typename/` from `SUPPRESSED_UNIQUENESS_CHECK_MODULES`.

## Root cause

`Example5` and `Example6` were configured identically (`format="^[a-z](_?[a-zA-Z0-9]+)*$"`, `applyToPackage="false"`), producing identical output  an exact duplicate rather than a coincidental config-difference collision.

## Fix

Repurposed `Example6` to demonstrate `tokens="ENUM_DEF"`, a property combination not covered by any of the module's other 6 examples. Under this scope, only the `enum Fifth_Name` declaration is evaluated (all class/interface declarations fall out of scope), and since `Fifth_Name` fails the naming pattern, it becomes the example's sole violation. This also fills a real documentation gap: previously no example demonstrated scoping the check to enums specifically, despite the shared source already containing an enum declaration that fails the pattern in every other example without ever being flagged. No structural/code change same 5 type declarations, only properties and violation-comment placement changed.

## Files changed

- `src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/typename/Example6.java`
- `src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java` — removed `"checks/naming/typename/"` from `SUPPRESSED_UNIQUENESS_CHECK_MODULES`

## Testing

- Ran `testAllModuleExamplesAreBehaviorallyUnique` locally — `typename` no longer appears in the failure output.
- Manually re-verified all 7 examples don't produce any other pairwise collision.
- Confirmed `Example6.java` remains structurally valid Java and AST-consistent with siblings (only property values and comment placement differ).