### PR TITLE
Issue #20982: Add JavadocEndCommentDelimiter check

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -745,6 +745,10 @@
       <property name="tags" value="noinspection"/>
     </module>
     <module name="JavadocContentLocation"/>
+    <module name="JavadocEndCommentDelimiter">
+      <!-- Existing project sources use additional asterisks in Javadoc closing delimiters. -->
+      <property name="severity" value="ignore"/>
+    </module>
     <module name="JavadocMethod">
       <property name="validateThrows" value="true"/>
     </module>

--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -183,6 +183,10 @@
   <suppress checks="LineLength"
             files="regexponfilename/Example[14].java"/>
 
+  <!-- The full violation message is longer than the example line-length limit. -->
+  <suppress checks="LineLength"
+            files="javadocendcommentdelimiter/Example1.java"/>
+
   <!-- Example needs to exclude fully qualified name longer than 85 characters  -->
   <suppress checks="LineLength" files="classdataabstractioncoupling/UseCase6.java"/>
 

--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -323,6 +323,8 @@
   <suppress id="propertiesMacroMustExist"
          files="src/site/xdoc/checks/javadoc/invalidjavadocposition.xml.template"/>
   <suppress id="propertiesMacroMustExist"
+         files="src/site/xdoc/checks/javadoc/javadocendcommentdelimiter.xml.template"/>
+  <suppress id="propertiesMacroMustExist"
          files="src/site/xdoc/checks/javadoc/missingjavadocpackage.xml.template"/>
   <suppress id="propertiesMacroMustExist"
          files="src/site/xdoc/checks/misc/nocodeinfile.xml.template"/>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionJavadocEndCommentDelimiterTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/javadoc/XpathRegressionJavadocEndCommentDelimiterTest.java
