### PR TITLE
Issue #21137: add default config example for SuppressionXpathSingleFilter

### DIFF
--- a/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionxpathsinglefilter.xml
@@ -20,13 +20,14 @@
             <input type="checkbox" id="toc-sub-Examples" class="toc-sub-toggle-checkbox" checked="checked"/>
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#SuppressionXpathSingleFilter_Examples">Examples</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
-              <li><a href="#Example1-config" class="toc-sublink">Suppress the MethodName check for all methods with name MyMethod inside Example1 and Example3 files</a></li>
+              <li><a href="#Example1-config" class="toc-sublink">Default configuration does nothing</a></li>
               <li><a href="#Example2-config" class="toc-sublink">To suppress MethodName check for method names matched pattern 'MyMethod[0-9]'</a></li>
               <li><a href="#Example3-config" class="toc-sublink">To suppress checks being specified by id property</a></li>
               <li><a href="#Example4-config" class="toc-sublink">To suppress checks for all package definitions</a></li>
               <li><a href="#Example5-config" class="toc-sublink">To suppress MethodName check for all methods</a></li>
               <li><a href="#Example6-config" class="toc-sublink">To suppress checks in the Example6 file by non-query</a></li>
               <li><a href="#Example7-config" class="toc-sublink">The following example is an example of what checks would be suppressed while building Spring projects with checkstyle plugin. Please find more information at: spring-javaformat</a></li>
+              <li><a href="#Example8-config" class="toc-sublink">Suppress the MethodName check for all methods with name MyMethod inside Example8 and Example3 files</a></li>
             </ul>
           </li>
           <li>
@@ -132,22 +133,13 @@
       </subsection>
       <subsection name="Examples" id="SuppressionXpathSingleFilter_Examples">
         <p id="Example1-config">
