### PR TITLE
Issue #20954: Quote IllegalType static imports violation messages

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -318,7 +318,6 @@ public final class InlineConfigParser {
             "checks/coding/illegaltype/InputIllegalTypeSameFileNameFalsePositive.java",
             "checks/coding/illegaltype/InputIllegalTypeTestSameFileNameGeneral.java",
             "checks/coding/illegaltype/InputIllegalTypeTestStarImports.java",
-            "checks/coding/illegaltype/InputIllegalTypeTestStaticImports.java",
             "checks/coding/noclone/Example1.java",
             "checks/coding/unusedlocalvariable/Example1.java",
             "checks/coding/unusedlocalvariable/Example2.java",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestStaticImports.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeTestStaticImports.java
@@ -23,8 +23,8 @@ public class InputIllegalTypeTestStaticImports
      private boolean foo(String s) {
          return true;
      }
-     SomeStaticClass staticClass; // violation 'Usage of type SomeStaticClass is not allowed'.
+     SomeStaticClass staticClass; // violation "Usage of type 'SomeStaticClass' is not allowed."
      private static SomeStaticClass foo1() { return null;}
      private static void foo2(SomeStaticClass s) {}
-     // violation above 'Usage of type 'SomeStaticClass' is not allowed'
+     // violation above "Usage of type 'SomeStaticClass' is not allowed."
 }


### PR DESCRIPTION
Issue: #20954

Updated violation message comments in
`InputIllegalTypeTestStaticImports.java` to use the actual quoted
IllegalType messages.

The message is defined as
`illegal.type=Usage of type ''{0}'' is not allowed.`, which renders as
`Usage of type 'SomeStaticClass' is not allowed.` The existing comment on
line 26 omitted the quotes around the type name, so
`InlineConfigParser`'s message-capturing group never activated and the
message text was never validated. Both comments now use the
double-quoted wrapper form already used elsewhere in this package.

Removed `checks/coding/illegaltype/InputIllegalTypeTestStaticImports.java`
from `SUPPRESSED_VALIDATE_MESSAGE_FILES` so violation messages are now
validated.

`IllegalTypeCheckTest` passes (32/32). With the previous comment restored
and the suppression removed, `testStaticImports` fails with
`Violation message should be specified on line 26`, confirming the
message is now actually verified.
