### PR TITLE
Issue #21222: Added coverage for PreferLiteralJavadocInlineTag

### DIFF
--- a/src/it/java/com/openjdk/checkstyle/test/chapterformatting/rulejavadoc/JavadocTest.java
+++ b/src/it/java/com/openjdk/checkstyle/test/chapterformatting/rulejavadoc/JavadocTest.java
@@ -45,4 +45,9 @@ public class JavadocTest extends AbstractOpenJdkModuleTestSupport {
         verifyWithWholeConfig(getPath("InputJavadocTwo.java"));
     }
 
+    @Test
+    public void testJavadocThree() throws Exception {
+        verifyWithWholeConfig(getPath("InputJavadocThree.java"));
+    }
+
 }

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulejavadoc/InputJavadocThree.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulejavadoc/InputJavadocThree.java
@@ -1,0 +1,107 @@
+package com.openjdk.checkstyle.test.chapterformatting.rulejavadoc;
+
+// violation first line 'Header mismatch'
+
+public class InputJavadocThree {
+
+    // 5 violations 7 lines below:
+    //  'Prefer literal or code javadoc inline tag over '&amp;'.'
+    //  'Prefer literal or code javadoc inline tag over '&quot;'.'
+    //  'Prefer literal or code javadoc inline tag over '&apos;'.'
+    //  'Prefer literal or code javadoc inline tag over '&lt;'.'
+    //  'Prefer literal or code javadoc inline tag over '&gt;'.'
+    /**
+     * Prefer &amp; , &quot; , &apos; &lt; &gt; for special characters.
+     */
+    class Bad {
+    }
+
+    /**
+     * Prefer {@literal &}, {@literal "}, {@literal '}, {@literal <}, {@literal >}
+     * for special characters.
+     */
+    class Good {
+    }
+
+    // 2 violations 4 lines below:
+    //  'Prefer literal or code javadoc inline tag over '&lt;'.'
+    //  'Prefer literal or code javadoc inline tag over '&gt;'.'
+    /**
+     * Type parameter is &lt;E&gt; here.
+     */
+    public void methodBad1() {
+    }
+
+    /**
+     * Type parameter is {@code <E>} here.
+     */
+    public void methodGood1() {
+    }
+
+    // 2 violations 4 lines below:
+    //  'Prefer literal or code javadoc inline tag over '&lt;'.'
+    //  'Prefer literal or code javadoc inline tag over '&gt;'.'
+    /**
+     * &lt;T&gt; generic type.
+     */
+    public void methodBad2() {
+    }
+
+    /**
+     * {@code <T>} generic type.
+     */
+    public void methodGood2() {
+    }
+
+    // violation 2 lines below 'Prefer literal or code javadoc inline tag over '&gt;'.'
+    /**
+     * &gt; is the greater than sign.
+     * &apos; and &quot; is used for quotes.
+     */
+    public void methodBad3() {
+        // 2 violations 3 lines above:
+        //  'Prefer literal or code javadoc inline tag over '&apos;'.'
+        //  'Prefer literal or code javadoc inline tag over '&quot;'.'
+    }
+
+    /**
+     * {@literal >} is the greater than sign.
+     * {@literal '} and {@literal "} are used for quotes.
+     */
+    public void methodGood3() {
+    }
+
+    // 2 violations 4 lines below:
+    //  'Prefer literal or code javadoc inline tag over '&lt;'.'
+    //  'Prefer literal or code javadoc inline tag over '&gt;'.'
+    /**
+     * <b>&lt;T&gt;</b> bold generic.
+     * <p> if (a &amp; b &gt; c) then do something. </p>
+     */
+    public void methodBad4() {
+        // 2 violations 3 lines above:
+        //  'Prefer literal or code javadoc inline tag over '&amp;'.'
+        //  'Prefer literal or code javadoc inline tag over '&gt;'.'
+    }
+
+    /**
+     * <b>{@code <T>}</b> bold generic.
+     * <p> {@code if (a & b > c) then do something. } </p>
+     */
+    public void methodGood4() {
+    }
+
+    // violation 2 lines below 'Prefer literal or code javadoc inline tag over '&gt;'.'
+    /**
+     * <i>&gt;</i> italic greater than.
+     */
+    public void methodBad5() {
+    }
+
+    /**
+     * <i>{@literal >}</i> italic greater than.
+     */
+    public void methodGood5() {
+    }
+
+}

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -301,6 +301,7 @@
 
     <module name="SummaryJavadoc"/>
     <module name="JavadocContentLocation"/>
+    <module name="PreferLiteralJavadocInlineTag"/>
 
     <module name="MissingOverride"/>
     <module name="MissingOverrideOnRecordAccessor"/>

--- a/src/site/xdoc/checks/javadoc/preferliteraljavadocinlinetag.xml
+++ b/src/site/xdoc/checks/javadoc/preferliteraljavadocinlinetag.xml
@@ -153,6 +153,10 @@ public class Example1 {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+PreferLiteralJavadocInlineTag">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PreferLiteralJavadocInlineTag">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/preferliteraljavadocinlinetag.xml.template
+++ b/src/site/xdoc/checks/javadoc/preferliteraljavadocinlinetag.xml.template
@@ -54,6 +54,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+PreferLiteralJavadocInlineTag">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PreferLiteralJavadocInlineTag">
+            OpenJDK Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/openjdk_style.xml
+++ b/src/site/xdoc/openjdk_style.xml
@@ -1176,11 +1176,19 @@
                   config</a>)
                   <br />
                   <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/javadoc/preferliteraljavadocinlinetag.html#PreferLiteralJavadocInlineTag">
+                    PreferLiteralJavadocInlineTag</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PreferLiteralJavadocInlineTag">
+                  config</a>)
+                  <br />
+                  <span class="wrapper inline">
                     <img src="images/ban_red.png" alt="" />
                   </span>
                   Inline tag rule can not be covered until:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/18570">
-                    #18570
+                  <a href="https://github.com/checkstyle/checkstyle/issues/20980">
+                    #20980
                   </a>
                   <br />
                   <span class="wrapper inline">


### PR DESCRIPTION
Issue: #21222 


Added PreferLiteralJavadocInlineTagCheck in openjdk_checks.xml.