### PR TITLE
Issue #21137: Added default config Example : matchxpath

### DIFF
--- a/src/site/xdoc/checks/coding/matchxpath.xml
+++ b/src/site/xdoc/checks/coding/matchxpath.xml
@@ -20,7 +20,8 @@
             <input type="checkbox" id="toc-sub-Examples" class="toc-sub-toggle-checkbox" checked="checked"/>
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#MatchXpath_Examples">Examples</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
-              <li><a href="#Example1-config" class="toc-sublink">The following example demonstrates validation of methods order, so that public methods should come before the private ones</a></li>
+              <li><a href="#Example1-config" class="toc-sublink">The following example demonstrates the default configuration (no xpath query) that do nothing</a></li>
+              <li><a href="#Example2-config" class="toc-sublink">The following example demonstrates validation of methods order, so that public methods should come before the private ones</a></li>
             </ul>
           </li>
           <li>
@@ -94,7 +95,30 @@
       </subsection>
 
       <subsection name="Examples" id="MatchXpath_Examples">
-        <p id="Example1-config">
+        <p id="Example1-config">The following example demonstrates the default
+        configuration (no xpath query) that do nothing</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MatchXpath"&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example1-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example1 {
+  public void method1() { }
+
+  private void method2() { }
+  public void method3() { }
+
+  private void method4() { }
+  public void method5() { }
+  private void method6() { }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example2-config">
           The following example demonstrates validation of methods order, so that public methods
           should come before the private ones:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
@@ -110,9 +134,9 @@
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example1-code">Example:</p>
+        <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example1 {
+public class Example2 {
   public void method1() { }
   // violation below 'Private methods must appear after public methods'
   private void method2() { }

--- a/src/site/xdoc/checks/coding/matchxpath.xml.template
+++ b/src/site/xdoc/checks/coding/matchxpath.xml.template
@@ -37,9 +37,8 @@
       </subsection>
 
       <subsection name="Examples" id="MatchXpath_Examples">
-        <p id="Example1-config">
-          The following example demonstrates validation of methods order, so that public methods
-          should come before the private ones:</p>
+        <p id="Example1-config">The following example demonstrates the default
+        configuration (no xpath query) that do nothing</p>
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example1.java"/>
@@ -49,6 +48,20 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example1.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example2-config">
+          The following example demonstrates validation of methods order, so that public methods
+          should come before the private ones:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example2-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example2.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -158,7 +158,6 @@ public class XdocsExamplesAstConsistencyTest {
      * Until: <a href="https://github.com/checkstyle/checkstyle/issues/21137">...</a>
      */
     private static final Set<String> EXAMPLE_DEFAULT_CONFIG_SUPPRESSED_MODULES = Set.of(
-            "checks/coding/matchxpath",
             "checks/coding/returncount",
             "checks/descendanttoken",
             "checks/imports/importcontrol",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckExamplesTest.java
@@ -32,12 +32,19 @@ public class MatchXpathCheckExamplesTest extends AbstractExamplesModuleTestSuppo
 
     @Test
     public void testExample1() throws Exception {
+        final String[] expected = {};
+
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+    }
+
+    @Test
+    public void testExample2() throws Exception {
         final String[] expected = {
             "20:3: " + "Private methods must appear after public methods",
             "23:3: " + "Private methods must appear after public methods",
         };
 
-        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example1.java
@@ -2,11 +2,6 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="MatchXpath">
-      <property name="query"
-           value="//METHOD_DEF[.//LITERAL_PRIVATE
-                  and following-sibling::METHOD_DEF[.//LITERAL_PUBLIC]]"/>
-      <message key="matchxpath.match"
-           value="Private methods must appear after public methods"/>
     </module>
   </module>
 </module>
@@ -16,10 +11,10 @@ package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
 // xdoc section - start
 public class Example1 {
   public void method1() { }
-  // violation below 'Private methods must appear after public methods'
+
   private void method2() { }
   public void method3() { }
-  // violation below 'Private methods must appear after public methods'
+
   private void method4() { }
   public void method5() { }
   private void method6() { }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/Example2.java
@@ -1,0 +1,27 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MatchXpath">
+      <property name="query"
+           value="//METHOD_DEF[.//LITERAL_PRIVATE
+                  and following-sibling::METHOD_DEF[.//LITERAL_PUBLIC]]"/>
+      <message key="matchxpath.match"
+           value="Private methods must appear after public methods"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
+
+// xdoc section - start
+public class Example2 {
+  public void method1() { }
+  // violation below 'Private methods must appear after public methods'
+  private void method2() { }
+  public void method3() { }
+  // violation below 'Private methods must appear after public methods'
+  private void method4() { }
+  public void method5() { }
+  private void method6() { }
+}
+// xdoc section - end


### PR DESCRIPTION
#21137 


Adds a default-config xdocs example for `MatchXpathCheck`, so it no longer needs to be suppressed in `testEveryModuleHasDefaultConfigExample`.

`MatchXpathCheck`'s `query` property defaults to an empty string, and `beginTree` explicitly no-ops when `query` is empty. If Xpath query is not specified explicitly, then the check does nothing. So a default-config example can't demonstrate a violation.

**Changes:**
- New xdocs example under `checks/coding/matchxpath` using `<module name="MatchXpath"/>` with no properties, containing an inline comment explaining why no violations are reported.
- Removed `"checks/coding/matchxpath"` from `EXAMPLE_DEFAULT_CONFIG_SUPPRESSED_MODULES` in `XdocsExamplesAstConsistencyTest`.