-          To configure to suppress the MethodName check
-          for all methods with name MyMethod
-          inside Example1 and Example3 files:
+          Default configuration does nothing:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="MethodName"/&gt;
-    &lt;module name="SuppressionXpathSingleFilter"&gt;
-      &lt;property name="files" value="Example(1|3)\.java"/&gt;
-      &lt;property name="checks" value="MethodName"/&gt;
-      &lt;property name="query" value="(//CLASS_DEF[./IDENT[@text='Example1']]
-                /OBJBLOCK/METHOD_DEF/IDENT[@text='MyMethod'])|
-                (//CLASS_DEF[./IDENT[@text='Example3']]/OBJBLOCK
-                /METHOD_DEF/IDENT[@text='MyMethod'])"/&gt;
-    &lt;/module&gt;
+    &lt;module name="SuppressionXpathSingleFilter"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -156,7 +148,8 @@
 package com.puppycrawl.tools.checkstyle.filters.suppressionxpathsinglefilter;
 
 public class Example1 {
-  // filtered violation below 'Name 'MyMethod' must match pattern'
+  public Example1() {}
+  // violation below 'Name 'MyMethod' must match pattern'
   public void MyMethod() {}
   // violation below 'Name 'MyMethod2' must match pattern'
   public void MyMethod2() {}
@@ -345,6 +338,40 @@ public class Example6 {
 .../src/myApplicationTests.java // filtered violation 'must match pattern'
 .../src/test/java/insidePackage.java // filtered violation 'must match pattern'
 </code></pre></div><hr class="example-separator"/>
+        <p id="Example8-config">
+          To configure to suppress the MethodName check
+          for all methods with name MyMethod
+          inside Example8 and Example3 files:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MethodName"/&gt;
+    &lt;module name="SuppressionXpathSingleFilter"&gt;
+      &lt;property name="files" value="Example(8|3)\.java"/&gt;
+      &lt;property name="checks" value="MethodName"/&gt;
+      &lt;property name="query" value="(//CLASS_DEF[./IDENT[@text='Example8']]
+                /OBJBLOCK/METHOD_DEF/IDENT[@text='MyMethod'])|
+                (//CLASS_DEF[./IDENT[@text='Example3']]/OBJBLOCK
+                /METHOD_DEF/IDENT[@text='MyMethod'])"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example8-code">Code example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+package com.puppycrawl.tools.checkstyle.filters.suppressionxpathsinglefilter;
+
+public class Example8 {
+  // filtered violation below 'Name 'MyMethod' must match pattern'
+  public void MyMethod() {}
+  // violation below 'Name 'MyMethod2' must match pattern'
+  public void MyMethod2() {}
+  // violation below 'Name 'MyMethodA' must match pattern'
+  public void MyMethodA() {}
+  private int field = 177;
+}
+</code></pre></div><hr class="example-separator"/>
         </subsection>
         <subsection name="Use Cases" id="SuppressionXpathSingleFilter_Use_Cases">
         <p id="UseCase1-config">
@@ -364,7 +391,7 @@ public class Example6 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="UseCase1-code">Code Example:</p>
+         <p id="UseCase1-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class UseCase1 {
   public void testMethod1()

--- a/src/site/xdoc/filters/suppressionxpathsinglefilter.xml.template
+++ b/src/site/xdoc/filters/suppressionxpathsinglefilter.xml.template
@@ -42,9 +42,7 @@
       </subsection>
       <subsection name="Examples" id="SuppressionXpathSingleFilter_Examples">
         <p id="Example1-config">
-          To configure to suppress the MethodName check
-          for all methods with name MyMethod
-          inside Example1 and Example3 files:
+          Default configuration does nothing:
         </p>
         <macro name="example">
           <param name="path"
@@ -144,6 +142,22 @@
                  value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/Example7.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
+        <p id="Example8-config">
+          To configure to suppress the MethodName check
+          for all methods with name MyMethod
+          inside Example8 and Example3 files:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/Example8.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example8-code">Code example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/Example8.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
         </subsection>
         <subsection name="Use Cases" id="SuppressionXpathSingleFilter_Use_Cases">
         <p id="UseCase1-config">
@@ -156,7 +170,7 @@
                  value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/UseCase1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="UseCase1-code">Code Example:</p>
+         <p id="UseCase1-code">Code Example:</p>
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/UseCase1.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -157,7 +157,6 @@ public class XdocsExamplesAstConsistencyTest {
             "filters/suppressionfilter",
             "filters/suppressionsinglefilter",
             "filters/suppressionxpathfilter",
-            "filters/suppressionxpathsinglefilter",
             "filters/suppresswithplaintextcommentfilter"
     );
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterExamplesTest.java
@@ -55,23 +55,17 @@ public class SuppressionXpathSingleFilterExamplesTest extends AbstractExamplesMo
 
     @Test
     public void testExample1() throws Exception {
-        final String[] expectedWithoutFilter = {
-            "22:15: " + getCheckMessage(AbstractNameCheck.class, MSG_INVALID_PATTERN,
-            "MyMethod", "^[a-z][a-zA-Z0-9]*$"),
-            "24:15: " + getCheckMessage(AbstractNameCheck.class, MSG_INVALID_PATTERN,
-            "MyMethod2", "^[a-z][a-zA-Z0-9]*$"),
-            "26:15: " + getCheckMessage(AbstractNameCheck.class, MSG_INVALID_PATTERN,
-            "MyMethodA", "^[a-z][a-zA-Z0-9]*$"),
-        };
-        final String[] expectedWithFilter = {
-            "24:15: " + getCheckMessage(AbstractNameCheck.class, MSG_INVALID_PATTERN,
-            "MyMethod2", "^[a-z][a-zA-Z0-9]*$"),
-            "26:15: " + getCheckMessage(AbstractNameCheck.class, MSG_INVALID_PATTERN,
-            "MyMethodA", "^[a-z][a-zA-Z0-9]*$"),
+        final String[] expected = {
+            "15:15: " + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "MyMethod", "^[a-z][a-zA-Z0-9]*$"),
+            "17:15: " + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "MyMethod2", "^[a-z][a-zA-Z0-9]*$"),
+            "19:15: " + getCheckMessage(AbstractNameCheck.class,
+                    MSG_INVALID_PATTERN, "MyMethodA", "^[a-z][a-zA-Z0-9]*$"),
         };
 
         verifyFilterWithInlineConfigParser(getPath("Example1.java"),
-                expectedWithoutFilter, expectedWithFilter);
+                expected, expected);
     }
 
     @Test
@@ -314,6 +308,27 @@ public class SuppressionXpathSingleFilterExamplesTest extends AbstractExamplesMo
         final DefaultConfiguration parsedConfig =
                 testInputConfiguration.createConfiguration();
         verify(createChecker(parsedConfig), getFilesInFolder(path), expected);
