### PR TITLE
Issue #21137: add default config example for SuppressionFilter

### DIFF
--- a/src/site/xdoc/filters/suppressionfilter.xml
+++ b/src/site/xdoc/filters/suppressionfilter.xml
@@ -20,7 +20,9 @@
             <input type="checkbox" id="toc-sub-Examples" class="toc-sub-toggle-checkbox" checked="checked"/>
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#SuppressionFilter_Examples">Examples</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
-              <li><a href="#Example1-config" class="toc-sublink">Suppress certain checks by check name, file, and line number</a></li>
+              <li><a href="#Example1-config" class="toc-sublink">Default configuration does nothing</a></li>
+              <li><a href="#Example2-config" class="toc-sublink">Suppress certain checks by check name, file, and line number</a></li>
+              <li><a href="#Example3-config" class="toc-sublink">To ignore a missing suppressions file</a></li>
             </ul>
           </li>
           <li>
@@ -153,6 +155,38 @@
       </subsection>
       <subsection name="Examples" id="SuppressionFilter_Examples">
         <p id="Example1-config">
+          Default configuration does nothing:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="SuppressionFilter"/&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MemberName"/&gt;
+    &lt;module name="MagicNumber"/&gt;
+    &lt;module name="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example1-code">Code example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example1 {
+
+  // violation below 'Name 'MyVariable' must match pattern'
+  int MyVariable;
+
+  int a = 10; // violation ''10' is a magic number.'
+
+  public void exampleMethod() {
+
+    int num = 100; // violation ''100' is a magic number.'
+
+    if (true) {
+      // violation above 'Must have at least one statement.'
+    }
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example2-config">
             Suppress certain checks by check name, file, and line number:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
@@ -173,9 +207,9 @@
           a <code>SuppressionFilter</code> to
           reject <code>MemberNameCheck</code> violations for
           line 20 of
-          file <code>Example1.java</code>,
+          file <code>Example2.java</code>,
           and <code>MagicNumberCheck</code> violations for lines
-          22 and 26 of file <code>Example1.java</code>,
+          22 and 26 of file <code>Example2.java</code>,
           and <code>'Missing a Javadoc comment for'</code> violations
           for all lines and files:
         </p>
@@ -188,17 +222,17 @@
 
 &lt;suppressions&gt;
   &lt;suppress checks="MemberName"
-    files="Example1.java"
+    files="Example2.java"
     lines="20"/&gt;
   &lt;suppress checks="MagicNumber"
-    files="Example1.java"
+    files="Example2.java"
     lines="22,26"/&gt;
   &lt;suppress message="Missing a Javadoc comment for"/&gt;
 &lt;/suppressions&gt;
 </code></pre></div>
-        <p id="Example1-code">Example:</p>
+        <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example1 {
+public class Example2 {
 
   // filtered violation below 'Name 'MyVariable' must match pattern'
   int MyVariable;
@@ -208,6 +242,41 @@ public class Example1 {
   public void exampleMethod() {
 
     int num = 100; // filtered violation ''100' is a magic number.'
+
+    if (true) {
+      // violation above 'Must have at least one statement.'
+    }
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example3-config">
+          To ignore a missing suppressions file:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="SuppressionFilter"&gt;
+    &lt;property name="file" value="nonexisting.xml"/&gt;
+    &lt;property name="optional" value="true"/&gt;
+  &lt;/module&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MemberName"/&gt;
+    &lt;module name="MagicNumber"/&gt;
+    &lt;module name="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example3-code">Code example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example3 {
+
+  // violation below 'Name 'MyVariable' must match pattern'
+  int MyVariable;
+
+  int a = 10; // violation ''10' is a magic number.'
+
+  public void exampleMethod() {
+
+    int num = 100; // violation ''100' is a magic number.'
 
     if (true) {
       // violation above 'Must have at least one statement.'

--- a/src/site/xdoc/filters/suppressionfilter.xml.template
+++ b/src/site/xdoc/filters/suppressionfilter.xml.template
@@ -37,11 +37,25 @@
       </subsection>
       <subsection name="Examples" id="SuppressionFilter_Examples">
         <p id="Example1-config">
-            Suppress certain checks by check name, file, and line number:
+          Default configuration does nothing:
         </p>
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example1.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example1-code">Code example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example1.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example2-config">
+            Suppress certain checks by check name, file, and line number:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example2.java"/>
           <param name="type" value="config"/>
         </macro>
         <p id="suppressionexample1-raw">
@@ -49,9 +63,9 @@
           a <code>SuppressionFilter</code> to
           reject <code>MemberNameCheck</code> violations for
           line 20 of
-          file <code>Example1.java</code>,
+          file <code>Example2.java</code>,
           and <code>MagicNumberCheck</code> violations for lines
-          22 and 26 of file <code>Example1.java</code>,
+          22 and 26 of file <code>Example2.java</code>,
           and <code>'Missing a Javadoc comment for'</code> violations
           for all lines and files:
         </p>
@@ -60,10 +74,24 @@
                  value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample1.xml"/>
           <param name="type" value="raw"/>
         </macro>
-        <p id="Example1-code">Example:</p>
+        <p id="Example2-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example1.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example2.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="Example3-config">
+          To ignore a missing suppressions file:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example3.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example3-code">Code example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example3.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -154,7 +154,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/descendanttoken",
             "checks/imports/importcontrol",
             "filters/severitymatchfilter",
-            "filters/suppressionfilter",
             "filters/suppressionsinglefilter",
             "filters/suppressionxpathfilter",
             "filters/suppresswithplaintextcommentfilter"

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterExamplesTest.java
@@ -41,6 +41,21 @@ public class SuppressionFilterExamplesTest extends AbstractExamplesModuleTestSup
 
     @Test
     public void testExample1() throws Exception {
+        final String[] expected = {
+            "20:7: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN,
+                    "MyVariable", "^[a-z][a-zA-Z0-9]*$"),
+            "22:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "10"),
+            "26:15: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "100"),
+            "28:15: " + getCheckMessage(EmptyBlockCheck.class,
+                    "block.noStatement"),
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example1.java"),
+                expected, expected);
+    }
+
+    @Test
+    public void testExample2() throws Exception {
 
         final String[] expectedWithoutFilter = {
             "20:7: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN,
@@ -56,9 +71,23 @@ public class SuppressionFilterExamplesTest extends AbstractExamplesModuleTestSup
                     EmptyBlockCheck.MSG_KEY_BLOCK_NO_STATEMENT),
         };
 
-        verifyFilterWithInlineConfigParser(getPath("Example1.java"),
+        verifyFilterWithInlineConfigParser(getPath("Example2.java"),
                 expectedWithoutFilter,
                 expectedWithFilter);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = {
+            "20:7: " + getCheckMessage(MemberNameCheck.class, MSG_INVALID_PATTERN,
+                    "MyVariable", "^[a-z][a-zA-Z0-9]*$"),
+            "22:11: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "10"),
+            "26:15: " + getCheckMessage(MagicNumberCheck.class, MagicNumberCheck.MSG_KEY, "100"),
+            "28:15: " + getCheckMessage(EmptyBlockCheck.class, "block.noStatement"),
+        };
+
+        verifyFilterWithInlineConfigParser(getPath("Example3.java"),
+                expected, expected);
     }
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example2.java
@@ -1,6 +1,9 @@
 /*xml
 <module name="Checker">
-  <module name="SuppressionFilter"/>
+  <module name="SuppressionFilter">
+    <property name="file" value="suppressionexample1.xml"/>
+    <property name="optional" value="false"/>
+  </module>
   <module name="TreeWalker">
     <module name="MemberName"/>
     <module name="MagicNumber"/>
@@ -9,21 +12,18 @@
 </module>
 */
 
-
-
-
 package com.puppycrawl.tools.checkstyle.filters.suppressionfilter;
 // xdoc section - start
-public class Example1 {
+public class Example2 {
 
-  // violation below 'Name 'MyVariable' must match pattern'
+  // filtered violation below 'Name 'MyVariable' must match pattern'
   int MyVariable;
 
-  int a = 10; // violation ''10' is a magic number.'
+  int a = 10; // filtered violation ''10' is a magic number.'
 
   public void exampleMethod() {
 
-    int num = 100; // violation ''100' is a magic number.'
+    int num = 100; // filtered violation ''100' is a magic number.'
 
     if (true) {
       // violation above 'Must have at least one statement.'

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/Example3.java
@@ -1,6 +1,9 @@
 /*xml
 <module name="Checker">
-  <module name="SuppressionFilter"/>
+  <module name="SuppressionFilter">
+    <property name="file" value="nonexisting.xml"/>
+    <property name="optional" value="true"/>
+  </module>
   <module name="TreeWalker">
     <module name="MemberName"/>
     <module name="MagicNumber"/>
@@ -9,12 +12,9 @@
 </module>
 */
 
-
-
-
 package com.puppycrawl.tools.checkstyle.filters.suppressionfilter;
 // xdoc section - start
-public class Example1 {
+public class Example3 {
 
   // violation below 'Name 'MyVariable' must match pattern'
   int MyVariable;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample1.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionfilter/suppressionexample1.xml
@@ -6,10 +6,10 @@
 
 <suppressions>
   <suppress checks="MemberName"
-    files="Example1.java"
+    files="Example2.java"
     lines="20"/>
   <suppress checks="MagicNumber"
-    files="Example1.java"
+    files="Example2.java"
     lines="22,26"/>
   <suppress message="Missing a Javadoc comment for"/>
 </suppressions>


### PR DESCRIPTION
 Issue: #21137

SuppressionFilter had no example demonstrating its default configuration,
so it was listed in EXAMPLE_DEFAULT_CONFIG_SUPPRESSED_MODULES.

 Changes:
- Added Example1.java demonstrating the zero-property configuration. 
- Added Example3.java demonstrating `optional="true"` 
- Added testExample1 and testExample3 and the previous testExample1 became
  testExample2.
- Updated suppressionfilter.xml.template and .xml accordingly.
- Removed "filters/suppressionfilter" from
  EXAMPLE_DEFAULT_CONFIG_SUPPRESSED_MODULES.

mvn clean verify passes locally.

https://checkstyle.org/filters/suppressionfilter.html
