### PR TITLE
Issue #21229: align example count with property count

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -151,7 +151,7 @@
 
   <!-- Examples contains important violations that need to be shown -->
   <suppress checks="FileLength"
-    files="illegaltype/Example\d+.*"/>
+    files="illegaltype/(Example|UseCase)\d+.*"/>
 
   <!-- Examples contains important violations that need to be shown -->
   <suppress checks="FileLength"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -83,7 +83,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </ul>
  *
  * <p>
- * as methods that are differ from interface methods are rarely used, so in most cases user will
+ * as methods that differ from interface methods are rarely used, so in most cases user will
  * benefit from checking for them.
  * </p>
  *

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTypeCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTypeCheck.xml
@@ -50,7 +50,7 @@
  &lt;/ul&gt;
 
  &lt;p&gt;
- as methods that are differ from interface methods are rarely used, so in most cases user will
+ as methods that differ from interface methods are rarely used, so in most cases user will
  benefit from checking for them.
  &lt;/p&gt;</description>
          <properties>

--- a/src/site/xdoc/checks/coding/illegaltype.xml
+++ b/src/site/xdoc/checks/coding/illegaltype.xml
@@ -27,8 +27,14 @@
               <li><a href="#Example5-config" class="toc-sublink">So that it verifies only public, protected or static methods and fields</a></li>
               <li><a href="#Example6-config" class="toc-sublink">So that it verifies usage of types Boolean and Foo</a></li>
               <li><a href="#Example7-config" class="toc-sublink">Target fields types only</a></li>
-              <li><a href="#Example8-config" class="toc-sublink">So that it violates usage of var</a></li>
-              <li><a href="#Example9-config" class="toc-sublink">So that it violates Abstract Types which are illegal</a></li>
+              <li><a href="#Example8-config" class="toc-sublink">So that it violates Abstract Types which are illegal</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#IllegalType_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">So that it violates usage of var</a></li>
             </ul>
           </li>
           <li><a href="#IllegalType_Example_of_Usage">Example of Usage</a></li>
@@ -87,7 +93,7 @@ List list; //No violation here
         </ul>
 
         <p>
-          as methods that are differ from interface methods are rarely used, so in most cases user will
+          as methods that differ from interface methods are rarely used, so in most cases user will
           benefit from checking for them.
         </p>
       </subsection>
