### PR TITLE
minor: remove reference to non existant example files

### DIFF
--- a/src/site/xdoc/checks/javadoc/writetag.xml
+++ b/src/site/xdoc/checks/javadoc/writetag.xml
@@ -22,16 +22,8 @@
             <ul class="toc-sublist">
               <li><a href="#Example1-config" class="toc-sublink">Example of default Check configuration that do nothing.</a></li>
               <li><a href="#Example2-config" class="toc-sublink">Check to demand <code>@since</code> tag to be present on type javadoc.</a></li>
-              <li><a href="#Example3-config" class="toc-sublink">Check to demand <code>@since</code> tag to be present on type and method javadocs. Attention: all presence of tags are also highlighted as violation.</a></li>
-              <li><a href="#Example4-config" class="toc-sublink">Check to demand <code>@since</code> tag to be present with digital value on method javadocs also in addition to default tokens. Set <code>tagSeverity</code> to <code>ignore</code> to suppress <code>javadoc.writeTag</code> violations for matching <code>@since</code> tags. Missing <code>@since</code> tags and tag format violations are still reported with the common severity property.</a></li>
-              <li><a href="#Example5-config" class="toc-sublink">Check to demand <code>@since</code> tag to be present with digital value on method javadocs also in addition to default tokens. The <code>tagSeverity</code> property is set to <code>error</code>, but tag format violations are still reported with the common severity property.</a></li>
-            </ul>
-          </li>
-          <li>
-            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
-            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#WriteTag_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
-            <ul class="toc-sublist">
-              <li><a href="#UseCase1-config" class="toc-sublink">Check to forbid <code>@author</code> tags in Javadoc comments. The <code>SuppressionSingleFilter</code> suppresses missing tag violations, as missing <code>@author</code> tags are desired in this use case.</a></li>
+              <li><a href="#Example3-config" class="toc-sublink">Check to demand <code>@since</code> tag to be present on type and method javadocs. Matching tags produce no violation.</a></li>
+              <li><a href="#Example4-config" class="toc-sublink">Check to demand <code>@since</code> tag to be present with digital value on method javadocs also in addition to default tokens. Missing <code>@since</code> tags and tag format violations are reported with the common severity property.</a></li>
             </ul>
           </li>
           <li><a href="#WriteTag_Example_of_Usage">Example of Usage</a></li>


### PR DESCRIPTION
The recent writetag PR removes `Example5.java` and `UseCase1.java` but leave references to those files in the `writetag.xml`.

This causes the validation tests to fail because the referenced example files no longer exist.
See CI failure: https://dev.azure.com/romanivanovjr/romanivanovjr/_build/results?buildId=45987&view=logs&j=c902ebb4-c9f8-5f09-4e17-ff78fbbc842e&t=9ca98c81-ff64-58f0-9d03-a23ac1c4a111

This PR removes the stale references from the XML file to restore the affected validation tests.

## Testing

* `./mvnw clean verify`
