### PR TITLE
Issue #21241: Drop `nexus-codehaus-snapshot` plugin repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,15 +507,6 @@
     </dependency>
   </dependencies>
 
-  <!-- that repositories are required for testing plugin's snapshot version -->
-  <pluginRepositories>
-    <pluginRepository>
-      <id>nexus-codehaus-snapshot</id>
-      <name>Codehaus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/codehaus-snapshots/</url>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
# Description

`oss.sonatype.org` is effectively unavailable and its existence in `pom.xml` causes builds to get stuck so this PR removes it from `pluginRepositories`.

Fixes #21241.

# Rules compliance

- **Issue Requirement**
   - [ ] ~~The issue you are trying to fix/resolve **must** have the `"approved"` label~~ (build-infra specific fix so I assumed that it's worth creating PR ASAP).
   - [x] If an issue exists, reference it in the Pull Request description.
- **Commit message** should adhere to the following rules:
   - [x] MUST match any one of the following patterns:

     ```
     ^Issue #\d+: .*$
     ^Pull #\d+: .*$
     ^(minor|config|infra|doc|spelling|dependency): .*$
     ```

   - [x] MUST contain only one line of text
   - [x] MUST NOT end with a period, space, or tab
   - [x] MUST be less than or equal to 200 characters
