### PR TITLE
Issue #21119: Fix duplicate violation behavior in examples: trailingcomment

### DIFF
--- a/src/site/xdoc/checks/misc/trailingcomment.xml
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml
@@ -22,7 +22,7 @@
             <ul class="toc-sublist">
               <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
               <li><a href="#Example2-config" class="toc-sublink">Enforce only comment on a line</a></li>
-              <li><a href="#Example3-config" class="toc-sublink">Check so that trailing comment with exact comments like "SUPPRESS CHECKSTYLE", "NOPMD", "NOSONAR" are suppressed</a></li>
+              <li><a href="#Example3-config" class="toc-sublink">So that a trailing comment matching legalComment is suppressed</a></li>
             </ul>
           </li>
           <li>
@@ -205,15 +205,14 @@ public class Example2 {
 </code></pre></div><hr class="example-separator"/>
 
         <p id="Example3-config">
-          To configure check so that trailing comment with exact comments like
-          &quot;SUPPRESS CHECKSTYLE&quot;, &quot;NOPMD&quot;, &quot;NOSONAR&quot;
-          are suppressed:
+          To configure the check so that a trailing comment matching
+          legalComment is suppressed:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="TrailingComment"&gt;
-      &lt;property name="legalComment" value="^ (SUPPRESS CHECKSTYLE|NOPMD|NOSONAR)$"/&gt;
+      &lt;property name="legalComment" value="^ ok, SUPPRESS CHECKSTYLE$"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -227,7 +226,7 @@ public class Example3 {
   int a;
   int b;
   int c;
-  int d; // violation 'Don't use trailing comments.'
+  int d; // ok, SUPPRESS CHECKSTYLE
 
   public static void main(String[] args) {
     int x = 10;

--- a/src/site/xdoc/checks/misc/trailingcomment.xml.template
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml.template
@@ -69,9 +69,8 @@
         </macro><hr class="example-separator"/>
 
         <p id="Example3-config">
-          To configure check so that trailing comment with exact comments like
-          "SUPPRESS CHECKSTYLE", "NOPMD", "NOSONAR"
-          are suppressed:
+          To configure the check so that a trailing comment matching
+          legalComment is suppressed:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -109,8 +109,7 @@ public class XdocsExampleFileTest {
         "checks/naming/patternvariablename/",
         "checks/outertypefilename/",
         "checks/regexp/regexpmultiline/",
-        "checks/regexp/regexpsingleline/",
-        "checks/trailingcomment/"
+        "checks/regexp/regexpsingleline/"
     );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
@@ -59,7 +59,6 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "18:10: " + getCheckMessage(MSG_KEY),
             "24:16: " + getCheckMessage(MSG_KEY),
         };
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
@@ -2,7 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="TrailingComment">
-      <property name="legalComment" value="^ (SUPPRESS CHECKSTYLE|NOPMD|NOSONAR)$"/>
+      <property name="legalComment" value="^ ok, SUPPRESS CHECKSTYLE$"/>
     </module>
   </module>
 </module>
@@ -15,7 +15,7 @@ public class Example3 {
   int a;
   int b;
   int c;
-  int d; // violation 'Don't use trailing comments.'
+  int d; // ok, SUPPRESS CHECKSTYLE
 
   public static void main(String[] args) {
     int x = 10;


### PR DESCRIPTION
Issue: #21119

TrailingComment Example1 and Example3 produced the same visible
violation signature because legalComment was never exercised.

Example3 now matches a legalComment so that trailing comment is
allowed, and the module is removed from
SUPPRESSED_UNIQUENESS_CHECK_MODULES.

Executed:
- TrailingCommentCheckExamplesTest (6/6)
- XdocsExampleFileTest (5/5)
- XdocsExamplesAstConsistencyTest (5/5)
- XdocsPagesTest (20/20)