### PR TITLE
doc: remove redundant `toc` Doxia macro

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -1131,10 +1131,13 @@ table {
 
 @media screen and (max-width: 823px) {
     .toc-panel {
-        display: none !important;
-        width: 0 !important;
-        height: 0 !important;
-        position: absolute !important;
+        position: relative !important;
+        display: block !important;
+        top: auto !important;
+        right: auto !important;
+        width: auto !important;
+        max-height: none !important;
+        margin-bottom: 20px;
     }
 
     #bodyColumn,

--- a/src/site/xdoc/anttask.xml.vm
+++ b/src/site/xdoc/anttask.xml.vm
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Description">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/cmdline.xml.vm
+++ b/src/site/xdoc/cmdline.xml.vm
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Description">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/config.xml
+++ b/src/site/xdoc/config.xml
@@ -9,13 +9,7 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-    <section name="Content">
+    <section name="Overview">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>
         <label for="toc-toggle" class="toc-toggle-arrow" title="Collapse">&#160;</label>
@@ -40,8 +34,6 @@
           </ul>
         </div>
       </div>
-    </section>
-    <section name="Overview">
       <p>
         A Checkstyle configuration specifies which <em>modules</em> to
         plug in and apply to Java source files. Modules are structured

--- a/src/site/xdoc/config_system_properties.xml
+++ b/src/site/xdoc/config_system_properties.xml
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
   <section name="How To Set System Property For CLI">
     <div class="toc-panel">
       <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/eclipse.xml
+++ b/src/site/xdoc/eclipse.xml
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Download Eclipse">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/idea.xml
+++ b/src/site/xdoc/idea.xml
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Import Checkstyle Project">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/netbeans.xml
+++ b/src/site/xdoc/netbeans.xml
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Import Checkstyle Project">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/property_types.xml
+++ b/src/site/xdoc/property_types.xml
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Overview">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/result_reports.xml
+++ b/src/site/xdoc/result_reports.xml
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Overview">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/writingchecks.xml
+++ b/src/site/xdoc/writingchecks.xml
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Overview">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/writingfilefilters.xml
+++ b/src/site/xdoc/writingfilefilters.xml
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Overview">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/writingfilters.xml
+++ b/src/site/xdoc/writingfilters.xml
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Overview">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/writingjavadocchecks.xml.vm
+++ b/src/site/xdoc/writingjavadocchecks.xml.vm
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="What is Javadoc comment">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/writinglisteners.xml.vm
+++ b/src/site/xdoc/writinglisteners.xml.vm
@@ -9,13 +9,6 @@
   </head>
 
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Overview">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/site/xdoc/xpath.xml
+++ b/src/site/xdoc/xpath.xml
@@ -6,13 +6,6 @@
     <title>XPath Support</title>
   </head>
   <body>
-    <section name="Content">
-      <macro name="toc">
-        <param name="fromDepth" value="1"/>
-        <param name="toDepth" value="1"/>
-      </macro>
-    </section>
-
     <section name="Overview">
       <div class="toc-panel">
         <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
@@ -47,7 +47,7 @@ public class CliOptionsXdocsSyncTest {
     @Test
     public void validateCliDocSections() throws Exception {
         final NodeList sections = getSectionsFromXdoc("src/site/xdoc/cmdline.xml.vm");
-        final Node cmdUsageSection = sections.item(2);
+        final Node cmdUsageSection = sections.item(1);
         final Map<String, String> cmdOptions = getOptions(cmdUsageSection);
 
         final Class<?> cliOptions = Class.forName("com.puppycrawl.tools.checkstyle"
@@ -82,7 +82,7 @@ public class CliOptionsXdocsSyncTest {
     @Test
     public void validateCliUsageSection() throws Exception {
         final NodeList sections = getSectionsFromXdoc("src/site/xdoc/cmdline.xml.vm");
-        final Node usageSource = XmlUtil.getFirstChildElement(sections.item(2));
+        final Node usageSource = XmlUtil.getFirstChildElement(sections.item(1));
         final String usageText = XmlUtil.getFirstChildElement(usageSource).getTextContent();
 
         final Set<String> shortParamsXdoc = getParameters(usageText, "-[a-zA-CE-X]\\b");


### PR DESCRIPTION
Removed all usage of `toc` Doxia macro:
```xml
      <macro name="toc">
        <param name="fromDepth" value="1"/>
        <param name="toDepth" value="1"/>
      </macro>
```

This is a built-in Doxia macro that we used before. We now have our own custom table of contents; thus, this `toc` macro is redundant.

Example of what I mean:

Before:
<img width="1920" height="1003" alt="image" src="https://github.com/user-attachments/assets/8ee40d07-9c41-4fd5-9a46-200ce8bd53e3" />

After:
<img width="1915" height="1004" alt="image" src="https://github.com/user-attachments/assets/46931a32-5ef8-43ff-abcc-af050e21045a" />
