### PR TITLE
Issue #13206: Improvements to site workflow

### DIFF
--- a/.ci/build-pr-comment.sh
+++ b/.ci/build-pr-comment.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+source ./.ci/util.sh
+
+mkdir -p .ci-temp
+
+if [ -n "$MSG" ]; then
+  echo "$MSG" > .ci-temp/message
+  exit 0
+fi
+
+checkForVariable "GITHUB_TOKEN"
+checkForVariable "GITHUB_RUN_ID"
+
+JOBS_LINK="https://github.com/checkstyle/checkstyle/actions/runs/${GITHUB_RUN_ID}"
+API_LINK="https://api.github.com/repos/checkstyle/checkstyle/actions/runs/${GITHUB_RUN_ID}/jobs"
+
+curl --fail-with-body -X GET "${API_LINK}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -o .ci-temp/info.json
+
+jq '.jobs' .ci-temp/info.json > .ci-temp/jobs
+jq '.[] | select(.conclusion == "failure") | .name' .ci-temp/jobs > .ci-temp/job_name
+jq '.[] | select(.conclusion == "failure") | .steps' .ci-temp/jobs > .ci-temp/steps
+jq '.[] | select(.conclusion == "failure") | .name' .ci-temp/steps > .ci-temp/step_name
+
+if [ -n "$FAILURE_PREFIX" ]; then
+  echo "${FAILURE_PREFIX} failed on phase $(cat .ci-temp/job_name)," > .ci-temp/message
+else
+  echo "Job failed on phase $(cat .ci-temp/job_name)," > .ci-temp/message
+fi
+echo "step $(cat .ci-temp/step_name).<br>Link: $JOBS_LINK" >> .ci-temp/message

--- a/.ci/site.sh
+++ b/.ci/site.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+
+source ./.ci/util.sh
+
+case $1 in
+
+# Gets PR information (branch, commit_sha) and saves to .ci-temp
+get-pr-info)
+  checkForVariable "GITHUB_TOKEN"
+  checkForVariable "PR_NUMBER"
+  mkdir -p .ci-temp
+  
+  URL="https://api.github.com/repos/checkstyle/checkstyle/pulls/${PR_NUMBER}"
+  
+  curl --fail-with-body -X GET "$URL" \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: token $GITHUB_TOKEN" \
+      -o .ci-temp/info.json
+
+  jq .head.ref .ci-temp/info.json > .ci-temp/branch
+  jq .head.sha .ci-temp/info.json > .ci-temp/commit_sha
+  
+  BRANCH=$(xargs < .ci-temp/branch)
+  COMMIT_SHA=$(xargs < .ci-temp/commit_sha | cut -c 1-7)
+  
+  ./.ci/append-to-github-output.sh "branch" "$BRANCH"
+  ./.ci/append-to-github-output.sh "commit_sha" "$COMMIT_SHA"
+  ;;
+
+# Generates the site using Maven
+generate-site)
+  cd .ci-temp/checkstyle
+  ../../mvnw -e --no-transfer-progress clean site -Pno-validations \
+    -Dmaven.javadoc.skip=false -Djdepend.skip=false
+  ;;
+
+# Copies the site to AWS S3 bucket and generates the message
+publish-site)
+  checkForVariable "GITHUB_TOKEN"
+  checkForVariable "COMMIT_SHA"
+  checkForVariable "PR_NUMBER"
+  checkForVariable "AWS_BUCKET_NAME"
+  checkForVariable "AWS_REGION"
+  
+  TIME=$(date +%Y%m%d%H%M%S)
+  FOLDER="${COMMIT_SHA}_$TIME"
+  SITE=".ci-temp/checkstyle/target/site"
+  LINK="https://${AWS_BUCKET_NAME}.s3.${AWS_REGION}.amazonaws.com"
+  
+  aws s3 cp "$SITE" "s3://${AWS_BUCKET_NAME}/$FOLDER/" --recursive
+  echo "$LINK/$FOLDER/index.html" > .ci-temp/message
+  
+  ./.ci/generate-extra-site-links.sh "$PR_NUMBER" "$LINK/$FOLDER"
+  
+  ./.ci/append-to-github-output.sh "message" "$(cat .ci-temp/message)"
+  ;;
+
+*)
+  echo "Unexpected argument: $1"
+  sleep 5s
+  false
+  ;;
+
+esac

