### PR TITLE
Issue #20227: Support implied modifiers in compact source files

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheck.java
@@ -53,6 +53,18 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * }
  *
  * <p>
+ * Enum, interface, and record declarations in a compact source file are members of the
+ * implicitly declared class, so they are also implicitly {@code static}.
+ * </p>
+ * <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+ * enum Age {  // violation
+ *   CHILD, ADULT
+ * }
+ *
+ * void main() {}
+ * </code></pre></div>
+ *
+ * <p>
  * Rationale for this check: Nested enums, interfaces, and records are treated differently from
  * nested classes as they are only allowed to be {@code static}. Developers should not need to
  * remember this rule, and this check provides the means to enforce that the modifier is coded
@@ -185,16 +197,19 @@ public class ClassMemberImpliedModifierCheck
     }
 
     /**
-     * Checks if ast is in a class, enum, anon class or record block.
+     * Checks if ast is in a class, enum, anon class or record block, including the
+     * implicitly declared class of a compact source file.
      *
      * @param ast the current ast
-     * @return true if ast is in a class, enum, anon class or record
+     * @return true if ast is in a class, enum, anon class or record, including
+     *         the implicitly declared class of a compact source file
      */
     private static boolean isInTypeBlock(DetailAST ast) {
         return ScopeUtil.isInScope(ast, Scope.ANONINNER)
                 || ScopeUtil.isInClassBlock(ast)
                 || ScopeUtil.isInEnumBlock(ast)
-                || ScopeUtil.isInRecordBlock(ast);
+                || ScopeUtil.isInRecordBlock(ast)
+                || ast.getParent().getType() == TokenTypes.COMPACT_COMPILATION_UNIT;
     }
 
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/ClassMemberImpliedModifierCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/ClassMemberImpliedModifierCheck.xml
@@ -30,6 +30,18 @@
  &lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
 
  &lt;p&gt;
+ Enum, interface, and record declarations in a compact source file are members of the
+ implicitly declared class, so they are also implicitly &lt;code&gt;static&lt;/code&gt;.
+ &lt;/p&gt;
+ &lt;div class="wrapper"&gt;&lt;pre class="prettyprint"&gt;&lt;code class="language-java"&gt;
+ enum Age {  // violation
+   CHILD, ADULT
+ }
+
+ void main() {}
+ &lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+ &lt;p&gt;
  Rationale for this check: Nested enums, interfaces, and records are treated differently from
  nested classes as they are only allowed to be &lt;code&gt;static&lt;/code&gt;. Developers should not need to
  remember this rule, and this check provides the means to enforce that the modifier is coded

--- a/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
+++ b/src/site/xdoc/checks/modifier/classmemberimpliedmodifier.xml
@@ -60,6 +60,18 @@ public final class Person {
         </code></pre></div>
 
         <p>
+          Enum, interface, and record declarations in a compact source file are members of the
+          implicitly declared class, so they are also implicitly <code>static</code>.
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+enum Age {  // violation
+  CHILD, ADULT
+}
+
+void main() {}
+        </code></pre></div>
+
+        <p>
           Rationale for this check: Nested enums, interfaces, and records are treated differently from
           nested classes as they are only allowed to be <code>static</code>. Developers should not need to
           remember this rule, and this check provides the means to enforce that the modifier is coded

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
@@ -145,6 +145,29 @@ public class ClassMemberImpliedModifierCheckTest
     }
 
     @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "12:1: " + getCheckMessage(MSG_KEY, "static"),
+            "14:1: " + getCheckMessage(MSG_KEY, "static"),
+            "17:1: " + getCheckMessage(MSG_KEY, "static"),
+            "19:1: " + getCheckMessage(MSG_KEY, "static"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                    "compact/InputClassMemberImpliedModifierCompactSource.java"),
+                expected);
+    }
+
+    @Test
+    public void testCompactSourceFilePropertiesDisabled() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                    "compact/InputClassMemberImpliedModifierCompactSourceCustom.java"),
+                expected);
+    }
+
+    @Test
     public void testIllegalState() {
         final DetailAstImpl init = new DetailAstImpl();
         init.setType(TokenTypes.STATIC_INIT);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -104,7 +104,6 @@ public class AllChecksCompactSourceCoverageTest {
         "BooleanExpressionComplexityCheck",
         "CatchParameterNameCheck",
         "ClassDataAbstractionCouplingCheck",
-        "ClassMemberImpliedModifierCheck",
         "ClassTypeParameterNameCheck",
         "CommentsIndentationCheck",
         "ConstantNameCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/compact/InputClassMemberImpliedModifierCompactSource.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/compact/InputClassMemberImpliedModifierCompactSource.java
@@ -1,0 +1,30 @@
+/*
+ClassMemberImpliedModifier
+violateImpliedStaticOnNestedEnum = (default)true
+violateImpliedStaticOnNestedInterface = (default)true
+violateImpliedStaticOnNestedRecord = (default)true
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+// violation below 'Implied modifier 'static' should be explicit.'
+enum Color { RED, GREEN, BLUE }
+
+interface Printable { // violation 'Implied modifier 'static' should be explicit.'
+    void print();
+}
+record Point(int x, int y) { } // violation 'Implied modifier 'static' should be explicit.'
+
+@Deprecated enum Status { ACTIVE } // violation 'Implied modifier 'static' should be explicit.'
+
+static enum StaticColor { RED }
+static interface StaticPrintable { }
+static record StaticPoint(int x, int y) { }
+
+class OrdinaryClass { }
+
+void main() {
+    enum LocalColor { RED }
+    interface LocalPrintable { }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/compact/InputClassMemberImpliedModifierCompactSourceCustom.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/compact/InputClassMemberImpliedModifierCompactSourceCustom.java
@@ -1,0 +1,15 @@
+/*
+ClassMemberImpliedModifier
+violateImpliedStaticOnNestedEnum = false
+violateImpliedStaticOnNestedInterface = false
+violateImpliedStaticOnNestedRecord = false
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+enum Color { RED, GREEN, BLUE }
+interface Printable { }
+record Point(int x, int y) { }
+
+void main() { }


### PR DESCRIPTION
Issue: #20227

Treats enum, interface, and record declarations that are direct members of a compact compilation unit as members of its implicit class, so their implied `static` modifier can be reported. The documentation and generated metadata describe the compact-source behavior.

Adds compact-source coverage for reported declarations, explicit modifiers, ordinary and local declarations, annotations, and disabled properties.

Validation:
- focused check and compact-source coverage tests
- metadata and documentation generation tests
- `pitest-modifier` (736/736 mutations killed)
- `./mvnw -e --no-transfer-progress clean verify`
- site generation and internal link check