### PR TITLE
Issue #21207: Make MethodLength default-config example Example1

### DIFF
--- a/src/site/xdoc/checks/sizes/methodlength.xml
+++ b/src/site/xdoc/checks/sizes/methodlength.xml
@@ -20,10 +20,10 @@
             <input type="checkbox" id="toc-sub-Examples" class="toc-sub-toggle-checkbox" checked="checked"/>
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#MethodLength_Examples">Examples</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
-              <li><a href="#Example1-config" class="toc-sublink">So that it accepts at most 4 lines</a></li>
-              <li><a href="#Example2-config" class="toc-sublink">So that it accepts methods with at most 4 lines</a></li>
-              <li><a href="#Example3-config" class="toc-sublink">So that it accepts methods with at most 4 lines, not counting empty lines and comments</a></li>
-              <li><a href="#Example4-config" class="toc-sublink">With default settings, so that it accepts methods with at most 150 lines</a></li>
+              <li><a href="#Example1-config" class="toc-sublink">With default settings, so that it accepts methods with at most 150 lines</a></li>
+              <li><a href="#Example2-config" class="toc-sublink">So that it accepts at most 4 lines</a></li>
+              <li><a href="#Example3-config" class="toc-sublink">So that it accepts methods with at most 4 lines</a></li>
+              <li><a href="#Example4-config" class="toc-sublink">So that it accepts methods with at most 4 lines, not counting empty lines and comments</a></li>
             </ul>
           </li>
           <li><a href="#MethodLength_Example_of_Usage">Example of Usage</a></li>
@@ -98,6 +98,63 @@
 
       <subsection name="Examples" id="MethodLength_Examples">
         <p id="Example1-config">
