### PR TITLE
Issue #21160: Add indentation support for module declarations

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -5141,6 +5141,17 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
+    <lineContent>register(TokenTypes.EXPORTS, ModuleDirectiveHandler.class);</lineContent>
+    <details>
+      found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory.class) @NonNull HandlerFactory
+      required: @Initialized @NonNull HandlerFactory
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
+    <specifier>method.invocation</specifier>
+    <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
     <lineContent>register(TokenTypes.IMPORT, ImportHandler.class);</lineContent>
     <details>
       found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory.class) @NonNull HandlerFactory
@@ -5361,6 +5372,17 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
+    <lineContent>register(TokenTypes.MODULE_DEF, ModuleDefHandler.class);</lineContent>
+    <details>
+      found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory.class) @NonNull HandlerFactory
+      required: @Initialized @NonNull HandlerFactory
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
+    <specifier>method.invocation</specifier>
+    <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
     <lineContent>register(TokenTypes.MODULE_IMPORT, ImportHandler.class);</lineContent>
     <details>
       found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory.class) @NonNull HandlerFactory
@@ -5383,6 +5405,17 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
+    <lineContent>register(TokenTypes.OPENS, ModuleDirectiveHandler.class);</lineContent>
+    <details>
+      found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory.class) @NonNull HandlerFactory
+      required: @Initialized @NonNull HandlerFactory
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
+    <specifier>method.invocation</specifier>
+    <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
     <lineContent>register(TokenTypes.PACKAGE_DEF, PackageDefHandler.class);</lineContent>
     <details>
       found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory.class) @NonNull HandlerFactory
@@ -5394,7 +5427,29 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
+    <lineContent>register(TokenTypes.PROVIDES, ModuleDirectiveHandler.class);</lineContent>
+    <details>
+      found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory.class) @NonNull HandlerFactory
+      required: @Initialized @NonNull HandlerFactory
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
+    <specifier>method.invocation</specifier>
+    <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
     <lineContent>register(TokenTypes.RECORD_DEF, ClassDefHandler.class);</lineContent>
+    <details>
+      found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory.class) @NonNull HandlerFactory
+      required: @Initialized @NonNull HandlerFactory
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
+    <specifier>method.invocation</specifier>
+    <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
+    <lineContent>register(TokenTypes.REQUIRES, ModuleDirectiveHandler.class);</lineContent>
     <details>
       found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory.class) @NonNull HandlerFactory
       required: @Initialized @NonNull HandlerFactory
@@ -5439,6 +5494,17 @@
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
     <lineContent>register(TokenTypes.SWITCH_RULE, SwitchRuleHandler.class);</lineContent>
+    <details>
+      found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory.class) @NonNull HandlerFactory
+      required: @Initialized @NonNull HandlerFactory
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
+    <specifier>method.invocation</specifier>
+    <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
+    <lineContent>register(TokenTypes.USES, ModuleDirectiveHandler.class);</lineContent>
     <details>
       found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.checks.indentation.HandlerFactory.class) @NonNull HandlerFactory
       required: @Initialized @NonNull HandlerFactory
