### PR TITLE
infra: undo automatic site generation for changes in `src/site`

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -20,13 +20,9 @@ env:
     ${{
       inputs.pr-number
       || github.event.issue.number
-      || github.event.pull_request.number
     }}
 
 on:
-  pull_request_target:
-    paths:
-      - 'src/site/**'
   issue_comment:
     types: [ created, edited ]
   workflow_dispatch:
@@ -46,7 +42,6 @@ concurrency:
     ${{ github.workflow }}-${{
       inputs.pr-number
       || github.event.issue.number
-      || github.event.pull_request.number
       || github.ref
     }}
   cancel-in-progress: false
@@ -57,7 +52,6 @@ jobs:
           || github.event.comment.body == 'GitHub, generate website'
           || github.event.comment.body == 'GitHub, generate site'
           || inputs.pr-number != ''
-          || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: React to comment


### PR DESCRIPTION
Undo all changes we made in:
- https://github.com/checkstyle/checkstyle/commit/fa695fa15bec04afac3cfa4ecf1b25aaaf2e4b29

Site generation still fails:
https://github.com/checkstyle/checkstyle/actions/runs/32154418080

> Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.