### PR TITLE
Issue #21251: fix landing page broken anchors, replace JavadocStyle, …

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -672,7 +672,6 @@ javadocpackage
 javadocparagraph
 javadocpropertiesgenerator
 javadocregexp
-javadocstyle
 javadoctagcontinuationindentation
 javadoctags
 javadoctype

--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -369,7 +369,7 @@ a.cs-card {
 #demo-typename:checked ~ .cs-toggle-labels label[for="demo-typename"],
 #demo-finalclass:checked ~ .cs-toggle-labels label[for="demo-finalclass"],
 #demo-magicnumber:checked ~ .cs-toggle-labels label[for="demo-magicnumber"],
-#demo-javadocstyle:checked ~ .cs-toggle-labels label[for="demo-javadocstyle"],
+#demo-missingjavadocmethod:checked ~ .cs-toggle-labels label[for="demo-missingjavadocmethod"],
 #demo-leftcurly:checked ~ .cs-toggle-labels label[for="demo-leftcurly"] {
   background: #08c;
   color: #fff;
@@ -379,7 +379,7 @@ a.cs-card {
 #demo-typename:checked ~ #panel-typename,
 #demo-finalclass:checked ~ #panel-finalclass,
 #demo-magicnumber:checked ~ #panel-magicnumber,
-#demo-javadocstyle:checked ~ #panel-javadocstyle,
+#demo-missingjavadocmethod:checked ~ #panel-missingjavadocmethod,
 #demo-leftcurly:checked ~ #panel-leftcurly {
   display: block;
 }
@@ -909,6 +909,15 @@ section#Properties .wrapper table td a {
     align-self: center;
     transform: rotate(90deg);
     padding: 2px 0;
+  }
+
+  .cs-workflow-code {
+    max-height: none;
+    padding: 8px 10px;
+  }
+
+  .cs-workflow-card > .wrapper {
+    margin: 0;
   }
 
   #leftColumn {

--- a/src/site/resources/js/anchors.js
+++ b/src/site/resources/js/anchors.js
@@ -69,7 +69,16 @@
                 return;
             }
 
-            const name = anchorItem.previousSibling.previousElementSibling.id;
+            // skip headings that have no preceding anchor element
+            const previousSibling = anchorItem.previousSibling;
+            if (!previousSibling || !previousSibling.previousElementSibling) {
+                return;
+            }
+
+            const name = previousSibling.previousElementSibling.id;
+            if (!name) {
+                return;
+            }
             const link = url + "#" + name;
 
             createAnchor(anchorItem, link, name, relativePath, anchorItem);

--- a/src/site/xdoc/index.xml.vm
+++ b/src/site/xdoc/index.xml.vm
@@ -118,14 +118,14 @@
                checked="checked"/>
         <input type="radio" name="cs-check-demo" id="demo-finalclass" class="cs-toggle-input"/>
         <input type="radio" name="cs-check-demo" id="demo-magicnumber" class="cs-toggle-input"/>
-        <input type="radio" name="cs-check-demo" id="demo-javadocstyle" class="cs-toggle-input"/>
+        <input type="radio" name="cs-check-demo" id="demo-missingjavadocmethod" class="cs-toggle-input"/>
         <input type="radio" name="cs-check-demo" id="demo-leftcurly" class="cs-toggle-input"/>
 
         <div class="cs-toggle-labels">
           <label for="demo-typename">TypeName</label>
           <label for="demo-finalclass">FinalClass</label>
           <label for="demo-magicnumber">MagicNumber</label>
-          <label for="demo-javadocstyle">JavadocStyle</label>
+          <label for="demo-missingjavadocmethod">MissingJavadocMethod</label>
           <label for="demo-leftcurly">LeftCurly</label>
         </div>
 
@@ -158,13 +158,15 @@
             should be named constants.</p>
         </div>
 
-        <div id="panel-javadocstyle" class="cs-toggle-panel cs-check-panel cs-code-wrapper">
-          <pre class="cs-check-code"><span class="cs-code-comment">// Missing javadoc</span>
-<span class="cs-code-keyword">public void</span> method() {}</pre>
+        <div id="panel-missingjavadocmethod" class="cs-toggle-panel cs-check-panel cs-code-wrapper">
+          <pre class="cs-check-code"><span class="cs-code-keyword">public class</span> MyClass {
+  <span class="cs-code-keyword">public void</span> method() {}
+}</pre>
           <p class="cs-check-violation"><span class="cs-check-badge">ERROR</span>
-            MyClass.java:2:1: Missing a Javadoc comment. <b>[JavadocStyle]</b></p>
-          <p class="cs-check-desc">Ensures public methods have Javadoc comments for proper
-            documentation.</p>
+            MyClass.java:2:3: Missing a Javadoc comment for 'method'.
+            <b>[MissingJavadocMethod]</b></p>
+          <p class="cs-check-desc">Requires Javadoc comments on public methods to ensure
+            proper API documentation.</p>
         </div>
 
         <div id="panel-leftcurly" class="cs-toggle-panel cs-check-panel cs-code-wrapper">


### PR DESCRIPTION
Issue #21251: fix landing page broken anchors, replace JavadocStyle, reduce mobile padding

1. anchors.js: Add null-safety to prevent crash on empty h1 from <section name="">
2. index.xml.vm: Replace removed JavadocStyle demo with MissingJavadocMethod
3. site.css: Update CSS selectors and add mobile overrides for workflow code padding
