### PR TITLE
Issue #21152: Test's violation-line comparison uses absolute file lin…

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -96,10 +96,20 @@ public class XdocsExampleFileTest {
      * <a href="https://github.com/checkstyle/checkstyle/issues/21072">...</a>
      */
     private static final Set<String> SUPPRESSED_UNIQUENESS_CHECK_MODULES = Set.of(
-        "checks/javadoc/missingjavadocmethod/",
-        "checks/naming/constantname/",
-        "checks/nocodeinfile/",
-        "checks/outertypefilename/"
+        "checks/annotation/annotationlocation/",
+        "checks/coding/hiddenfield/",
+        "checks/coding/returncount/",
+        "checks/imports/avoidstarimport/",
+        "checks/javadoc/javadocvariable/",
+        "checks/javadoc/missingjavadoctype/",
+        "checks/naming/illegalidentifiername/",
+        "checks/naming/localfinalvariablename/",
+        "checks/naming/patternvariablename/",
+        "checks/outertypefilename/",
+        "checks/regexp/regexpmultiline/",
+        "checks/regexp/regexpsingleline/",
+        "checks/trailingcomment/",
+        "checks/whitespace/filetabcharacter/"
     );
 
     @Test
@@ -408,16 +418,26 @@ public class XdocsExampleFileTest {
     }
 
     /**
-     * Builds a signature from an example's expected violations: line number plus
-     * message, joined per violation. Line number is included (not stripped)
-     * because all examples of a check are guaranteed structurally identical by
-     * AST (enforced separately by XdocsExamplesAstConsistencyTest) - only
-     * comments/config differ - so a given line number means the same structural
-     * position across every example of that module, making it a meaningful part
-     * of the comparison rather than noise.
+     * Builds a signature from an example's expected violations, restricted to the
+     * region between "// xdoc section - start" and "// xdoc section - end" (the
+     * only part actually rendered to users in the generated HTML), with line
+     * numbers normalized relative to the start marker.
      *
-     * <p>Returns null if any violation message in the file is unspecified, or if
-     * the file has zero violations, since neither case is a reliable duplicate
+     * <p>Line number is included (not stripped) because all examples of a check
+     * are guaranteed structurally identical by AST (enforced separately by
+     * XdocsExamplesAstConsistencyTest) - only comments/config differ - so a given
+     * relative line number means the same structural position within the visible
+     * section across every example of that module, making it a meaningful part of
+     * the comparison rather than noise. Restricting to the visible section and
+     * normalizing against the start marker (rather than the absolute file line)
+     * avoids false collisions/false negatives caused by incidental whitespace or
+     * config-block padding above the marker, which is invisible to users and
+     * should never affect whether two examples look identical in the rendered
+     * docs - see review discussion on #21072.
+     *
+     * <p>Returns null if any violation message in the file is unspecified, if
+     * the file has zero violations within the visible section, or if the markers
+     * themselves cannot be found, since none of those are a reliable duplicate
      * signal - see InlineConfigParser.SUPPRESSED_VALIDATE_MESSAGE_FILES /
      * SUPPRESSED_CHECKS.
      *
@@ -437,14 +457,34 @@ public class XdocsExampleFileTest {
             final boolean hasUnspecifiedMessage = violations.stream()
                     .anyMatch(violation -> violation.message() == null);
 
-            if (hasUnspecifiedMessage || violations.isEmpty()) {
+            final int[] sectionBounds = findVisibleSectionBounds(exampleFile);
+
+            if (hasUnspecifiedMessage || sectionBounds == null || violations.isEmpty()) {
                 signature = null;
             }
             else {
-                signature = violations.stream()
-                        .sorted()
-                        .map(violation -> violation.lineNo() + ":" + violation.message())
-                        .collect(Collectors.joining("|"));
+                final int startLine = sectionBounds[0];
+                final int endLine = sectionBounds[1];
+
+                final List<TestInputViolation> visibleViolations = violations.stream()
+                        .filter(violation -> {
+                            return violation.lineNo() > startLine
+                                    && violation.lineNo() < endLine;
+                        })
+                        .toList();
+
+                if (visibleViolations.isEmpty()) {
+                    signature = null;
+                }
+                else {
+                    signature = visibleViolations.stream()
+                            .sorted()
+                            .map(violation -> {
+                                final int relativeLine = violation.lineNo() - startLine;
+                                return relativeLine + ":" + violation.message();
+                            })
+                            .collect(Collectors.joining("|"));
+                }
             }
         }
         // -@cs[IllegalCatch] InlineConfigParser.parse declares "throws Exception";
@@ -455,6 +495,36 @@ public class XdocsExampleFileTest {
             signature = null;
         }
         return signature;
+    }
+
+    /**
+     * Locates the 1-based line numbers of the "// xdoc section - start" and
+     * "// xdoc section - end" marker comments in a file.
+     *
+     * @return a two-element array {startLine, endLine}, or null if either marker
+     *     is missing (in which case the file is skipped from comparison rather
+     *     than guessed at).
+     */
+    private static int[] findVisibleSectionBounds(Path exampleFile) throws IOException {
+        final List<String> lines = Files.readAllLines(exampleFile);
+        int startLine = -1;
+        int endLine = -1;
+
+        for (int index = 0; index < lines.size(); index++) {
+            final String trimmed = lines.get(index).trim();
+            if (XdocsExamplesAstConsistencyTest.XDOC_START_MARKER.equals(trimmed)) {
+                startLine = index + 1;
+            }
+            else if (XdocsExamplesAstConsistencyTest.XDOC_END_MARKER.equals(trimmed)) {
+                endLine = index + 1;
+            }
+        }
+
+        int[] result = null;
+        if (startLine != -1 && endLine != -1) {
+            result = new int[] {startLine, endLine};
+        }
+        return result;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -77,6 +77,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  */
 public class XdocsExamplesAstConsistencyTest {
 
+    public static final String XDOC_START_MARKER = "// xdoc section - start";
+    public static final String XDOC_END_MARKER = "// xdoc section - end";
+
     private static final Path XDOCS_ROOT = Path.of(
             "src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle"
     );
@@ -84,8 +87,7 @@ public class XdocsExamplesAstConsistencyTest {
     private static final Path XDOCS_NONCOMPILABLE_ROOT = Path.of(
             "src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle"
     );
-    private static final String XDOC_START_MARKER = "// xdoc section - start";
-    private static final String XDOC_END_MARKER = "// xdoc section - end";
+
     private static final Pattern BLOCK_COMMENT_PATTERN = Pattern.compile("(?s)/\\*.*?\\*/");
 
     /**


### PR DESCRIPTION
#21152

## Fix

Restricted violation comparison to the region between `// xdoc section - start` and `// xdoc section - end`, and normalized each violation's line number relative to the start marker rather than the absolute file position:

1. Locates the 1-based line numbers of both marker comments in the file.
2. Filters `TestInputViolation`s to only those strictly between the two markers (excluding violations landing exactly on the marker lines themselves).
3. Computes each included violation's signature component as `(lineNo - startMarkerLine) + ":" + message`, so the same relative position within the visible section always produces the same number regardless of unrelated content above the marker.
4. If either marker is missing from a file, skips that file from comparison (return `null` from `buildSignature`, consistent with existing null-signature handling for unspecified messages / zero violations) rather than guessing.

```
Found examples with duplicate behavior:
Module 'annotationlocation': examples [Example1.java, Example5.java] produce identical violations (12:Annotation 'SuppressWarnings' should be alone on line|14:Annotation 'SuppressWarnings' should be alone on line|16:Annotation 'Mock' should be alone on line).
Module 'hiddenfield': examples [Example5.java, Example6.java] produce identical violations (6:'testField' hides a field|9:'field' hides a field|18:'field' hides a field).
Module 'returncount': examples [Example1.java, Example4.java] produce identical violations (11:max allowed for non-void methods/lambdas is 3).
Module 'avoidstarimport': examples [Example3.java, Example5.java] produce identical violations (3:form of import should be avoided.).
Module 'avoidstarimport': examples [Example2.java, Example6.java] produce identical violations (4:Using the '.*' form of import should be avoided.).
Module 'javadocvariable': examples [Example1.java, Example4.java] produce identical violations (2:Missing a Javadoc comment for 'a'.|8:Missing a Javadoc comment for 'c'.|9:Missing a Javadoc comment for 'd'.|10:Missing a Javadoc comment for 'e'.|13:Missing a Javadoc comment for 'CONSTANT'.|17:Missing a Javadoc comment for 'CONSTANT'.).
Module 'missingjavadoctype': examples [Example1.java, Example5.java] produce identical violations (20:Missing a Javadoc comment for 'F'.).
Module 'missingjavadoctype': examples [Example2.java, Example4.java] produce identical violations (6:Missing a Javadoc comment for 'B'.|8:Missing a Javadoc comment for 'C'.|20:Missing a Javadoc comment for 'F'.).
Module 'illegalidentifiername': examples [Example1.java, Example3.java] produce identical violations (2:Name 'var' must match pattern|6:must match pattern).
Module 'localfinalvariablename': examples [Example1.java, Example2.java] produce identical violations (5:Name 'VAR1' must match pattern|10:Name 'VAR2' must match pattern).
Module 'patternvariablename': examples [Example1.java, Example3.java] produce identical violations (3:Name 'STRING' must match pattern*.|6:Name 'num_1' must match pattern*.).
Module 'outertypefilename': examples [Example2.java, Example3.java, Example4.java, Example5.java] produce identical violations (2:The name of the outer type and the file do not match.).
Module 'regexpmultiline': examples [Example5.java, Example7.java] produce identical violations (19:Line matches the illegal pattern|28:Line matches the illegal pattern).
Module 'regexpsingleline': examples [Example3.java, Example5.java] produce identical violations (2:Line matches the illegal pattern).
Module 'trailingcomment': examples [Example1.java, Example3.java] produce identical violations (5:Don't use trailing comments.|11:Don't use trailing comments.).
Module 'filetabcharacter': examples [Example1.java, Example3.java] produce identical violations (2:File contains tab characters).

	at com.puppycrawl.tools.checkstyle.internal.XdocsExampleFileTest.testAllModuleExamplesAreBehaviorallyUnique(XdocsExampleFileTest.java:248)

```