### PR TITLE
Issue #21268: fix broken JavadocTokenTypes.html anchor links in lyche…

### DIFF
--- a/config/lychee.toml
+++ b/config/lychee.toml
@@ -1,10 +1,3 @@
 # Suppressions for lychee link checker
-# until https://github.com/checkstyle/checkstyle/issues/21268
 exclude = [
-  "apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_BLOCK_TAG",
-  "apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#EXCEPTION_BLOCK_TAG",
-  "apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_BLOCK_TAG",
-  "apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_BLOCK_TAG",
-  "apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#SINCE_BLOCK_TAG",
-  "apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_BLOCK_TAG",
 ]

--- a/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml
+++ b/src/site/xdoc/checks/javadoc/nonemptyatclausedescription.xml
@@ -58,32 +58,32 @@
               <td><a id="javadocTokens"/><a href="#javadocTokens">javadocTokens</a></td>
               <td>javadoc tokens to check</td>
               <td>subset of javadoc tokens
-                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_BLOCK_TAG">
+                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#PARAM_BLOCK_TAG">
                     PARAM_BLOCK_TAG</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_BLOCK_TAG">
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#RETURN_BLOCK_TAG">
                     RETURN_BLOCK_TAG</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_BLOCK_TAG">
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#THROWS_BLOCK_TAG">
                     THROWS_BLOCK_TAG</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#EXCEPTION_BLOCK_TAG">
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#EXCEPTION_BLOCK_TAG">
                     EXCEPTION_BLOCK_TAG</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_BLOCK_TAG">
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#DEPRECATED_BLOCK_TAG">
                     DEPRECATED_BLOCK_TAG</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#SINCE_BLOCK_TAG">
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#SINCE_BLOCK_TAG">
                     SINCE_BLOCK_TAG</a>
                   .
               </td>
               <td>
-                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_BLOCK_TAG">
+                <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#PARAM_BLOCK_TAG">
                     PARAM_BLOCK_TAG</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_BLOCK_TAG">
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#RETURN_BLOCK_TAG">
                     RETURN_BLOCK_TAG</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_BLOCK_TAG">
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#THROWS_BLOCK_TAG">
                     THROWS_BLOCK_TAG</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#EXCEPTION_BLOCK_TAG">
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#EXCEPTION_BLOCK_TAG">
                     EXCEPTION_BLOCK_TAG</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_BLOCK_TAG">
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#DEPRECATED_BLOCK_TAG">
                     DEPRECATED_BLOCK_TAG</a>
-                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#SINCE_BLOCK_TAG">
+                , <a href="../../apidocs/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.html#SINCE_BLOCK_TAG">
                     SINCE_BLOCK_TAG</a>
                   .
               </td>


### PR DESCRIPTION
#21268

follow-up PR of https://github.com/checkstyle/checkstyle-files-generator/pull/14
part of Issue: #21268

Changes added in `checkstyle-files-generator`, on build generated SNAPSHOT which was used to build main repo -> auto generated these changes.

ci is expected to fail due to version difference in both repos.