### PR TITLE
Issue #97: Add ignoreMethodsWithImplementation to JavadocMethod

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -167,6 +167,9 @@ public class JavadocMethodCheck extends AbstractJavadocCheck {
      */
     private boolean allowInlineReturn;
 
+    /** Control whether to ignore Javadoc requirements for methods with an implementation. */
+    private boolean ignoreMethodsWithImplementation;
+
     /** Specify the access modifiers where Javadoc comments are checked. */
     private AccessModifierOption[] accessModifiers = {
         AccessModifierOption.PUBLIC,
@@ -213,6 +216,17 @@ public class JavadocMethodCheck extends AbstractJavadocCheck {
      */
     public void setAllowInlineReturn(boolean value) {
         allowInlineReturn = value;
+    }
+
+    /**
+     * Setter to control whether to ignore Javadoc requirements for methods
+     * with an implementation.
+     *
+     * @param value user's value.
+     * @since 13.10.0
+     */
+    public void setIgnoreMethodsWithImplementation(boolean value) {
+        ignoreMethodsWithImplementation = value;
     }
 
     /**
@@ -312,6 +326,19 @@ public class JavadocMethodCheck extends AbstractJavadocCheck {
                 super.visitToken(blockCommentNode);
             }
         }
+    }
+
+    /**
+     * Checks whether the method has an implementation whose Javadoc requirements
+     * should be ignored.
+     *
+     * @param ast the declaration to check
+     * @return {@code true} when the method should be ignored
+     */
+    private boolean shouldIgnoreMethod(DetailAST ast) {
+        return ignoreMethodsWithImplementation
+                && ast.getType() == TokenTypes.METHOD_DEF
+                && ast.findFirstToken(TokenTypes.SLIST) != null;
     }
 
     @Override
@@ -444,22 +471,28 @@ public class JavadocMethodCheck extends AbstractJavadocCheck {
     /**
      * Checks whether the given declaration should be validated.
      *
-     * <p>The declaration is checked only when both its own access modifier and the
-     * access modifier of the surrounding type match the configured
+     * <p>The declaration is checked only when it is not ignored by
+     * {@code ignoreMethodsWithImplementation}, and both its own access modifier
+     * and the access modifier of the surrounding type match the configured
      * {@code accessModifiers}.</p>
      *
      * @param ast the method, constructor, annotation field, or compact constructor
      *        AST node to check
-     * @return {@code true} if the declaration is inside the configured access scope
+     * @return {@code true} if the declaration should be checked
      */
     private boolean shouldCheck(final DetailAST ast) {
-        final Optional<AccessModifierOption> surroundingAccessModifier = CheckUtil
-                .getSurroundingAccessModifier(ast);
-        final AccessModifierOption accessModifier = CheckUtil
-                .getAccessModifierFromModifiersToken(ast);
-        return surroundingAccessModifier.isPresent() && Arrays.stream(accessModifiers)
-                        .anyMatch(modifier -> modifier == surroundingAccessModifier.get())
-                && Arrays.stream(accessModifiers).anyMatch(modifier -> modifier == accessModifier);
+        boolean result = !shouldIgnoreMethod(ast);
+        if (result) {
+            final Optional<AccessModifierOption> surroundingAccessModifier = CheckUtil
+                    .getSurroundingAccessModifier(ast);
+            final AccessModifierOption accessModifier = CheckUtil
+                    .getAccessModifierFromModifiersToken(ast);
+            result = surroundingAccessModifier.isPresent() && Arrays.stream(accessModifiers)
+                            .anyMatch(modifier -> modifier == surroundingAccessModifier.get())
+                    && Arrays.stream(accessModifiers)
+                            .anyMatch(modifier -> modifier == accessModifier);
+        }
+        return result;
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMethodCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMethodCheck.xml
@@ -87,6 +87,11 @@
                       type="java.lang.String[]">
                <description>Specify annotations that allow missed documentation.</description>
             </property>
+            <property default-value="false"
+                      name="ignoreMethodsWithImplementation"
+                      type="boolean">
+               <description>Control whether to ignore Javadoc requirements for methods with an implementation.</description>
+            </property>
             <property default-value="METHOD_DEF,CTOR_DEF,ANNOTATION_FIELD_DEF,COMPACT_CTOR_DEF"
                       name="tokens"
                       type="java.lang.String[]"

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml
@@ -28,6 +28,7 @@
               <li><a href="#Example6-config" class="toc-sublink">Ly for tokens which are Constructor Definitions</a></li>
               <li><a href="#Example7-config" class="toc-sublink">Validate <code>throws</code> tags, you can use following config.</a></li>
               <li><a href="#Example8-config" class="toc-sublink">Allow inline <code>return</code> tags, you can use following config.</a></li>
+              <li><a href="#Example9-config" class="toc-sublink">Ignore Javadoc requirements for methods that have an implementation</a></li>
             </ul>
           </li>
           <li><a href="#JavadocMethod_Example_of_Usage">Example of Usage</a></li>
@@ -148,6 +149,13 @@ public int checkReturnTag(final int aTagIndex,
               <td><a href="../../property_types.html#String.5B.5D">String[]</a></td>
               <td><code>Override</code></td>
               <td>6.0</td>
+            </tr>
+            <tr>
+              <td><a id="ignoreMethodsWithImplementation"/><a href="#ignoreMethodsWithImplementation">ignoreMethodsWithImplementation</a></td>
+              <td>Control whether to ignore Javadoc requirements for methods with an implementation.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>13.10.0</td>
             </tr>
             <tr>
               <td><a id="validateThrows"/><a href="#validateThrows">validateThrows</a></td>
@@ -570,6 +578,54 @@ public class Example8 {
    */
   public int getFoo() {
     // ok, allowInlineReturn is true
+    return 0;
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example9-config">
+          To configure the check to ignore Javadoc requirements for methods
+          that have an implementation:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocMethod"&gt;
+        &lt;property name="ignoreMethodsWithImplementation" value="true"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example9-code"> Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example9 {
+
+  /** */
+  Example9(int x) {}
+  // violation above 'Expected @param tag for 'x'.'
+  /** */
+  public int m1(int p1) throws IOException {
+    // ok, Javadoc requirements are ignored
+    // because the method has
+    // an implementation
+    throw new IOException();
+  }
+
+  /**
+   * @param p1 The first number
+   */
+  @Deprecated
+  private int m2(int p1) {
+    return p1;
+  }
+  // ok, Javadoc requirements are ignored
+  /** */
+  void m3(int p1) {}
+  // ok, Javadoc requirements are ignored
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+    // ok, Javadoc requirements are ignored
     return 0;
   }
 }

--- a/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocmethod.xml.template
@@ -148,6 +148,21 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example8.java"/>
           <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example9-config">
+          To configure the check to ignore Javadoc requirements for methods
+          that have an implementation:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example9.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example9-code"> Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example9.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
       <subsection name="Example of Usage" id="JavadocMethod_Example_of_Usage">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -614,6 +614,17 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testIgnoreMethodsWithImplementation() throws Exception {
+        final String[] expected = {
+            "24:41: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "value"),
+            "27:45: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "value"),
+            "32:33: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "value"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethodIgnoreMethodsWithImplementation.java"), expected);
+    }
+
+    @Test
     public void testJavadocMethodBlockComment() throws Exception {
         final String[] expected = {
             "29: " + getCheckMessage(MSG_RETURN_EXPECTED),

--- a/src/test/resources-with-javadoc-error/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionTwo.java
+++ b/src/test/resources-with-javadoc-error/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionTwo.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodThrowsDetectionTwo {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod1.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod3.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAboveComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAboveComments.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodAboveComments {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAllowInlineReturn.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAllowInlineReturn.java
@@ -6,11 +6,11 @@ validateThrows = (default)false
 accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodAllowInlineReturn {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAllowedAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodAllowedAnnotations.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodAllowedAnnotations implements SomeInterface {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodBlockComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodBlockComment.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodBlockComment {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompilationUnit.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCompilationUnit.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 @Deprecated @ProblemCauser

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodConstructor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodConstructor.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodConstructor {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCustomMessage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCustomMessage.java
@@ -6,6 +6,7 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 message.javadoc.return.expected = @return tag should be present and have description :)
@@ -13,7 +14,6 @@ message.javadoc.expectedTag = Expected {0} tag for ''{1}'' :)
 message.javadoc.unusedTag = Unused {0} tag for ''{1}'' :)
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodCustomMessage {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDefaultAccessModifier.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDefaultAccessModifier.java
@@ -6,11 +6,11 @@ accessModifiers = public
 allowMissingParamTags = (default)false
 allowMissingReturnTag = true
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public interface InputJavadocMethodDefaultAccessModifier {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDoNotAllowInlineReturn.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDoNotAllowInlineReturn.java
@@ -1,6 +1,7 @@
 /*
 JavadocMethod
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 allowedAnnotations = (default)Override
 validateThrows = (default)false
 accessModifiers = (default)public, protected, package, private
@@ -10,7 +11,6 @@ violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodDoNotAllowInlineReturn {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDuplicateParam.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDuplicateParam.java
@@ -1,6 +1,7 @@
 /*
 JavadocMethod
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 allowedAnnotations = (default)Override
 validateThrows = (default)false
 accessModifiers = (default)public, protected, package, private
@@ -10,7 +11,6 @@ violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodDuplicateParam {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDuplicateThrows.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDuplicateThrows.java
@@ -1,6 +1,7 @@
 /*
 JavadocMethod
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 allowedAnnotations = (default)Override
 validateThrows = (default)false
 accessModifiers = (default)public, protected, package, private
@@ -10,7 +11,6 @@ violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodDuplicateThrows {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodEnum.java
@@ -6,11 +6,11 @@ accessModifiers = private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodEnum {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtendAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtendAnnotation.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 import com.google.common.collect.Multiset;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtraThrowsOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtraThrowsOne.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodExtraThrowsOne {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtraThrowsTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodExtraThrowsTwo.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 import java.io.File;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodGenerics.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodGenerics.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodGenerics <E extends java.lang.Exception,

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodHtml.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodHtml.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = true
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodHtml {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreMethodsWithImplementation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreMethodsWithImplementation.java
@@ -1,0 +1,49 @@
+/*
+JavadocMethod
+allowedAnnotations = (default)Override
+validateThrows = (default)false
+accessModifiers = (default)public, protected, package, private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = true
+violateExecutionOnNonTightHtml = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public abstract class InputJavadocMethodIgnoreMethodsWithImplementation {
+
+    /** A concrete method. */
+    public void concreteMethod(int value) {
+    }
+
+    /** A native method. */
+    public native void nativeMethod(int value); // violation 'Expected @param tag for 'value'.'
+
+    /** An abstract method. */
+    public abstract void abstractMethod(int value); // violation 'Expected @param tag for 'value'.'
+
+    interface ExampleInterface {
+
+        /** A bodyless interface method. */
+        void bodylessMethod(int value); // violation 'Expected @param tag for 'value'.'
+
+        /** A default interface method. */
+        default void defaultMethod(int value) {
+        }
+
+        /** A static interface method. */
+        static void staticMethod(int value) {
+        }
+
+        /** A private interface method. */
+        private void privateMethod(int value) {
+        }
+    }
+
+    public void undocumentedMethod() {
+    } // ok, method has an implementation and no Javadoc is required
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsOne.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 import java.util.function.Function;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrowsTwo.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 import java.io.BufferedReader;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodInheritDoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodInheritDoc.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodInheritDoc

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodJavadocInMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodJavadocInMethod.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodJavadocInMethod {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodLoadErrors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodLoadErrors.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodLoadErrors

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodMissingJavadocNoMissingTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodMissingJavadocNoMissingTags.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = true
 allowMissingReturnTag = true
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodMissingJavadocNoMissingTags {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodMissingJavadocTagsDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodMissingJavadocTagsDefault.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodMissingJavadocTagsDefault {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocDefault.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodNoJavadocDefault //comment test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocOnlyPrivateScope.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocOnlyPrivateScope.java
@@ -6,11 +6,11 @@ accessModifiers = private, package, public
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodNoJavadocOnlyPrivateScope //comment test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocOnlyPrivateScopePackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocOnlyPrivateScopePackage.java
@@ -6,11 +6,11 @@ accessModifiers = private, package, public
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodNoJavadocOnlyPrivateScopePackage { // ignored

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocProtectedScope.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocProtectedScope.java
@@ -6,11 +6,11 @@ accessModifiers = public, protected
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodNoJavadocProtectedScope //comment test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocProtectedScopePackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodNoJavadocProtectedScopePackage.java
@@ -6,11 +6,11 @@ accessModifiers = public, protected
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodNoJavadocProtectedScopePackage { // ignored

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPackageClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPackageClass.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodPackageClass { // ignored

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPackageClass2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPackageClass2.java
@@ -6,10 +6,10 @@ accessModifiers = private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodPackageClass2 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodParamsTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodParamsTags.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodParamsTags {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodProtectedScopeJavadocOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodProtectedScopeJavadocOne.java
@@ -6,11 +6,11 @@ accessModifiers = public, protected
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodProtectedScopeJavadocOne // ignore - need javadoc

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodProtectedScopeJavadocTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodProtectedScopeJavadocTwo.java
@@ -6,11 +6,11 @@ accessModifiers = public, protected
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodProtectedScopeJavadocTwo {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly1One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly1One.java
@@ -6,11 +6,11 @@ accessModifiers =
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodPublicOnly1One // ignore - need javadoc

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly1Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly1Two.java
@@ -6,11 +6,11 @@ accessModifiers =
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodPublicOnly1Two {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnlyOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnlyOne.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodPublicOnlyOne // ignore - need javadoc

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnlyTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnlyTwo.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodPublicOnlyTwo {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodReceiverParameter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodReceiverParameter.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 import java.lang.annotation.ElementType;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords2.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = true
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecords3.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodScopeAnonInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodScopeAnonInner.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 import java.awt.event.MouseEvent;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodScopeInnerInterfaces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodScopeInnerInterfaces.java
@@ -6,11 +6,11 @@ accessModifiers = public
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodScopeInnerInterfaces

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodSetterGetter.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodSetterGetter.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodSetterGetter

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodSurroundingAccessModifier.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodSurroundingAccessModifier.java
@@ -6,11 +6,11 @@ accessModifiers = private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodSurroundingAccessModifier //comment test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 enum InputJavadocMethodTagsEnum

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1One.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1One.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1Three.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1Three.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 import java.io.IOException;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1Two.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTags1Two.java
@@ -6,10 +6,10 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 import java.io.IOException;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionOne.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionOne.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodThrowsDetectionOne {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionTwo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetectionTwo.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTypeParamsTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodTypeParamsTags.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_01.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_01.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethod_01 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_02.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_02.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethod_02 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_03.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_03.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethod_03 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_1379666.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_1379666.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethod_1379666 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodsNotSkipWritten.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodsNotSkipWritten.java
@@ -6,11 +6,11 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
 
 public class InputJavadocMethodsNotSkipWritten {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressByIdJavadocCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressByIdJavadocCheck.java
@@ -14,12 +14,12 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 id = foo
 
 */
-
 package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
 
 public class InputSuppressWithPlainTextCommentFilterSuppressByIdJavadocCheck {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil4.java
@@ -6,11 +6,11 @@ validateThrows = (default)false
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.utils.checkutil;
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil5.java
@@ -6,11 +6,11 @@ validateThrows = (default)false
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.utils.checkutil;
 
 final class InputCheckUtil5 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtil7.java
@@ -6,11 +6,11 @@ accessModifiers = public
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
-
 package com.puppycrawl.tools.checkstyle.utils.checkutil;
 
 public class InputCheckUtil7 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilAnnotationFieldDefComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilAnnotationFieldDefComments.java
@@ -6,12 +6,12 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 
 */
-
 package com.puppycrawl.tools.checkstyle.utils.javadocutil;
 
 @interface InputJavadocUtilAnnotationFieldDefComments {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilCompactCtorDefComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilCompactCtorDefComments.java
@@ -6,12 +6,12 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 
 */
-
 package com.puppycrawl.tools.checkstyle.utils.javadocutil;
 
 public class InputJavadocUtilCompactCtorDefComments {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilCtorDefComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilCtorDefComments.java
@@ -6,12 +6,12 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 
 */
-
 package com.puppycrawl.tools.checkstyle.utils.javadocutil;
 
 class InputJavadocUtilCtorDefComments {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilMethodDefComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilMethodDefComments.java
@@ -6,12 +6,12 @@ accessModifiers = (default)public, protected, package, private
 allowMissingParamTags = (default)false
 allowMissingReturnTag = (default)false
 allowInlineReturn = (default)false
+ignoreMethodsWithImplementation = (default)false
 violateExecutionOnNonTightHtml = (default)false
 tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 
 */
-
 package com.puppycrawl.tools.checkstyle.utils.javadocutil;
 
 class InputJavadocUtilMethodDefComments {

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckExamplesTest.java
@@ -124,4 +124,12 @@ public class JavadocMethodCheckExamplesTest extends AbstractExamplesModuleTestSu
         verifyWithInlineConfigParser(getPath("Example8.java"), expected);
     }
 
+    @Test
+    public void testExample9() throws Exception {
+        final String[] expected = {
+            "18:16: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "x"),
+        };
+        verifyWithInlineConfigParser(getPath("Example9.java"), expected);
+    }
+
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example9.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/Example9.java
@@ -1,0 +1,47 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocMethod">
+        <property name="ignoreMethodsWithImplementation" value="true"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+import java.io.IOException;
+
+// xdoc section - start
+public class Example9 {
+
+  /** */
+  Example9(int x) {}
+  // violation above 'Expected @param tag for 'x'.'
+  /** */
+  public int m1(int p1) throws IOException {
+    // ok, Javadoc requirements are ignored
+    // because the method has
+    // an implementation
+    throw new IOException();
+  }
+
+  /**
+   * @param p1 The first number
+   */
+  @Deprecated
+  private int m2(int p1) {
+    return p1;
+  }
+  // ok, Javadoc requirements are ignored
+  /** */
+  void m3(int p1) {}
+  // ok, Javadoc requirements are ignored
+  /**
+   * {@return the foo}
+   */
+  public int getFoo() {
+    // ok, Javadoc requirements are ignored
+    return 0;
+  }
+}
+// xdoc section - end


### PR DESCRIPTION
Issue: #97

## Summary

- add the `ignoreMethodsWithImplementation` property to `JavadocMethod`
- ignore methods containing a body (`SLIST`) when the property is enabled
- continue checking native, abstract, and bodyless interface methods
- document the property and add focused unit and documentation examples

The property defaults to `false`, so existing behavior remains unchanged.

## Validation

- `mvnw clean verify`
- `mvnw clean -Dtest=JavadocMethodCheckTest,JavadocMethodCheckExamplesTest,XdocsExamplesAstConsistencyTest,XdocsPagesTest test` (94 tests passed)

## Diff regression

Diff Regression config: https://gist.githubusercontent.com/BitsToBytes-Saksham/4cc26cab00d6d74038aa1a8f1cf62132/raw/5f73df93b42871fed896cffb662508b07e7c1fcb/javadoc-method-base.xml
Diff Regression patch config: https://gist.githubusercontent.com/BitsToBytes-Saksham/4cc26cab00d6d74038aa1a8f1cf62132/raw/c372ce314396680fd8e55934f27bde076c84dd64/javadoc-method-patch.xml
Report label: ignoreMethodsWithImplementation=true

Upstream contribution configuration: https://github.com/checkstyle/contribution/pull/1102

@romani, this follows the clarified scope from the issue discussion and is ready for review.
