### PR TITLE
Issue #21229: Move MissingDeprecated extra example to use case

### DIFF
--- a/src/site/xdoc/checks/annotation/missingdeprecated.xml
+++ b/src/site/xdoc/checks/annotation/missingdeprecated.xml
@@ -22,7 +22,13 @@
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#MissingDeprecated_Examples">Examples</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
               <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
-              <li><a href="#Example2-config" class="toc-sublink">Such that it prints violation messages if tight HTML rules are not obeyed</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#MissingDeprecated_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">Such that it reports violations when tight HTML rules are not obeyed</a></li>
             </ul>
           </li>
           <li><a href="#MissingDeprecated_Example_of_Usage">Example of Usage</a></li>
@@ -128,10 +134,13 @@ class Example1 {
   @Deprecated
   public static final int CONST = 12;
 }
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example2-config">
-          To configure the check such that it prints violation
-          messages if tight HTML rules are not obeyed
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Use Cases" id="MissingDeprecated_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check such that it reports violations when tight HTML rules are not
+          obeyed:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -142,9 +151,9 @@ class Example1 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example2-code">Example:</p>
+        <p id="UseCase1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example2 {
+class UseCase1 {
   @Deprecated
   public static final int MY_CONST = 13;
 

--- a/src/site/xdoc/checks/annotation/missingdeprecated.xml.template
+++ b/src/site/xdoc/checks/annotation/missingdeprecated.xml.template
@@ -44,21 +44,24 @@
           <param name="path"
                    value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example1.java"/>
             <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-        <p id="Example2-config">
-          To configure the check such that it prints violation
-          messages if tight HTML rules are not obeyed
+        </macro>
+      </subsection>
+
+      <subsection name="Use Cases" id="MissingDeprecated_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check such that it reports violations when tight HTML rules are not
+          obeyed:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example2.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/UseCase1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example2-code">Example:</p>
+        <p id="UseCase1-code">Example:</p>
         <macro name="example">
           <param name="path"
-                   value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/Example2.java"/>
-            <param name="type" value="code"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/UseCase1.java"/>
+          <param name="type" value="code"/>
         </macro>
       </subsection>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -169,7 +169,6 @@ public class XdocsExamplesAstConsistencyTest {
      * Until: <a href="https://github.com/checkstyle/checkstyle/issues/21229">...</a>
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
-            "checks/annotation/missingdeprecated",
             "checks/coding/illegaltype",
             "checks/design/designforextension",
             "checks/imports/avoidstarimport",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckExamplesTest.java
@@ -43,13 +43,13 @@ public class MissingDeprecatedCheckExamplesTest extends AbstractExamplesModuleTe
     }
 
     @Test
-    public void testExample2() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expected = {
             "21: " + getCheckMessage(MSG_KEY_ANNOTATION_MISSING_DEPRECATED),
             "33: " + getCheckMessage(MSG_KEY_UNCLOSED_HTML_TAG, "p"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/UseCase1.java
@@ -11,7 +11,7 @@
 package com.puppycrawl.tools.checkstyle.checks.annotation.missingdeprecated;
 
 // xdoc section - start
-class Example2 {
+class UseCase1 {
   @Deprecated
   public static final int MY_CONST = 13;
 


### PR DESCRIPTION
Issue: #21229

## Summary

- Move the non-default MissingDeprecated configuration from numbered `Example2` to `UseCase1`.
- Add a dedicated Use Cases section while preserving the documented configuration and expected violations.
- Remove `checks/annotation/missingdeprecated` from `EXAMPLE_COUNT_SUPPRESSED_MODULES`.

## Verification

- `.\mvnw.cmd '-Dtest=MissingDeprecatedCheckExamplesTest,XdocsExamplesAstConsistencyTest,XdocsExampleFileTest,XdocsPagesTest' test`
  - 32 tests, 0 failures, 0 errors
- `.\mvnw.cmd clean verify`
  - BUILD SUCCESS
  - 6,464 unit tests (0 failures, 0 errors; 7 skipped)
  - 1,301 integration tests (0 failures, 0 errors)
  - Checkstyle, PMD, SpotBugs, coverage, forbidden APIs, and JSON validation passed