### PR TITLE
Issue #21119: Fix duplicate violation behavior in examples: localfinalvariablename

### DIFF
--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml
@@ -20,7 +20,7 @@
             <input type="checkbox" id="toc-sub-Examples" class="toc-sub-toggle-checkbox" checked="checked"/>
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#LocalFinalVariableName_Examples">Examples</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
-              <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
+              <li><a href="#Example1-config" class="toc-sublink">An example of how to configure the check so that the length of the name is not less than 4</a></li>
               <li><a href="#Example2-config" class="toc-sublink">With default properties</a></li>
               <li><a href="#Example3-config" class="toc-sublink">An example of how to configure the check for names of local final parameters and resources in try statements (without checks on variables)</a></li>
             </ul>
@@ -99,13 +99,14 @@
 
       <subsection name="Examples" id="LocalFinalVariableName_Examples">
         <p id="Example1-config">
-          To configure the check:
+          An example of how to configure the check so that the length of the
+          name is not less than 4:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="LocalFinalVariableName"&gt;
-       &lt;property name="format" value="^[a-z][a-zA-Z0-9]*$"/&gt;
+       &lt;property name="format" value="^[a-z][a-zA-Z0-9]{4,}$"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -116,13 +117,13 @@ class Example1 {
   void MyMethod() {
     try (Scanner scanner = new Scanner(System.in)) {
 
-      final int VAR1 = 5;  // violation 'Name 'VAR1' must match pattern'
-      final int var1 = 10;
+      final int VAR1 = 5; // violation 'Name 'VAR1' must match pattern'
+      final int var1 = 10; // violation 'Name 'var1' must match pattern'
     }
-    catch (final Exception ex) {
+    catch (final Exception ex) { // violation 'Name 'ex' must match pattern'
 
       final int VAR2 = 15; // violation 'Name 'VAR2' must match pattern'
-      final int var2 = 20;
+      final int var2 = 20; // violation 'Name 'var2' must match pattern'
     }
   }
 }

--- a/src/site/xdoc/checks/naming/localfinalvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/localfinalvariablename.xml.template
@@ -33,7 +33,8 @@
 
       <subsection name="Examples" id="LocalFinalVariableName_Examples">
         <p id="Example1-config">
-          To configure the check:
+          An example of how to configure the check so that the length of the
+          name is not less than 4:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -106,7 +106,6 @@ public class XdocsExampleFileTest {
         "checks/javadoc/javadocvariable/",
         "checks/javadoc/missingjavadoctype/",
         "checks/naming/illegalidentifiername/",
-        "checks/naming/localfinalvariablename/",
         "checks/naming/patternvariablename/",
         "checks/outertypefilename/",
         "checks/regexp/regexpmultiline/",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckExamplesTest.java
@@ -35,8 +35,16 @@ public class LocalFinalVariableNameCheckExamplesTest extends AbstractExamplesMod
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "20:17: " + getCheckMessage(MSG_INVALID_PATTERN, "VAR1", "^[a-z][a-zA-Z0-9]*$"),
-            "25:17: " + getCheckMessage(MSG_INVALID_PATTERN, "VAR2", "^[a-z][a-zA-Z0-9]*$"),
+            "20:17: " + getCheckMessage(MSG_INVALID_PATTERN, "VAR1",
+                    "^[a-z][a-zA-Z0-9]{4,}$"),
+            "21:17: " + getCheckMessage(MSG_INVALID_PATTERN, "var1",
+                    "^[a-z][a-zA-Z0-9]{4,}$"),
+            "23:28: " + getCheckMessage(MSG_INVALID_PATTERN, "ex",
+                    "^[a-z][a-zA-Z0-9]{4,}$"),
+            "25:17: " + getCheckMessage(MSG_INVALID_PATTERN, "VAR2",
+                    "^[a-z][a-zA-Z0-9]{4,}$"),
+            "26:17: " + getCheckMessage(MSG_INVALID_PATTERN, "var2",
+                    "^[a-z][a-zA-Z0-9]{4,}$"),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/Example1.java
@@ -2,7 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="LocalFinalVariableName">
-       <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+       <property name="format" value="^[a-z][a-zA-Z0-9]{4,}$"/>
     </module>
   </module>
 </module>
@@ -17,13 +17,13 @@ class Example1 {
   void MyMethod() {
     try (Scanner scanner = new Scanner(System.in)) {
 
-      final int VAR1 = 5;  // violation 'Name 'VAR1' must match pattern'
-      final int var1 = 10;
+      final int VAR1 = 5; // violation 'Name 'VAR1' must match pattern'
+      final int var1 = 10; // violation 'Name 'var1' must match pattern'
     }
-    catch (final Exception ex) {
+    catch (final Exception ex) { // violation 'Name 'ex' must match pattern'
 
       final int VAR2 = 15; // violation 'Name 'VAR2' must match pattern'
-      final int var2 = 20;
+      final int var2 = 20; // violation 'Name 'var2' must match pattern'
     }
   }
 }


### PR DESCRIPTION
## Summary
Example1 for `LocalFinalVariableName` used a custom `format` that was effectively the same as the default for the demo identifiers, so Example1 and Example2 produced identical violation signatures under `testAllModuleExamplesAreBehaviorallyUnique`.

- Tighten Example1 `format` to `^[a-z][a-zA-Z0-9]{4,}$` so short camelCase names and uppercase finals both fail
- Update violation markers and `LocalFinalVariableNameCheckExamplesTest`
- Regenerate xdoc via `XdocsPagesTest`
- Remove `checks/naming/localfinalvariablename/` from `SUPPRESSED_UNIQUENESS_CHECK_MODULES`

Fixes #21119 (partial: one suppressed module)

## Testing
- `./mvnw clean test -Dtest=LocalFinalVariableNameCheckExamplesTest,XdocsExampleFileTest#testAllModuleExamplesAreBehaviorallyUnique,XdocsExamplesAstConsistencyTest#testExamplesDifferOnlyByComments -Dsurefire.failIfNoSpecifiedTests=false` (6 tests, GREEN)
- `./mvnw clean test -Dtest=XdocsPagesTest -Dsurefire.failIfNoSpecifiedTests=false` (20 tests, GREEN)