### PR TITLE
minor: add forgotten failure() condition

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -151,7 +151,7 @@ jobs:
   send_message:
     runs-on: ubuntu-latest
     needs: [ site, publish_site ]
-    if: always()
+    if: failure() || success()
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
After the recent changes in 4252c1c23b, the `site` workflow runs on every PR comment. This PR fixes that by adding a forgotten `failure()` check. That check is present in our 2 other workflows that are triggered by `issue_comment`:
https://github.com/checkstyle/checkstyle/blob/d182d8b25adb3ca9c7b259b251eaf124e250b9d3/.github/workflows/diff-report.yml#L200

Tested on my fork:
- https://github.com/stoyanK7/checkstyle/pull/16
- https://github.com/stoyanK7/checkstyle/actions/runs/32335161519 (workflow skipped for regular comment)
- https://github.com/stoyanK7/checkstyle/actions/runs/32335207735 (workflow runs for `Github, generate site`)
- <img width="905" height="350" alt="image" src="https://github.com/user-attachments/assets/2c33b6c0-728b-494b-9988-8abca8f66958" />
