### PR TITLE
infra: generate site automatically for `src/site` changes

### DIFF
--- a/.ci/build-pr-comment.sh
+++ b/.ci/build-pr-comment.sh
@@ -22,9 +22,10 @@ curl --fail-with-body -X GET "${API_LINK}" \
   -o .ci-temp/info.json
 
 jq '.jobs' .ci-temp/info.json > .ci-temp/jobs
-jq '.[] | select(.conclusion == "failure") | .name' .ci-temp/jobs > .ci-temp/job_name
-jq '.[] | select(.conclusion == "failure") | .steps' .ci-temp/jobs > .ci-temp/steps
-jq '.[] | select(.conclusion == "failure") | .name' .ci-temp/steps > .ci-temp/step_name
+jq -r '.[] | select(any(.steps[]; .conclusion == "failure")) | .name' \
+  .ci-temp/jobs > .ci-temp/job_name
+jq '.[] | select(any(.steps[]; .conclusion == "failure")) | .steps' .ci-temp/jobs > .ci-temp/steps
+jq -r '.[] | select(.conclusion == "failure") | .name' .ci-temp/steps > .ci-temp/step_name
 
 if [ -n "$FAILURE_PREFIX" ]; then
   echo "${FAILURE_PREFIX} failed on phase $(cat .ci-temp/job_name)," > .ci-temp/message

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -16,8 +16,17 @@ name: "Site"
 env:
   AWS_REGION: "us-east-2"
   AWS_BUCKET_NAME: "checkstyle-diff-reports"
+  PR_NUMBER: >-
+    ${{
+      inputs.pr-number
+      || github.event.issue.number
+      || github.event.pull_request.number
+    }}
 
 on:
+  pull_request:
+    paths:
+      - 'src/site/**'
   issue_comment:
     types: [ created, edited ]
   workflow_dispatch:
@@ -33,7 +42,13 @@ permissions:
   actions: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.pr-number || github.event.issue.number || github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{
+      inputs.pr-number
+      || github.event.issue.number
+      || github.event.pull_request.number
+      || github.ref
+    }}
   cancel-in-progress: false
 
 jobs:
@@ -42,6 +57,7 @@ jobs:
           || github.event.comment.body == 'GitHub, generate website'
           || github.event.comment.body == 'GitHub, generate site'
           || inputs.pr-number != ''
+          || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: React to comment
@@ -66,14 +82,14 @@ jobs:
         id: pr_info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ inputs.pr-number || github.event.issue.number }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
         run: |
           ./.ci/site.sh get-pr-info
 
       - name: Download checkstyle for PR
         uses: actions/checkout@v7
         with:
-          ref: refs/pull/${{ inputs.pr-number || github.event.issue.number }}/head
+          ref: refs/pull/${{ env.PR_NUMBER }}/head
           path: .ci-temp/checkstyle
           fetch-depth: 0
 
@@ -105,7 +121,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_SHA: ${{ steps.pr_info.outputs.commit_sha }}
-          PR_NUMBER: ${{ inputs.pr-number || github.event.issue.number }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
           AWS_BUCKET_NAME: ${{ env.AWS_BUCKET_NAME }}
           AWS_REGION: ${{ env.AWS_REGION }}
         run: |
@@ -132,5 +148,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          issue-number: ${{ inputs.pr-number || github.event.issue.number }}
+          issue-number: ${{ env.PR_NUMBER }}
           body: ${{ steps.out.outputs.message }}


### PR DESCRIPTION
## Problem

At the moment, the Checkstyle site preview is generated only after someone manually asks GitHub to do it by posting a comment such as:

```
GitHub, generate site
```

This creates unnecessary manual work during review. Usually, maintainer arrives to new PR, sees that site has been changed, writes `GitHub, generate site`, **waits 5-10 minutes for generation** and only then reviews the actual PR changes.

There is no reason to wait for this manual interaction when GitHub already knows that the pull request modifies site sources.

## Change

Trigger site generation automatically for pull requests that modify `src/site/**`.

## Proof that it works

See https://github.com/stoyanK7/checkstyle/pull/11

<img width="901" height="432" alt="image" src="https://github.com/user-attachments/assets/c948dd99-4b0c-430a-99d2-e82f7742e8b9" />
