### PR TITLE
Issue #21229: Align ClassTypeParameterName examples with property count

### DIFF
--- a/src/site/xdoc/checks/naming/classtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/classtypeparametername.xml
@@ -22,7 +22,13 @@
             <ul class="toc-sublist">
               <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
               <li><a href="#Example2-config" class="toc-sublink">For names that are uppercase word</a></li>
-              <li><a href="#Example3-config" class="toc-sublink">For names that are camel case word with T as suffix (Google Style)</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#ClassTypeParameterName_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">For names that are camel case word with T as suffix (Google Style)</a></li>
             </ul>
           </li>
           <li><a href="#ClassTypeParameterName_Example_of_Usage">Example of Usage</a></li>
@@ -101,8 +107,11 @@ class Example2 {
   class MyClass4&lt;LISTENER&gt; {}
   class MyClass5&lt;RequestT&gt; {} // violation 'Name 'RequestT' must match pattern'
 }
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example3-config">
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Use Cases" id="ClassTypeParameterName_Use_Cases">
+        <p id="UseCase1-config">
           To configure the check for names that are camel case word with T as suffix
           (<a href="../../styleguides/google-java-style-20250426/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
         </p>
@@ -115,9 +124,9 @@ class Example2 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example3-code">Example:</p>
+        <p id="UseCase1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example3 {
+class UseCase1 {
   class MyClass1&lt;T&gt; {}
   class MyClass2&lt;t&gt; {}        // violation 'Name 't' must match pattern'
   class MyClass3&lt;abc&gt; {}      // violation 'Name 'abc' must match pattern'

--- a/src/site/xdoc/checks/naming/classtypeparametername.xml.template
+++ b/src/site/xdoc/checks/naming/classtypeparametername.xml.template
@@ -59,20 +59,23 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example2.java"/>
           <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-        <p id="Example3-config">
+        </macro>
+      </subsection>
+
+      <subsection name="Use Cases" id="ClassTypeParameterName_Use_Cases">
+        <p id="UseCase1-config">
           To configure the check for names that are camel case word with T as suffix
           (<a href="../../styleguides/google-java-style-20250426/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example3.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/UseCase1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example3-code">Example:</p>
+        <p id="UseCase1-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/Example3.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/UseCase1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -175,7 +175,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/javadoc/javadocblocktaglocation",
             "checks/javadoc/javadocpackage",
             "checks/lineending",
-            "checks/naming/classtypeparametername",
             "checks/naming/patternvariablename",
             "checks/newlineatendoffile",
             "checks/sizes/linelength",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ClassTypeParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/ClassTypeParameterNameCheckExamplesTest.java
@@ -59,7 +59,7 @@ public class ClassTypeParameterNameCheckExamplesTest extends AbstractExamplesMod
     }
 
     @Test
-    public void testExample3() throws Exception {
+    public void testUseCase1() throws Exception {
         final String pattern = "(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)";
         final String[] expected = {
             "16:18: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "t", pattern),
@@ -67,7 +67,7 @@ public class ClassTypeParameterNameCheckExamplesTest extends AbstractExamplesMod
             "18:18: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "LISTENER", pattern),
         };
 
-        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/classtypeparametername/UseCase1.java
@@ -11,7 +11,7 @@
 package com.puppycrawl.tools.checkstyle.checks.naming.classtypeparametername;
 
 // xdoc section - start
-class Example3 {
+class UseCase1 {
   class MyClass1<T> {}
   class MyClass2<t> {}        // violation 'Name 't' must match pattern'
   class MyClass3<abc> {}      // violation 'Name 'abc' must match pattern'


### PR DESCRIPTION
Issue: #21229

`ClassTypeParameterName` only documents the `format` property, so
`testExampleCountMatchesPropertyCount` expects 2 AST-matching examples
(default + one property). The module had 3 structurally identical
examples (default, uppercase `format`, and Google Style `format`).

Examples now has the default config plus the uppercase-word `format`
example. The extra Google Style `format` example is kept under Use
Cases.

Other modules listed in #21229 are left for separate PRs.

## Testing

Executed:

- `mvn clean test -Dtest=ClassTypeParameterNameCheckExamplesTest,XdocsExamplesAstConsistencyTest`
  - ClassTypeParameterNameCheckExamplesTest 3/3
  - XdocsExamplesAstConsistencyTest 5/5
- `mvn clean test -Dtest=XdocsExampleFileTest,XdocsPagesTest`
  - XdocsExampleFileTest 5/5
  - XdocsPagesTest 20/20