--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -182,33 +182,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Get message
+      - name: Build PR comment message
         env:
           MSG: ${{ needs.make_report.outputs.message }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p .ci-temp
-          if [ -z "$MSG" ]; then
-            JOBS_LINK="https://github.com/checkstyle/checkstyle/actions/runs/${{github.run_id}}"
-            API_LINK="https://api.github.com/repos/checkstyle/checkstyle/actions/runs/"
-            API_LINK="${API_LINK}${{github.run_id}}/jobs"
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          FAILURE_PREFIX: "Report generation"
+        run: ./.ci/build-pr-comment.sh
 
-            curl --fail-with-body -X GET "${API_LINK}" \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -o .ci-temp/info.json
-
-            jq '.jobs' .ci-temp/info.json > ".ci-temp/jobs"
-            jq '.[] | select(.conclusion == "failure") | .name' .ci-temp/jobs > .ci-temp/job_name
-            jq '.[] | select(.conclusion == "failure") | .steps' .ci-temp/jobs > .ci-temp/steps
-            jq '.[] | select(.conclusion == "failure") | .name' .ci-temp/steps > .ci-temp/step_name
-            echo "Report generation failed on phase $(cat .ci-temp/job_name)," > .ci-temp/message
-            echo "step $(cat .ci-temp/step_name).<br>Link: $JOBS_LINK" >> .ci-temp/message
-          else
-            echo "$MSG" > .ci-temp/message
-          fi
-
-      - name: Set message
+      - name: Export PR comment message
         id: out
         run: |
           ./.ci/append-to-github-output.sh "message" "$(cat .ci-temp/message)"

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -37,16 +37,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  parse_pr_info:
+  site:
     if: github.event.comment.body == 'GitHub, generate web site'
           || github.event.comment.body == 'GitHub, generate website'
           || github.event.comment.body == 'GitHub, generate site'
           || inputs.pr-number != ''
     runs-on: ubuntu-latest
-    outputs:
-      branch: ${{ steps.branch.outputs.ref }}
-      commit_sha: ${{ steps.branch.outputs.commit_sha }}
-
     steps:
       - name: React to comment
         if: github.event_name == 'issue_comment'
@@ -61,38 +57,19 @@ jobs:
               content: 'rocket'
             })
 
-      - name: Getting PR description
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          repository: checkstyle/checkstyle
+
+      - name: Getting PR info
+        id: pr_info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr-number || github.event.issue.number }}
         run: |
-          mkdir -p .ci-temp
-          if [ -z "${{inputs.pr-number}}" ]; then
-            URL="${{github.event.issue.pull_request.url}}"
-          else
-            URL="https://api.github.com/repos/checkstyle/checkstyle/pulls/""${{inputs.pr-number}}"
-          fi
-          curl --fail-with-body -X GET "$URL" \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -o .ci-temp/info.json
+          ./.ci/site.sh get-pr-info
 
-          jq .head.ref .ci-temp/info.json > .ci-temp/branch
-          jq .head.sha .ci-temp/info.json > .ci-temp/commit_sha
-
-      - name: Set branch
-        id: branch
-        run: |
-          echo "ref=$(xargs < .ci-temp/branch)" >> "$GITHUB_OUTPUT"
-          echo "commit_sha=$(xargs < .ci-temp/commit_sha | cut -c 1-7)" >> "$GITHUB_OUTPUT"
-
-  generate_site:
-    needs: parse_pr_info
-    runs-on: ubuntu-latest
-    steps:
-      # fetch-depth - number of commits to fetch.
-      # 0 indicates all history for all branches and tags.
-      # 0, because we need access to all branches to create a report.
-      # ref - branch to checkout.
       - name: Download checkstyle for PR
         uses: actions/checkout@v7
         with:
@@ -114,41 +91,7 @@ jobs:
 
       - name: Generate site
         run: |
-          bash
-          cd .ci-temp/checkstyle
-          mvn -e --no-transfer-progress clean site -Pno-validations \
-            -Dmaven.javadoc.skip=false -Djdepend.skip=false
-
-      - name: Upload generated site artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: checkstyle-site-artifact-${{ github.run_id }}
-          path: .ci-temp/checkstyle/target/site
-          retention-days: 1
-          if-no-files-found: error
-
-  publish_site:
-    needs: [ parse_pr_info, generate_site ]
-    runs-on: ubuntu-latest
-    outputs:
-      message: ${{ steps.out.outputs.message}}
-    steps:
-      - name: Checkout master branch
-        uses: actions/checkout@v7
-        with:
-          repository: checkstyle/checkstyle
-
-      - name: Setup local maven cache
-        uses: actions/cache/restore@v6
-        with:
-          path: ~/.m2/repository
-          key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
-
-      - name: Download generated site artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: checkstyle-site-artifact-${{ github.run_id }}
-          path: .ci-temp/checkstyle/target/site
+          ./.ci/site.sh generate-site
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -157,69 +100,34 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Copy site to AWS S3 Bucket
+      - name: Publish site to AWS S3
+        id: publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ steps.pr_info.outputs.commit_sha }}
+          PR_NUMBER: ${{ inputs.pr-number || github.event.issue.number }}
+          AWS_BUCKET_NAME: ${{ env.AWS_BUCKET_NAME }}
+          AWS_REGION: ${{ env.AWS_REGION }}
         run: |
