### PR TITLE
Issue #20545: add manual workflow dispatch

### DIFF
--- a/.github/workflows/antlr-report.yml
+++ b/.github/workflows/antlr-report.yml
@@ -15,11 +15,24 @@ name: ANTLR-Report
 env:
   AWS_REGION: us-east-2
   AWS_BUCKET_NAME: "checkstyle-diff-reports"
-  USER_LOGIN: ${{ github.event.issue.user.login }}
+  PULL_REQUEST_URL: >-
+    ${{ github.event.issue.pull_request.url
+        || format('https://api.github.com/repos/checkstyle/checkstyle/pulls/{0}',
+                  inputs.pr-number) }}
 
 on:
   issue_comment:
     types: [ created, edited ]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number'
+        required: true
+        type: string
+      trigger-phrase:
+        description: 'Comment phrase that normally triggers this workflow'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -32,14 +45,16 @@ concurrency:
 
 jobs:
   make_report:
-    if: github.event.issue.pull_request != null
-        && (github.event.comment.body == 'GitHub, generate ANTLR report'
-            || startsWith(github.event.comment.body, 'GitHub, generate ANTLR report for '))
+    if: (github.event.issue.pull_request != null || inputs.pr-number != '')
+        && ((inputs.trigger-phrase || github.event.comment.body) == 'GitHub, generate ANTLR report'
+            || startsWith(inputs.trigger-phrase || github.event.comment.body,
+                          'GitHub, generate ANTLR report for '))
     runs-on: ubuntu-latest
     outputs:
       commit_sha: ${{ steps.branch.outputs.commit_sha }}
     steps:
       - name: React to comment
+        if: github.event_name == 'issue_comment'
         uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -57,7 +72,7 @@ jobs:
       - name: Resolve PR branch and SHA
         id: branch
         env:
-          PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
+          PULL_REQUEST_URL: ${{ env.PULL_REQUEST_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p .ci-temp
@@ -68,14 +83,16 @@ jobs:
 
           BRANCH=$(jq --raw-output .head.ref .ci-temp/info.json)
           FULL_SHA=$(jq --raw-output .head.sha .ci-temp/info.json)
+          USER_LOGIN=$(jq --raw-output .head.repo.owner.login .ci-temp/info.json)
           ./.ci/append-to-github-output.sh "ref" "$BRANCH"
           ./.ci/append-to-github-output.sh "full_sha" "$FULL_SHA"
           ./.ci/append-to-github-output.sh "commit_sha" "$(echo "$FULL_SHA" | cut -c 1-7)"
+          ./.ci/append-to-github-output.sh "user_login" "$USER_LOGIN"
 
       - name: Parse project from comment
         id: project
         env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_BODY: ${{ inputs.trigger-phrase || github.event.comment.body }}
         run: |
           PATTERN='^GitHub, generate ANTLR report for ([a-zA-Z0-9-]+)[[:space:]]*$'
           if [ "$COMMENT_BODY" = 'GitHub, generate ANTLR report' ]; then
@@ -89,11 +106,13 @@ jobs:
           ./.ci/append-to-github-output.sh "name" "$PROJECT"
 
       - name: Set upstream and forked remotes
+        env:
+          FORK_REPO_OWNER: ${{ steps.branch.outputs.user_login }}
         run: |
           MAIN_REPO_GIT_URL="https://github.com/checkstyle/checkstyle.git"
           git remote add upstream "$MAIN_REPO_GIT_URL"
           git fetch upstream
-          FORK_REPO_GIT_URL="https://github.com/$USER_LOGIN/checkstyle.git"
+          FORK_REPO_GIT_URL="https://github.com/$FORK_REPO_OWNER/checkstyle.git"
           git remote add forked "$FORK_REPO_GIT_URL"
           git fetch forked
 
@@ -125,6 +144,7 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.ref }}
           FULL_SHA: ${{ steps.branch.outputs.full_sha }}
           PROJECT_NAME: ${{ steps.project.outputs.name }}
+          FORK_REPO_OWNER: ${{ steps.branch.outputs.user_login }}
         run: |
           cd .ci-temp/contribution/checkstyle-tester
 
@@ -152,7 +172,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/launch_diff"
 
           if [ "$PROJECT_NAME" = "checkstyle" ]; then
