### PR TITLE
infra: use latest xwiki to fix build problem on stale parents

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -447,8 +447,7 @@ no-error-xwiki)
   cd ..
   removeFolderWithProtectedFiles xwiki-rendering
   cd ..
-  checkout_from https://github.com/xwiki/xwiki-platform.git \
-    "16906187c4ab5d3c""cf93cd4818ad577579a7e7eb"
+  checkout_from https://github.com/xwiki/xwiki-platform.git
   cd .ci-temp/xwiki-platform
   # Validate xwiki-platform
   mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version="${CS_POM_VERSION}"


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/checkstyle/checkstyle/50603/workflows/cca57a13-f170-4efb-afd2-39c2537e1b88/jobs/1780738

```
Cloning into 'xwiki-platform'...
remote: Enumerating objects: 2308615, done.        
remote: Counting objects: 100% (1953/1953), done.        
remote: Compressing objects: 100% (719/719), done.        
remote: Total 2308615 (delta 1454), reused 1286 (delta 1196), pack-reused 2306662 (from 3)        
Receiving objects: 100% (2308615/2308615), 626.67 MiB | 39.40 MiB/s, done.
Resolving deltas: 100% (1112175/1112175), done.
Updating files: 100% (14814/14814), done.
Note: switching to '16906187c4ab5d3ccf93cd4818ad577579a7e7eb'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 16906187c4a [Misc] Apply the logging best practices to oldcore and 7 more platform modules (#6068)
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for org.xwiki.platform:xwiki-platform:18.7.0-SNAPSHOT: The following artifacts could not be resolved: org.xwiki.commons:xwiki-commons-pom:pom:18.7.0-SNAPSHOT (absent): Could not find artifact org.xwiki.commons:xwiki-commons-pom:pom:18.7.0-SNAPSHOT and 'parent.relativePath' points at no local POM @ line 23, column 11
 @ 
[ERROR] Error executing a DevelocityListener callback
org.apache.maven.MavenExecutionException: Failed to evaluate custom user data Groovy script: /home/circleci/project/.ci-temp/xwiki-platform/.mvn/develocity-custom-user-data.groovy
    at com.gradle.GroovyScriptUserData.evaluateGroovyScript (GroovyScriptUserData.java:79)
    at com.gradle.GroovyScriptUserData.evaluateGroovyScriptInRootProject (GroovyScriptUserData.java:37)
    at com.gradle.GroovyScriptUserData.evaluate (GroovyScriptUserData.java:21)
    at com.gradle.CommonCustomUserDataListener.configure (CommonCustomUserDataListener.java:32)
    at com.gradle.CommonCustomUserDataDevelocityListener.configure (CommonCustomUserDataDevelocityListener.java:13)
    at com.gradle.maven.internal.DevelocityLifecycleManager.a (SourceFile:385)
    at java.lang.Iterable.forEach (Iterable.java:75)
    at java.util.Collections$UnmodifiableCollection.forEach (Collections.java:1116)
    at com.gradle.maven.internal.DevelocityLifecycleManager.b (SourceFile:383)
    at com.gradle.maven.internal.DevelocityLifecycleManager.c (SourceFile:355)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.accept (ForEachOps.java:184)
    at java.util.stream.ReferencePipeline$15$1.accept (ReferencePipeline.java:541)
    at java.util.stream.IntPipeline$1$1.accept (IntPipeline.java:180)
    at java.util.stream.Streams$RangeIntSpliterator.forEachRemaining (Streams.java:104)
    at java.util.Spliterator$OfInt.forEachRemaining (Spliterator.java:712)
    at java.util.stream.AbstractPipeline.copyInto (AbstractPipeline.java:509)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto (AbstractPipeline.java:499)
    at java.util.stream.ForEachOps$ForEachOp.evaluateSequential (ForEachOps.java:151)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential (ForEachOps.java:174)
    at java.util.stream.AbstractPipeline.evaluate (AbstractPipeline.java:234)
    at java.util.stream.ReferencePipeline.forEach (ReferencePipeline.java:596)
    at com.gradle.maven.internal.DevelocityLifecycleManager.a (SourceFile:355)
    at com.gradle.maven.internal.DevelocityLifecycleManager.onEvent (SourceFile:298)
    at org.apache.maven.eventspy.internal.EventSpyDispatcher.onEvent (EventSpyDispatcher.java:86)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:908)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
Caused by: java.lang.NullPointerException: Cannot get property 'activeProfiles' on null object
```