+    }
+
+    @Test
+    public void testExample8() throws Exception {
+        final String[] expectedWithoutFilter = {
+            "22:15: " + getCheckMessage(AbstractNameCheck.class, MSG_INVALID_PATTERN,
+            "MyMethod", "^[a-z][a-zA-Z0-9]*$"),
+            "24:15: " + getCheckMessage(AbstractNameCheck.class, MSG_INVALID_PATTERN,
+            "MyMethod2", "^[a-z][a-zA-Z0-9]*$"),
+            "26:15: " + getCheckMessage(AbstractNameCheck.class, MSG_INVALID_PATTERN,
+            "MyMethodA", "^[a-z][a-zA-Z0-9]*$"),
+        };
+        final String[] expectedWithFilter = {
+            "24:15: " + getCheckMessage(AbstractNameCheck.class, MSG_INVALID_PATTERN,
+            "MyMethod2", "^[a-z][a-zA-Z0-9]*$"),
+            "26:15: " + getCheckMessage(AbstractNameCheck.class, MSG_INVALID_PATTERN,
+            "MyMethodA", "^[a-z][a-zA-Z0-9]*$"),
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example8.java"),
+                expectedWithoutFilter, expectedWithFilter);
     }
 
     private static File[] getFilesInFolder(Path path) throws IOException {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/Example1.java
@@ -2,23 +2,16 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="MethodName"/>
-    <module name="SuppressionXpathSingleFilter">
-      <property name="files" value="Example(1|3)\.java"/>
-      <property name="checks" value="MethodName"/>
-      <property name="query" value="(//CLASS_DEF[./IDENT[@text='Example1']]
-                /OBJBLOCK/METHOD_DEF/IDENT[@text='MyMethod'])|
-                (//CLASS_DEF[./IDENT[@text='Example3']]/OBJBLOCK
-                /METHOD_DEF/IDENT[@text='MyMethod'])"/>
-    </module>
+    <module name="SuppressionXpathSingleFilter"/>
   </module>
 </module>
 */
-
 // xdoc section - start
 package com.puppycrawl.tools.checkstyle.filters.suppressionxpathsinglefilter;
 
 public class Example1 {
-  // filtered violation below 'Name 'MyMethod' must match pattern'
+  public Example1() {}
+  // violation below 'Name 'MyMethod' must match pattern'
   public void MyMethod() {}
   // violation below 'Name 'MyMethod2' must match pattern'
   public void MyMethod2() {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/Example8.java
@@ -1,0 +1,29 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="MethodName"/>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="files" value="Example(8|3)\.java"/>
+      <property name="checks" value="MethodName"/>
+      <property name="query" value="(//CLASS_DEF[./IDENT[@text='Example8']]
+                /OBJBLOCK/METHOD_DEF/IDENT[@text='MyMethod'])|
+                (//CLASS_DEF[./IDENT[@text='Example3']]/OBJBLOCK
+                /METHOD_DEF/IDENT[@text='MyMethod'])"/>
+    </module>
+  </module>
+</module>
+*/
+
+// xdoc section - start
+package com.puppycrawl.tools.checkstyle.filters.suppressionxpathsinglefilter;
+
+public class Example8 {
+  // filtered violation below 'Name 'MyMethod' must match pattern'
+  public void MyMethod() {}
+  // violation below 'Name 'MyMethod2' must match pattern'
+  public void MyMethod2() {}
+  // violation below 'Name 'MyMethodA' must match pattern'
+  public void MyMethodA() {}
+  private int field = 177;
+}
+// xdoc section - end


### PR DESCRIPTION
 Issue #21137: Added default config example for SuppressionXpathSinglefilter

This PR adds a default-config xdocs example for SuppressionXpathSingleFilter so it no longer needs to be suppressed in testEveryModuleHasDefaultConfigExample.
 
File changed:
 1-src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathsinglefilter/Example8.java
2-src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterExamplesTest.java
3-src/site/xdoc/filters/suppressionxpathsinglefilter.xml.template.
4-src/site/xdoc/filters/suppressionxpathsinglefilter.xml
5-src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java

Deleted the unwanted run log(Line should not be longer than 100 symbols).

validation steps to run:
git status
git log
./mvnw clean verify - BUILD SUCCESS 36:40min
mvn clean verify- BUILD SUCCESS (20:23 min)