-            echo "checkstyle|git|https://github.com/$USER_LOGIN/checkstyle.git|$FULL_SHA||" \
+            echo "checkstyle|git|https://github.com/$FORK_REPO_OWNER/checkstyle.git|$FULL_SHA||" \
               > projects-to-test-on.properties
           else
             CONFIGS_DIR="$GITHUB_WORKSPACE/config/projects-to-test"
@@ -271,7 +291,9 @@ jobs:
           ./.ci/append-to-github-output.sh "message" "$(cat .ci-temp/message)"
 
       - name: Comment PR
-        uses: checkstyle/contribution/comment-action@master
+        uses: peter-evans/create-or-update-comment@v5
         with:
-          message: ${{steps.out.outputs.message}}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ inputs.pr-number || github.event.issue.number }}
+          body: ${{ steps.out.outputs.message }}

--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -15,13 +15,26 @@ name: Diff-Report
 env:
   AWS_REGION: us-east-2
   AWS_BUCKET_NAME: "checkstyle-diff-reports"
+  PULL_REQUEST_URL: >-
+    ${{ github.event.issue.pull_request.url
+        || format('https://api.github.com/repos/checkstyle/checkstyle/pulls/{0}',
+                  inputs.pr-number) }}
   # yamllint disable-line rule:line-length
   DEFAULT_PROJECTS_LINK: "https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/projects-to-test-on-for-github-action.properties"
-  USER_LOGIN: ${{ github.event.issue.user.login }}
 
 on:
   issue_comment:
     types: [ created, edited ]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number'
+        required: true
+        type: string
+      trigger-phrase:
+        description: 'Comment phrase that normally triggers this workflow'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -35,7 +48,7 @@ concurrency:
 jobs:
   # Parse PR Body, search for links to .properties and .xml files
   parse_body:
-    if: github.event.comment.body == 'GitHub, generate report'
+    if: (inputs.trigger-phrase || github.event.comment.body) == 'GitHub, generate report'
     runs-on: ubuntu-latest
     outputs:
       projects_link: ${{ steps.parse.outputs.projects_link }}
@@ -45,9 +58,11 @@ jobs:
       report_label: ${{ steps.parse.outputs.report_label }}
       branch: ${{ steps.branch.outputs.ref }}
       commit_sha: ${{ steps.branch.outputs.commit_sha }}
+      user_login: ${{ steps.branch.outputs.user_login }}
 
     steps:
       - name: React to comment
+        if: github.event_name == 'issue_comment'
         uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -65,10 +80,14 @@ jobs:
       - name: Getting PR description
         env:
           ISSUE_BODY: ${{ github.event.issue.body }}