-          bash
-          TIME=$(date +%Y%m%d%H%M%S)
-          FOLDER="${{needs.parse_pr_info.outputs.commit_sha}}_$TIME"
-          SITE=".ci-temp/checkstyle/target/site"
-          LINK="https://${{env.AWS_BUCKET_NAME}}.s3.${{env.AWS_REGION}}.amazonaws.com"
-          aws s3 cp "$SITE" "s3://${{env.AWS_BUCKET_NAME}}/$FOLDER/" --recursive
-          echo "$LINK/$FOLDER/index.html" > .ci-temp/message
-          PR_NUMBER="${{ inputs.pr-number || github.event.issue.number }}"
-          ./.ci/generate-extra-site-links.sh "$PR_NUMBER" "$LINK/$FOLDER"
+          ./.ci/site.sh publish-site
 
-      - name: Set output
-        id: out
-        run: |
-          ./.ci/append-to-github-output.sh "message" "$(cat .ci-temp/message)"
-
-  # should be always last step
-  send_message:
-    runs-on: ubuntu-latest
-    needs: [ publish_site ]
-    if: failure() || success()
-    steps:
-      - name: Checkout master branch
-        uses: actions/checkout@v7
-        with:
-          repository: checkstyle/checkstyle
-
-      - name: Get message
+      - name: Build PR comment message
+        if: always()
         env:
-          MSG: ${{needs.publish_site.outputs.message}}
+          MSG: ${{ steps.publish.outputs.message }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p .ci-temp
-          if [ -z  "$MSG" ]; then
-            JOBS_LINK="https://github.com/checkstyle/checkstyle/actions/runs/${{github.run_id}}"
-            API_LINK="https://api.github.com/repos/checkstyle/checkstyle/actions/runs/"
-            API_LINK="${API_LINK}${{github.run_id}}/jobs"
-            echo "API_LINK=${API_LINK}"
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          FAILURE_PREFIX: "Site generation"
+        run: ./.ci/build-pr-comment.sh
 
-            curl --fail-with-body -X GET "${API_LINK}" \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -o .ci-temp/info.json
-
-            jq '.jobs' .ci-temp/info.json > ".ci-temp/jobs"
-            jq '.[] | select(.conclusion == "failure") | .name' .ci-temp/jobs > .ci-temp/job_name
-            jq '.[] | select(.conclusion == "failure") | .steps' .ci-temp/jobs > .ci-temp/steps
-            jq '.[] | select(.conclusion == "failure") | .name' .ci-temp/steps > .ci-temp/step_name
-            echo "Site generation job failed on phase $(cat .ci-temp/job_name)," > .ci-temp/message
-            echo "step $(cat .ci-temp/step_name).<br>Link: $JOBS_LINK" >> .ci-temp/message
-          else
-            echo "$MSG" > .ci-temp/message
-          fi
-
-      - name: Set message
+      - name: Export PR comment message
         id: out
+        if: always()
         run: |
           ./.ci/append-to-github-output.sh "message" "$(cat .ci-temp/message)"
 
       - name: Comment PR
+        if: always()
         uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#13206

1. Created `.ci/send_message.sh`
A shared script for the identical message handling logic used by both workflows:
- get-message command handles both success and failure cases
- Fetches job failure information from GitHub API when MSG is empty
- Uses configurable `FAILURE_PREFIX` for different workflows

2. Created `.ci/site.sh`
A command-based script following the pattern of` diff-report.sh` and `validation.sh`:
- get-pr-info - Fetches PR branch and commit_sha
- generate-site - Runs Maven to generate the site
- publish-site - Copies site to AWS S3 and generates the message

3. Updated `.github/workflows/site.yml`
Consolidated from 4 jobs to a single job:

Before: `parse_pr_info`, `generate_site`, `publish_site`, `send_message` (4 jobs)
After: site (1 job with all steps)

- All bash logic extracted to site.sh script
- Message handling uses shared send_message.sh script
- Uses if: always() for the comment step to ensure it runs even on failure

4. Updated `.github/workflows/diff-report.yml`

- Updated the send_message job to use the shared send_message.sh script
- Removed duplicate bash logic, now using the common script