### PR TITLE
Issue #21174: Include renderSeverityLevel in Pitest testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4901,10 +4901,6 @@
                 <param>replaceVersionString</param>
                 <!-- this method in XMLLogger.java works properly only when execution is from jar -->
                 <param>printVersionString</param>
-                <!-- Switch expressions with enum cases produce equivalent mutations
-                that cannot be killed since all branches are already covered.
-                See https://github.com/checkstyle/checkstyle/issues/18024 -->
-                <param>renderSeverityLevel</param>
               </excludedMethods>
               <features>
                 <feature>+funmodifiablecollection</feature>


### PR DESCRIPTION
Resolves issue
- https://github.com/checkstyle/checkstyle/issues/21174

---

Removed exclusion for `SarifLogger#renderSeverityLevel()` from Pitest testing.

Local run was successful:
```shell
$ .ci/pitest.sh pitest-common
No surviving mutations.
No new surviving mutation(s) found.
```