### PR TITLE
infra: use pull_request_target for site workflow

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -24,7 +24,7 @@ env:
     }}
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'src/site/**'
   issue_comment:
@@ -57,7 +57,7 @@ jobs:
           || github.event.comment.body == 'GitHub, generate website'
           || github.event.comment.body == 'GitHub, generate site'
           || inputs.pr-number != ''
-          || github.event_name == 'pull_request'
+          || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: React to comment


### PR DESCRIPTION
**Problem:**
Detected in https://github.com/checkstyle/checkstyle/pull/21250#issuecomment-5311299348:
> https://github.com/checkstyle/checkstyle/actions/runs/31984604063/job/95257293549?pr=21250
>
> @stoyanK7 , some failure on auto site generation
---
**PR Description:**
Changed the site workflow trigger from `pull_request` to `pull_request_target`.

For pull requests opened from forks, [GitHub runs `pull_request` workflows with a read-only `GITHUB_TOKEN`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflows-in-forked-repositories) and does not provide repository secrets. This prevents the workflow from:

* accessing the AWS credentials required to publish the generated site;
* posting the result back to the PR.

[`pull_request_target`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target) runs in the context of the base repository, so the workflow can access the required repository secrets and use the configured `pull-requests: write` permission.

The workflow still explicitly checks out the PR head when generating the site.