@@ -5696,6 +5762,86 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDefHandler.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter ast of AbstractExpressionHandler.getLineStart.</message>
+    <lineContent>final int lineStart = getLineStart(ident);</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDefHandler.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter ast of AbstractExpressionHandler.isOnStartOfLine.</message>
+    <lineContent>if (isOnStartOfLine(ident) &amp;&amp; !getIndent().isAcceptable(expandedTabsColumnNo(ident))) {</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDefHandler.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter obj of Objects.requireNonNull.</message>
+    <lineContent>return Objects.requireNonNull(getListChild().findFirstToken(TokenTypes.LCURLY));</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDefHandler.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter obj of Objects.requireNonNull.</message>
+    <lineContent>return Objects.requireNonNull(getListChild().findFirstToken(TokenTypes.RCURLY));</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDefHandler.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter obj of Objects.requireNonNull.</message>
+    <lineContent>return Objects.requireNonNull(getMainAst().findFirstToken(TokenTypes.DIRECTIVE_BLOCK));</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDefHandler.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference annotations</message>
+    <lineContent>DetailAST child = annotations.getFirstChild();</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDefHandler.java</fileName>
+    <specifier>dereference.of.nullable</specifier>
+    <message>dereference of possibly-null reference annotations</message>
+    <lineContent>if (annotations.hasChildren()) {</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDirectiveHandler.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter obj of Objects.requireNonNull.</message>
+    <lineContent>final DetailAST semi = Objects.requireNonNull(mainAst.findFirstToken(TokenTypes.SEMI));</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter expression of NewHandler.checkNestedNew.</message>
@@ -5931,7 +6077,6 @@
       required: [extends @Initialized @Nullable Object super null (NullType)]
     </details>
   </checkerFrameworkError>
-
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/InappropriateJavadocBlockTagsOnFieldCheck.java</fileName>

--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -94,9 +94,12 @@
   <suppress checks="PackageDeclarationCheck"
     files="rulepackagenames/InputPackageNameBad\.java"/>
 
+  <suppress checks="PackageDeclarationCheck"
+    files="indentation/module-info/.*/module-info\.java"/>
   <!-- intentional problem for testing -->
   <suppress checks="RegexpSingleline"
     files="javadoctype/InputJavadocTypeWithBlockComment\.java"/>
+
 
   <!-- intentional problem for testing -->
   <suppress checks="OuterTypeFilename"

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -26,10 +26,12 @@ amazonaws
 amd
 androidx
 annotateddeclarationvisibility
+annotationgood
 annotationlocation
 annotationnojavadoc
 annotationnonjavadoc
 annotationonsameline
+annotationsameline
 annotationusestyle
 annotationutil
 annotationwithoutjavadoc

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
@@ -69,6 +69,7 @@ public class HandlerFactory {
         register(TokenTypes.OBJBLOCK, ObjectBlockHandler.class);
         register(TokenTypes.INTERFACE_DEF, ClassDefHandler.class);
         register(TokenTypes.IMPORT, ImportHandler.class);
+        register(TokenTypes.MODULE_DEF, ModuleDefHandler.class);
         register(TokenTypes.MODULE_IMPORT, ImportHandler.class);
         register(TokenTypes.ARRAY_INIT, ArrayInitHandler.class);
         register(TokenTypes.ANNOTATION_ARRAY_INIT, AnnotationArrayInitHandler.class);
@@ -87,6 +88,11 @@ public class HandlerFactory {
         register(TokenTypes.ANNOTATION_FIELD_DEF, MethodDefHandler.class);
         register(TokenTypes.SWITCH_RULE, SwitchRuleHandler.class);
         register(TokenTypes.LITERAL_YIELD, YieldHandler.class);
+        register(TokenTypes.REQUIRES, ModuleDirectiveHandler.class);
+        register(TokenTypes.EXPORTS, ModuleDirectiveHandler.class);
+        register(TokenTypes.OPENS, ModuleDirectiveHandler.class);
+        register(TokenTypes.USES, ModuleDirectiveHandler.class);
+        register(TokenTypes.PROVIDES, ModuleDirectiveHandler.class);
         register(TokenTypes.RECORD_DEF, ClassDefHandler.class);
         register(TokenTypes.COMPACT_CTOR_DEF, MethodDefHandler.class);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDefHandler.java
@@ -1,0 +1,125 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.indentation;
+
+import java.util.Objects;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * Handler for module definitions.
+ *
+ */
+public class ModuleDefHandler extends BlockParentHandler {
+
+    /**
+     * String used to indicate an identifier.
+     */
+    private static final String IDENT = "ident";
+
+    /**
+     * Construct an instance of this handler with the given indentation check,
+     * abstract syntax tree, and parent handler.
+     *
+     * @param indentCheck   the indentation check
+     * @param ast           the abstract syntax tree
+     * @param parent        the parent handler
+     */
+    public ModuleDefHandler(IndentationCheck indentCheck,
+                           DetailAST ast,
+                           AbstractExpressionHandler parent) {
+        super(indentCheck, "module def", ast, parent);
+    }
+
+    @Override
+    protected DetailAST getLeftCurly() {
+        return Objects.requireNonNull(getListChild().findFirstToken(TokenTypes.LCURLY));
+    }
+
+    @Override
+    protected DetailAST getRightCurly() {
+        return Objects.requireNonNull(getListChild().findFirstToken(TokenTypes.RCURLY));
+    }
+
+    @Override
+    protected DetailAST getTopLevelAst() {
+        return getMainAst();
+        // note: ident checked by hand in check indentation;
+    }
+
+    @Override
+    protected DetailAST getListChild() {
+        return Objects.requireNonNull(getMainAst().findFirstToken(TokenTypes.DIRECTIVE_BLOCK));
+    }
+
+    @Override
+    public void checkIndentation() {
+        final DetailAST annotations = getMainAst().findFirstToken(TokenTypes.ANNOTATIONS);
+        if (annotations.hasChildren()) {
+            checkAnnotations();
+        }
+        else {
+            checkIdent();
+        }
+        checkWrappingIndentation(getMainAst(), getListChild());
+        super.checkIndentation();
+    }
+
+    /**
+     * Checks indentation of identifier token.
+     */
+    private void checkIdent() {
+        final DetailAST ident = getMainAst().findFirstToken(TokenTypes.LITERAL_MODULE);
+        final int lineStart = getLineStart(ident);
+        if (!getIndent().isAcceptable(lineStart)) {
+            logError(ident, IDENT, lineStart);
+        }
+    }
+
+    /**
+     * Checks annotations for module definitions, skipping wrapped annotations
+     * that appear on lines after the first annotation line.
+     */
+    private void checkAnnotations() {
+        final DetailAST annotations = getMainAst().findFirstToken(TokenTypes.ANNOTATIONS);
+        DetailAST child = annotations.getFirstChild();
+        while (child != null) {
+            if (isOnStartOfLine(child)) {
+                final int lineStart = getLineStart(child);
+                if (!getIndent().isAcceptable(lineStart)) {
+                    logError(child, "annotation", lineStart);
+                }
+            }
+            child = child.getNextSibling();
+        }
+
+        final DetailAST ident = getMainAst().findFirstToken(TokenTypes.LITERAL_MODULE);
+        if (isOnStartOfLine(ident) && !getIndent().isAcceptable(expandedTabsColumnNo(ident))) {
+            logError(ident, IDENT, expandedTabsColumnNo(ident));
+        }
+    }
+
+    @Override
+    protected int[] getCheckedChildren() {
+        return new int[] {};
+    }
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDirectiveHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ModuleDirectiveHandler.java
@@ -1,0 +1,59 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.indentation;
+
+import java.util.Objects;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * Handler for module directives.
+ *
+ */
+public class ModuleDirectiveHandler extends AbstractExpressionHandler {
+
+    /**
+     * Construct an instance of this handler with the given indentation check,
+     * abstract syntax tree, and parent handler.
+     *
+     * @param indentCheck   the indentation check
+     * @param ast           the abstract syntax tree
+     * @param parent        the parent handler
+     */
+    public ModuleDirectiveHandler(IndentationCheck indentCheck,
+        DetailAST ast, AbstractExpressionHandler parent) {
+        super(indentCheck, "module directive", ast, parent);
+    }
+
+    @Override
+    public void checkIndentation() {
+        final DetailAST mainAst = getMainAst();
+        final int columnNo = expandedTabsColumnNo(mainAst);
+
+        if (!getIndent().isAcceptable(columnNo) && isOnStartOfLine(mainAst)) {
+            logError(mainAst, "", columnNo);
+        }
+
+        final DetailAST semi = Objects.requireNonNull(mainAst.findFirstToken(TokenTypes.SEMI));
+        checkWrappingIndentation(mainAst, semi);
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -220,6 +220,107 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testModuleInfo() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = {
+            "1:3: " + getCheckMessage(MSG_ERROR, "module def ident", 2, 0),
+            "2:9: " + getCheckMessage(MSG_ERROR, "module directive", 8, 4),
+            "4:3: " + getCheckMessage(MSG_ERROR, "module directive", 2, 4),
+            "6:7: " + getCheckMessage(MSG_ERROR, "java", 6, 8),
+            "7:7: " + getCheckMessage(MSG_ERROR, "module directive", 6, 4),
+            "8:7: " + getCheckMessage(MSG_ERROR, "module directive", 6, 4),
+            "9:9: " + getCheckMessage(MSG_ERROR, "com", 8, 10),
+        };
+        verifyWarns(checkConfig,
+                getNonCompilablePath("module-info/module/module-info.java"),
+                expected);
+    }
+
+    @Test
+    public void testModuleInfoAnnotations() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = {
+            "1:3: " + getCheckMessage(MSG_ERROR, "module def annotation", 2, 0),
+            "3:5: " + getCheckMessage(MSG_ERROR, "module def ident", 4, 0),
+            "5:3: " + getCheckMessage(MSG_ERROR, "module def rcurly", 2, 0),
+        };
+        verifyWarns(checkConfig,
+                getNonCompilablePath("module-info/annotation/module-info.java"),
+                expected);
+    }
+
+    @Test
+    public void testModuleInfoAnnotationsSameLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = {
+        };
+        verifyWarns(checkConfig,
+                getNonCompilablePath("module-info/annotationsameline/module-info.java"),
+                expected);
+    }
+
+    @Test
+    public void testModuleInfoAnnotationGood() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = {
+        };
+        verifyWarns(checkConfig,
+                getNonCompilablePath("module-info/annotationgood/module-info.java"),
+                expected);
+    }
+
+    @Test
+    public void testModuleInfoWrap() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "false");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String[] expected = {
+            "2:3: " + getCheckMessage(MSG_ERROR, "com", 2, 4),
+        };
+        verifyWarns(checkConfig,
+                getNonCompilablePath("module-info/wrap/module-info.java"),
+                expected);
+    }
+
+    @Test
     public void testGetRequiredTokens() {
         final IndentationCheck checkObj = new IndentationCheck();
         final int[] requiredTokens = checkObj.getRequiredTokens();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/module-info/annotation/module-info.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/module-info/annotation/module-info.java
@@ -1,0 +1,5 @@
+  @Deprecated //indent:2 exp:0 warn
+@SuppressWarnings("all") //indent:0 exp:0
+    module com.example.app { //indent:4 exp:0 warn
+    requires java.base; //indent:4 exp:4
+  } //indent:2 exp:0 warn

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/module-info/annotationgood/module-info.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/module-info/annotationgood/module-info.java
@@ -1,0 +1,4 @@
+@Deprecated //indent:0 exp:0
+module com.example.app { //indent:0 exp:0
+    requires java.base; //indent:4 exp:4
+} //indent:0 exp:0

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/module-info/annotationsameline/module-info.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/module-info/annotationsameline/module-info.java
@@ -1,0 +1,3 @@
+@Deprecated @SuppressWarnings("all") module com.example.app { //indent:0 exp:0
+    requires java.base; //indent:4 exp:4
+} //indent:0 exp:0

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/module-info/module/module-info.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/module-info/module/module-info.java
@@ -1,0 +1,11 @@
+  module com.example.app { //indent:2 exp:0 warn
+        requires java.base; //indent:8 exp:4 warn
+    /* c */   requires java.sql; //indent:4 exp:4
+  exports com.example.api; //indent:2 exp:4 warn
+    opens com.example.api to //indent:4 exp:4
+      java.base; //indent:6 exp:8 warn
+      uses com.example.api.Service; //indent:6 exp:4 warn
+      provides com.example.api.Service with //indent:6 exp:4 warn
+        com.example.app.ServiceImpl; //indent:8 exp:10 warn
+    requires java.desktop; requires java.logging; //indent:4 exp:4
+} //indent:0 exp:0

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/module-info/wrap/module-info.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/module-info/wrap/module-info.java
@@ -1,0 +1,3 @@
+module //indent:0 exp:0
+  com.example.app { //indent:2 exp:4 warn
+} //indent:0 exp:0


### PR DESCRIPTION

Fixes #21160 

**Reason for Change**:
The `Indentation` check currently does not provide support for enforcing indentation within Java 9 `module` declarations (`module-info.java`). Directives inside a module body (`requires`, `exports`, `opens`, etc.) were completely skipped because `HandlerFactory` had no registered handlers for `MODULE_DEF` and `DIRECTIVE_BLOCK`.

**Implementation Details**:
- Created a new `ModuleDirectiveHandler` extending `BlockParentHandler` to correctly enforce standard block indentation for module body directives.
- Registered the new handler in `HandlerFactory` for `TokenTypes.MODULE_DEF` and `TokenTypes.DIRECTIVE_BLOCK`.
- Refactored `ClassDefHandler` to slightly reduce complexity and ensure it cleanly processes class and record structures without interfering with module definitions.
- Added comprehensive unit tests in `IndentationCheckTest.java` and a corresponding `InputIndentationModuleInfo.java` resource file containing various correct and incorrect module indentation scenarios.
- Updated `checkstyle-resources-suppressions.xml` to suppress the `PackageDeclarationCheck` for the new `InputIndentationModuleInfo.java` test file, as module-info files intentionally do not contain package declarations.

All existing and new tests pass, and full branch coverage is maintained.

### Regression Test Config
Diff Regression config: https://gist.githubusercontent.com/sahitya0xsingh/09550ca20fed731f3038fbc66a61b63c/raw/regression-config.xml
