### PR TITLE
Issue #20954: Quote EqualsHashCode example violation message

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -186,6 +186,9 @@
   <!-- Example needs to exclude fully qualified name longer than 85 characters  -->
   <suppress checks="LineLength" files="classdataabstractioncoupling/UseCase6.java"/>
 
+  <!-- we need to show the whole violation message -->
+  <suppress checks="LineLength" files="equalshashcode/Example1.java"/>
+
   <!-- Example needs to have really long regex format properly shown in config  -->
   <suppress checks="LineLength" files="illegalidentifiername/Example[2].java"/>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -302,7 +302,6 @@ public final class InlineConfigParser {
      * <a href="https://github.com/checkstyle/checkstyle/issues/20954">#20954</a>
      */
     private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of(
-            "checks/coding/equalshashcode/Example1.java",
             "checks/coding/illegaltype/InputIllegalTypeTestIgnoreMethodNames.java",
             "checks/coding/illegaltype/InputIllegalTypeTestEnhancedInstanceof.java",
             "checks/coding/illegaltype/InputIllegalTypeTestLegalAbstractClassNames.java",

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode/Example1.java
@@ -8,14 +8,14 @@
 package com.puppycrawl.tools.checkstyle.checks.coding.equalshashcode;
 // xdoc section - start
 class Example1 {
-  public int hashCode() { // violation, no valid 'equals'
+  public int hashCode() { // violation 'Definition of 'hashCode()' without corresponding definition of 'equals()'.'
     return 0;
   }
   public boolean equals(String o) { return false; }
 }
 
 class ExampleNoHashCode {
-  public boolean equals(Object o) { // violation, no 'hashCode'
+  public boolean equals(Object o) { // violation 'Definition of 'equals()' without corresponding definition of 'hashCode()'.'
     return false;
   }
   public boolean equals(String o) { return false; }
@@ -38,13 +38,13 @@ class ExampleBothMethods2 {
 
 class ExampleNoValidHashCode {
   public static int hashCode(int i) { return 0; }
-  public boolean equals(Object o) { // violation, no valid 'hashCode'
+  public boolean equals(Object o) { // violation 'Definition of 'equals()' without corresponding definition of 'hashCode()'.'
     return false;
   }
 }
 
 class ExampleNoValidEquals {
-  public int hashCode() { // violation, no valid 'equals'
+  public int hashCode() { // violation 'Definition of 'hashCode()' without corresponding definition of 'equals()'.'
     return 0;
   }
   public static boolean equals(Object o, Object o2) { return false; }


### PR DESCRIPTION
## Summary

Part of #20954.

`checks/coding/equalshashcode/Example1.java` was in `SUPPRESSED_VALIDATE_MESSAGE_FILES` because its `// violation` comments used unquoted, paraphrased text (e.g. `// violation, no valid 'equals'`), so `InlineConfigParser`'s message-capturing group never activated and the message text was never actually checked.

This PR:
- Rewrites the four violation comments to use the real, quoted `EqualsHashCodeCheck` output (`equals.noEquals` / `equals.noHashCode`), matching the format already used elsewhere (e.g. `arraytrailingcomma/Example1.java`).
- Removes `checks/coding/equalshashcode/Example1.java` from `SUPPRESSED_VALIDATE_MESSAGE_FILES` in `InlineConfigParser.java`.
- Adds a `LineLength` suppression for this file in `checkstyle-examples-suppressions.xml`, since the full quoted message pushes two lines past the 85-char xdocs-examples limit (mirroring the existing "we need to show the whole user defined message" suppressions used for the same reason elsewhere in that file).

## Test plan

- [x] `EqualsHashCodeCheckExamplesTest#testExample1` passes with message validation now actually enforced (previously it passed vacuously since the file was suppressed).