### PR TITLE
Issue #20691: Restore website deployment to SourceForge

### DIFF
--- a/.ci/release-copy-github-io-to-sourceforge.sh
+++ b/.ci/release-copy-github-io-to-sourceforge.sh
@@ -4,93 +4,122 @@ set -e
 
 source ./.ci/util.sh
 
-RELEASE=$1
+checkForVariable "SF_USER"
 
-echo "RELEASE version:""$RELEASE"
-
-if [[ -z $RELEASE ]]; then
-  echo "Problem to calculate release version."
+if [[ -z $1 ]]; then
+  echo "Release version is not set"
+  echo "usage: $BASH_SOURCE {release version}"
   exit 1
 fi
 
-checkForVariable "SF_USER"
+RELEASE_VERSION=$1
+echo "RELEASE_VERSION=$RELEASE_VERSION"
 
-echo "Creating shell for $SF_USER@shell.sourceforge.net"
-ssh -i ~/.ssh/private_sourceforge_key "$SF_USER"@shell.sourceforge.net create
+REMOTE_PATH="/home/project-web/checkstyle"
+SSH_KEY_PATH="$HOME/.ssh/private_sourceforge_key"
 
-echo "Creating .ci-temp if it does not exist"
+echo "Preparing local deployment workspace in .ci-temp"
 mkdir -p .ci-temp
 cd .ci-temp
 rm -fr checkstyle.github.io
+rm -fr sourceforge
 
-echo "Cloning checkstyle.github.io repo"
-git clone https://github.com/checkstyle/checkstyle.github.io.git
+echo "Cloning the current checkstyle.github.io website"
+git clone --depth 1 https://github.com/checkstyle/checkstyle.github.io.git
 
-echo "Cleaning up git files"
+echo "Removing Git metadata and the GitHub Pages CNAME file"
 rm -rf checkstyle.github.io/.git
 rm -rf checkstyle.github.io/CNAME
 
-echo "Archiving"
-tar cfz checkstyle.github.io.tar.gz checkstyle.github.io
+echo "Creating the local SourceForge staging directory"
+mkdir sourceforge
+echo "Downloading the current SourceForge website from $REMOTE_PATH/htdocs/"
+rsync --archive --compress --rsh "ssh -i $SSH_KEY_PATH" \
+  --include="htdocs/***" --exclude="*" \
+  "$SF_USER@web.sourceforge.net:$REMOTE_PATH/" sourceforge/
+cd sourceforge
 
-echo "Uploading to sourceforge"
-scp -i ~/.ssh/private_sourceforge_key checkstyle.github.io.tar.gz \
-  "$SF_USER"@web.sourceforge.net:/home/project-web/checkstyle
+PREV_RELEASE_VERSION=""
+if [[ -f htdocs/index.html ]]; then
+  echo "Existing SourceForge website found; extracting its release version"
+  PREVIOUS_RELEASE_VERSION_SPAN=$(grep "projectVersion" htdocs/index.html)
+  REGEX="Version: (.*)<"
+  [[ $PREVIOUS_RELEASE_VERSION_SPAN =~ $REGEX ]]
+  PREV_RELEASE_VERSION="${BASH_REMATCH[1]}"
+  echo "Previous release version: $PREV_RELEASE_VERSION"
+  if [[ -z "$PREV_RELEASE_VERSION" ]]
+  then
+    echo "Problem with extracting previous release version."
+    exit 1
+  fi
 
-echo "Using shell for $SF_USER@shell.sourceforge.net"
-ssh -i ~/.ssh/private_sourceforge_key "$SF_USER"@shell.sourceforge.net << 'EOF'
-
-cd /home/project-web/checkstyle
-
-echo "Extracting previous release version"
-PREVIOUS_RELEASE_VERSION_SPAN=$(grep "projectVersion" htdocs/index.html)
-REGEX="Version: (.*)<"
-[[ $PREVIOUS_RELEASE_VERSION_SPAN =~ $REGEX ]]
-PREV_RELEASE="${BASH_REMATCH[1]}"
-echo "PREVIOUS RELEASE version:""$PREV_RELEASE"
-if [[ -z "$PREV_RELEASE" ]]
-then
-  echo "Problem to calculate previous release version."
-  exit 1
+  echo "Saving the existing website as htdocs-$PREV_RELEASE_VERSION"
+  mv htdocs "htdocs-$PREV_RELEASE_VERSION"
+else
+  echo "No existing SourceForge website found; preparing the first deployment"
+  rm -rf htdocs
 fi
 