@@ -788,89 +794,6 @@ public class Example7 extends TreeSet {
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example8-config">
-          To configure the check so that it violates usage of var:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="IllegalType"&gt;
-      &lt;property name="illegalClassNames" value="var"/&gt;
-      &lt;property name="tokens" value="VARIABLE_DEF"/&gt;
-      &lt;property name="id" value="IllegalTypeVarAsField"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example8-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example8 extends TreeSet {
-
-  public &lt;T extends java.util.HashSet&gt; void method() {
-
-    LinkedHashMap&lt;Integer, String&gt; linkedHashMap =
-        new LinkedHashMap&lt;Integer, String&gt;();
-
-    TreeMap&lt;Integer, String&gt; treemap = new TreeMap&lt;Integer, String&gt;();
-    java.lang.IllegalArgumentException illegalex;
-
-    java.util.TreeSet treeset;
-  }
-
-  public &lt;T extends java.util.HashSet&gt; void typeParam(T t) {}
-
-  public HashMap&lt;String, String&gt; function1() {
-    return null;
-  }
-
-  private HashMap&lt;String, String&gt; function2() {
-    return null;
-  }
-
-  protected HashMap&lt;Integer, String&gt; function3() {
-    return null;
-  }
-
-  public &lt;T extends Boolean, U extends Serializable&gt; void typeParam(T a) {}
-
-  public &lt;T extends java.util.Optional&gt; void method(T t) {
-    Optional&lt;T&gt; i;
-  }
-
-  abstract class A {
-
-    public abstract Set&lt;Boolean&gt; shortName(Set&lt;? super Boolean&gt; a);
-
-  }
-
-  class B extends Gitter {}
-  class C extends Github {}
-
-  public Optional&lt;String&gt; field2;
-  protected String field3;
-  Optional&lt;String&gt; field4;
-
-  private void method(List&lt;Foo&gt; list, Boolean value) {}
-
-  void foo() {
-    Optional&lt;String&gt; i;
-  }
-
-  final Consumer&lt;Foo&gt; consumer = Foo&lt;Boolean&gt;::foo;
-
-  public void var() {
-    var message = "Hello, World!";
-  } // violation above 'Usage of type 'var' is not allowed'
-
-  public AbstractSet&lt;String&gt; function4() {
-    return null;
-  }
-
-  private AbstractList&lt;String&gt; function5() {
-    return null;
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example9-config">
           To configure the check so that it violates Abstract Types which are illegal:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
@@ -883,10 +806,10 @@ public class Example8 extends TreeSet {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example9-code">Example:</p>
+        <p id="Example8-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 // violation below 'Usage of type 'TreeSet' is not allowed'
-public class Example9 extends TreeSet {
+public class Example8 extends TreeSet {
   // violation below 'Usage of type 'java.util.HashSet' is not allowed'
   public &lt;T extends java.util.HashSet&gt; void method() {
     // violation below 'Usage of type 'LinkedHashMap' is not allowed'
@@ -944,6 +867,92 @@ public class Example9 extends TreeSet {
     var message = "Hello, World!";
   }
   // violation below 'Usage of type 'AbstractSet' is not allowed'
+  public AbstractSet&lt;String&gt; function4() {
+    return null;
+  }
+
+  private AbstractList&lt;String&gt; function5() {
+    return null;
+  }
+}
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Use Cases" id="IllegalType_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check so that it violates usage of var:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="IllegalType"&gt;
+      &lt;property name="illegalClassNames" value="var"/&gt;
+      &lt;property name="tokens" value="VARIABLE_DEF"/&gt;
+      &lt;property name="id" value="IllegalTypeVarAsField"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="UseCase1-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class UseCase1 extends TreeSet {
+
+  public &lt;T extends java.util.HashSet&gt; void method() {
+
+    LinkedHashMap&lt;Integer, String&gt; linkedHashMap =
+        new LinkedHashMap&lt;Integer, String&gt;();
+
+    TreeMap&lt;Integer, String&gt; treemap = new TreeMap&lt;Integer, String&gt;();
+    java.lang.IllegalArgumentException illegalex;
+
+    java.util.TreeSet treeset;
+  }
+
+  public &lt;T extends java.util.HashSet&gt; void typeParam(T t) {}
+
+  public HashMap&lt;String, String&gt; function1() {
+    return null;
+  }
+
+  private HashMap&lt;String, String&gt; function2() {
+    return null;
+  }
+
+  protected HashMap&lt;Integer, String&gt; function3() {
+    return null;
+  }
+
+  public &lt;T extends Boolean, U extends Serializable&gt; void typeParam(T a) {}
+
+  public &lt;T extends java.util.Optional&gt; void method(T t) {
+    Optional&lt;T&gt; i;
+  }
+
+  abstract class A {
+
+    public abstract Set&lt;Boolean&gt; shortName(Set&lt;? super Boolean&gt; a);
+
+  }
+
+  class B extends Gitter {}
+  class C extends Github {}
+
+  public Optional&lt;String&gt; field2;
+  protected String field3;
+  Optional&lt;String&gt; field4;
+
+  private void method(List&lt;Foo&gt; list, Boolean value) {}
+
+  void foo() {
+    Optional&lt;String&gt; i;
+  }
+
+  final Consumer&lt;Foo&gt; consumer = Foo&lt;Boolean&gt;::foo;
+
+  public void var() {
+    var message = "Hello, World!";
+  } // violation above 'Usage of type 'var' is not allowed'
+
   public AbstractSet&lt;String&gt; function4() {
     return null;
   }

--- a/src/site/xdoc/checks/coding/illegaltype.xml.template
+++ b/src/site/xdoc/checks/coding/illegaltype.xml.template
@@ -140,7 +140,7 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example8-config">
-          To configure the check so that it violates usage of var:
+          To configure the check so that it violates Abstract Types which are illegal:
         </p>
         <macro name="example">
           <param name="path"
@@ -152,19 +152,22 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example8.java"/>
           <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-        <p id="Example9-config">
-          To configure the check so that it violates Abstract Types which are illegal:
+        </macro>
+      </subsection>
+
+      <subsection name="Use Cases" id="IllegalType_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check so that it violates usage of var:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example9.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/UseCase1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example9-code">Example:</p>
+        <p id="UseCase1-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example9.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/UseCase1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -168,7 +168,6 @@ public class XdocsExamplesAstConsistencyTest {
      * Until: <a href="https://github.com/checkstyle/checkstyle/issues/21229">...</a>
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
-            "checks/coding/illegaltype",
             "checks/design/designforextension",
             "checks/imports/avoidstarimport",
             "checks/javadoc/atclauseorder",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckExamplesTest.java
@@ -134,15 +134,6 @@ public class IllegalTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample8() throws Exception {
         final String[] expected = {
-            "76:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "var"),
-        };
-
-        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
-    }
-
-    @Test
-    public void testExample9() throws Exception {
-        final String[] expected = {
             "20:31: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "TreeSet"),
             "22:21: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "java.util.HashSet"),
             "24:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "LinkedHashMap"),
@@ -155,7 +146,16 @@ public class IllegalTypeCheckExamplesTest extends AbstractExamplesModuleTestSupp
             "78:10: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "AbstractSet"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example9.java"), expected);
+        verifyWithInlineConfigParser(getPath("Example8.java"), expected);
+    }
+
+    @Test
+    public void testUseCase1() throws Exception {
+        final String[] expected = {
+            "76:5: " + getCheckMessage(IllegalTypeCheck.MSG_KEY, "var"),
+        };
+
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example8.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/Example8.java
@@ -2,9 +2,8 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="IllegalType">
-      <property name="illegalClassNames" value="var"/>
-      <property name="tokens" value="VARIABLE_DEF"/>
-      <property name="id" value="IllegalTypeVarAsField"/>
+      <property name="validateAbstractClassNames" value="true"/>
+      <property name="legalAbstractClassNames" value="AbstractList"/>
     </module>
   </module>
 </module>
@@ -17,30 +16,30 @@ import java.util.*;
 import java.util.function.Consumer;
 
 // xdoc section - start
-
+// violation below 'Usage of type 'TreeSet' is not allowed'
 public class Example8 extends TreeSet {
-
+  // violation below 'Usage of type 'java.util.HashSet' is not allowed'
   public <T extends java.util.HashSet> void method() {
-
+    // violation below 'Usage of type 'LinkedHashMap' is not allowed'
     LinkedHashMap<Integer, String> linkedHashMap =
         new LinkedHashMap<Integer, String>();
-
+    // violation below 'Usage of type 'TreeMap' is not allowed'
     TreeMap<Integer, String> treemap = new TreeMap<Integer, String>();
     java.lang.IllegalArgumentException illegalex;
-
+    // violation below 'Usage of type 'java.util.TreeSet' is not allowed'
     java.util.TreeSet treeset;
   }
-
+  // violation below 'Usage of type 'java.util.HashSet' is not allowed'
   public <T extends java.util.HashSet> void typeParam(T t) {}
-
+  // violation below 'Usage of type 'HashMap' is not allowed'
   public HashMap<String, String> function1() {
     return null;
   }
-
+  // violation below 'Usage of type 'HashMap' is not allowed'
   private HashMap<String, String> function2() {
     return null;
   }
-
+  // violation below 'Usage of type 'HashMap' is not allowed'
   protected HashMap<Integer, String> function3() {
     return null;
   }
@@ -74,8 +73,8 @@ public class Example8 extends TreeSet {
 
   public void var() {
     var message = "Hello, World!";
-  } // violation above 'Usage of type 'var' is not allowed'
-
+  }
+  // violation below 'Usage of type 'AbstractSet' is not allowed'
   public AbstractSet<String> function4() {
     return null;
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/UseCase1.java
@@ -2,8 +2,9 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="IllegalType">
-      <property name="validateAbstractClassNames" value="true"/>
-      <property name="legalAbstractClassNames" value="AbstractList"/>
+      <property name="illegalClassNames" value="var"/>
+      <property name="tokens" value="VARIABLE_DEF"/>
+      <property name="id" value="IllegalTypeVarAsField"/>
     </module>
   </module>
 </module>
@@ -16,30 +17,30 @@ import java.util.*;
 import java.util.function.Consumer;
 
 // xdoc section - start
-// violation below 'Usage of type 'TreeSet' is not allowed'
-public class Example9 extends TreeSet {
-  // violation below 'Usage of type 'java.util.HashSet' is not allowed'
+
+public class UseCase1 extends TreeSet {
+
   public <T extends java.util.HashSet> void method() {
-    // violation below 'Usage of type 'LinkedHashMap' is not allowed'
+
     LinkedHashMap<Integer, String> linkedHashMap =
         new LinkedHashMap<Integer, String>();
-    // violation below 'Usage of type 'TreeMap' is not allowed'
+
     TreeMap<Integer, String> treemap = new TreeMap<Integer, String>();
     java.lang.IllegalArgumentException illegalex;
-    // violation below 'Usage of type 'java.util.TreeSet' is not allowed'
+
     java.util.TreeSet treeset;
   }
-  // violation below 'Usage of type 'java.util.HashSet' is not allowed'
+
   public <T extends java.util.HashSet> void typeParam(T t) {}
-  // violation below 'Usage of type 'HashMap' is not allowed'
+
   public HashMap<String, String> function1() {
     return null;
   }
-  // violation below 'Usage of type 'HashMap' is not allowed'
+
   private HashMap<String, String> function2() {
     return null;
   }
-  // violation below 'Usage of type 'HashMap' is not allowed'
+
   protected HashMap<Integer, String> function3() {
     return null;
   }
@@ -73,8 +74,8 @@ public class Example9 extends TreeSet {
 
   public void var() {
     var message = "Hello, World!";
-  }
-  // violation below 'Usage of type 'AbstractSet' is not allowed'
+  } // violation above 'Usage of type 'var' is not allowed'
+
   public AbstractSet<String> function4() {
     return null;
   }


### PR DESCRIPTION
Issue #21229 

### summary

- update grammar of IllegalType check description
Before  `as methods that are differ` Now `as methods that differ`
- Made `Example8` a use case
- Update `illegaltype.xml` and `illegaltype.xml.template` to have latest config
- Modify `IllegalTypeCheckExamplesTest` to contain the use case and modified example 8 tests
- Add Usecase to the illegaltype supression's regex in `checkstyle-examples-suppressions.xml`