@@ -1,0 +1,110 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter.javadoc;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.checkstyle.suppressionxpathfilter.AbstractXpathTestSupport;
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocEndCommentDelimiterCheck;
+
+public class XpathRegressionJavadocEndCommentDelimiterTest
+        extends AbstractXpathTestSupport {
+
+    private static final Class<JavadocEndCommentDelimiterCheck> CLASS =
+            JavadocEndCommentDelimiterCheck.class;
+
+    @Override
+    protected String getCheckName() {
+        return CLASS.getSimpleName();
+    }
+
+    @Override
+    public String getPackageLocation() {
+        return "org/checkstyle/suppressionxpathfilter/javadoc/javadocendcommentdelimiter";
+    }
+
+    @Test
+    public void testInvalidDelimiter() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathJavadocEndCommentDelimiter.java"));
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);
+        final String[] expectedViolation = {
+            "5:18: " + getCheckMessage(CLASS,
+                    JavadocEndCommentDelimiterCheck.MSG_END_COMMENT_DELIMITER),
+        };
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/CLASS_DEF"
+                        + "[./IDENT[@text='InputXpathJavadocEndCommentDelimiter']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='method']]"
+                        + "/MODIFIERS/BLOCK_COMMENT_BEGIN"
+                        + "[./COMMENT_CONTENT[@text='* Invalid. *']]"
+                        + "/BLOCK_COMMENT_END"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testClassJavadoc() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathJavadocEndCommentDelimiterClass.java"));
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);
+        final String[] expectedViolation = {
+            "3:14: " + getCheckMessage(CLASS,
+                    JavadocEndCommentDelimiterCheck.MSG_END_COMMENT_DELIMITER),
+        };
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/CLASS_DEF"
+                        + "[./IDENT[@text='InputXpathJavadocEndCommentDelimiterClass']]"
+                        + "/MODIFIERS/BLOCK_COMMENT_BEGIN"
+                        + "[./COMMENT_CONTENT[@text='* Invalid. *']]"
+                        + "/BLOCK_COMMENT_END"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testFieldJavadoc() throws Exception {
+        final File fileToProcess =
+                new File(getPath("InputXpathJavadocEndCommentDelimiterField.java"));
+        final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);
+        final String[] expectedViolation = {
+            "5:18: " + getCheckMessage(CLASS,
+                    JavadocEndCommentDelimiterCheck.MSG_END_COMMENT_DELIMITER),
+        };
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/COMPILATION_UNIT/CLASS_DEF"
+                        + "[./IDENT[@text='InputXpathJavadocEndCommentDelimiterField']]"
+                        + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='field']]"
+                        + "/MODIFIERS/BLOCK_COMMENT_BEGIN"
+                        + "[./COMMENT_CONTENT[@text='* Invalid. *']]"
+                        + "/BLOCK_COMMENT_END"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/javadocendcommentdelimiter/InputXpathJavadocEndCommentDelimiter.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/javadocendcommentdelimiter/InputXpathJavadocEndCommentDelimiter.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.javadoc.javadocendcommentdelimiter;
+
+public class InputXpathJavadocEndCommentDelimiter {
+
+    /** Invalid. **/ // warn
+    public void method() { }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/javadocendcommentdelimiter/InputXpathJavadocEndCommentDelimiterClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/javadocendcommentdelimiter/InputXpathJavadocEndCommentDelimiterClass.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.javadoc.javadocendcommentdelimiter;
+
+/** Invalid. **/ // warn
+public class InputXpathJavadocEndCommentDelimiterClass {
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/javadocendcommentdelimiter/InputXpathJavadocEndCommentDelimiterField.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoc/javadocendcommentdelimiter/InputXpathJavadocEndCommentDelimiterField.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.javadoc.javadocendcommentdelimiter;
+
+public class InputXpathJavadocEndCommentDelimiterField {
+
+    /** Invalid. **/ // warn
+    private int field;
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -708,6 +708,8 @@ public class PackageObjectFactory implements ModuleFactory {
                 BASE_PACKAGE + ".checks.javadoc.JavadocBlockTagLocationCheck");
         NAME_TO_FULL_MODULE_NAME.put("JavadocContentLocationCheck",
                 BASE_PACKAGE + ".checks.javadoc.JavadocContentLocationCheck");
+        NAME_TO_FULL_MODULE_NAME.put("JavadocEndCommentDelimiterCheck",
+                BASE_PACKAGE + ".checks.javadoc.JavadocEndCommentDelimiterCheck");
         NAME_TO_FULL_MODULE_NAME.put("JavadocLeadingAsteriskAlignCheck",
                 BASE_PACKAGE + ".checks.javadoc.JavadocLeadingAsteriskAlignCheck");
         NAME_TO_FULL_MODULE_NAME.put("JavadocMethodCheck",

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocEndCommentDelimiterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocEndCommentDelimiterCheck.java
@@ -1,0 +1,78 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import com.puppycrawl.tools.checkstyle.StatelessCheck;
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
+
+/**
+ * Checks that the Javadoc end-comment delimiter contains exactly one asterisk.
+ *
+ * @since 13.10.0
+ */
+@StatelessCheck
+public class JavadocEndCommentDelimiterCheck extends AbstractCheck {
+
+    /** A key is pointing to the warning message text in "messages.properties" file. */
+    public static final String MSG_END_COMMENT_DELIMITER = "javadoc.end.comment.delimiter";
+
+    /**
+     * Creates a new {@code JavadocEndCommentDelimiterCheck} instance.
+     */
+    public JavadocEndCommentDelimiterCheck() {
+        // no code by default
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[] {
+            TokenTypes.BLOCK_COMMENT_BEGIN,
+        };
+    }
+
+    @Override
+    public boolean isCommentNodesRequired() {
+        return true;
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        if (JavadocUtil.isJavadocComment(ast)) {
+            final DetailAST commentContent = ast.findFirstToken(TokenTypes.COMMENT_CONTENT);
+            if (commentContent.getText().endsWith("*")) {
+                log(ast.getLastChild(), MSG_END_COMMENT_DELIMITER);
+            }
+        }
+    }
+
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -7,6 +7,7 @@ javadoc.classInfo=Unable to get class information for {0} tag ''{1}''.
 javadoc.content.first.line=Javadoc content should start from the same line as /**.
 javadoc.content.second.line=Javadoc content should start from the next line after /**.
 javadoc.duplicateTag=Duplicate {0} tag.
+javadoc.end.comment.delimiter=Javadoc closing delimiter should contain exactly one asterisk.
 javadoc.expectedTag=Expected {0} tag for ''{1}''.
 javadoc.invalidInheritDoc=Invalid use of the ''@inheritDoc'' tag.
 javadoc.legacyPackageHtml=Legacy package.html file should be removed.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -7,6 +7,7 @@ javadoc.classInfo=Kann für das Tag ''{1}'' keine Klasseninformation zu {0} lade
 javadoc.content.first.line=Javadoc-Inhalt sollte in der gleichen Zeile wie /** beginnen.
 javadoc.content.second.line=Javadoc-Inhalt sollte in der nächsten Zeile nach /** beginnen.
 javadoc.duplicateTag=Doppeltes Tag {0}.
+javadoc.end.comment.delimiter=Der Javadoc-Abschlussbegrenzer sollte genau ein Sternchen enthalten.
 javadoc.expectedTag=Erwartetes Tag {0} für ''{1}''.
 javadoc.invalidInheritDoc=Unerlaubte Verwendung des Tags ''@inheritDoc''.
 javadoc.legacyPackageHtml=Die veraltete Datei package.html sollte entfernt werden.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -7,6 +7,7 @@ javadoc.classInfo=No se puede obtener la información de clase para {0} etiqueta
 javadoc.content.first.line=El contenido de Javadoc debe comenzar desde la misma línea que /**.
 javadoc.content.second.line=El contenido de Javadoc debe comenzar desde la siguiente línea después de /**.
 javadoc.duplicateTag=Etiqueta {0} duplicada.
+javadoc.end.comment.delimiter=El delimitador de cierre de Javadoc debe contener exactamente un asterisco.
 javadoc.expectedTag=Se esperaba la etiqueta {0} para ''{1}''.
 javadoc.invalidInheritDoc=Uso no válido de la etiqueta ''@inheritDoc''.
 javadoc.legacyPackageHtml=Archivo package.html legado debe ser eliminado.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -7,6 +7,7 @@ javadoc.classInfo=Luokkatiedot ei saatavilla: {0} tagi ''{1}''.
 javadoc.content.first.line=Javadoc-sisällön pitäisi alkaa samalta riviltä kuin /**.
 javadoc.content.second.line=Javadocin sisällön pitäisi alkaa seuraavasta rivistä /**: n jälkeen.
 javadoc.duplicateTag=Duplikaatti {0}-tagi.
+javadoc.end.comment.delimiter=Javadoc-kommentin lopetuserottimessa pitäisi olla täsmälleen yksi asteriski.
 javadoc.expectedTag=Javadoc-tagi puuttuu: {0} tagi ''{1}''.
 javadoc.invalidInheritDoc=Virheellinen käyttö ''@inheritDoc'' tag.
 javadoc.legacyPackageHtml=Legacy package.html tiedosto tulisi poistaa.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -7,6 +7,7 @@ javadoc.classInfo=Impossible d''obtenir les informations relatives à la classe 
 javadoc.content.first.line=Le contenu Javadoc doit commencer par la même ligne que /**.
 javadoc.content.second.line=Le contenu Javadoc doit commencer à la ligne suivante après /**.
 javadoc.duplicateTag=Balise Javadoc {0} présente plus d''une fois.
+javadoc.end.comment.delimiter=Le délimiteur de fin de commentaire Javadoc doit contenir exactement un astérisque.
 javadoc.expectedTag=Balise Javadoc {0} manquante pour ''{1}''.
 javadoc.invalidInheritDoc=Utilisation invalide de la balise ''@inheritDoc''.
 javadoc.legacyPackageHtml=L''ancien fichier package.html doit être supprimé.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -7,6 +7,7 @@ javadoc.classInfo={0} タグの ''{1}'' のクラス情報が取得できませ�
 javadoc.content.first.line=Javadoc コンテンツは、 /** と同じ行から開始する必要があります。
 javadoc.content.second.line=Javadoc コンテンツは、 /** の後の次の行から開始する必要があります。
 javadoc.duplicateTag={0} タグが重複しています。
+javadoc.end.comment.delimiter=Javadoc コメントの終了区切り文字には、アスタリスクを 1 つだけ含める必要があります。
 javadoc.expectedTag=''{1}'' には {0} タグが必要です。
 javadoc.invalidInheritDoc='' @inheritDoc ''タグの使用が無効です。
 javadoc.legacyPackageHtml=古い形式のpackage.htmlファイルは削除してください。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -7,6 +7,7 @@ javadoc.classInfo=Não foi possível obter informações de classe para {0} tag 
 javadoc.content.first.line=O conteúdo Javadoc deveria começar da mesma linha que o /**.
 javadoc.content.second.line=O conteúdo Javadoc deveria começar a partir da próxima linha depois do /**.
 javadoc.duplicateTag=A tag ''{0}'' está duplicada.
+javadoc.end.comment.delimiter=O delimitador de fim do comentário Javadoc deve conter exatamente um asterisco.
 javadoc.expectedTag=Esperada a tag {0} para ''{1}''.
 javadoc.invalidInheritDoc=Uso inválido da tag ''@inheritDoc''.
 javadoc.legacyPackageHtml=O arquivo package.html legado deve ser removido.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ru.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ru.properties
@@ -7,6 +7,7 @@ javadoc.classInfo=Не удалось получить информацию о �
 javadoc.content.first.line=Содержимое Javadoc должно начинаться с той же строки, что и /**.
 javadoc.content.second.line=Содержимое Javadoc должно начинаться со следующей строки, после /**.
 javadoc.duplicateTag=Повторяющийся тег {0}.
+javadoc.end.comment.delimiter=Закрывающий ограничитель Javadoc должен содержать ровно одну звёздочку.
 javadoc.expectedTag=Ожидается тег {0} для ''{1}''.
 javadoc.invalidInheritDoc=Недопустимое использование тега ''@inheritDoc''.
 javadoc.legacyPackageHtml=Устаревший файл package.html следует удалить.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -7,6 +7,7 @@ javadoc.classInfo={0} etiketi ''{1}'' için sınıf bilgisi alınamıyor.
 javadoc.content.first.line=Javadoc içeriği /** ile aynı satırdan başlamalıdır.
 javadoc.content.second.line=Javadoc içeriği /** dan sonraki satırdan başlamalıdır.
 javadoc.duplicateTag={0} etiketi tekrarlanmış.
+javadoc.end.comment.delimiter=Javadoc yorum sonu sınırlayıcısı tam olarak bir yıldız işareti içermelidir.
 javadoc.expectedTag=''{1}'' için {0} etiketi gerekli.
 javadoc.invalidInheritDoc=''@inheritDoc'' etiketi kullanımı geçersiz.
 javadoc.legacyPackageHtml=Eskide kalan package.html dosyaları kaldırılmalı.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -7,6 +7,7 @@ javadoc.classInfo=无法获得 {0} 标签的 ''{1}'' 类信息。
 javadoc.content.first.line=Javadoc 内容应该从与 /** 相同的行开始。
 javadoc.content.second.line=Javadoc 内容应该从 /** 之后的下一行开始。
 javadoc.duplicateTag=重复的 Javadoc 注释 {0} 。
+javadoc.end.comment.delimiter=Javadoc 注释结束分隔符应仅包含一个星号。
 javadoc.expectedTag=''{1}''需要Javadoc注释 {0} 。
 javadoc.invalidInheritDoc=''@inheritDoc'' 标签使用方式错误。
 javadoc.legacyPackageHtml=文件 package.html 应被删除。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocEndCommentDelimiterCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocEndCommentDelimiterCheck.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle-metadata>
+   <module>
+      <check fully-qualified-name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocEndCommentDelimiterCheck"
+             name="JavadocEndCommentDelimiter"
+             parent="com.puppycrawl.tools.checkstyle.TreeWalker">
+         <description>Checks that the Javadoc end-comment delimiter contains exactly one asterisk.</description>
+         <message-keys>
+            <message-key key="javadoc.end.comment.delimiter"/>
+         </message-keys>
+      </check>
+   </module>
+</checkstyle-metadata>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -231,6 +231,8 @@
           <item name="InvalidJavadocPosition" href="checks/javadoc/invalidjavadocposition.html"/>
           <item name="JavadocBlockTagLocation" href="checks/javadoc/javadocblocktaglocation.html"/>
           <item name="JavadocContentLocation" href="checks/javadoc/javadoccontentlocation.html"/>
+          <item name="JavadocEndCommentDelimiter"
+                href="checks/javadoc/javadocendcommentdelimiter.html"/>
           <item name="JavadocLeadingAsteriskAlign"
                 href="checks/javadoc/javadocleadingasteriskalign.html"/>
           <item name="JavadocMethod" href="checks/javadoc/javadocmethod.html"/>

--- a/src/site/xdoc/checks.xml
+++ b/src/site/xdoc/checks.xml
@@ -857,6 +857,16 @@
           </tr>
           <tr>
             <td>
+              <a href="checks/javadoc/javadocendcommentdelimiter.html#JavadocEndCommentDelimiter">
+                JavadocEndCommentDelimiter
+              </a>
+            </td>
+            <td>
+              Checks that the Javadoc end-comment delimiter contains exactly one asterisk.
+            </td>
+          </tr>
+          <tr>
+            <td>
               <a href="checks/javadoc/javadocleadingasteriskalign.html#JavadocLeadingAsteriskAlign">
                 JavadocLeadingAsteriskAlign
               </a>

--- a/src/site/xdoc/checks/javadoc/index.xml
+++ b/src/site/xdoc/checks/javadoc/index.xml
@@ -66,6 +66,16 @@
           </tr>
           <tr>
             <td>
+              <a href="javadocendcommentdelimiter.html#JavadocEndCommentDelimiter">
+                JavadocEndCommentDelimiter
+              </a>
+            </td>
+            <td>
+              Checks that the Javadoc end-comment delimiter contains exactly one asterisk.
+            </td>
+          </tr>
+          <tr>
+            <td>
               <a href="javadocleadingasteriskalign.html#JavadocLeadingAsteriskAlign">
                 JavadocLeadingAsteriskAlign
               </a>

--- a/src/site/xdoc/checks/javadoc/javadocendcommentdelimiter.xml
+++ b/src/site/xdoc/checks/javadoc/javadocendcommentdelimiter.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>JavadocEndCommentDelimiter</title>
+  </head>
+  <body>
+    <section name="JavadocEndCommentDelimiter">
+      <p>Since Checkstyle 13.10.0</p>
+      <subsection name="Description" id="JavadocEndCommentDelimiter_Description">
+        Checks that the Javadoc end-comment delimiter contains exactly one asterisk.
+      </subsection>
+
+      <subsection name="Examples" id="JavadocEndCommentDelimiter_Examples">
+        <p id="Example1-config">
+          To configure the check:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocEndCommentDelimiter"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example1-code">
+          The following code produces violations for Javadoc comments whose closing delimiters
+          contain more than one asterisk:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example1 {
+
+  /**
+   * Valid Javadoc.
+   */
+  public void valid1() { }
+
+  /** Valid single-line Javadoc. */
+  public void valid2() { }
+
+  // violation 3 lines below 'Javadoc closing delimiter should contain exactly one asterisk.'
+  /**
+   * Invalid Javadoc.
+   **/
+  public void invalid1() { }
+
+  // violation below 'Javadoc closing delimiter should contain exactly one asterisk.'
+  /** Invalid single-line Javadoc. **/
+  public void invalid2() { }
+}
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Example of Usage" id="JavadocEndCommentDelimiter_Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocEndCommentDelimiter">
+              Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="JavadocEndCommentDelimiter_Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.end.comment.delimiter%22">
+              javadoc.end.comment.delimiter
+            </a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Fully Qualified Name" id="JavadocEndCommentDelimiter_Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocEndCommentDelimiterCheck</p>
+        <p>
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="JavadocEndCommentDelimiter_Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/site/xdoc/checks/javadoc/javadocendcommentdelimiter.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocendcommentdelimiter.xml.template
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>JavadocEndCommentDelimiter</title>
+  </head>
+  <body>
+    <section name="JavadocEndCommentDelimiter">
+      <macro name="since">
+        <param name="modulePath"
+               value="src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocEndCommentDelimiterCheck.java"/>
+      </macro>
+      <subsection name="Description" id="JavadocEndCommentDelimiter_Description">
+        <macro name="description">
+          <param name="modulePath"
+                 value="src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocEndCommentDelimiterCheck.java"/>
+        </macro>
+      </subsection>
+
+      <subsection name="Examples" id="JavadocEndCommentDelimiter_Examples">
+        <p id="Example1-config">
+          To configure the check:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocendcommentdelimiter/Example1.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example1-code">
+          The following code produces violations for Javadoc comments whose closing delimiters
+          contain more than one asterisk:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocendcommentdelimiter/Example1.java"/>
+          <param name="type" value="code"/>
+        </macro>
+      </subsection>
+
+      <subsection name="Example of Usage" id="JavadocEndCommentDelimiter_Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocEndCommentDelimiter">
+              Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="JavadocEndCommentDelimiter_Violation_Messages">
+        <macro name="violation-messages">
+          <param name="checkName" value="JavadocEndCommentDelimiter"/>
+        </macro>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Fully Qualified Name" id="JavadocEndCommentDelimiter_Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocEndCommentDelimiterCheck</p>
+        <p>
+              Use this fully qualified class name in configuration when an exact class reference is
+              required.
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="JavadocEndCommentDelimiter_Parent_Module">
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocEndCommentDelimiter"/>
+        </macro>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocEndCommentDelimiterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocEndCommentDelimiterCheckTest.java
@@ -1,0 +1,58 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocEndCommentDelimiterCheck.MSG_END_COMMENT_DELIMITER;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+public class JavadocEndCommentDelimiterCheckTest extends AbstractModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocendcommentdelimiter";
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        final JavadocEndCommentDelimiterCheck check = new JavadocEndCommentDelimiterCheck();
+        final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
+
+        assertWithMessage("Acceptable tokens are invalid")
+            .that(check.getAcceptableTokens())
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void testDefault() throws Exception {
+        final String[] expected = {
+            "19:38: " + getCheckMessage(MSG_END_COMMENT_DELIMITER),
+            "25:8: " + getCheckMessage(MSG_END_COMMENT_DELIMITER),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocEndCommentDelimiterDefault.java"), expected);
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -155,6 +155,7 @@ public class AllChecksCompactSourceCoverageTest {
         "JavaNCSSCheck",
         "JavadocBlockTagLocationCheck",
         "JavadocContentLocationCheck",
+        "JavadocEndCommentDelimiterCheck",
         "JavadocLeadingAsteriskAlignCheck",
         "JavadocMethodCheck",
         "JavadocMissingLeadingAsteriskCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
@@ -41,20 +41,20 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
 
     @Test
     public void test() {
-        assertThat(XmlMetaReader.readAllModulesIncludingThirdPartyIfAny()).hasSize(228);
+        assertThat(XmlMetaReader.readAllModulesIncludingThirdPartyIfAny()).hasSize(229);
     }
 
     @Test
     public void testDuplicatePackage() {
         assertThat(XmlMetaReader
                 .readAllModulesIncludingThirdPartyIfAny("com.puppycrawl.tools.checkstyle.meta"))
-                .hasSize(228);
+                .hasSize(229);
     }
 
     @Test
     public void testBadPackage() {
         assertThat(XmlMetaReader.readAllModulesIncludingThirdPartyIfAny("DOES.NOT.EXIST"))
-                .hasSize(228);
+                .hasSize(229);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocendcommentdelimiter/InputJavadocEndCommentDelimiterDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocendcommentdelimiter/InputJavadocEndCommentDelimiterDefault.java
@@ -1,0 +1,37 @@
+/*
+JavadocEndCommentDelimiter
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocendcommentdelimiter;
+
+public class InputJavadocEndCommentDelimiterDefault {
+
+    /** Valid Javadoc. */
+    public void validSingleLine() { }
+
+    /**
+     * Valid Javadoc.
+     */
+    public void validMultiline() { }
+
+    // violation below 'Javadoc closing delimiter should contain exactly one asterisk.'
+    /** Invalid single-line Javadoc. **/
+    public void invalidSingleLine() { }
+
+    // violation 3 lines below 'Javadoc closing delimiter should contain exactly one asterisk.'
+    /**
+     * Invalid Javadoc.
+     ***/
+    public void invalidMultiline() { }
+
+    /** Valid because the extra asterisk is separated. * */
+    public void separatedAsterisk() { }
+
+    /* Not a Javadoc comment. **/
+    public void blockComment() { }
+
+    /**/
+    public void emptyComment() { }
+
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocEndCommentDelimiterCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocEndCommentDelimiterCheckExamplesTest.java
@@ -1,0 +1,46 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocEndCommentDelimiterCheck.MSG_END_COMMENT_DELIMITER;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+
+public class JavadocEndCommentDelimiterCheckExamplesTest
+        extends AbstractExamplesModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocendcommentdelimiter";
+    }
+
+    @Test
+    public void testExample1() throws Exception {
+        final String[] expected = {
+            "25:5: " + getCheckMessage(MSG_END_COMMENT_DELIMITER),
+            "29:36: " + getCheckMessage(MSG_END_COMMENT_DELIMITER),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+    }
+
+}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocendcommentdelimiter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocendcommentdelimiter/Example1.java
@@ -1,0 +1,32 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocEndCommentDelimiter"/>
+  </module>
+</module>
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocendcommentdelimiter;
+
+// xdoc section - start
+public class Example1 {
+
+  /**
+   * Valid Javadoc.
+   */
+  public void valid1() { }
+
+  /** Valid single-line Javadoc. */
+  public void valid2() { }
+
+  // violation 3 lines below 'Javadoc closing delimiter should contain exactly one asterisk.'
+  /**
+   * Invalid Javadoc.
+   **/
+  public void invalid1() { }
+
+  // violation below 'Javadoc closing delimiter should contain exactly one asterisk.'
+  /** Invalid single-line Javadoc. **/
+  public void invalid2() { }
+}
+// xdoc section - end


### PR DESCRIPTION
 Issue: #20982

  Adds `JavadocEndCommentDelimiter` to report Javadoc comments whose
  closing delimiter contains extra asterisks, such as `**/`.

  The check is registered in the metadata and factory, documented, and
  covered by unit, XDoc example, and suppression XPath tests. The project
  self-check entry remains ignored because the existing source tree
  contains legacy delimiters.

  Validation: `mvn clean verify`