### PR TITLE
Issue #19913: add JavadocRegexp coverage

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -83,6 +83,7 @@ Autowiring
 avoiddoublebraceinitialization
 avoidescapedunicodecharacters
 avoidinlineconditionals
+avoidlatin
 avoidnestedblocks
 avoidnoargumentsuperconstructorcall
 avoidstarimport

--- a/src/it/java/com/doccomments/checkstyle/test/writingdoccomments/descriptions/avoidlatin/AvoidLatinTest.java
+++ b/src/it/java/com/doccomments/checkstyle/test/writingdoccomments/descriptions/avoidlatin/AvoidLatinTest.java
@@ -1,0 +1,38 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.doccomments.checkstyle.test.writingdoccomments.descriptions.avoidlatin;
+
+import org.junit.jupiter.api.Test;
+
+import com.doccomments.checkstyle.test.base.AbstractDocCommentsModuleTestSupport;
+
+public class AvoidLatinTest extends AbstractDocCommentsModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/doccomments/checkstyle/test/writingdoccomments/descriptions/avoidlatin/";
+    }
+
+    @Test
+    public void testAvoidLatin() throws Exception {
+        verifyWithWholeConfig(getPath("InputAvoidLatin.java"));
+    }
+
+}

--- a/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/descriptions/avoidlatin/InputAvoidLatin.java
+++ b/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/descriptions/avoidlatin/InputAvoidLatin.java
@@ -1,0 +1,65 @@
+package com.doccomments.checkstyle.test.writingdoccomments.descriptions.avoidlatin;
+
+/**
+ * Input for Avoid Latin examples.
+ */
+class InputAvoidLatin {
+
+  /** Creates a sample instance. */
+  InputAvoidLatin() {}
+
+  /**
+   * Creates a user, also known as an account owner.
+   */
+  void createsUserGood() {}
+
+  // violation below 'Javadoc content matches the illegal pattern'
+  /**
+   * Creates a user, aka an account owner.
+   */
+  void createsUserWarn() {}
+
+  /**
+   * Normalizes text, that is, removes redundant separators.
+   */
+  void normalizesTextGood() {}
+
+  /**
+   * Selects a default value, to be specific, the empty value.
+   */
+  void selectsDefaultGood() {}
+
+  // violation below 'Javadoc content matches the illegal pattern'
+  /**
+   * Normalizes text, i.e. removes redundant separators.
+   */
+  void normalizesTextWarn() {}
+
+  /**
+   * Adds one generated item, for example a missing identifier.
+   */
+  void addsGeneratedItemGood() {}
+
+  // violation below 'Javadoc content matches the illegal pattern'
+  /**
+   * Adds one generated item, e.g. a missing identifier.
+   */
+  void addsGeneratedItemWarn() {}
+
+  /**
+   * Picks the fallback, in other words, the last configured value.
+   */
+  void picksFallbackGood() {}
+
+  /**
+   * Stores the display name, namely the visible user label.
+   */
+  void storesDisplayNameGood() {}
+
+  // violation below 'Javadoc content matches the illegal pattern'
+  /**
+   * Picks the fallback, viz. the last configured value.
+   */
+  void picksFallbackWarn() {}
+
+}

--- a/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/descriptions/avoidlatin/package.html
+++ b/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/descriptions/avoidlatin/package.html
@@ -1,0 +1,1 @@
+<p>Test package for Documentation Comments Style Avoid Latin examples.</p>

--- a/src/main/resources/doc_comments_checks.xml
+++ b/src/main/resources/doc_comments_checks.xml
@@ -97,6 +97,14 @@
     <!-- First Sentence -->
     <module name="SummaryJavadoc"/>
 
+    <!-- Avoid Latin -->
+    <module name="JavadocRegexp">
+      <property name="format"
+                value="(^|\W)(aka|i\.e\.|e\.g\.|viz\.)(\W|$)"/>
+      <property name="ignoreCase" value="true"/>
+      <property name="ignoreMarkup" value="true"/>
+    </module>
+
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.doc.comments.suppressionxpathfilter.config}"

--- a/src/site/xdoc/checks/javadoc/javadocregexp.xml
+++ b/src/site/xdoc/checks/javadoc/javadocregexp.xml
@@ -242,6 +242,10 @@ class Example4 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocRegexp">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fdoc_comments_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocRegexp">
+              Documentation Comments Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocregexp.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocregexp.xml.template
@@ -98,6 +98,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocRegexp">
               Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fdoc_comments_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocRegexp">
+              Documentation Comments Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/doc_comments_style.xml
+++ b/src/site/xdoc/doc_comments_style.xml
@@ -703,12 +703,18 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img src="images/ban_red.png" alt=""/>
+                    <img src="images/ok_green.png" alt=""/>
                   </span>
-                  Guideline is not covered until:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/20987">#20987</a>.
+                  <a href="checks/javadoc/javadocregexp.html#JavadocRegexp">
+                    JavadocRegexp</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fdoc_comments_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocRegexp">
+                  config</a>)
                 </td>
-                <td/>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/doccomments/checkstyle/test/writingdoccomments/descriptions/avoidlatin">
+                    samples
+                  </a>
+                </td>
               </tr>
 
               <!-- TAGS -->


### PR DESCRIPTION
issue #19913

After completion of https://github.com/checkstyle/checkstyle/issues/20987