### PR TITLE
Fix violation message comments for separatorwrap and recordcomponentnumber examples

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -343,8 +343,6 @@ public final class InlineConfigParser {
                     + "InputUnusedLocalVariablePatternVariablesCondition2.java",
             "checks/coding/unusedlocalvariable/InputUnusedLocalVariableUnnamedTryCatch.java",
             "checks/imports/avoidstarimport/InputAvoidStarImportExcludes.java",
-            "checks/sizes/recordcomponentnumber/Example2.java",
-            "checks/whitespace/separatorwrap/Example1.java",
             "com/google/checkstyle/test/chapter5naming/rule522classnames/"
                     + "InputClassNamesWithUnderscore.java",
             "com/google/checkstyle/test/chapter5naming/rule53camelcase/"

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/Example2.java
@@ -15,10 +15,10 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 class Example2{
   public record MyRecord1(int x, int y, String str) {}
 
-  public record MyRecord2(int x, int y, double d, // violation, 6 components
+  public record MyRecord2(int x, int y, double d, // violation 'Number of record components is 6 (max allowed is 5).'
                     String str, char c, float f) {}
 
-  record MyRecord3(int x, int y, int z, double d, // violation, 9 components
+  record MyRecord3(int x, int y, int z, double d, // violation 'Number of record components is 9 (max allowed is 5).'
                     String str1, String str2, char c, float f, String location) {}
 
   private record MyRecord4(int x, int y,

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/Example1.java
@@ -24,9 +24,9 @@ class Example1 {
   }
 
   void bar(int p
-          , int q) { // violation ',' should be on the previous line
+          , int q) { // violation '',' should be on the previous line.'
     if (s
-            .isEmpty()) { // violation '.' should be on the previous line
+            .isEmpty()) { // violation ''.' should be on the previous line.'
     }
   }
 }


### PR DESCRIPTION
Fixes part of #20954

`separatorwrap/Example1.java` and `recordcomponentnumber/Example2.java`
had paraphrased `// violation` comments instead of the exact quoted
Checkstyle message, so `InlineConfigParser` was silently skipping
message validation for both files (they were listed in
`SUPPRESSED_VALIDATE_MESSAGE_FILES`).

This PR:
- Rewrites both comments to the real, exact quoted message
- Removes both files' entries from `SUPPRESSED_VALIDATE_MESSAGE_FILES`

Verified locally: `mvn test -Dtest=SeparatorWrapExamplesTest,RecordComponentNumberCheckExamplesTest`
passes, and I confirmed the check is actually live by deliberately
breaking one message and seeing the test correctly fail before
reverting.