-          PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
+          PULL_REQUEST_URL: ${{ env.PULL_REQUEST_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p .ci-temp
+          if [ -z "$ISSUE_BODY" ]; then
+            ISSUE_BODY=$(curl --fail-with-body -s -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" "$PULL_REQUEST_URL" | jq --raw-output .body)
+          fi
           # convert windows line endings to unix in event text
           echo "$ISSUE_BODY" > .ci-temp/windows.txt
           tr -d '\15\32' < .ci-temp/windows.txt > .ci-temp/text
@@ -80,6 +99,7 @@ jobs:
 
           jq --raw-output .head.ref .ci-temp/info.json > .ci-temp/branch
           jq --raw-output .head.sha .ci-temp/info.json > .ci-temp/commit_sha
+          jq --raw-output .head.repo.owner.login .ci-temp/info.json > .ci-temp/user_login
 
       - name: Parsing content of PR description
         id: parse
@@ -92,6 +112,7 @@ jobs:
           ./.ci/append-to-github-output.sh "ref" "$(cat .ci-temp/branch)"
           # shellcheck disable=SC2002
           ./.ci/append-to-github-output.sh "commit_sha" "$(cat .ci-temp/commit_sha | cut -c 1-7)"
+          ./.ci/append-to-github-output.sh "user_login" "$(cat .ci-temp/user_login)"
 
           echo "GITHUB_OUTPUT:"
           # need to 'echo' to see output in Github CI
@@ -120,6 +141,8 @@ jobs:
       # set main checkstyle repo as an upstream
       # Diff report will be generated taking upstream's master branch as a base branch
       - name: set upstream
+        env:
+          USER_LOGIN: ${{ needs.parse_body.outputs.user_login }}
         run: |
           ./.ci/diff-report.sh set-upstream
 
@@ -217,7 +240,9 @@ jobs:
           ./.ci/append-to-github-output.sh "message" "$(cat .ci-temp/message)"
 
       - name: Comment PR
-        uses: checkstyle/contribution/comment-action@master
+        uses: peter-evans/create-or-update-comment@v5
         with:
-          message: ${{steps.out.outputs.message}}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ inputs.pr-number || github.event.issue.number }}
+          body: ${{ steps.out.outputs.message }}

--- a/.github/workflows/linkcheck-on-comment.yml
+++ b/.github/workflows/linkcheck-on-comment.yml
@@ -10,6 +10,16 @@ name: "Linkcheck on Comment"
 on:
   issue_comment:
     types: [ created ]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number'
+        required: true
+        type: string
+      trigger-phrase:
+        description: 'Comment phrase that normally triggers this workflow'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -17,24 +27,25 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.pr-number || github.event.issue.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
   run_linkcheck:
     if: >-
       github.repository == 'checkstyle/checkstyle'
-      && github.event.issue.pull_request != null
-      && (contains(github.event.comment.body, 'Github, validate links')
-          || contains(github.event.comment.body, 'GitHub, validate links'))
-      && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'),
-                  github.event.comment.author_association)
+      && (github.event.issue.pull_request != null || inputs.pr-number != '')
+      && (contains(inputs.trigger-phrase || github.event.comment.body, 'Github, validate links')
+          || contains(inputs.trigger-phrase || github.event.comment.body, 'GitHub, validate links'))
+      && (github.event_name == 'workflow_dispatch'
+          || contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'),
+                      github.event.comment.author_association))
     runs-on: ubuntu-24.04
     steps:
       - name: Download checkstyle for PR
         uses: actions/checkout@v7
         with:
-          ref: refs/pull/${{ github.event.issue.number }}/head
+          ref: refs/pull/${{ inputs.pr-number || github.event.issue.number }}/head
 
       - name: Set up JDK 21
         uses: actions/setup-java@v6.0.0
@@ -85,7 +96,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ inputs.pr-number || github.event.issue.number }}
           body-path: .ci-temp/message
 
       - name: Fail if linkcheck failed

--- a/.github/workflows/regression-report.yml
+++ b/.github/workflows/regression-report.yml
@@ -15,14 +15,18 @@ name: regression-report
 env:
   AWS_REGION: us-east-2
   AWS_BUCKET_NAME: "checkstyle-diff-reports"
-  USER_LOGIN: ${{ github.event.issue.user.login }}
+  PULL_REQUEST_URL: >-
+    ${{ github.event.issue.pull_request.url
+        || format('https://api.github.com/repos/checkstyle/checkstyle/pulls/{0}',
+                  inputs.pr-number) }}
+  TRIGGER_PHRASE: ${{ inputs.trigger-phrase || github.event.comment.body }}
   # yamllint disable-line rule:line-length
   DEFAULT_PROJECTS_LINK: "https://raw.githubusercontent.com/checkstyle/test-configs/main/extractor/src/main/resources/list-of-projects.yml"
   BASE_TEST_CONFIGS_URL: "https://raw.githubusercontent.com/checkstyle/test-configs/main"
   EXTRACTOR_VERSION: 2024-10-08
   DIFF_TOOL_VERSION: "1.0-2026-08-26"
   PATCH_DIFF_TOOL_VERSION: "0.1-SNAPSHOT"
-  CACHE_KEY: "regression-report-${{ github.sha }}-${{ github.event.comment.id }}"
+  CACHE_KEY: "regression-report-${{ github.run_id }}"
   GENERATED_CONFIGS_PATH: generated_configs
   LOCAL_CONFIG_BASE_PATH: "src/main/resources"
   LOCAL_PROJECTS_FILE_PATH: "config/list-of-projects.yml"
@@ -30,6 +34,16 @@ env:
 on:
   issue_comment:
     types: [ created ]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number'
+        required: true
+        type: string
+      trigger-phrase:
+        description: 'Comment phrase that normally triggers this workflow'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -43,20 +57,22 @@ concurrency:
 jobs:
   check_pr_status:
     if: |
