### PR TITLE
Issue #21036: Change recommendation from Splitter to String.split() w…

### DIFF
--- a/config/signatures.txt
+++ b/config/signatures.txt
@@ -4,3 +4,4 @@ com.puppycrawl.tools.checkstyle.DefaultConfiguration#addAttribute(java.lang.Stri
 com.puppycrawl.tools.checkstyle.api.AbstractCheck#log(int,int,java.lang.String,java.lang.Object[]) @ Use of this log method is forbidden, please use AbstractCheck#log(DetailAST ast, String key, Object... args)
 com.puppycrawl.tools.checkstyle.api.AbstractCheck#log(int,java.lang.String,java.lang.Object[]) @ Use of this log method is forbidden, please use AbstractCheck#log(DetailAST ast, String key, Object... args)
 java.net.URI#toString() @ This method can return garbage for non-ascii data, please use URI#toASCIIString()
+java.lang.String#split(java.lang.String) @ String.split() without limit has surprising behavior, please use String#split(String, int) with limit argument, e.g. String.split(regex, -1).

--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,8 @@
       -Xep:StreamResourceLeak:ERROR
       -Xep:StringJoin:ERROR
       -Xep:StringJoining:ERROR
-      -Xep:StringSplitter:ERROR
+      <!-- Reason at https://github.com/checkstyle/checkstyle/issues/21036. -->
+      -Xep:StringSplitter:OFF
       -Xep:TimeZoneUsage:ERROR
       -Xep:TruthAssertExpected:ERROR
       -Xep:TypeParameterUnusedInFormals:ERROR

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -608,7 +608,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * @since 6.3
      */
     public void setMemberModifiers(String modifiers) {
-        memberModifiers = TokenUtil.asBitSet(modifiers.split(","));
+        memberModifiers = TokenUtil.asBitSet(modifiers.split(",", -1));
     }
 
 }


### PR DESCRIPTION
closes #21036 

### Summary

- removed -Xep:StringSplitter:ERROR from error-prone.configuration-args in pom.xml from which the Guava's splitter recommendation comes from
- added a new signature for forbidden api
- Updated modifiers parameter to use String.split() with limit in IllegalTypeCheck


### Validation 

Ran `mvn clean compile forbiddenapis:check@forbiddenapis-main` using split without limit on IllegalTypeCheck and it reports : 

[ERROR] Forbidden method invocation: java.lang.String#split(java.lang.String) [String.split() without limit has surprising behavior, please use String#split(String, int) with limit argument, e.g. String.split(regex, -1).]

[ERROR]   in com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck (IllegalTypeCheck.java:611)




