### PR TITLE
Issue #21139: Avoid duplicate regex match in SuppressFilterElement

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java
@@ -168,10 +168,21 @@ public class SuppressFilterElement
     private boolean isFileMatch(String fileName) {
         boolean match = fileRegexp.matcher(fileName).find();
         if (!match) {
-            final String slashesFileName = fileName.replace('\\', '/');
-            match = fileRegexp.matcher(slashesFileName).find();
+            match = matchNormalizedPathIfRequired(fileName);
         }
         return match;
+    }
+
+    /**
+     * Fallback match for file names containing backslashes.
+     *
+     * @param fileName the name of the file to check
+     * @return true if the normalized file name matches the pattern
+     */
+    private boolean matchNormalizedPathIfRequired(String fileName) {
+        final String slashesFileName = fileName.replace('\\', '/');
+        return !slashesFileName.equals(fileName)
+                && fileRegexp.matcher(slashesFileName).find();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElementTest.java
@@ -341,4 +341,15 @@ public class SuppressFilterElementTest {
                 .isFalse();
     }
 
+    @Test
+    public void testMatchNormalizedPathIfRequiredWhenIdentical() {
+        final SuppressFilterElement testFilter = new SuppressFilterElement(
+                "MyClass\\.java", null, null, null, null, null);
+        final AuditEvent event = new AuditEvent(this, "OtherClass.java", null);
+
+        assertWithMessage("Filter should accept event when file name does not match")
+                .that(testFilter.accept(event))
+                .isTrue();
+    }
+
 }


### PR DESCRIPTION
Fixes #21139

Performance: In `SuppressFilterElement.isFileMatch`, when a file path does not contain backslashes, the second regex check can be avoided.