### PR TITLE
Issue #20954: Fix AvoidStarImport violation message

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -342,7 +342,6 @@ public final class InlineConfigParser {
             "checks/coding/unusedlocalvariable/"
                     + "InputUnusedLocalVariablePatternVariablesCondition2.java",
             "checks/coding/unusedlocalvariable/InputUnusedLocalVariableUnnamedTryCatch.java",
-            "checks/imports/avoidstarimport/InputAvoidStarImportExcludes.java",
             "checks/sizes/recordcomponentnumber/Example2.java",
             "checks/whitespace/separatorwrap/Example1.java",
             "com/google/checkstyle/test/chapter5naming/rule522classnames/"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/InputAvoidStarImportExcludes.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/InputAvoidStarImportExcludes.java
@@ -28,7 +28,7 @@ import static java.io.File.listRoots;
 import static javax.swing.WindowConstants.*; // ok as excluded in checks
 import static javax.swing.WindowConstants.*; // ok as excluded in checks
 import static java.io.File.createTempFile;
-import static java.io.File.*; // violation 'Avoid Star Import'.
+import static java.io.File.*; // violation 'Using the '.*' form of import should be avoided.'
 
 import java.awt.Component;
 import java.awt.Graphics2D;


### PR DESCRIPTION
Issue: #20954

Changes:
- Updated the violation message comment in `InputAvoidStarImportExcludes.java` to use an actual quoted substring of Checkstyle output
- Removed the corresponding temporary message-validation suppression

Validation:
- `./mvnw -Dtest=AvoidStarImportCheckTest test`
- `./mvnw test`