-echo "Swapping html content"
-tar -xzvf checkstyle.github.io.tar.gz
-mv htdocs htdocs-$PREV_RELEASE
-mv checkstyle.github.io htdocs
+echo "Staging the new website as htdocs"
+mv ../checkstyle.github.io htdocs
 
-echo "Creating .htaccess for dtds redirection"
+echo "Adding DTD redirects to htdocs/.htaccess"
 cat <<HTACCESS >> htdocs/.htaccess
 Redirect 301 "/dtds" "https://checkstyle.org/dtds"
 RedirectMatch 301 "/version/.*/dtds/(.*)" "https://checkstyle.org/dtds/\$1"
 HTACCESS
 chmod o+r htdocs/.htaccess
 
-ln -s /home/project-web/checkstyle/reports htdocs/reports
-echo "Removing dtds folder from unsecure web site"
+echo "Linking the website to the SourceForge reports directory"
+ln -s "$REMOTE_PATH/reports" htdocs/reports
+echo "Removing the DTD files from the SourceForge website"
 rm -r htdocs/dtds
 
-echo "Restoring folder with links to old releases"
-mv htdocs-$PREV_RELEASE/version htdocs
+if [[ -n "$PREV_RELEASE_VERSION" ]]; then
+  echo "Restoring links to all previously published releases"
+  mv "htdocs-$PREV_RELEASE_VERSION/version" htdocs
 
-echo "Archiving"
-tar cfz htdocs-$PREV_RELEASE.tar.gz htdocs-$PREV_RELEASE/
-mv htdocs-$PREV_RELEASE.tar.gz htdocs-archive/
-rm -rf htdocs-$PREV_RELEASE/
+  echo "Creating the full website archive for release $PREV_RELEASE_VERSION"
+  tar cfz "htdocs-$PREV_RELEASE_VERSION.tar.gz" "htdocs-$PREV_RELEASE_VERSION/"
+  mkdir htdocs-archive
+  mv "htdocs-$PREV_RELEASE_VERSION.tar.gz" htdocs-archive/
+  rm -rf "htdocs-$PREV_RELEASE_VERSION/"
 
-echo "Extracting archive to previous releases documentation"
-tar -xzvf htdocs-archive/htdocs-$PREV_RELEASE.tar.gz -C htdocs-version/ --same-owner \
---exclude="*/apidocs" \
---exclude="*/xref" --exclude="*/xref-test" --exclude="*/cobertura" --exclude="*/dsm" \
---exclude="*/api" --exclude="reports" --exclude="jacoco" --exclude="dtds" \
---exclude="dependency-updates-report.html" --exclude="plugin-updates-report.html" \
---exclude="jdepend-report.html" --exclude="failsafe-report.html" \
---exclude="surefire-report.html" \
---exclude="linkcheck.html" --exclude="findbugs.html" --exclude="taglist.html" \
---exclude="releasenotes_old_6-0_7-8.html" --exclude="releasenotes_old_1-0_5-9.html" \
---exclude="dependencies.html"
+  echo "Creating the reduced historical website for release $PREV_RELEASE_VERSION"
+  mkdir htdocs-version
+  tar -xzvf "htdocs-archive/htdocs-$PREV_RELEASE_VERSION.tar.gz" \
+    -C htdocs-version/ --same-owner \
+    --exclude="*/apidocs" \
+    --exclude="*/xref" --exclude="*/xref-test" --exclude="*/cobertura" --exclude="*/dsm" \
+    --exclude="*/api" --exclude="reports" --exclude="jacoco" --exclude="dtds" \
+    --exclude="dependency-updates-report.html" --exclude="plugin-updates-report.html" \
+    --exclude="jdepend-report.html" --exclude="failsafe-report.html" \
+    --exclude="surefire-report.html" \
+    --exclude="linkcheck.html" --exclude="findbugs.html" --exclude="taglist.html" \
+    --exclude="releasenotes_old_6-0_7-8.html" --exclude="releasenotes_old_1-0_5-9.html" \
+    --exclude="dependencies.html"
 
