### PR TITLE
infra: isolate AWS credentials from untrusted diff report generation

### DIFF
--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -103,10 +103,7 @@ jobs:
     needs: parse_body
     if: needs.parse_body.outputs.config_link != ''
             || needs.parse_body.outputs.new_module_config_link != ''
-    outputs:
-      message: ${{ steps.out.outputs.message }}
     steps:
-
       - name: Download checkstyle
         uses: actions/checkout@v7
 
@@ -148,18 +145,41 @@ jobs:
         run: |
           ./.ci/diff-report.sh prepare-environment
 
+      - name: Generate report
+        env:
+          BRANCH: ${{ needs.parse_body.outputs.branch }}
+        run: |
+          ./.ci/diff-report.sh generate-report
+
+      - name: Upload generated report
+        uses: actions/upload-artifact@v7
+        with:
+          name: diff-report
+          path: .ci-temp/contribution/checkstyle-tester/reports/diff
+          if-no-files-found: error
+          retention-days: 1
+
+  publish_report:
+    runs-on: ubuntu-latest
+    needs: [ parse_body, make_report ]
+    outputs:
+      message: ${{ steps.out.outputs.message }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Download generated report
+        uses: actions/download-artifact@v8
+        with:
+          name: diff-report
+          path: .ci-temp/contribution/checkstyle-tester/reports/diff
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
-
-      - name: Generate report
-        env:
-          BRANCH: ${{ needs.parse_body.outputs.branch }}
-        run: |
-          ./.ci/diff-report.sh generate-report
 
       - name: Copy Report to AWS S3 Bucket
         env:
@@ -176,7 +196,7 @@ jobs:
   # should be always last step
   send_message:
     runs-on: ubuntu-latest
-    needs: [ parse_body, make_report ]
+    needs: [ parse_body, make_report, publish_report ]
     if: failure() || success()
     steps:
       - name: Checkout repository
@@ -184,7 +204,7 @@ jobs:
 
       - name: Build PR comment message
         env:
-          MSG: ${{ needs.make_report.outputs.message }}
+          MSG: ${{ needs.publish_report.outputs.message }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           FAILURE_PREFIX: "Report generation"


### PR DESCRIPTION
This PR separates report generation from AWS publishing.

We run the diff report against PR-controlled code. That code can execute Maven plugins. Previously, we configured AWS credentials on the same runner.

We now generate the report in an untrusted job without AWS credentials. We pass the result as a workflow artifact to a new publishing job. The publishing job runs on a fresh runner and configures our AWS credentials there.

This prevents PR-controlled code from accessing our AWS credentials.
