### PR TITLE
minor: fix broken link to Maven Central project

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ https://codecov.io/github/checkstyle/checkstyle/coverage.svg?branch=master
 [maven-central]:
 https://mvnrepository.com/artifact/com.puppycrawl.tools/checkstyle
 [mavenbadge]:
-https://search.maven.org/search?q=g:%22com.puppycrawl.tools%22%20AND%20a:%22checkstyle%22
+https://central.sonatype.com/artifact/com.puppycrawl.tools/checkstyle
 [mavenbadge img]:
 https://img.shields.io/maven-central/v/com.puppycrawl.tools/checkstyle.svg?label=Maven%20Central
 


### PR DESCRIPTION
## Problem

If you click on the `Maven Central` badge in the README, it opens a page with 0 results:
<img width="1681" height="621" alt="image" src="https://github.com/user-attachments/assets/97a3eee1-e626-408f-8578-63ff3a5dbe86" />

This PR fixes the link behind the `Maven Central` badge to point to the right page:
<img width="1724" height="757" alt="image" src="https://github.com/user-attachments/assets/464ac72b-e7c5-4d90-a354-26adf4925fdf" />
