### PR TITLE
Fix issue 20954 illegaltype ignore method names

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -303,7 +303,6 @@ public final class InlineConfigParser {
      */
     private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of(
             "checks/coding/equalshashcode/Example1.java",
-            "checks/coding/illegaltype/InputIllegalTypeTestIgnoreMethodNames.java",
             "checks/coding/illegaltype/InputIllegalTypeTestEnhancedInstanceof.java",
             "checks/coding/illegaltype/InputIllegalTypeTestLegalAbstractClassNames.java",
             "checks/coding/illegaltype/InputIllegalTypeTestMemberModifiers.java",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestIgnoreMethodNames.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestIgnoreMethodNames.java
@@ -20,12 +20,12 @@ import java.util.HashMap;
 import java.util.TreeSet;
 
 public class InputIllegalTypeTestIgnoreMethodNames implements InputIllegalTypeSuper {
-    private AbstractClass a = null; // violation 'Usage of type AbstractClass is not allowed'.
+    private AbstractClass a = null; // violation "Usage of type 'AbstractClass' is not allowed."
     private NotAnAbstractClass b = null; /*another comment*/
 
     private com.puppycrawl.tools.checkstyle.checks.coding.illegaltype.InputIllegalType.AbstractClass
             c = null;
-    // violation 2 lines above 'is not allowed'
+    // violation 2 lines above "Usage of type '.*InputIllegalType.AbstractClass' is not allowed."
 
     private java.util.List d = null;
 
@@ -34,7 +34,7 @@ public class InputIllegalTypeTestIgnoreMethodNames implements InputIllegalTypeSu
     private class NotAnAbstractClass {}
 
     private java.util.TreeSet table1() { return null; }
-    // violation above 'Usage of type 'java.util.TreeSet' is not allowed'
+    // violation above "Usage of type 'java.util.TreeSet' is not allowed."
     private TreeSet table2() { return null; }
     static class SomeStaticClass {
 
@@ -44,7 +44,7 @@ public class InputIllegalTypeTestIgnoreMethodNames implements InputIllegalTypeSu
     private void table2(Integer i) {}
 
     private void getInitialContext(java.util.TreeSet v) {}
-    // violation above 'Usage of type 'java.util.TreeSet' is not allowed'
+    // violation above "Usage of type 'java.util.TreeSet' is not allowed."
 
     @Override
     public void foo(HashMap<?, ?> buffer) {} // ignore
@@ -61,9 +61,9 @@ public class InputIllegalTypeTestIgnoreMethodNames implements InputIllegalTypeSu
 }
 
 interface InputIllegalTypeSuperTestIgnoreMethodNames {
-    void foo(HashMap<?, ?> buffer); // violation 'Usage of type HashMap is not allowed'.
+    void foo(HashMap<?, ?> buffer); // violation "Usage of type 'HashMap' is not allowed."
 
-    HashMap<?, ?> foo(); // violation 'Usage of type HashMap is not allowed'.
+    HashMap<?, ?> foo(); // violation "Usage of type 'HashMap' is not allowed."
 
     Object bar();
 }


### PR DESCRIPTION
Issue: #20954

Updates the expected violation message in
InputIllegalTypeTestIgnoreMethodNames.java to match the
current IllegalTypeCheck message.

Tests:
.\mvnw "-Dtest=IllegalTypeCheckTest" "-Djacoco.skip=true" test

Tests run: 32, Failures: 0, Errors: 0, Skipped: 0
