### PR TITLE
Issue #17728: Add ArrayBracketNoWhitespace to google_checks

### DIFF
--- a/config/google-java-format/excluded/compilable-input-paths.txt
+++ b/config/google-java-format/excluded/compilable-input-paths.txt
@@ -40,6 +40,7 @@ src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobre
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule452indentcontinuationlines/InputClassWithChainedMethods2.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputVerticalWhitespace.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/InputEmptyLineSeparator3.java
+src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputArrayBracketNoWhitespace.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterBad.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAfterGood.java

--- a/config/google-java-format/suppressions/suppress-diff-lte-100.txt
+++ b/config/google-java-format/suppressions/suppress-diff-lte-100.txt
@@ -1,3 +1,4 @@
+InputArrayBracketNoWhitespace.java
 InputTryCatchIfElse.java
 InputVerticalWhitespace.java
 InputClassWithChainedMethods.java

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/HorizontalWhitespaceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/HorizontalWhitespaceTest.java
@@ -235,4 +235,14 @@ public class HorizontalWhitespaceTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputSingleSpaceSeparatorReservedWords.java"));
     }
 
+    @Test
+    public void testArrayBracketNoWhitespace() throws Exception {
+        verifyWithWholeConfig(getPath("InputArrayBracketNoWhitespace.java"));
+    }
+
+    @Test
+    public void testArrayBracketNoWhitespaceFormatted() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedArrayBracketNoWhitespace.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapArrayDeclarator.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapArrayDeclarator.java
@@ -5,5 +5,8 @@ class InputSeparatorWrapArrayDeclarator {
   protected int[] arrayDeclarationWithGoodWrapping = new int[] {1, 2};
 
   protected int[] arrayDeclarationWithBadWrapping = new int
-      [] {1, 2}; // violation ''\[' should be on the previous line.'
+      [] {1, 2};
+      // 2 violations above:
+      // ''\[' is preceded with whitespace'
+      // ''\[' should be on the previous line'
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputArrayBracketNoWhitespace.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputArrayBracketNoWhitespace.java
@@ -1,0 +1,104 @@
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+import java.util.function.IntFunction;
+
+/** Some javadoc. */
+public class InputArrayBracketNoWhitespace {
+
+  private int @Ann[] nums1;
+  // 2 violations above:
+  // 'Ann' is not followed by whitespace'
+  // '\[' is not preceded with whitespace'
+
+  private int @Ann [] nums2;
+
+  void method() {
+    String[]strings = {};
+    // violation above ''\]' is not followed by whitespace'
+
+    int [] arr = {1, 2, 3, 4, 5};
+    // violation above ''\[' is preceded with whitespace'
+
+    int [] [] arr2 = {{arr[0 ], arr[ 1], arr[ 2 ] }};
+    // 8 violations above:
+    // ''\[' is preceded with whitespace'
+    // ''\]' is followed by whitespace'
+    // ''\[' is preceded with whitespace'
+    // ''\]' is preceded with whitespace'
+    // ''\[' is followed by whitespace'
+    // ''\[' is followed by whitespace'
+    // ''\]' is followed by whitespace'
+    // ''\]' is preceded with whitespace'
+
+    arr2[ 0 ][ 1] = arr[4];
+    // 3 violations above:
+    // ''\[' is followed by whitespace'
+    // ''\]' is preceded with whitespace'
+    // ''\[' is followed by whitespace'
+
+    int[] emptyArray = new int[ ] {};
+    // 2 violations above:
+    // ''\[' is followed by whitespace'
+    // ''\]' is preceded with whitespace'
+
+    Class<?> cls = int [] .class;
+    // 3 violations above:
+    // ''\[' is preceded with whitespace'
+    // ''\]' is followed by whitespace'
+    // ''.' is preceded with whitespace'
+
+    boolean intArray = arr instanceof int [];
+    // violation above ''\[' is preceded with whitespace'
+
+    int [][] matrix = new int[2][3];
+    // violation above ''\[' is preceded with whitespace'
+
+    foo(arr[1] , arr[2] );
+    // 4 violations above:
+    // ''\]' is followed by whitespace'
+    // '',' is preceded with whitespace'
+    // ''\]' is followed by whitespace'
+    // '')' is preceded with whitespace'
+
+    int num = arr[1] ++;
+    // 2 violations above:
+    // ''\]' is followed by whitespace'
+    // ''\++' is preceded with whitespace'
+
+    num = arr[1] --;
+    // 2 violations above:
+    // ''\]' is followed by whitespace'
+    // ''--' is preceded with whitespace'
+
+    num = arr[1]+ arr[2]- arr[3]* arr[4]/ arr[5];
+    // 8 violations above:
+    // ''\]' is not followed by whitespace'
+    // ''\+' is not preceded with whitespace'
+    // ''\]' is not followed by whitespace'
+    // ''\-' is not preceded with whitespace'
+    // ''\]' is not followed by whitespace'
+    // ''\*' is not preceded with whitespace'
+    // ''\]' is not followed by whitespace'
+    // ''/' is not preceded with whitespace'
+
+    num = arr[1]<< 1;
+    // 2 violations above:
+    // ''\]' is not followed by whitespace'
+    // '<<' is not preceded with whitespace'
+
+    num = arr[1]>> 1;
+    //  2 violations above:
+    // ''\]' is not followed by whitespace'
+    // '>>' is not preceded with whitespace'
+
+    IntFunction<int[]> methodRef = int[] ::new;
+    // 2 violations above:
+    // ''\]' is followed by whitespace'
+    // ''::' is preceded with whitespace'
+  }
+
+  void foo(int... a) {}
+
+  @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)
+  @interface Ann {}
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedArrayBracketNoWhitespace.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedArrayBracketNoWhitespace.java
@@ -1,0 +1,48 @@
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+import java.util.function.IntFunction;
+
+/** Some javadoc. */
+public class InputFormattedArrayBracketNoWhitespace {
+
+  private int @Ann [] nums1;
+
+  private int @Ann [] nums2;
+
+  void method() {
+    String[] strings = {};
+
+    int[] arr = {1, 2, 3, 4, 5};
+
+    int[][] arr2 = {{arr[0], arr[1], arr[2]}};
+
+    arr2[0][1] = arr[4];
+
+    int[] emptyArray = new int[] {};
+
+    Class<?> cls = int[].class;
+
+    boolean intArray = arr instanceof int[];
+
+    int[][] matrix = new int[2][3];
+
+    foo(arr[1], arr[2]);
+
+    int num = arr[1]++;
+
+    num = arr[1]--;
+
+    num = arr[1] + arr[2] - arr[3] * arr[4] / arr[5];
+
+    num = arr[1] << 1;
+
+    num = arr[1] >> 1;
+
+    IntFunction<int[]> methodRef = int[]::new;
+  }
+
+  void foo(int... a) {}
+
+  @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)
+  @interface Ann {}
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputMethodParamPad2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputMethodParamPad2.java
@@ -54,7 +54,7 @@ public class InputMethodParamPad2 {
 
   /** Some javadoc. */
   public void newArray() {
-    int[] a = new int[]{0, 1};
+    int[] a = new int[]{0, 1}; // violation ''\]' is not followed by whitespace'
     java.util.Vector<String> v = new java.util.Vector<String>();
     java.util.Vector<String> v1 = new Vector<String>();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
@@ -16,14 +16,18 @@ public class InputNoWhitespaceBeforeAnnotations {
   @interface NonNull2 {}
 
   @NonNull int @AnnoType[] @NonNull2[] field1;
-  // 2 violations above:
+  // 4 violations above:
   //   ''AnnoType' is not followed by whitespace'
+  //   ''\[' is not preceded with whitespace'
   //   ''NonNull2' is not followed by whitespace'
+  //   ''\[' is not preceded with whitespace'
 
   @NonNull int @AnnoType [] @NonNull2 [] field2;
 
   @NonNull int @AnnoType [] @NonNull2[] field3;
-  // violation above ''NonNull2' is not followed by whitespace'
+  // 2 violations above:
+  // ''NonNull2' is not followed by whitespace'
+  // ''\[' is not preceded with whitespace'
 
   // @NonNull int @NonNull ... field3; // non-compilable
   // @NonNull int @NonNull... field4; // non-compilable
@@ -39,7 +43,9 @@ public class InputNoWhitespaceBeforeAnnotations {
 
   /** Some javadoc. */
   public void foo3(final char @NonNull[] param) {}
-  // violation above ''NonNull' is not followed by whitespace'
+  // 2 violations above:
+  // ''NonNull' is not followed by whitespace'
+  // ''\[' is not preceded with whitespace'
 
   /** Some javadoc. */
   public void foo4(final char @NonNull [] param) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEllipsis.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEllipsis.java
@@ -40,16 +40,23 @@ public class InputNoWhitespaceBeforeEllipsis {
   void test5(String[]... param) {}
 
   /** Some javadoc. */
-  void test6(String[] ... param) {} // violation ''...' is preceded with whitespace.'
+  void test6(String[] ... param) {}
+  // 2 violations above:
+  // ''\]' is followed by whitespace'
+  // ''...' is preceded with whitespace.'
 
   /** Some javadoc. */
   void test7(String @NonNull[]... param) {}
-  // violation above ''NonNull' is not followed by whitespace'
+  // 2 violations above:
+  // ''NonNull' is not followed by whitespace'
+  // ''\[' is not preceded with whitespace'
 
   /** Some javadoc. */
   void test8(String @NonNull[] ... param) {}
-  // 2 violations above:
+  // 4 violations above:
   //   ''NonNull' is not followed by whitespace'
+  // ''\[' is not preceded with whitespace'
+  // ''\]' is followed by whitespace'
   //   ''...' is preceded with whitespace.'
 
   void test9(String @Size(max = 10) ... names) {}
@@ -60,14 +67,20 @@ public class InputNoWhitespaceBeforeEllipsis {
   void test11(@NonNull String @C [] @B ... arg) {}
 
   void test12(@NonNull String @C []    ... arg) {}
-  // violation above ''...' is preceded with whitespace'
-  // violation 2 lines above 'Use a single space to separate non-whitespace characters'
+  // 3 violations above:
+  // ''\]' is followed by whitespace'
+  // ''...' is preceded with whitespace'
+  // 'Use a single space to separate non-whitespace characters'
 
-  // violation below 'Use a single space to separate non-whitespace characters'
   void test13(@NonNull String    [] @B ... arg) {}
+  // 2 violations above:
+  // ''\[' is preceded with whitespace'
+  // 'Use a single space to separate non-whitespace characters'
 
   void test14(   String    [] @B ... arg) {}
-  // violation above ''(' is followed by whitespace'
-  // violation 2 lines above 'Use a single space to separate non-whitespace characters'
-  // violation 3 lines above 'Use a single space to separate non-whitespace characters'
+  // 4 violations above:
+  // ''(' is followed by whitespace'
+  // 'Use a single space to separate non-whitespace characters'
+  // ''\[' is preceded with whitespace'
+  // 'Use a single space to separate non-whitespace characters'
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundGenerics.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundGenerics.java
@@ -39,9 +39,10 @@ class BadCommas < A, B, C extends Map < A, String > > {
 // violation below 'Top-level class Wildcard has to reside in its own source file.'
 class Wildcard {
   public static void foo(Collection < ? extends Wildcard[] > collection) {
-    // 3 violations above:
+    // 4 violations above:
     //  ''\<' is followed by whitespace.'
     //  ''\<' is preceded with whitespace.'
+    // ''\]' is followed by whitespace'
     //  ''\>' is preceded with whitespace.'
     // A statement is important in this method to flush out any
     // issues with parsing the wildcard in the signature

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaAndChildOnTheSameLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaAndChildOnTheSameLine.java
@@ -37,6 +37,7 @@ public class InputLambdaAndChildOnTheSameLine {
   }
 
   void testMethod2() {
+    // violation 3 lines below ''\]' is not followed by whitespace'
     var service = (CharSequence) Proxy.newProxyInstance(
         InputLambdaAndChildOnTheSameLine.class.getClassLoader(),
         new Class[]{CharSequence.class},
@@ -50,6 +51,7 @@ public class InputLambdaAndChildOnTheSameLine {
   }
 
   void testMethod3() {
+    // violation 3 lines below ''\]' is not followed by whitespace'
     var service = (CharSequence) Proxy.newProxyInstance(
         InputLambdaAndChildOnTheSameLine.class.getClassLoader(),
         new Class[]{CharSequence.class},

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -207,6 +207,7 @@
                                    may only be represented as '{}' when not part of a
                                    multi-block statement (4.1.3)"/>
     </module>
+    <module name="ArrayBracketNoWhitespace"/>
     <module name="SingleSpaceSeparator"/>
     <module name="OneStatementPerLine"/>
     <module name="MultipleVariableDeclarations"/>

--- a/src/site/xdoc/checks/whitespace/arraybracketnowhitespace.xml
+++ b/src/site/xdoc/checks/whitespace/arraybracketnowhitespace.xml
@@ -131,6 +131,10 @@ class Example1 {
       <subsection name="Example of Usage" id="ArrayBracketNoWhitespace_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ArrayBracketNoWhitespace">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ArrayBracketNoWhitespace">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/whitespace/arraybracketnowhitespace.xml.template
+++ b/src/site/xdoc/checks/whitespace/arraybracketnowhitespace.xml.template
@@ -44,6 +44,10 @@
       <subsection name="Example of Usage" id="ArrayBracketNoWhitespace_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ArrayBracketNoWhitespace">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ArrayBracketNoWhitespace">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/google_style.xml
+++ b/src/site/xdoc/google_style.xml
@@ -1024,6 +1024,15 @@
                   <span class="wrapper inline">
                     <img src="images/ok_green.png" alt="" />
                   </span>
+                  <a href="checks/whitespace/arraybracketnowhitespace.html#ArrayBracketNoWhitespace">
+                    ArrayBracketNoWhitespace</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ArrayBracketNoWhitespace">
+                  config</a>)
+                  <br />
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
                   <a href="checks/whitespace/whitespacearound.html#WhitespaceAround">
                     WhitespaceAround</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+WhitespaceAround">


### PR DESCRIPTION
Issue: #17728 

## 4.6.2 Horizontal whitespace
[4.6.2 Horizontal whitespace](https://google.github.io/styleguide/javaguide.html#s4.6.2-horizontal-whitespace)
> 10. Between a type annotation and [] or ....

Adding module  ArrayBracketNoWhitespace to google_checks