### PR TITLE
dependency: bump jetbrains/qodana-jvm-community image from 2026.1 to 2026.2

### DIFF
--- a/config/qodana.yml
+++ b/config/qodana.yml
@@ -1,6 +1,6 @@
 version: 1.0
 
-image: jetbrains/qodana-jvm-community:2026.1
+image: jetbrains/qodana-jvm-community:2026.2
 projectJDK: "21"
 
 failureConditions:
@@ -57,3 +57,11 @@ exclude:
       - src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
       - src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
       - src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
+
+  # until https://github.com/checkstyle/checkstyle/issues/21219
+  - name: Annotator
+    paths:
+      - src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
+  - name: ClassCanBeRecord
+    paths:
+      - src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java


### PR DESCRIPTION
Reasons to bump:
1. Prerequisite for
    - https://github.com/checkstyle/checkstyle/pull/21215
2. Qodana logs suggested it:
    - https://github.com/checkstyle/checkstyle/actions/runs/31811125945/job/94801733561?pr=21217#step:3:23
    ```text
    Warning: You are using a non-compatible Qodana linter jetbrains/qodana-jvm-community:2026.1 with the current CLI (2026.2.0) Consider updating CLI or using a compatible linter jetbrains/qodana-jvm-community:2026.2
    ```