### PR TITLE
Issue-21177: Support bracket auto-escaping in BDD expected messages a…

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -105,9 +105,6 @@
   <!-- Without showing symbol, user can get confused which one we are referring to -->
   <suppress id="discouragedRegexpInViolationMessage"
     files="operatorwrap/Example1.java"/>
-  <!-- Example contains '[' in violation message intentionally -->
-  <suppress id="discouragedRegexpInViolationMessage"
-    files="arraybracketnowhitespace/Example1.java"/>
   <suppress id="discouragedRegexpInViolationMessage"
     files="operatorwrap/Example2.java"/>
   <!-- it prints user regexp -->

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapArrayDeclarator.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/InputSeparatorWrapArrayDeclarator.java
@@ -7,6 +7,6 @@ class InputSeparatorWrapArrayDeclarator {
   protected int[] arrayDeclarationWithBadWrapping = new int
       [] {1, 2};
       // 2 violations above:
-      // ''\[' is preceded with whitespace'
-      // ''\[' should be on the previous line'
+      // ''[' is preceded with whitespace'
+      // ''[' should be on the previous line'
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputArrayBracketNoWhitespace.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputArrayBracketNoWhitespace.java
@@ -8,92 +8,92 @@ public class InputArrayBracketNoWhitespace {
   private int @Ann[] nums1;
   // 2 violations above:
   // 'Ann' is not followed by whitespace'
-  // '\[' is not preceded with whitespace'
+  // '[' is not preceded with whitespace'
 
   private int @Ann [] nums2;
 
   void method() {
     String[]strings = {};
-    // violation above ''\]' is not followed by whitespace'
+    // violation above '']' is not followed by whitespace'
 
     int [] arr = {1, 2, 3, 4, 5};
-    // violation above ''\[' is preceded with whitespace'
+    // violation above ''[' is preceded with whitespace'
 
     int [] [] arr2 = {{arr[0 ], arr[ 1], arr[ 2 ] }};
     // 8 violations above:
-    // ''\[' is preceded with whitespace'
-    // ''\]' is followed by whitespace'
-    // ''\[' is preceded with whitespace'
-    // ''\]' is preceded with whitespace'
-    // ''\[' is followed by whitespace'
-    // ''\[' is followed by whitespace'
-    // ''\]' is followed by whitespace'
-    // ''\]' is preceded with whitespace'
+    // ''[' is preceded with whitespace'
+    // '']' is followed by whitespace'
+    // ''[' is preceded with whitespace'
+    // '']' is preceded with whitespace'
+    // ''[' is followed by whitespace'
+    // ''[' is followed by whitespace'
+    // '']' is followed by whitespace'
+    // '']' is preceded with whitespace'
 
     arr2[ 0 ][ 1] = arr[4];
     // 3 violations above:
-    // ''\[' is followed by whitespace'
-    // ''\]' is preceded with whitespace'
-    // ''\[' is followed by whitespace'
+    // ''[' is followed by whitespace'
+    // '']' is preceded with whitespace'
+    // ''[' is followed by whitespace'
 
     int[] emptyArray = new int[ ] {};
     // 2 violations above:
-    // ''\[' is followed by whitespace'
-    // ''\]' is preceded with whitespace'
+    // ''[' is followed by whitespace'
+    // '']' is preceded with whitespace'
 
     Class<?> cls = int [] .class;
     // 3 violations above:
-    // ''\[' is preceded with whitespace'
-    // ''\]' is followed by whitespace'
+    // ''[' is preceded with whitespace'
+    // '']' is followed by whitespace'
     // ''.' is preceded with whitespace'
 
     boolean intArray = arr instanceof int [];
-    // violation above ''\[' is preceded with whitespace'
+    // violation above ''[' is preceded with whitespace'
 
     int [][] matrix = new int[2][3];
-    // violation above ''\[' is preceded with whitespace'
+    // violation above ''[' is preceded with whitespace'
 
     foo(arr[1] , arr[2] );
     // 4 violations above:
-    // ''\]' is followed by whitespace'
+    // '']' is followed by whitespace'
     // '',' is preceded with whitespace'
-    // ''\]' is followed by whitespace'
+    // '']' is followed by whitespace'
     // '')' is preceded with whitespace'
 
     int num = arr[1] ++;
     // 2 violations above:
-    // ''\]' is followed by whitespace'
+    // '']' is followed by whitespace'
     // ''\++' is preceded with whitespace'
 
     num = arr[1] --;
     // 2 violations above:
-    // ''\]' is followed by whitespace'
+    // '']' is followed by whitespace'
     // ''--' is preceded with whitespace'
 
     num = arr[1]+ arr[2]- arr[3]* arr[4]/ arr[5];
     // 8 violations above:
-    // ''\]' is not followed by whitespace'
+    // '']' is not followed by whitespace'
     // ''\+' is not preceded with whitespace'
-    // ''\]' is not followed by whitespace'
+    // '']' is not followed by whitespace'
     // ''\-' is not preceded with whitespace'
-    // ''\]' is not followed by whitespace'
+    // '']' is not followed by whitespace'
     // ''\*' is not preceded with whitespace'
-    // ''\]' is not followed by whitespace'
+    // '']' is not followed by whitespace'
     // ''/' is not preceded with whitespace'
 
     num = arr[1]<< 1;
     // 2 violations above:
-    // ''\]' is not followed by whitespace'
+    // '']' is not followed by whitespace'
     // '<<' is not preceded with whitespace'
 
     num = arr[1]>> 1;
     //  2 violations above:
-    // ''\]' is not followed by whitespace'
+    // '']' is not followed by whitespace'
     // '>>' is not preceded with whitespace'
 
     IntFunction<int[]> methodRef = int[] ::new;
     // 2 violations above:
-    // ''\]' is followed by whitespace'
+    // '']' is followed by whitespace'
     // ''::' is preceded with whitespace'
   }
 

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputMethodParamPad2.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputMethodParamPad2.java
@@ -54,7 +54,7 @@ public class InputMethodParamPad2 {
 
   /** Some javadoc. */
   public void newArray() {
-    int[] a = new int[]{0, 1}; // violation ''\]' is not followed by whitespace'
+    int[] a = new int[]{0, 1}; // violation '']' is not followed by whitespace'
     java.util.Vector<String> v = new java.util.Vector<String>();
     java.util.Vector<String> v1 = new Vector<String>();
   }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
@@ -18,16 +18,16 @@ public class InputNoWhitespaceBeforeAnnotations {
   @NonNull int @AnnoType[] @NonNull2[] field1;
   // 4 violations above:
   //   ''AnnoType' is not followed by whitespace'
-  //   ''\[' is not preceded with whitespace'
+  //   ''[' is not preceded with whitespace'
   //   ''NonNull2' is not followed by whitespace'
-  //   ''\[' is not preceded with whitespace'
+  //   ''[' is not preceded with whitespace'
 
   @NonNull int @AnnoType [] @NonNull2 [] field2;
 
   @NonNull int @AnnoType [] @NonNull2[] field3;
   // 2 violations above:
   // ''NonNull2' is not followed by whitespace'
-  // ''\[' is not preceded with whitespace'
+  // ''[' is not preceded with whitespace'
 
   // @NonNull int @NonNull ... field3; // non-compilable
   // @NonNull int @NonNull... field4; // non-compilable
@@ -45,7 +45,7 @@ public class InputNoWhitespaceBeforeAnnotations {
   public void foo3(final char @NonNull[] param) {}
   // 2 violations above:
   // ''NonNull' is not followed by whitespace'
-  // ''\[' is not preceded with whitespace'
+  // ''[' is not preceded with whitespace'
 
   /** Some javadoc. */
   public void foo4(final char @NonNull [] param) {}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEllipsis.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeEllipsis.java
@@ -42,21 +42,21 @@ public class InputNoWhitespaceBeforeEllipsis {
   /** Some javadoc. */
   void test6(String[] ... param) {}
   // 2 violations above:
-  // ''\]' is followed by whitespace'
+  // '']' is followed by whitespace'
   // ''...' is preceded with whitespace.'
 
   /** Some javadoc. */
   void test7(String @NonNull[]... param) {}
   // 2 violations above:
   // ''NonNull' is not followed by whitespace'
-  // ''\[' is not preceded with whitespace'
+  // ''[' is not preceded with whitespace'
 
   /** Some javadoc. */
   void test8(String @NonNull[] ... param) {}
   // 4 violations above:
   //   ''NonNull' is not followed by whitespace'
-  // ''\[' is not preceded with whitespace'
-  // ''\]' is followed by whitespace'
+  // ''[' is not preceded with whitespace'
+  // '']' is followed by whitespace'
   //   ''...' is preceded with whitespace.'
 
   void test9(String @Size(max = 10) ... names) {}
@@ -68,19 +68,19 @@ public class InputNoWhitespaceBeforeEllipsis {
 
   void test12(@NonNull String @C []    ... arg) {}
   // 3 violations above:
-  // ''\]' is followed by whitespace'
+  // '']' is followed by whitespace'
   // ''...' is preceded with whitespace'
   // 'Use a single space to separate non-whitespace characters'
 
   void test13(@NonNull String    [] @B ... arg) {}
   // 2 violations above:
-  // ''\[' is preceded with whitespace'
+  // ''[' is preceded with whitespace'
   // 'Use a single space to separate non-whitespace characters'
 
   void test14(   String    [] @B ... arg) {}
   // 4 violations above:
   // ''(' is followed by whitespace'
   // 'Use a single space to separate non-whitespace characters'
-  // ''\[' is preceded with whitespace'
+  // ''[' is preceded with whitespace'
   // 'Use a single space to separate non-whitespace characters'
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundGenerics.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundGenerics.java
@@ -42,7 +42,7 @@ class Wildcard {
     // 4 violations above:
     //  ''\<' is followed by whitespace.'
     //  ''\<' is preceded with whitespace.'
-    // ''\]' is followed by whitespace'
+    // '']' is followed by whitespace'
     //  ''\>' is preceded with whitespace.'
     // A statement is important in this method to flush out any
     // issues with parsing the wildcard in the signature

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaAndChildOnTheSameLine.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4841indentation/InputLambdaAndChildOnTheSameLine.java
@@ -37,7 +37,7 @@ public class InputLambdaAndChildOnTheSameLine {
   }
 
   void testMethod2() {
-    // violation 3 lines below ''\]' is not followed by whitespace'
+    // violation 3 lines below '']' is not followed by whitespace'
     var service = (CharSequence) Proxy.newProxyInstance(
         InputLambdaAndChildOnTheSameLine.class.getClassLoader(),
         new Class[]{CharSequence.class},
@@ -51,7 +51,7 @@ public class InputLambdaAndChildOnTheSameLine {
   }
 
   void testMethod3() {
-    // violation 3 lines below ''\]' is not followed by whitespace'
+    // violation 3 lines below '']' is not followed by whitespace'
     var service = (CharSequence) Proxy.newProxyInstance(
         InputLambdaAndChildOnTheSameLine.class.getClassLoader(),
         new Class[]{CharSequence.class},

--- a/src/site/xdoc/checks/whitespace/arraybracketnowhitespace.xml
+++ b/src/site/xdoc/checks/whitespace/arraybracketnowhitespace.xml
@@ -81,49 +81,49 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
   int[] numbersGood = new int[10];
-  int[] numbersWarn = new int[10 ]; // violation ''\]' is preceded with whitespace'
+  int[] numbersWarn = new int[10 ]; // violation '']' is preceded with whitespace'
 
   String[] dataGood = {"a", "b"};
-  String [] dataWarn = {"a", "b"}; // violation ''\[' is preceded with whitespace'
+  String [] dataWarn = {"a", "b"}; // violation ''[' is preceded with whitespace'
 
   byte bufferGood[];
   byte bufferWarn[ ];
   // 2 violations above:
-  // ''\[' is followed by whitespace'
-  // ''\]' is preceded with whitespace'
+  // ''[' is followed by whitespace'
+  // '']' is preceded with whitespace'
 
   int[] matrixGood[];
-  int[] matrixWarn[] ; // violation ''\]' is followed by whitespace'
+  int[] matrixWarn[] ; // violation '']' is followed by whitespace'
 
   void methodGood(int[] arr) {}
-  void methodWarn(int[]arr) {} // violation ''\]' is not followed by whitespace'
+  void methodWarn(int[]arr) {} // violation '']' is not followed by whitespace'
 
   void processArray(int[] arr) {
     int[] goodArr = {arr[0], arr[1]};
-    int[] warnArr = {arr[0], arr[1] };// violation ''\]' is followed by whitespace'
+    int[] warnArr = {arr[0], arr[1] };// violation '']' is followed by whitespace'
 
     int valueGood = arr[0] * 2;
-    int valueWarn = arr[0]* 2; // violation ''\]' is not followed by whitespace'
+    int valueWarn = arr[0]* 2; // violation '']' is not followed by whitespace'
 
     int good = arr[0] &gt;&gt; 2;
-    int warn = arr[0]&gt;&gt;2; // violation ''\]' is not followed by whitespace'
+    int warn = arr[0]&gt;&gt;2; // violation '']' is not followed by whitespace'
 
     arr[0]++;
-    arr[0] ++; // violation ''\]' is followed by whitespace'
+    arr[0] ++; // violation '']' is followed by whitespace'
 
     Class&lt;?&gt; goodClass = int[].class;
-    Class&lt;?&gt; warnClass = int[] .class; // violation ''\]' is followed by whitespace.'
+    Class&lt;?&gt; warnClass = int[] .class; // violation '']' is followed by whitespace.'
 
     IntFunction&lt;int[]&gt; goodMethodRef = int[]::new;
     IntFunction&lt;int[]&gt; warnMethodRef = int[] ::new;
-    // violation above ''\]' is followed by whitespace.'
+    // violation above '']' is followed by whitespace.'
     IntFunction&lt;int[] &gt; warnAngleBracket = int[]::new;
-    // violation above ''\]' is followed by whitespace.'
+    // violation above '']' is followed by whitespace.'
   }
 
   void goodEllipsis(String[]... params) {}
   void warnEllipsis(String[] ... params) {}
-  // violation above ''\]' is followed by whitespace'
+  // violation above '']' is followed by whitespace'
 }
 </code></pre></div><hr class="example-separator"/>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolation.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolation.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.bdd;
 
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 /**
  * Represents a test input violation with line number and message.
@@ -30,15 +29,6 @@ import java.util.regex.Pattern;
  */
 public record TestInputViolation(int lineNo, String message)
         implements Comparable<TestInputViolation> {
-
-    /** Pattern to match the symbol: "{". */
-    private static final Pattern OPEN_CURLY_PATTERN = Pattern.compile("\\{");
-
-    /** Pattern to match the symbol: "(". */
-    private static final Pattern OPEN_PAREN_PATTERN = Pattern.compile("\\(");
-
-    /** Pattern to match the symbol: ")". */
-    private static final Pattern CLOSE_PAREN_PATTERN = Pattern.compile("\\)");
 
     /** Legacy getter for line number (backward compatibility). */
     public int getLineNo() {
@@ -58,13 +48,82 @@ public record TestInputViolation(int lineNo, String message)
     public String toRegex() {
         String regex = lineNo + ":(?:\\d+:)?\\s.*";
         if (message != null) {
-            String rawMessage = message;
-            rawMessage = OPEN_CURLY_PATTERN.matcher(rawMessage).replaceAll("\\\\{");
-            rawMessage = OPEN_PAREN_PATTERN.matcher(rawMessage).replaceAll("\\\\(");
-            rawMessage = CLOSE_PAREN_PATTERN.matcher(rawMessage).replaceAll("\\\\)");
-            regex += rawMessage + ".*";
+            regex += escapeSegment(message) + ".*";
         }
         return regex;
+    }
+
+    /**
+     * Escapes standard BDD violation special characters in a message segment.
+     *
+     * @param segment the segment to escape
+     * @return the escaped segment
+     */
+    private static String escapeSegment(String segment) {
+        final StringBuilder result = new StringBuilder(segment.length());
+        boolean inQuote = false;
+        int index = 0;
+        while (index < segment.length()) {
+            if (isQuoteStart(segment, index)) {
+                inQuote = true;
+                result.append("\\Q");
+                index += 2;
+            }
+            else if (isQuoteEnd(segment, index)) {
+                inQuote = false;
+                result.append("\\E");
+                index += 2;
+            }
+            else {
+                final char character = segment.charAt(index);
+                if (!inQuote && isSpecialChar(character)) {
+                    result.append('\\');
+                }
+                result.append(character);
+                index++;
+            }
+        }
+        return result.toString();
+    }
+
+    /**
+     * Checks if the segment at the given index is the start of a quote block.
+     *
+     * @param segment the segment
+     * @param index the index
+     * @return true if it is the start of a quote block
+     */
+    private static boolean isQuoteStart(String segment, int index) {
+        return index < segment.length() - 1
+                && segment.charAt(index) == '\\'
+                && segment.charAt(index + 1) == 'Q';
+    }
+
+    /**
+     * Checks if the segment at the given index is the end of a quote block.
+     *
+     * @param segment the segment
+     * @param index the index
+     * @return true if it is the end of a quote block
+     */
+    private static boolean isQuoteEnd(String segment, int index) {
+        return index < segment.length() - 1
+                && segment.charAt(index) == '\\'
+                && segment.charAt(index + 1) == 'E';
+    }
+
+    /**
+     * Checks if the character is a special regex character that needs escaping.
+     *
+     * @param character the character
+     * @return true if the character is a special character
+     */
+    private static boolean isSpecialChar(char character) {
+        return character == '{'
+                || character == '('
+                || character == ')'
+                || character == '['
+                || character == ']';
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputViolationTest.java
@@ -1,0 +1,89 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.bdd;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TestInputViolation}.
+ */
+public class TestInputViolationTest {
+
+    @Test
+    public void testToRegexNullMessage() {
+        final TestInputViolation violation = new TestInputViolation(10, null);
+        assertWithMessage("Regex with null message should match line pattern only")
+                .that(violation.toRegex())
+                .isEqualTo("10:(?:\\d+:)?\\s.*");
+    }
+
+    @Test
+    public void testToRegexNoSpecialCharacters() {
+        final TestInputViolation violation = new TestInputViolation(5, "simple message");
+        assertWithMessage("Regex should match simple message")
+                .that(violation.toRegex())
+                .isEqualTo("5:(?:\\d+:)?\\s.*simple message.*");
+    }
+
+    @Test
+    public void testToRegexWithSpecialCharactersOutsideQuotes() {
+        final TestInputViolation violation = new TestInputViolation(12,
+                "message (with) {special} [brackets]");
+        assertWithMessage("Regex should escape special characters outside quotes")
+                .that(violation.toRegex())
+                .isEqualTo("12:(?:\\d+:)?\\s.*message \\(with\\) \\{special} \\[brackets\\].*");
+    }
+
+    @Test
+    public void testToRegexWithQuotedSpecialCharacters() {
+        final TestInputViolation violation = new TestInputViolation(1, "\\Q^[a-z][a-zA-Z0-9]*$\\E");
+        assertWithMessage("Regex should not escape special characters inside \\Q...\\E block")
+                .that(violation.toRegex())
+                .isEqualTo("1:(?:\\d+:)?\\s.*\\Q^[a-z][a-zA-Z0-9]*$\\E.*");
+    }
+
+    @Test
+    public void testToRegexWithMultipleQuotedBlocks() {
+        final TestInputViolation violation = new TestInputViolation(2,
+                "before \\Q^[a-z]\\E middle \\Q(test)\\E after (parenthesis)");
+        assertWithMessage(
+                "Regex should escape characters outside multiple \\Q...\\E blocks but not inside")
+                .that(violation.toRegex())
+                .isEqualTo("2:(?:\\d+:)?\\s.*before \\Q^[a-z]\\E middle \\Q(test)\\E after "
+                        + "\\(parenthesis\\).*");
+    }
+
+    @Test
+    public void testToRegexWithUnmatchedQuotes() {
+        final TestInputViolation violation1 = new TestInputViolation(3, "unmatched \\Q^[a-z][A-Z]");
+        assertWithMessage("Regex should not escape characters after unmatched \\Q")
+                .that(violation1.toRegex())
+                .isEqualTo("3:(?:\\d+:)?\\s.*unmatched \\Q^[a-z][A-Z].*");
+
+        final TestInputViolation violation2 = new TestInputViolation(4,
+                "unmatched \\E(parenthesis)");
+        assertWithMessage("Regex should escape characters outside unmatched \\E")
+                .that(violation2.toRegex())
+                .isEqualTo("4:(?:\\d+:)?\\s.*unmatched \\E\\(parenthesis\\).*");
+    }
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/compact/InputArrayBracketNoWhitespaceCompact.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/compact/InputArrayBracketNoWhitespaceCompact.java
@@ -7,9 +7,9 @@ ArrayBracketNoWhitespace
 // non-compiled with javac: Compilable with Java25
 
 void main() {
-    int[] arr2 = new int [10]; // violation ''\[' is preceded with whitespace.'
-    int[] arr3 = new int[ 10]; // violation ''\[' is followed by whitespace.'
+    int[] arr2 = new int [10]; // violation ''[' is preceded with whitespace.'
+    int[] arr3 = new int[ 10]; // violation ''[' is followed by whitespace.'
 
-    int a = arr2[0] ; // violation ''\]' is followed by whitespace.'
-    int b = arr2 [0]; // violation ''\[' is preceded with whitespace.'
+    int a = arr2[0] ; // violation '']' is followed by whitespace.'
+    int b = arr2 [0]; // violation ''[' is preceded with whitespace.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeArrays.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeArrays.java
@@ -17,22 +17,22 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
 public class InputIllegalTypeArrays {
 
-    public Boolean[] array; // violation "Usage of type 'Boolean\[\]' is not allowed."
+    public Boolean[] array; // violation "Usage of type 'Boolean[]' is not allowed."
 
-    public Boolean[][] matrix; // violation "Usage of type 'Boolean\[\]\[\]' is not allowed."
+    public Boolean[][] matrix; // violation "Usage of type 'Boolean[][]' is not allowed."
 
-    public Boolean[] getArray() { // violation "Usage of type 'Boolean\[\]' is not allowed."
+    public Boolean[] getArray() { // violation "Usage of type 'Boolean[]' is not allowed."
         Boolean[] value = array != null ? array : new Boolean[0];
-        // violation above "Usage of type 'Boolean\[\]' is not allowed."
+        // violation above "Usage of type 'Boolean[]' is not allowed."
 
         return value;
     }
 
     public Boolean[][] getMatrix() {
-        // violation above "Usage of type 'Boolean\[\]\[\]' is not allowed."
+        // violation above "Usage of type 'Boolean[][]' is not allowed."
 
         Boolean[][] value = matrix != null ? matrix : new Boolean[0][0];
-        // violation above "Usage of type 'Boolean\[\]\[\]' is not allowed."
+        // violation above "Usage of type 'Boolean[][]' is not allowed."
 
         return value;
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestPlainAndArraysTypes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestPlainAndArraysTypes.java
@@ -33,9 +33,9 @@ public class InputIllegalTypeTestPlainAndArraysTypes {
     }
 
     public Boolean[][] getMatrix() {
-        // violation above 'Usage of type 'Boolean\[\]\[\]' is not allowed'
+        // violation above 'Usage of type 'Boolean[][]' is not allowed'
         Boolean[][] value = matrix != null ? matrix : new Boolean[0][0];
-        // violation above 'Usage of type 'Boolean\[\]\[\]' is not allowed'
+        // violation above 'Usage of type 'Boolean[][]' is not allowed'
         return value;
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect1.java
@@ -11,9 +11,9 @@ tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 /** Javadoc for import */
 import java.io.Serializable;
-// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 7 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
 /**
  * Some javadoc.
  *
@@ -41,7 +41,7 @@ class InputAtclauseOrderIncorrect1 implements Serializable {
      * @serialField
      */
     private String tThirdName;
-    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some text.
      * @param aString Some text.
@@ -53,9 +53,9 @@ class InputAtclauseOrderIncorrect1 implements Serializable {
     String method(String aString) throws Exception {
         return "null";
     }
-    // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 6 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 6 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 6 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some text.
      * @serialData Some javadoc.
@@ -66,14 +66,14 @@ class InputAtclauseOrderIncorrect1 implements Serializable {
     String method1(String aString) throws Exception {
         return "null";
     }
-    // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 4 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some text.
      * @throws Exception Some text.
      * @param aString Some text.
      */
     void method2(String aString) throws Exception {}
-    // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 4 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some text.
      * @deprecated Some text.
@@ -89,8 +89,8 @@ class InputAtclauseOrderIncorrect1 implements Serializable {
     String method4() throws Exception {
         return "null";
     }
-    // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some text.
      * @deprecated Some text.
@@ -101,9 +101,9 @@ class InputAtclauseOrderIncorrect1 implements Serializable {
     {
         return "null";
     }
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some text.
      * @param aString Some text.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect2.java
@@ -13,9 +13,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 /** Javadoc for import */
 import java.io.Serializable;
 
-// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 7 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
 /**
  * Some javadoc.
  *
@@ -27,7 +27,7 @@ import java.io.Serializable;
  */
 class InputAtclauseOrderIncorrect2 implements Serializable
 {
-    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some javadoc.
      *
@@ -38,8 +38,8 @@ class InputAtclauseOrderIncorrect2 implements Serializable
      */
     class InnerClassWithAnnotations2
     {
-        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
-        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 6 lines below 'Block tags have to appear in the order .[@author.*'
+        // violation 6 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @return Some text.
@@ -52,8 +52,8 @@ class InputAtclauseOrderIncorrect2 implements Serializable
             return "null";
         }
 
-        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
-        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @throws Exception Some text.
@@ -65,8 +65,8 @@ class InputAtclauseOrderIncorrect2 implements Serializable
             return "null";
         }
 
-        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
-        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @serialData Some javadoc.
@@ -78,8 +78,8 @@ class InputAtclauseOrderIncorrect2 implements Serializable
 
     InnerClassWithAnnotations2 anon = new InnerClassWithAnnotations2()
     {
-        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
-        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
+        // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @throws Exception Some text.
@@ -93,7 +93,7 @@ class InputAtclauseOrderIncorrect2 implements Serializable
             return "null";
         }
 
-        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @param aString Some text.
@@ -105,7 +105,7 @@ class InputAtclauseOrderIncorrect2 implements Serializable
             return "null";
         }
 
-        // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 4 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @throws Exception Some text.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect3.java
@@ -13,9 +13,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 /** Javadoc for import */
 import java.io.Serializable;
 
-// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 7 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
 /**
  * Some javadoc.
  *
@@ -27,7 +27,7 @@ import java.io.Serializable;
  */
 class InputAtclauseOrderIncorrect3 implements Serializable
 {
-    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some javadoc.
      *
@@ -38,7 +38,7 @@ class InputAtclauseOrderIncorrect3 implements Serializable
      */
     class InnerClassWithAnnotations3
     {
-        // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 4 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @deprecated Some text.
@@ -46,7 +46,7 @@ class InputAtclauseOrderIncorrect3 implements Serializable
          */
         void method3() throws Exception {}
 
-        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @throws Exception Some text.
@@ -61,7 +61,7 @@ class InputAtclauseOrderIncorrect3 implements Serializable
 
     InnerClassWithAnnotations3 anon = new InnerClassWithAnnotations3()
     {
-        // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 4 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @deprecated Some text.
@@ -69,7 +69,7 @@ class InputAtclauseOrderIncorrect3 implements Serializable
          */
         void method3() throws Exception {}
 
-        // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 4 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @throws Exception Some text.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect4.java
@@ -11,9 +11,9 @@ tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 /** Javadoc for import */
 import java.io.Serializable;
-// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 7 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
 /**
  * Some javadoc.
  *
@@ -24,7 +24,7 @@ import java.io.Serializable;
  * @author max
  */
 class InputAtclauseOrderIncorrect4 implements Serializable {
-    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some javadoc.
      *
@@ -33,7 +33,7 @@ class InputAtclauseOrderIncorrect4 implements Serializable {
      * @serialData Some javadoc.
      * @author max
      */
-    // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 6 lines below 'Block tags have to appear in the order .[@author.*'
     class InnerClassWithAnnotations4 {
         /**
          * Some text.
@@ -44,8 +44,8 @@ class InputAtclauseOrderIncorrect4 implements Serializable {
         String method5(String aString) {
             return "null";
         }
-        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
-        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 6 lines below 'Block tags have to appear in the order .[@author.*'
+        // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @param aString Some text.
@@ -60,8 +60,8 @@ class InputAtclauseOrderIncorrect4 implements Serializable {
         }
     }
     InnerClassWithAnnotations4 anon = new InnerClassWithAnnotations4() {
-        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
-        // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
+        // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @deprecated Some text.
@@ -72,8 +72,8 @@ class InputAtclauseOrderIncorrect4 implements Serializable {
             return "null";
         }
 
-        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
-        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 6 lines below 'Block tags have to appear in the order .[@author.*'
+        // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @param aString Some text.
@@ -88,9 +88,9 @@ class InputAtclauseOrderIncorrect4 implements Serializable {
         }
     };
 }
-// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 7 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
 /**
  * Some javadoc.
  *
@@ -101,7 +101,7 @@ class InputAtclauseOrderIncorrect4 implements Serializable {
  * @author max
  */
 enum Foo4 {}
-// violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 7 lines below 'Block tags have to appear in the order .[@author.*'
 /**
  * Some javadoc.
  *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom2.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
  */
 class InputAtclauseOrderIncorrectCustom2 implements Serializable
 {
-    // violation 5 lines below 'Block tags have to appear in the order .\[@since.*'
+    // violation 5 lines below 'Block tags have to appear in the order .[@since.*'
     /**
      * Some javadoc.
      *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom3.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
  */
 class InputAtclauseOrderIncorrectCustom3 implements Serializable
 {
-    // violation 5 lines below 'Block tags have to appear in the order .\[@since.*'
+    // violation 5 lines below 'Block tags have to appear in the order .[@since.*'
     /**
      * Some javadoc.
      *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom4.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
  */
 class InputAtclauseOrderIncorrectCustom4 implements Serializable
 {
-    // violation 5 lines below 'Block tags have to appear in the order .\[@since.*'
+    // violation 5 lines below 'Block tags have to appear in the order .[@since.*'
     /**
      * Some javadoc.
      *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderMethodReturningArrayType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderMethodReturningArrayType.java
@@ -13,7 +13,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 import java.sql.SQLException;
 
 public interface InputAtclauseOrderMethodReturningArrayType {
-    // violation 5 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 5 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * @return int array
      * @exception SQLException
@@ -25,8 +25,8 @@ public interface InputAtclauseOrderMethodReturningArrayType {
      */
     int[] executeBatch() throws SQLException;
 
-    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
     /**
       * {@code selected} is an array that will contain
       * the indices of items that have been selected.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderNewArrayDeclaratorStructure.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderNewArrayDeclaratorStructure.java
@@ -22,7 +22,7 @@ import javax.transaction.xa.Xid;
 
 public interface InputAtclauseOrderNewArrayDeclaratorStructure
         <D extends GenericDeclaration> extends Type, AnnotatedElement {
-    // violation 17 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 17 lines below 'Block tags have to appear in the order .[@author.*'
      /**
       * Returns an array of {@code Type} objects representing the
       * upper bound(s) of this type variable.  If no upper bound is
@@ -44,7 +44,7 @@ public interface InputAtclauseOrderNewArrayDeclaratorStructure
       */
      Type[] getBounds();
 
-     // violation 13 lines below 'Block tags have to appear in the order .\[@author.*'
+     // violation 13 lines below 'Block tags have to appear in the order .[@author.*'
       /**
        * Obtains a list of prepared transaction branches from a resource
        * manager. The transaction manager calls this method during recovery
@@ -68,9 +68,9 @@ public interface InputAtclauseOrderNewArrayDeclaratorStructure
 }
 
 class Other {
-    // violation 12 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 12 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 12 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 12 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 12 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 12 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * The focus traversal keys. These keys will generate focus traversal
      * behavior for Components for which focus traversal keys are enabled. If a

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
@@ -30,9 +30,9 @@ public class InputAtclauseOrderRecords {
             return "null";
         }
 
-        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
-        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
-        // violation 7 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
+        // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
+        // violation 7 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          *
@@ -45,8 +45,8 @@ public class InputAtclauseOrderRecords {
             return "null";
         }
 
-        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
-        // violation 6 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 6 lines below 'Block tags have to appear in the order .[@author.*'
+        // violation 6 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          *
@@ -57,7 +57,7 @@ public class InputAtclauseOrderRecords {
          */
         void method2(String aString) throws Exception {
         }
-        // violation 4 lines below 'Block tags have to appear in the order .\[@author.*'
+        // violation 4 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * Some text.
          * @since since
@@ -79,7 +79,7 @@ public class InputAtclauseOrderRecords {
  * @since Some javadoc.
  */
 record myOtherOtherRecord() {
-    // violation 3 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 3 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * @since Some javadoc.
      * @author max
@@ -96,7 +96,7 @@ record myOtherOtherRecord() {
  * @since Some javadoc.
  */
 class myOtherOtherClass {
-    // violation 3 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 3 lines below 'Block tags have to appear in the order .[@author.*'
         /**
          * @since Some javadoc.
          * @author max

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderWithAnnotationsOutsideJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderWithAnnotationsOutsideJavadoc.java
@@ -11,9 +11,9 @@ tagOrder = (default)@author, @version, @param, @return, @throws, @exception, \
 package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
 
 public class InputAtclauseOrderWithAnnotationsOutsideJavadoc {
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some javadoc.
      *
@@ -26,9 +26,9 @@ public class InputAtclauseOrderWithAnnotationsOutsideJavadoc {
     @Deprecated
     public boolean branchContains(int type) { return true; }
 
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some javadoc.
      *
@@ -41,9 +41,9 @@ public class InputAtclauseOrderWithAnnotationsOutsideJavadoc {
     public boolean branchContains2(int type) { return true; }
 }
 
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
 /**
  * Some javadoc.
  *
@@ -57,9 +57,9 @@ public class InputAtclauseOrderWithAnnotationsOutsideJavadoc {
 class TestClass {}
 
 class TestInnerClasses extends InputAtclauseOrderWithAnnotationsOutsideJavadoc{
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some javadoc.
      *
@@ -71,9 +71,9 @@ class TestInnerClasses extends InputAtclauseOrderWithAnnotationsOutsideJavadoc{
      */
     @Deprecated
     TestClass one = new TestClass(){};
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-    // violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+    // violation 8 lines below 'Block tags have to appear in the order .[@author.*'
     /**
      * Some javadoc.
      *
@@ -88,9 +88,9 @@ class TestInnerClasses extends InputAtclauseOrderWithAnnotationsOutsideJavadoc{
         return false;
     }
 }
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
 /**
  * Some javadoc.
  *
@@ -103,9 +103,9 @@ class TestInnerClasses extends InputAtclauseOrderWithAnnotationsOutsideJavadoc{
 @Deprecated
 enum TestEnums {}
 
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
-// violation 8 lines below 'Block tags have to appear in the order .\[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
+// violation 8 lines below 'Block tags have to appear in the order .[@author.*'
 /**
  * Some javadoc.
  *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceCreation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceCreation.java
@@ -5,48 +5,48 @@ ArrayBracketNoWhitespace
 package com.puppycrawl.tools.checkstyle.checks.whitespace.arraybracketnowhitespace;
 
 public class InputArrayBracketNoWhitespaceCreation {
-    int[] good; int bad []; // violation ''\[' is preceded with whitespace.'
+    int[] good; int bad []; // violation ''[' is preceded with whitespace.'
 
     void testArrayCreation() {
-        int[] arr2 = new int [10]; // violation ''\[' is preceded with whitespace.'
-        int[] arr3 = new int[ 10]; // violation ''\[' is followed by whitespace.'
-        int[] arr4 = new int[10 ]; // violation ''\]' is preceded with whitespace.'
+        int[] arr2 = new int [10]; // violation ''[' is preceded with whitespace.'
+        int[] arr3 = new int[ 10]; // violation ''[' is followed by whitespace.'
+        int[] arr4 = new int[10 ]; // violation '']' is preceded with whitespace.'
         int []arr5 = new int[10];
         // 2 violations above:
-        // ''\[' is preceded with whitespace'
-        // ''\]' is not followed by whitespace'
+        // ''[' is preceded with whitespace'
+        // '']' is not followed by whitespace'
         int[] arr6 = new int[ 10 ];
         // 2 violations above:
-        // ''\[' is followed by whitespace.'
-        // ''\]' is preceded with whitespace.'
+        // ''[' is followed by whitespace.'
+        // '']' is preceded with whitespace.'
     }
 
     void testArrayAccess() {
         int[] arr = new int[1];
-        int a = arr[0] ; // violation ''\]' is followed by whitespace.'
-        int b = arr [0]; // violation ''\[' is preceded with whitespace.'
-        int c = arr[ 0]; // violation ''\[' is followed by whitespace.'
-        int d = arr[0 ]; // violation ''\]' is preceded with whitespace.'
+        int a = arr[0] ; // violation '']' is followed by whitespace.'
+        int b = arr [0]; // violation ''[' is preceded with whitespace.'
+        int c = arr[ 0]; // violation ''[' is followed by whitespace.'
+        int d = arr[0 ]; // violation '']' is preceded with whitespace.'
         int e = arr[ 0 ];
         // 2 violations above:
-        // ''\[' is followed by whitespace.'
-        // ''\]' is preceded with whitespace.'
+        // ''[' is followed by whitespace.'
+        // '']' is preceded with whitespace.'
     }
 
     void testMulti() {
         int[][] m = new int[1][2];
         int[] [] n = new int[1][2];
         // 2 violations above:
-        // ''\]' is followed by whitespace.'
-        // ''\[' is preceded with whitespace.'
+        // '']' is followed by whitespace.'
+        // ''[' is preceded with whitespace.'
         int v = m[0] [1];
         // 2 violations above:
-        // ''\]' is followed by whitespace.'
-        // ''\[' is preceded with whitespace.'
+        // '']' is followed by whitespace.'
+        // ''[' is preceded with whitespace.'
         int[] arr = {1, 2};
         int x = m[arr[0] ][arr[0]];
         // 2 violations above:
-        // ''\]' is followed by whitespace.'
-        // ''\]' is preceded with whitespace.'
+        // '']' is followed by whitespace.'
+        // '']' is preceded with whitespace.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceDeclarations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceDeclarations.java
@@ -7,60 +7,60 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.arraybracketnowhitespa
 public class InputArrayBracketNoWhitespaceDeclarations {
 
     int[] ints;
-    int [] badInts; // violation ''\[' is preceded with whitespace.'
-    int[]arr; // violation ''\]' is not followed by whitespace.'
+    int [] badInts; // violation ''[' is preceded with whitespace.'
+    int[]arr; // violation '']' is not followed by whitespace.'
 
     int[][] matrix2D;
-    int [][] badMatrix2D; // violation ''\[' is preceded with whitespace.'
+    int [][] badMatrix2D; // violation ''[' is preceded with whitespace.'
     int[] [] badMatrix2D_2;
     // 2 violations above:
-    // ''\]' is followed by whitespace.'
-    // ''\[' is preceded with whitespace.'
+    // '']' is followed by whitespace.'
+    // ''[' is preceded with whitespace.'
 
     int[] afterType;
     int afterVar[];
-    int badAfterVar1 []; // violation ''\[' is preceded with whitespace.'
+    int badAfterVar1 []; // violation ''[' is preceded with whitespace.'
 
     int[] method1() { return null; }
-    int [] badMethod1() { return null; } // violation ''\[' is preceded with whitespace.'
+    int [] badMethod1() { return null; } // violation ''[' is preceded with whitespace.'
 
     void param1(int[] arr) {}
-    void param2(int[]arr) {} // violation ''\]' is not followed by whitespace.'
-    void badParam1(int [] arr) {} // violation ''\[' is preceded with whitespace.'
+    void param2(int[]arr) {} // violation '']' is not followed by whitespace.'
+    void badParam1(int [] arr) {} // violation ''[' is preceded with whitespace.'
 
     InputArrayBracketNoWhitespaceDeclarations(int[]arr) {}
-    // violation above ''\]' is not followed by whitespace.'
+    // violation above '']' is not followed by whitespace.'
 
     void localVariables() {
         int[] local1 = new int[10];
-        int [] badLocal1 = new int[10]; // violation ''\[' is preceded with whitespace.'
+        int [] badLocal1 = new int[10]; // violation ''[' is preceded with whitespace.'
         int local3[] = new int[10];
     }
 
     void anonymousArrays() {
         int[] arr1 = new int[] {1};
-        int[] arr2 = new int [] {1}; // violation ''\[' is preceded with whitespace.'
+        int[] arr2 = new int [] {1}; // violation ''[' is preceded with whitespace.'
         int[] arr3 = new int[ ] {1};
         // 2 violations above:
-        // ''\[' is followed by whitespace.'
-        // ''\]' is preceded with whitespace.'
+        // ''[' is followed by whitespace.'
+        // '']' is preceded with whitespace.'
     }
 
     void castExpressions() {
         Object obj = new int[1];
         int[] arr1 = (int[]) obj;
-        int[]arr2 = (int[]) obj; // violation ''\]' is not followed by whitespace.'
-        int[] arr3 = (int []) obj; // violation ''\[' is preceded with whitespace.'
+        int[]arr2 = (int[]) obj; // violation '']' is not followed by whitespace.'
+        int[] arr3 = (int []) obj; // violation ''[' is preceded with whitespace.'
     }
 
     void instanceofChecks(Object obj) {
         boolean b1 = obj instanceof int[];
-        boolean b2 = obj instanceof int []; // violation ''\[' is preceded with whitespace.'
+        boolean b2 = obj instanceof int []; // violation ''[' is preceded with whitespace.'
     }
 
     void classLiterals() {
         Class<?> cls1 = int[].class;
-        Class<?> cls2 = int [].class; // violation ''\[' is preceded with whitespace.'
+        Class<?> cls2 = int [].class; // violation ''[' is preceded with whitespace.'
     }
 
     void testArrayInitializationWithArrayAccess() {
@@ -73,12 +73,12 @@ public class InputArrayBracketNoWhitespaceDeclarations {
     @interface Ann {}
 
     int @Ann [] annotatedArr;
-    int @Ann[] annotatedArr2; // violation ''\[' is not preceded with whitespace.'
+    int @Ann[] annotatedArr2; // violation ''[' is not preceded with whitespace.'
     int @Ann [][] annotatedArr2D;
     void annotatedParam(@Ann int @Ann [] param) {}
 
     int @Ann [ ] badAnnotatedArr;
     // 2 violations above:
-    // ''\[' is followed by whitespace.'
-    // ''\]' is preceded with whitespace.'
+    // ''[' is followed by whitespace.'
+    // '']' is preceded with whitespace.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceExpressions.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceExpressions.java
@@ -13,8 +13,8 @@ public class InputArrayBracketNoWhitespaceExpressions {
         int result1 = matrix[arr[0]][arr[1]];
         int result2 = matrix[ arr[0]][arr[1 ]];
         // 2 violations above:
-        // ''\[' is followed by whitespace'
-        // ''\]' is preceded with whitespace'
+        // ''[' is followed by whitespace'
+        // '']' is preceded with whitespace'
 
         // Array access in ternary operator
         int result3 = arr[0] > 0 ? arr[1] : arr[2];
@@ -70,7 +70,7 @@ public class InputArrayBracketNoWhitespaceExpressions {
         int o = arr[0]
             + arr[1];
 
-        int q = arr[0]+ arr[1] // violation ''\]' is not followed by whitespace'
+        int q = arr[0]+ arr[1] // violation '']' is not followed by whitespace'
             + arr[2];
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceMemberAndOperators.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceMemberAndOperators.java
@@ -13,40 +13,40 @@ public class InputArrayBracketNoWhitespaceMemberAndOperators {
         String t1 = stringArray[0].toString();
         String t2 = stringArray[0]
             .toString();
-        String t3 = stringArray[0] .toString(); // violation ''\]' is followed by whitespace.'
+        String t3 = stringArray[0] .toString(); // violation '']' is followed by whitespace.'
     }
 
     void testPostfixOperators() {
         int[] arr = {1, 2};
         int x = arr[0], u = arr[1];
-        int y = arr[0] , v = arr[1]; // violation ''\]' is followed by whitespace.'
-        arr[2] ++; // violation ''\]' is followed by whitespace.'
+        int y = arr[0] , v = arr[1]; // violation '']' is followed by whitespace.'
+        arr[2] ++; // violation '']' is followed by whitespace.'
         arr[2]++;
-        arr[2] --; // violation ''\]' is followed by whitespace.'
+        arr[2] --; // violation '']' is followed by whitespace.'
         arr[2]--;
-        arr[0]+=1; // violation ''\]' is not followed by whitespace.'
+        arr[0]+=1; // violation '']' is not followed by whitespace.'
         int a = arr[0] + arr[1];
-        int b = arr[0]+ arr[1]; // violation ''\]' is not followed by whitespace.'
+        int b = arr[0]+ arr[1]; // violation '']' is not followed by whitespace.'
         int c = arr[0] - arr[1];
-        int d = arr[0]- arr[1]; // violation ''\]' is not followed by whitespace.'
+        int d = arr[0]- arr[1]; // violation '']' is not followed by whitespace.'
     }
 
     void testColonWhitespace() {
         IntFunction<int[]> f1 = int[]::new;
-        IntFunction<int[] > f2 = int[]::new; // violation ''\]' is followed by whitespace.'
-        IntFunction<int[]> f3 = int[] ::new; // violation ''\]' is followed by whitespace.'
+        IntFunction<int[] > f2 = int[]::new; // violation '']' is followed by whitespace.'
+        IntFunction<int[]> f3 = int[] ::new; // violation '']' is followed by whitespace.'
     }
 
     void testAngleBracket() {
         int[] arr = new int[5];
-        boolean result1 = arr[0]>=0; // violation ''\]' is not followed by whitespace.'
+        boolean result1 = arr[0]>=0; // violation '']' is not followed by whitespace.'
         boolean result2 = arr[0] >= 0;
-        boolean result3 = arr[0]<=0; // violation ''\]' is not followed by whitespace.'
+        boolean result3 = arr[0]<=0; // violation '']' is not followed by whitespace.'
         boolean result4 = arr[0] <= 0;
-        int result5 = arr[0]>> 2; // violation ''\]' is not followed by whitespace.'
+        int result5 = arr[0]>> 2; // violation '']' is not followed by whitespace.'
         int result6 = arr[0] >> 2;
-        int result7 = arr[0]<< 2; // violation ''\]' is not followed by whitespace.'
+        int result7 = arr[0]<< 2; // violation '']' is not followed by whitespace.'
         int result8 = arr[0] << 2;
-        boolean result9 = arr[0]< 2; // violation ''\]' is not followed by whitespace'
+        boolean result9 = arr[0]< 2; // violation '']' is not followed by whitespace'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceMisc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceMisc.java
@@ -7,12 +7,12 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.arraybracketnowhitespa
 public class InputArrayBracketNoWhitespaceMisc {
 
     void testVar(int... nums) {
-        int b = nums [0]; // violation ''\[' is preceded with whitespace.'
-        int[] arr3 = new int [] {1,2,3}; // violation ''\[' is preceded with whitespace.'
+        int b = nums [0]; // violation ''[' is preceded with whitespace.'
+        int[] arr3 = new int [] {1,2,3}; // violation ''[' is preceded with whitespace.'
     }
 
     void testInstanceof(Object o) {
-        if (o instanceof int []) {} // violation ''\[' is preceded with whitespace.'
+        if (o instanceof int []) {} // violation ''[' is preceded with whitespace.'
     }
 
     void testMultilineAncestor() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceMultiline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceMultiline.java
@@ -20,6 +20,6 @@ public class InputArrayBracketNoWhitespaceMultiline {
         int x[]  // ok - trailing spaces before a line comment, no warning
         ;
         int[] arr3 = new int
- [5]; // violation ''\[' is preceded with whitespace.'
+ [5]; // violation ''[' is preceded with whitespace.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceNextToken.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/InputArrayBracketNoWhitespaceNextToken.java
@@ -6,14 +6,14 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.arraybracketnowhitespa
 
 public class InputArrayBracketNoWhitespaceNextToken {
     void testImmediatelyAdjacentTokens(int[] arr) {
-        int a = arr[0]+1; // violation ''\]' is not followed by whitespace.'
-        int b = arr[0]-1; // violation ''\]' is not followed by whitespace.'
-        int c = arr[0]*2; // violation ''\]' is not followed by whitespace.'
+        int a = arr[0]+1; // violation '']' is not followed by whitespace.'
+        int b = arr[0]-1; // violation '']' is not followed by whitespace.'
+        int c = arr[0]*2; // violation '']' is not followed by whitespace.'
     }
 
     void testEarlierLineHighColumnTokens(
             int[] someVeryLongNamedArray) {
-        int result = someVeryLongNamedArray[0]+1; // violation ''\]' is not followed by whitespace.'
+        int result = someVeryLongNamedArray[0]+1; // violation '']' is not followed by whitespace.'
     }
 
     void testTokenOnNextLine(int[] arr) {
@@ -23,15 +23,15 @@ public class InputArrayBracketNoWhitespaceNextToken {
             ;
 
         int[][
-                  ] // violation ''\]' is preceded with whitespace.'
+                  ] // violation '']' is preceded with whitespace.'
                    a
-                    [] // violation ''\[' is preceded with whitespace.'
+                    [] // violation ''[' is preceded with whitespace.'
                           [] ;
         // 2 violations above:
-        // ''\[' is preceded with whitespace.'
-        // ''\]' is followed by whitespace.'
+        // ''[' is preceded with whitespace.'
+        // '']' is followed by whitespace.'
 
-        for (int i = 0; i < arr[0] ; i++) {} // violation ''\]' is followed by whitespace.'
+        for (int i = 0; i < arr[0] ; i++) {} // violation '']' is followed by whitespace.'
     }
 
     void testGetNextTokenFromParent(int[] arr) {
@@ -74,7 +74,7 @@ public class InputArrayBracketNoWhitespaceNextToken {
                         a[1] * b[1] * c[0];
     }
 
-    void method4(String[] ... params) { // violation ''\]' is followed by whitespace'
+    void method4(String[] ... params) { // violation '']' is followed by whitespace'
     }
 
     void method5(String[]... params) {
@@ -83,7 +83,7 @@ public class InputArrayBracketNoWhitespaceNextToken {
     @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)
     @interface Ann {}
 
-    void method6(String @Ann [] ... param) { // violation ''\]' is followed by whitespace'
+    void method6(String @Ann [] ... param) { // violation '']' is followed by whitespace'
     }
 
     void method7(String @Ann []... param) {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForArrayDeclarator.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapForArrayDeclarator.java
@@ -14,6 +14,6 @@ class InputSeparatorWrapForArrayDeclarator {
             ] {1, 2};
 
     protected int[] arrayDeclarationWithBadWrapping = new int
-            [] {1, 2}; // violation ''\[' should be on the previous line'
+            [] {1, 2}; // violation ''[' should be on the previous line'
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapWithEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapWithEmoji.java
@@ -11,10 +11,10 @@ import java.util.Arrays;
 
 public class InputSeparatorWrapWithEmoji {
     protected String[] s1 = new String[
-        /*🎄 with text */    ] {"aab🎄", "a🎄a👍ba"}; // violation above ''\[' should be on a new line'
+        /*🎄 with text */    ] {"aab🎄", "a🎄a👍ba"}; // violation above ''[' should be on a new line'
 
     /* emoji👍array */ protected String[] s2 = new String[
-        ] {"🥳", "😠", "😨"}; // violation above ''\[' should be on a new line'
+        ] {"🥳", "😠", "😨"}; // violation above ''[' should be on a new line'
 
     /*👆🏻 👇🏻*/ public void test1(String...
                         parameters) { // violation above ''...' should be on a new line'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/arraybracketnowhitespace/Example1.java
@@ -13,48 +13,48 @@ import java.util.function.IntFunction;
 // xdoc section - start
 class Example1 {
   int[] numbersGood = new int[10];
-  int[] numbersWarn = new int[10 ]; // violation ''\]' is preceded with whitespace'
+  int[] numbersWarn = new int[10 ]; // violation '']' is preceded with whitespace'
 
   String[] dataGood = {"a", "b"};
-  String [] dataWarn = {"a", "b"}; // violation ''\[' is preceded with whitespace'
+  String [] dataWarn = {"a", "b"}; // violation ''[' is preceded with whitespace'
 
   byte bufferGood[];
   byte bufferWarn[ ];
   // 2 violations above:
-  // ''\[' is followed by whitespace'
-  // ''\]' is preceded with whitespace'
+  // ''[' is followed by whitespace'
+  // '']' is preceded with whitespace'
 
   int[] matrixGood[];
-  int[] matrixWarn[] ; // violation ''\]' is followed by whitespace'
+  int[] matrixWarn[] ; // violation '']' is followed by whitespace'
 
   void methodGood(int[] arr) {}
-  void methodWarn(int[]arr) {} // violation ''\]' is not followed by whitespace'
+  void methodWarn(int[]arr) {} // violation '']' is not followed by whitespace'
 
   void processArray(int[] arr) {
     int[] goodArr = {arr[0], arr[1]};
-    int[] warnArr = {arr[0], arr[1] };// violation ''\]' is followed by whitespace'
+    int[] warnArr = {arr[0], arr[1] };// violation '']' is followed by whitespace'
 
     int valueGood = arr[0] * 2;
-    int valueWarn = arr[0]* 2; // violation ''\]' is not followed by whitespace'
+    int valueWarn = arr[0]* 2; // violation '']' is not followed by whitespace'
 
     int good = arr[0] >> 2;
-    int warn = arr[0]>>2; // violation ''\]' is not followed by whitespace'
+    int warn = arr[0]>>2; // violation '']' is not followed by whitespace'
 
     arr[0]++;
-    arr[0] ++; // violation ''\]' is followed by whitespace'
+    arr[0] ++; // violation '']' is followed by whitespace'
 
     Class<?> goodClass = int[].class;
-    Class<?> warnClass = int[] .class; // violation ''\]' is followed by whitespace.'
+    Class<?> warnClass = int[] .class; // violation '']' is followed by whitespace.'
 
     IntFunction<int[]> goodMethodRef = int[]::new;
     IntFunction<int[]> warnMethodRef = int[] ::new;
-    // violation above ''\]' is followed by whitespace.'
+    // violation above '']' is followed by whitespace.'
     IntFunction<int[] > warnAngleBracket = int[]::new;
-    // violation above ''\]' is followed by whitespace.'
+    // violation above '']' is followed by whitespace.'
   }
 
   void goodEllipsis(String[]... params) {}
   void warnEllipsis(String[] ... params) {}
-  // violation above ''\]' is followed by whitespace'
+  // violation above '']' is followed by whitespace'
 }
 // xdoc section - end


### PR DESCRIPTION
Issue: #21177

### Description
This PR resolves the inconsistency in violation message escaping by automatically escaping square brackets (`[` and `]`) in BDD expected violation messages, similar to how parentheses and curly braces are handled.

### Changes
- **Auto-escaping**: Updated `TestInputViolation.java`'s `toRegex()` method to automatically escape `[` and `]` metacharacters using regex replacement.
- **Removed Suppressions**: Removed the `discouragedRegexpInViolationMessage` suppression for `ArrayBracketNoWhitespace/Example1.java` in `checkstyle-examples-suppressions.xml`.
- **Cleanup**: Cleaned up all manual escape characters (`\\[` -> `[` and `\\]` -> `]`) from comments across 41 test/example resource files, and normalized their line endings to Unix-style (LF) format.