-echo "Making a link to make it accessible from web"
-ln -f -s $(pwd)/htdocs-version/htdocs-"$PREV_RELEASE" $(pwd)/htdocs/version/"$PREV_RELEASE"
+  echo "Linking release $PREV_RELEASE_VERSION from the live website"
+  ln -f -s \
+    "$REMOTE_PATH/htdocs-version/htdocs-$PREV_RELEASE_VERSION" \
+    "htdocs/version/$PREV_RELEASE_VERSION"
+else
+  echo "Creating an empty historical release directory for the first deployment"
+  mkdir htdocs/version
+fi
 
-EOF
+if [[ -n "$PREV_RELEASE_VERSION" ]]; then
+  echo "Uploading the full archive for release $PREV_RELEASE_VERSION to SourceForge"
+  rsync --archive --compress --rsh "ssh -i $SSH_KEY_PATH" \
+    "htdocs-archive/htdocs-$PREV_RELEASE_VERSION.tar.gz" \
+    "$SF_USER@web.sourceforge.net:$REMOTE_PATH/htdocs-archive/"
+  echo "Uploading the reduced historical website for release $PREV_RELEASE_VERSION"
+  rsync --archive --compress --rsh "ssh -i $SSH_KEY_PATH" \
+    htdocs-version "$SF_USER@web.sourceforge.net:$REMOTE_PATH/"
+fi
+echo "Uploading the new live website to SourceForge"
+rsync --archive --compress --rsh "ssh -i $SSH_KEY_PATH" \
+  --delete --omit-link-times \
+  htdocs/ "$SF_USER@web.sourceforge.net:$REMOTE_PATH/htdocs/"
+
+echo "SourceForge website deployment for release $RELEASE_VERSION completed"

--- a/.github/workflows/release-copy-github-io-to-sourceforge.yml
+++ b/.github/workflows/release-copy-github-io-to-sourceforge.yml
@@ -37,7 +37,6 @@ jobs:
           echo "$SF_SSH_KEY" > ~/.ssh/private_sourceforge_key
           chmod 400 ~/.ssh/private_sourceforge_key
           ssh-add ~/.ssh/private_sourceforge_key
-          ssh-keyscan -t ed25519 shell.sourceforge.net >> ~/.ssh/known_hosts
           ssh-keyscan -t ed25519 web.sourceforge.net >> ~/.ssh/known_hosts
 
       - name: Run Shell Script

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1202,7 +1202,9 @@ rpmfind
 rq
 Rr
 Rsa
+rsh
 RSPEC
+rsync
 Rtl
 ru
 ruleannotations
@@ -1259,7 +1261,6 @@ scache
 Schneeberger
 scm
 scopeutil
-scp
 screenshot
 Scss
 sdk


### PR DESCRIPTION
Resolves issue:
- #20691


This PR:
- Removed `shell.sourceforge.net` from the list of known hosts. It no longer exists
- Switched from `ssh`/`scp` to `rsync`
    - All Bash logic (if/else, grep, compression) is now run on the GitHub runner, not on the SourceForge server
- Added some `if-else` logic to ensure the script works with new SourceForge projects (such as my new `checkstyle-stoyan` project with 0 files in it)
- Added `echo`s for more descriptive logs

**Proof that it works**
- Successful deployment via my fork: https://github.com/stoyanK7/checkstyle/actions/runs/31633425201/job/94237677345.
- Website is reachable at https://checkstyle-stoyan.sourceforge.io/
- Archive and versions are there:
  ```
  $ sftp ***@web.sourceforge.net
  Connected to web.sourceforge.net.
  sftp> cd /home/project-web/checkstyle-stoyan
  sftp> pwd
  Remote working directory: /home/project-web/checkstyle-stoyan
  sftp> ls
  htdocs           htdocs-archive   htdocs-version   
  sftp> ls htdocs-archive
  htdocs-archive/htdocs-13.10.0.tar.gz  
  sftp> ls htdocs-version
  htdocs-version/htdocs-13.10.0 
  ```