+          To configure the check with default settings, so that it accepts
+          methods with at most 150 lines:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MethodLength"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example1-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example1 {
+
+  // ok, default max is 150 lines
+  public Example1() {
+    int var1 = 2;
+    int var2 = 4;
+    int sum = var1 + var2;
+  }
+
+  // ok, default max is 150 lines
+  public Example1(int a)  {
+    int var1 = 2;
+    int sum = var1 + a;
+  }
+
+  // ok, default max is 150 lines
+  public void firstMethod() {
+    int index = 0;
+    if (index &lt; 5) {
+      index++;
+    }
+  }
+
+  public void secondMethod() {
+
+    System.out.println("line 3");
+  }
+
+  public void thirdMethod() {
+
+    // ok, empty line above is counted by default, just like this comment
+    System.out.println("line 4");
+  }
+
+  record MyBadRecord() {
+
+    public MyBadRecord {
+
+      System.out.println("line3");
+      System.out.println("line4");
+    }
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example2-config">
           To configure the check so that it accepts at most 4
           lines:
         </p>
@@ -110,19 +167,19 @@
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example1-code">Example:</p>
+        <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example1 {
+public class Example2 {
 
-  // violation below 'Method Example1 length is 5 lines (max allowed is 4)'
-  public Example1() {
+  // violation below 'Method Example2 length is 5 lines (max allowed is 4)'
+  public Example2() {
     int var1 = 2;
     int var2 = 4;
     int sum = var1 + var2;
   }
 
   // ok, as it is less than 4 lines
-  public Example1(int a)  {
+  public Example2(int a)  {
     int var1 = 2;
     int sum = var1 + a;
   }
@@ -156,7 +213,7 @@ public class Example1 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example2-config">
+        <p id="Example3-config">
           To configure the check so that it accepts methods with at most 4
           lines:
         </p>
@@ -170,19 +227,19 @@ public class Example1 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example2-code">Example:</p>
+        <p id="Example3-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example2 {
+public class Example3 {
 
   // ok, CTOR_DEF is not in configured tokens
-  public Example2()  {
+  public Example3()  {
     int var1 = 2;
     int var2 = 4;
     int sum = var1 + var2;
   }
 
   // ok, CTOR_DEF is not in configured tokens
-  public Example2(int a)  {
+  public Example3(int a)  {
     int var1 = 2;
     int sum = var1 + a;
   }
@@ -216,7 +273,7 @@ public class Example2 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example3-config">
+        <p id="Example4-config">
           To configure the check so that it accepts methods with at most 4
           lines, not counting empty lines and comments:
         </p>
@@ -231,19 +288,19 @@ public class Example2 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example3-code">Example:</p>
+        <p id="Example4-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example3 {
+public class Example4 {
 
   // ok, CTOR_DEF is not in configured tokens
-  public Example3()  {
+  public Example4()  {
     int var1 = 2;
     int var2 = 4;
     int sum = var1 + var2;
   }
 
   // ok, CTOR_DEF is not in configured tokens
-  public Example3(int a)  {
+  public Example4(int a)  {
     int var1 = 2;
     int sum = var1 + a;
   }
@@ -269,63 +326,6 @@ public class Example3 {
 
   record MyBadRecord() {
     // ok, COMPACT_CTOR_DEF is not in configured tokens
-    public MyBadRecord {
-
-      System.out.println("line3");
-      System.out.println("line4");
-    }
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example4-config">
-          To configure the check with default settings, so that it accepts
-          methods with at most 150 lines:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="MethodLength"/&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example4-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example4 {
-
-  // ok, default max is 150 lines
-  public Example4() {
-    int var1 = 2;
-    int var2 = 4;
-    int sum = var1 + var2;
-  }
-
-  // ok, default max is 150 lines
-  public Example4(int a)  {
-    int var1 = 2;
-    int sum = var1 + a;
-  }
-
-  // ok, default max is 150 lines
-  public void firstMethod() {
-    int index = 0;
-    if (index &lt; 5) {
-      index++;
-    }
-  }
-
-  public void secondMethod() {
-
-    System.out.println("line 3");
-  }
-
-  public void thirdMethod() {
-
-    // ok, empty line above is counted by default, just like this comment
-    System.out.println("line 4");
-  }
-
-  record MyBadRecord() {
-
     public MyBadRecord {
 
       System.out.println("line3");

--- a/src/site/xdoc/checks/sizes/methodlength.xml.template
+++ b/src/site/xdoc/checks/sizes/methodlength.xml.template
@@ -33,8 +33,8 @@
 
       <subsection name="Examples" id="MethodLength_Examples">
         <p id="Example1-config">
-          To configure the check so that it accepts at most 4
-          lines:
+          To configure the check with default settings, so that it accepts
+          methods with at most 150 lines:
         </p>
         <macro name="example">
           <param name="path"
@@ -48,7 +48,7 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example2-config">
-          To configure the check so that it accepts methods with at most 4
+          To configure the check so that it accepts at most 4
           lines:
         </p>
         <macro name="example">
@@ -64,7 +64,7 @@
         </macro><hr class="example-separator"/>
         <p id="Example3-config">
           To configure the check so that it accepts methods with at most 4
-          lines, not counting empty lines and comments:
+          lines:
         </p>
         <macro name="example">
           <param name="path"
@@ -78,8 +78,8 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example4-config">
-          To configure the check with default settings, so that it accepts
-          methods with at most 150 lines:
+          To configure the check so that it accepts methods with at most 4
+          lines, not counting empty lines and comments:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -123,7 +123,6 @@ public class XdocsExampleFileTest {
     private static final Set<String> MODULES_WITHOUT_DEFAULT_FIRST_EXAMPLE = Set.of(
         "checks/coding/illegaltokentext",
         "checks/naming/localfinalvariablename",
-        "checks/sizes/methodlength",
         "checks/translation"
     );
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckExamplesTest.java
@@ -34,15 +34,7 @@ public class MethodLengthCheckExamplesTest extends AbstractExamplesModuleTestSup
 
     @Test
     public void testExample1() throws Exception {
-
-        final int max = 4;
-
-        final String[] expected = {
-            "18:3: " + getCheckMessage(MSG_KEY, 5, max, "Example1"),
-            "31:3: " + getCheckMessage(MSG_KEY, 6, max, "firstMethod"),
-            "43:3: " + getCheckMessage(MSG_KEY, 5, max, "thirdMethod"),
-            "51:5: " + getCheckMessage(MSG_KEY, 5, max, "MyBadRecord"),
-        };
+        final String[] expected = {};
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
 
@@ -52,23 +44,31 @@ public class MethodLengthCheckExamplesTest extends AbstractExamplesModuleTestSup
         final int max = 4;
 
         final String[] expected = {
-            "32:3: " + getCheckMessage(MSG_KEY, 6, max, "firstMethod"),
-            "44:3: " + getCheckMessage(MSG_KEY, 5, max, "thirdMethod"),
+            "18:3: " + getCheckMessage(MSG_KEY, 5, max, "Example2"),
+            "31:3: " + getCheckMessage(MSG_KEY, 6, max, "firstMethod"),
+            "43:3: " + getCheckMessage(MSG_KEY, 5, max, "thirdMethod"),
+            "51:5: " + getCheckMessage(MSG_KEY, 5, max, "MyBadRecord"),
         };
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
     }
 
     @Test
     public void testExample3() throws Exception {
+
+        final int max = 4;
+
         final String[] expected = {
-            "33:3: " + getCheckMessage(MSG_KEY, 6, 4, "firstMethod"),
+            "32:3: " + getCheckMessage(MSG_KEY, 6, max, "firstMethod"),
+            "44:3: " + getCheckMessage(MSG_KEY, 5, max, "thirdMethod"),
         };
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
 
     @Test
     public void testExample4() throws Exception {
-        final String[] expected = {};
+        final String[] expected = {
+            "33:3: " + getCheckMessage(MSG_KEY, 6, 4, "firstMethod"),
+        };
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example1.java
@@ -1,9 +1,7 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="MethodLength">
-      <property name="max" value="4"/>
-    </module>
+    <module name="MethodLength"/>
   </module>
 </module>
 */
@@ -14,20 +12,20 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
 // xdoc section - start
 public class Example1 {
 
-  // violation below 'Method Example1 length is 5 lines (max allowed is 4)'
+  // ok, default max is 150 lines
   public Example1() {
     int var1 = 2;
     int var2 = 4;
     int sum = var1 + var2;
   }
 
-  // ok, as it is less than 4 lines
+  // ok, default max is 150 lines
   public Example1(int a)  {
     int var1 = 2;
     int sum = var1 + a;
   }
 
-  // violation below 'Method firstMethod length is 6 lines (max allowed is 4)'
+  // ok, default max is 150 lines
   public void firstMethod() {
     int index = 0;
     if (index < 5) {
@@ -39,15 +37,15 @@ public class Example1 {
 
     System.out.println("line 3");
   }
-  // violation below 'Method thirdMethod length is 5 lines (max allowed is 4)'
+
   public void thirdMethod() {
 
-    // ok, empty line above is counted by default,just like this comment
+    // ok, empty line above is counted by default, just like this comment
     System.out.println("line 4");
   }
 
   record MyBadRecord() {
-    // violation below 'Method MyBadRecord length is 5 lines (max allowed is 4)'
+
     public MyBadRecord {
 
       System.out.println("line3");

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example2.java
@@ -2,7 +2,6 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="MethodLength">
-      <property name="tokens" value="METHOD_DEF"/>
       <property name="max" value="4"/>
     </module>
   </module>
@@ -15,14 +14,14 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
 // xdoc section - start
 public class Example2 {
 
-  // ok, CTOR_DEF is not in configured tokens
-  public Example2()  {
+  // violation below 'Method Example2 length is 5 lines (max allowed is 4)'
+  public Example2() {
     int var1 = 2;
     int var2 = 4;
     int sum = var1 + var2;
   }
 
-  // ok, CTOR_DEF is not in configured tokens
+  // ok, as it is less than 4 lines
   public Example2(int a)  {
     int var1 = 2;
     int sum = var1 + a;
@@ -48,7 +47,7 @@ public class Example2 {
   }
 
   record MyBadRecord() {
-    // ok, COMPACT_CTOR_DEF is not in configured tokens
+    // violation below 'Method MyBadRecord length is 5 lines (max allowed is 4)'
     public MyBadRecord {
 
       System.out.println("line3");

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example3.java
@@ -4,7 +4,6 @@
     <module name="MethodLength">
       <property name="tokens" value="METHOD_DEF"/>
       <property name="max" value="4"/>
-      <property name="countEmpty" value="false"/>
     </module>
   </module>
 </module>
@@ -38,13 +37,13 @@ public class Example3 {
   }
 
   public void secondMethod() {
-    // ok, countEmpty property is false,so this line doesn't count
+
     System.out.println("line 3");
   }
-
+  // violation below 'Method thirdMethod length is 5 lines (max allowed is 4)'
   public void thirdMethod() {
 
-    // ok, countEmpty property is false,so this line and the line above don't count
+    // ok, empty line above is counted by default,just like this comment
     System.out.println("line 4");
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/Example4.java
@@ -1,7 +1,11 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="MethodLength"/>
+    <module name="MethodLength">
+      <property name="tokens" value="METHOD_DEF"/>
+      <property name="max" value="4"/>
+      <property name="countEmpty" value="false"/>
+    </module>
   </module>
 </module>
 */
@@ -12,20 +16,20 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
 // xdoc section - start
 public class Example4 {
 
-  // ok, default max is 150 lines
-  public Example4() {
+  // ok, CTOR_DEF is not in configured tokens
+  public Example4()  {
     int var1 = 2;
     int var2 = 4;
     int sum = var1 + var2;
   }
 
-  // ok, default max is 150 lines
+  // ok, CTOR_DEF is not in configured tokens
   public Example4(int a)  {
     int var1 = 2;
     int sum = var1 + a;
   }
 
-  // ok, default max is 150 lines
+  // violation below 'Method firstMethod length is 6 lines (max allowed is 4)'
   public void firstMethod() {
     int index = 0;
     if (index < 5) {
@@ -34,18 +38,18 @@ public class Example4 {
   }
 
   public void secondMethod() {
-
+    // ok, countEmpty property is false,so this line doesn't count
     System.out.println("line 3");
   }
 
   public void thirdMethod() {
 
-    // ok, empty line above is counted by default, just like this comment
+    // ok, countEmpty property is false,so this line and the line above don't count
     System.out.println("line 4");
   }
 
   record MyBadRecord() {
-
+    // ok, COMPACT_CTOR_DEF is not in configured tokens
     public MyBadRecord {
 
       System.out.println("line3");


### PR DESCRIPTION
## Summary
`MethodLength` already had a zero-property default-config example, but it was numbered `Example4`. `testDefaultConfigExampleIsFirst` therefore still suppressed `checks/sizes/methodlength`.

- Renumber examples so the default (max 150) example is `Example1`
- Shift the `max=4`, `tokens=METHOD_DEF`, and `countEmpty=false` examples to `Example2`–`Example4`
- Update captions, example class names, and `MethodLengthCheckExamplesTest`
- Regenerate xdoc via `XdocsPagesTest`
- Remove `checks/sizes/methodlength` from `MODULES_WITHOUT_DEFAULT_FIRST_EXAMPLE`

Issue: #21207 (one module)

## Testing
- `./mvnw -Dtest=MethodLengthCheckExamplesTest test` (4 tests, GREEN)
- `./mvnw clean -Dtest=XdocsExampleFileTest,XdocsExamplesAstConsistencyTest test` (5+5 tests, GREEN)
- `./mvnw clean -Dtest=XdocsPagesTest test` (20 tests, GREEN)