### PR TITLE
Issue #21254: Use `com.puppycrawl.tools.checkstyle-files-generator`

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1341,7 +1341,6 @@ stemp
 stext
 sthref
 stmt
-stoyank
 streamapi
 streamreader
 strictfp

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
     <slf4j.version>2.0.18</slf4j.version>
     <saxon.version>12.9</saxon.version>
     <checkstyle.plugin.version>3.6.0</checkstyle.plugin.version>
-    <checkstyle-files-generator.version>1.0.4</checkstyle-files-generator.version>
+    <checkstyle-files-generator.version>1.0.0</checkstyle-files-generator.version>
     <sevntu.checkstyle.plugin.version>1.44.1</sevntu.checkstyle.plugin.version>
     <sevntu-checkstyle-check.checkstyle.version>
       10.4
@@ -1048,7 +1048,7 @@
         </executions>
         <dependencies>
           <dependency>
-            <groupId>io.github.stoyank7</groupId>
+            <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle-files-generator</artifactId>
             <version>${checkstyle-files-generator.version}</version>
             <exclusions>


### PR DESCRIPTION
This PR is the last step of the following issue:
- #21254

`com.puppycrawl.tools.checkstyle-files-generator` version `1.0.0` was [published yesterday](https://central.sonatype.com/artifact/com.puppycrawl.tools/checkstyle-files-generator).

The `checkstyle-files-generator` was supplied from `io.github.stoyank7` until now. This PR changes that `groupId` to `com.puppycrawl.tools`. 