-      github.event.issue.pull_request
-      && (startsWith(github.event.comment.body, 'Github, generate report for ')
-          ||  startsWith(github.event.comment.body, 'GitHub, generate report for ')
-          ||  startsWith(github.event.comment.body,
+      (github.event.issue.pull_request || inputs.pr-number != '')
+      && (startsWith(inputs.trigger-phrase || github.event.comment.body,
+                     'Github, generate report for ')
+          ||  startsWith(inputs.trigger-phrase || github.event.comment.body,
+                         'GitHub, generate report for ')
+          ||  startsWith(inputs.trigger-phrase || github.event.comment.body,
                          'Github, generate report for configs in PR description')
-          ||  startsWith(github.event.comment.body,
+          ||  startsWith(inputs.trigger-phrase || github.event.comment.body,
                          'GitHub, generate report for configs in PR description')
-          ||  startsWith(github.event.comment.body,
+          ||  startsWith(inputs.trigger-phrase || github.event.comment.body,
                          'Github, generate report by config from')
-          ||  startsWith(github.event.comment.body,
+          ||  startsWith(inputs.trigger-phrase || github.event.comment.body,
                          'GitHub, generate report by config from')
-          ||  startsWith(github.event.comment.body,
+          ||  startsWith(inputs.trigger-phrase || github.event.comment.body,
                          'Github, generate baseline report')
-          ||  startsWith(github.event.comment.body,
+          ||  startsWith(inputs.trigger-phrase || github.event.comment.body,
                          'GitHub, generate baseline report'))
 
     runs-on: ubuntu-latest
@@ -64,7 +80,7 @@ jobs:
       - name: Check PR status
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.issue.pull_request.url }}
+          PR_URL: ${{ env.PULL_REQUEST_URL }}
         run: |
           PR_STATE=$(curl --fail-with-body -s -H "Authorization: token $GITHUB_TOKEN" \
                      -H "Accept: application/vnd.github.v3+json" \
@@ -88,7 +104,7 @@ jobs:
         id: get_pr_details
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.issue.pull_request.url }}
+          PR_URL: ${{ env.PULL_REQUEST_URL }}
         run: |
           PR_INFO="$(curl --fail-with-body -s -H "Authorization: token $GITHUB_TOKEN" "$PR_URL")"
           BRANCH="$(echo "$PR_INFO" | jq -r .head.ref)"
@@ -150,6 +166,7 @@ jobs:
       config_path: ${{ steps.parse.outputs.config_path }}
     steps:
       - name: React to comment
+        if: github.event_name == 'issue_comment'
         uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -175,7 +192,7 @@ jobs:
       - name: Parse comment
         id: parse
         env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_BODY: ${{ env.TRIGGER_PHRASE }}
         run: |
           NAME='^Git[Hh]ub,'
           PATTERN_FOR_DESCRIPTION=$NAME' generate report for configs in PR description[[:space:]]*$'
@@ -379,10 +396,14 @@ jobs:
       - name: Getting PR description
         env:
           ISSUE_BODY: ${{ github.event.issue.body }}
-          PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
+          PULL_REQUEST_URL: ${{ env.PULL_REQUEST_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p .ci-temp
+          if [ -z "$ISSUE_BODY" ]; then
+            ISSUE_BODY=$(curl --fail-with-body -s -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" "$PULL_REQUEST_URL" | jq --raw-output .body)
+          fi
           # convert windows line endings to unix in event text
           echo "$ISSUE_BODY" > .ci-temp/windows.txt
           tr -d '\15\32' < .ci-temp/windows.txt > .ci-temp/text
@@ -897,7 +918,7 @@ jobs:
 
   add_sad_Emoji:
     needs: [ check_pr_status, parse_comment, make_report, publish_report ]
-    if: cancelled()
+    if: cancelled() && github.event_name == 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - name: Add sad Emoji
@@ -1080,5 +1101,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ inputs.pr-number || github.event.issue.number }}
           body: ${{ steps.out.outputs.message }}


### PR DESCRIPTION
Issue: #20545

## Summary
Add manual GitHub Actions dispatch support to comment-triggered report and linkcheck workflows.

## Why
Maintainers need to run these workflows from the Actions UI without posting a trigger comment.

## Impact
Manual runs accept a PR number and the matching trigger phrase, then use the same execution paths as comment-triggered runs.
