### PR TITLE
Issue #20792: New check: JavadocNoErrorInThrowsTag

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -767,6 +767,7 @@
     <module name="JavadocMissingLeadingAsterisk"/>
     <module name="JavadocLeadingAsteriskAlign"/>
     <module name="JavadocMissingWhitespaceAfterAsterisk"/>
+    <module name="JavadocNoErrorInThrowsTag"/>
     <module name="JavadocParagraph"/>
     <module name="JavadocParamOrder"/>
     <module name="JavadocRegexp"/>

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -668,6 +668,7 @@ javadoclinkwellknownapi
 javadocmethod
 javadocmissingleadingasterisk
 javadocmissingwhitespaceafterasterisk
+javadocnoerrorinthrowstag
 javadocpackage
 javadocparagraph
 javadocparamorder

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -720,6 +720,8 @@ public class PackageObjectFactory implements ModuleFactory {
                 BASE_PACKAGE + ".checks.javadoc.JavadocMissingLeadingAsteriskCheck");
         NAME_TO_FULL_MODULE_NAME.put("JavadocMissingWhitespaceAfterAsteriskCheck",
                 BASE_PACKAGE + ".checks.javadoc.JavadocMissingWhitespaceAfterAsteriskCheck");
+        NAME_TO_FULL_MODULE_NAME.put("JavadocNoErrorInThrowsTagCheck",
+                BASE_PACKAGE + ".checks.javadoc.JavadocNoErrorInThrowsTagCheck");
         NAME_TO_FULL_MODULE_NAME.put("JavadocPackageCheck",
                 BASE_PACKAGE + ".checks.javadoc.JavadocPackageCheck");
         NAME_TO_FULL_MODULE_NAME.put("JavadocParagraphCheck",

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNoErrorInThrowsTagCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNoErrorInThrowsTagCheck.java
@@ -1,0 +1,234 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
+import com.puppycrawl.tools.checkstyle.api.FullIdent;
+import com.puppycrawl.tools.checkstyle.api.JavadocCommentsTokenTypes;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
+
+/**
+ * <div>
+ * Checks that {@code Error} types are not documented in {@code @throws} or
+ * {@code @exception} Javadoc tags.
+ * </div>
+ *
+ * <p>
+ * Per the documentation comments style guide, errors generally should not be
+ * documented because they are unpredictable. This check reports documented
+ * throwable names whose simple name ends with {@code Error}, unless the same
+ * Error type is explicitly thrown with {@code throw new} in the documented
+ * method or constructor.
+ * </p>
+ *
+ * @since 14.1.0
+ */
+@FileStatefulCheck
+public class JavadocNoErrorInThrowsTagCheck extends AbstractJavadocCheck {
+
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_KEY = "javadoc.no.error.in.throws.tag";
+
+    /** Type names explicitly thrown in the current documented construct. */
+    private final Set<String> thrownTypeNames = new HashSet<>();
+
+    /**
+     * Creates a new {@code JavadocNoErrorInThrowsTagCheck} instance.
+     */
+    public JavadocNoErrorInThrowsTagCheck() {
+        // no code by default
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public final int[] getRequiredTokens() {
+        return new int[] {
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
+        };
+    }
+
+    @Override
+    public int[] getDefaultJavadocTokens() {
+        return getRequiredJavadocTokens();
+    }
+
+    @Override
+    public int[] getRequiredJavadocTokens() {
+        return new int[] {
+            JavadocCommentsTokenTypes.THROWS_BLOCK_TAG,
+            JavadocCommentsTokenTypes.EXCEPTION_BLOCK_TAG,
+        };
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        final DetailAST blockCommentNode = JavadocUtil.getAttachedJavadocComment(ast);
+        if (blockCommentNode != null) {
+            collectThrownErrorTypes(ast);
+            try {
+                super.visitToken(blockCommentNode);
+            }
+            finally {
+                thrownTypeNames.clear();
+            }
+        }
+    }
+
+    @Override
+    public void visitJavadocToken(DetailNode ast) {
+        final DetailNode identifier = JavadocUtil.findFirstToken(
+                ast, JavadocCommentsTokenTypes.IDENTIFIER);
+
+        if (identifier != null
+                && isErrorType(identifier.getText())
+                && !isExplicitlyThrown(identifier.getText())) {
+            final String tagName = getTagName(ast);
+            log(ast, MSG_KEY, identifier.getText(), tagName);
+        }
+    }
+
+    /**
+     * Collects type names explicitly thrown by {@code throw new} in a construct.
+     *
+     * @param ast documented construct
+     */
+    private void collectThrownErrorTypes(DetailAST ast) {
+        DetailAST current = ast;
+        while (current != null) {
+            if (current.getType() == TokenTypes.LITERAL_THROW
+                    && !isInIgnoreBlock(ast, current)) {
+                collectThrownErrorType(current);
+            }
+
+            if (current.hasChildren()) {
+                current = current.getFirstChild();
+            }
+            else {
+                while (!current.equals(ast) && current.getNextSibling() == null) {
+                    current = current.getParent();
+                }
+                if (current.equals(ast)) {
+                    current = null;
+                }
+                else {
+                    current = current.getNextSibling();
+                }
+            }
+        }
+    }
+
+    /**
+     * Collects type name from a {@code throw new} statement.
+     *
+     * @param throwAst throw statement
+     */
+    private void collectThrownErrorType(DetailAST throwAst) {
+        final DetailAST expressionAst = throwAst.getFirstChild();
+        final DetailAST firstExpressionAst = expressionAst.getFirstChild();
+        if (firstExpressionAst.getType() == TokenTypes.LITERAL_NEW) {
+            final String typeName = FullIdent.createFullIdentBelow(firstExpressionAst)
+                    .getText();
+            thrownTypeNames.add(getSimpleName(typeName));
+        }
+    }
+
+    /**
+     * Checks if a 'throw' usage is contained within a block that should be ignored.
+     * Such blocks consist of try (with catch) blocks, local classes, anonymous classes,
+     * and lambda expressions. Note that a try block without catch is not considered.
+     *
+     * @param constructAst DetailAST node representing the documented construct
+     * @param throwAst DetailAST node representing the 'throw' literal
+     * @return true if throwAst is inside a block that should be ignored
+     */
+    private static boolean isInIgnoreBlock(DetailAST constructAst, DetailAST throwAst) {
+        DetailAST ancestor = throwAst;
+        while (!ancestor.equals(constructAst)) {
+            if (ancestor.getType() == TokenTypes.LAMBDA
+                    || ancestor.getType() == TokenTypes.OBJBLOCK
+                    || ancestor.findFirstToken(TokenTypes.LITERAL_CATCH) != null) {
+                break;
+            }
+            if (ancestor.getType() == TokenTypes.LITERAL_CATCH
+                    || ancestor.getType() == TokenTypes.LITERAL_FINALLY) {
+                ancestor = ancestor.getParent();
+            }
+            ancestor = ancestor.getParent();
+        }
+        return !ancestor.equals(constructAst);
+    }
+
+    /**
+     * Checks whether class name is an Error type name.
+     *
+     * @param className class name
+     * @return true if class name is an Error type name
+     */
+    private static boolean isErrorType(String className) {
+        return className.endsWith("Error");
+    }
+
+    /**
+     * Checks whether Error type is explicitly thrown in current documented construct.
+     *
+     * @param className class name
+     * @return true if Error type is explicitly thrown in current documented construct
+     */
+    private boolean isExplicitlyThrown(String className) {
+        return thrownTypeNames.contains(getSimpleName(className));
+    }
+
+    /**
+     * Gets simple class name.
+     *
+     * @param className class name
+     * @return simple class name
+     */
+    private static String getSimpleName(String className) {
+        return className.substring(className.lastIndexOf('.') + 1);
+    }
+
+    /**
+     * Gets the Javadoc tag name from a throws or exception block tag.
+     *
+     * @param ast throws or exception block tag
+     * @return tag name with leading at sign
+     */
+    private static String getTagName(DetailNode ast) {
+        return "@" + JavadocUtil.findFirstToken(ast,
+                JavadocCommentsTokenTypes.TAG_NAME).getText();
+    }
+
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -14,6 +14,7 @@ javadoc.legacyPackageHtml=Legacy package.html file should be removed.
 javadoc.missing.asterisk=Javadoc line should start with leading asterisk.
 javadoc.missing.named=Missing a Javadoc comment for ''{0}''.
 javadoc.missing.whitespace=Missing a whitespace after the leading asterisk.
+javadoc.no.error.in.throws.tag=Error type ''{0}'' should not be documented in ''{1}'' tag.
 javadoc.packageInfo=Missing package-info.java file.
 javadoc.paragraph.line.before=<p> tag should be preceded with an empty line.
 javadoc.paragraph.misplaced.tag=<p> tag should be placed immediately before the first word, with no space after.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -14,6 +14,7 @@ javadoc.legacyPackageHtml=Die veraltete Datei package.html sollte entfernt werde
 javadoc.missing.asterisk=Javadoc-Zeile sollte mit führenden Sternchen.
 javadoc.missing.named=Es fehlt ein Javadoc-Kommentar für ''{0}''.
 javadoc.missing.whitespace=Nach dem Sternchen fehlt ein Leerzeichen.
+javadoc.no.error.in.throws.tag=Der Fehlertyp ''{0}'' sollte nicht im Tag ''{1}'' dokumentiert werden.
 javadoc.packageInfo=Es fehlt eine package-info.java.
 javadoc.paragraph.line.before=Einem <p>-Tag im Javadoc sollte eine leere Zeile vorangestellt werden.
 javadoc.paragraph.misplaced.tag=<p>-Tag sollte unmittelbar vor dem ersten Wort platziert werden, ohne Leerzeichen dazwischen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -14,6 +14,7 @@ javadoc.legacyPackageHtml=Archivo package.html legado debe ser eliminado.
 javadoc.missing.asterisk=La línea Javadoc debe comenzar con el asterisco inicial.
 javadoc.missing.named=Falta el comentario Javadoc para ''{0}''.
 javadoc.missing.whitespace=Falta un espacio en blanco después del asterisco principal.
+javadoc.no.error.in.throws.tag=El tipo de error ''{0}'' no debe documentarse en la etiqueta ''{1}''.
 javadoc.packageInfo=Falta el archivo package-info.java.
 javadoc.paragraph.line.before=<p> etiqueta debe ir precedida de una línea vacía.
 javadoc.paragraph.misplaced.tag=<p> etiqueta debe colocarse inmediatamente antes de la primera palabra, sin espacio después.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -14,6 +14,7 @@ javadoc.legacyPackageHtml=Legacy package.html tiedosto tulisi poistaa.
 javadoc.missing.asterisk=Javadoc linja pitäisi aloittaa johtava tähti.
 javadoc.missing.named=Javadoc-kommentti puuttuu kohteelta ''{0}''.
 javadoc.missing.whitespace=Valkoinen tila puuttuu edessä olevan tähden jälkeen.
+javadoc.no.error.in.throws.tag=Virhetyyppiä ''{0}'' ei pidä dokumentoida ''{1}''-tunnisteessa.
 javadoc.packageInfo=Puuttuu package-info.java tiedosto.
 javadoc.paragraph.line.before=<P> tag pitäisi edeltää tyhjä rivi.
 javadoc.paragraph.misplaced.tag=<P> tag olisi sijoitettava välittömästi ennen ensimmäistä sanaa, jossa ei ole tilaa jälkeen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -14,6 +14,7 @@ javadoc.legacyPackageHtml=L''ancien fichier package.html doit être supprimé.
 javadoc.missing.asterisk=La ligne Javadoc doit commencer par un astérisque.
 javadoc.missing.named=Commentaire Javadoc manquant pour ''{0}''.
 javadoc.missing.whitespace=Manque un espace après l''astérisque de tête.
+javadoc.no.error.in.throws.tag=Le type d''erreur ''{0}'' ne doit pas être documenté dans la balise ''{1}''.
 javadoc.packageInfo=Le fichier package-info.java est manquant.
 javadoc.paragraph.line.before=La balise <p> doit être précédée d''une ligne vide.
 javadoc.paragraph.misplaced.tag=La balise <p> doit être placée immédiatement avant le premier mot, sans espace après.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -14,6 +14,7 @@ javadoc.legacyPackageHtml=古い形式のpackage.htmlファイルは削除して
 javadoc.missing.asterisk=Javadoc 行の先頭はアスタリスクで始まる必要があります。
 javadoc.missing.named=''{0}'' の Javadoc コメントがありません。
 javadoc.missing.whitespace=先頭のアスタリスクの後に空白がありません。
+javadoc.no.error.in.throws.tag=エラー タイプ ''{0}'' は、''{1}'' タグ内に記述すべきではありません。
 javadoc.packageInfo=package-info.javaファイルがありません。
 javadoc.paragraph.line.before=<p> タグの前には空行を入れてください。
 javadoc.paragraph.misplaced.tag=<p> タグは、最初の単語のすぐ前に記載してください。タグの後ろにスペースを入れないでください。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -14,6 +14,7 @@ javadoc.legacyPackageHtml=O arquivo package.html legado deve ser removido.
 javadoc.missing.asterisk=A linha Javadoc deveria começar com um asterisco inicial.
 javadoc.missing.named=Falta o comentário Javadoc para ''{0}''.
 javadoc.missing.whitespace=Falta um espaço em branco após o asterisco inicial.
+javadoc.no.error.in.throws.tag=O tipo de erro ''{0}'' não deve ser documentado na tag ''{1}''.
 javadoc.packageInfo=O arquivo package-info.java está faltando.
 javadoc.paragraph.line.before=A tag <p> deveria ser precedida por uma linha vazia.
 javadoc.paragraph.misplaced.tag=A tag <p> deveria ser colocada imediatamente antes da primeira palavra, sem espaço depois.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ru.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ru.properties
@@ -14,6 +14,7 @@ javadoc.legacyPackageHtml=Устаревший файл package.html следу�
 javadoc.missing.asterisk=Строка Javadoc должна начинаться со звёздочки '*'.
 javadoc.missing.named=Пропущен Javadoc комментарий для ''{0}''.
 javadoc.missing.whitespace=Пропущен пробел после звёздочки '*'.
+javadoc.no.error.in.throws.tag=Тип ошибки ''{0}'' не должен документироваться в теге ''{1}''.
 javadoc.packageInfo=Пропущен файл package-info.java.
 javadoc.paragraph.line.before=Перед тегом <p> должна быть пустая строка.
 javadoc.paragraph.misplaced.tag=Тег <p> должен стоять перед первым символом, сразу после последнего, без пробелов между ними.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -14,6 +14,7 @@ javadoc.legacyPackageHtml=Eskide kalan package.html dosyaları kaldırılmalı.
 javadoc.missing.asterisk=Javadoc hattı önde gelen yıldız işareti ile başlamalıdır.
 javadoc.missing.named=''{0}'' için Javadoc açıklaması eksik.
 javadoc.missing.whitespace=Önde gelen yıldız işaretinden sonra boşluk bırakma.
+javadoc.no.error.in.throws.tag=''{0}'' hata türü, ''{1}'' etiketinde belgelenmemelidir.
 javadoc.packageInfo=package-info.java dosyası eksik.
 javadoc.paragraph.line.before=<p> etiketi boş bir çizgi ile gelmelidir.
 javadoc.paragraph.misplaced.tag=<p> etiketi sonra boşluk, ilk kelimenin hemen önce konulmalıdır.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -14,6 +14,7 @@ javadoc.legacyPackageHtml=文件 package.html 应被删除。
 javadoc.missing.asterisk=Javadoc行应该以领先的星号开始。
 javadoc.missing.named=缺少 ''{0}'' 的 Javadoc 。
 javadoc.missing.whitespace=前导星号后缺少空格。
+javadoc.no.error.in.throws.tag=错误类型 ''{0}'' 不应记录在 ''{1}'' 标记中。
 javadoc.packageInfo=缺少 package-info.java 文件。
 javadoc.paragraph.line.before=<p> 标签前应有空行。
 javadoc.paragraph.misplaced.tag=<p> 标签应在第一个字符之前，紧邻后者，之间不允许有空格。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocNoErrorInThrowsTagCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocNoErrorInThrowsTagCheck.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle-metadata>
+   <module>
+      <check fully-qualified-name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNoErrorInThrowsTagCheck"
+             name="JavadocNoErrorInThrowsTag"
+             parent="com.puppycrawl.tools.checkstyle.TreeWalker">
+         <description>&lt;div&gt;
+ Checks that &lt;code&gt;Error&lt;/code&gt; types are not documented in &lt;code&gt;@throws&lt;/code&gt; or
+ &lt;code&gt;@exception&lt;/code&gt; Javadoc tags.
+ &lt;/div&gt;
+
+ &lt;p&gt;
+ Per the documentation comments style guide, errors generally should not be
+ documented because they are unpredictable. This check reports documented
+ throwable names whose simple name ends with &lt;code&gt;Error&lt;/code&gt;, unless the same
+ Error type is explicitly thrown with &lt;code&gt;throw new&lt;/code&gt; in the documented
+ method or constructor.
+ &lt;/p&gt;</description>
+         <properties>
+            <property default-value="false"
+                      name="violateExecutionOnNonTightHtml"
+                      type="boolean">
+               <description>Control when to print violations if the Javadoc being examined by this check violates the tight html rules defined at &lt;a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules"&gt;Tight-HTML Rules&lt;/a&gt;.</description>
+            </property>
+         </properties>
+         <message-keys>
+            <message-key key="javadoc.no.error.in.throws.tag"/>
+            <message-key key="javadoc.parse.rule.error"/>
+            <message-key key="javadoc.unclosedHtml"/>
+         </message-keys>
+      </check>
+   </module>
+</checkstyle-metadata>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -243,6 +243,8 @@
                 href="checks/javadoc/javadocmissingleadingasterisk.html"/>
           <item name="JavadocMissingWhitespaceAfterAsterisk"
                 href="checks/javadoc/javadocmissingwhitespaceafterasterisk.html"/>
+          <item name="JavadocNoErrorInThrowsTag"
+                href="checks/javadoc/javadocnoerrorinthrowstag.html"/>
           <item name="JavadocPackage" href="checks/javadoc/javadocpackage.html"/>
           <item name="JavadocParagraph" href="checks/javadoc/javadocparagraph.html"/>
           <item name="JavadocParamOrder" href="checks/javadoc/javadocparamorder.html"/>

--- a/src/site/xdoc/checks.xml
+++ b/src/site/xdoc/checks.xml
@@ -921,6 +921,17 @@
           </tr>
           <tr>
             <td>
+              <a href="checks/javadoc/javadocnoerrorinthrowstag.html#JavadocNoErrorInThrowsTag">
+                JavadocNoErrorInThrowsTag
+              </a>
+            </td>
+            <td>
+              Checks that <code>Error</code> types are not documented in <code>@throws</code> or
+              <code>@exception</code> Javadoc tags.
+            </td>
+          </tr>
+          <tr>
+            <td>
               <a href="checks/javadoc/javadocpackage.html#JavadocPackage">
                 JavadocPackage
               </a>

--- a/src/site/xdoc/checks/javadoc/index.xml
+++ b/src/site/xdoc/checks/javadoc/index.xml
@@ -130,6 +130,17 @@
           </tr>
           <tr>
             <td>
+              <a href="javadocnoerrorinthrowstag.html#JavadocNoErrorInThrowsTag">
+                JavadocNoErrorInThrowsTag
+              </a>
+            </td>
+            <td>
+              Checks that <code>Error</code> types are not documented in <code>@throws</code> or
+              <code>@exception</code> Javadoc tags.
+            </td>
+          </tr>
+          <tr>
+            <td>
               <a href="javadocpackage.html#JavadocPackage">
                 JavadocPackage
               </a>

--- a/src/site/xdoc/checks/javadoc/javadocnoerrorinthrowstag.xml
+++ b/src/site/xdoc/checks/javadoc/javadocnoerrorinthrowstag.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>JavadocNoErrorInThrowsTag</title>
+  </head>
+  <body>
+    <section name="JavadocNoErrorInThrowsTag">
+      <p>Since Checkstyle 14.1.0</p>
+      <div class="toc-panel">
+  <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>
+  <label for="toc-toggle" class="toc-toggle-arrow" title="Collapse"/>
+  <div class="toc-content">
+    <p class="toc-heading">On This Page</p>
+    <ul class="toc-list">
+          <li><a href="#JavadocNoErrorInThrowsTag_Description">Description</a></li>
+          <li><a href="#JavadocNoErrorInThrowsTag_Properties">Properties</a></li>
+          <li>
+            <input type="checkbox" id="toc-sub-Examples" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#JavadocNoErrorInThrowsTag_Examples">Examples</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
+            </ul>
+          </li>
+          <li><a href="#JavadocNoErrorInThrowsTag_Example_of_Usage">Example of Usage</a></li>
+          <li><a href="#JavadocNoErrorInThrowsTag_Violation_Messages">Violation Messages</a></li>
+          <li><a href="#JavadocNoErrorInThrowsTag_Fully_Qualified_Name">Fully Qualified Name</a></li>
+          <li><a href="#JavadocNoErrorInThrowsTag_Parent_Module">Parent Module</a></li>
+    </ul>
+  </div>
+</div>
+      <subsection name="Description" id="JavadocNoErrorInThrowsTag_Description">
+        <div>
+          Checks that <code>Error</code> types are not documented in <code>@throws</code> or
+          <code>@exception</code> Javadoc tags.
+        </div>
+
+        <p>
+          Per the documentation comments style guide, errors generally should not be
+          documented because they are unpredictable. This check reports documented
+          throwable names whose simple name ends with <code>Error</code>, unless the same
+          Error type is explicitly thrown with <code>throw new</code> in the documented
+          method or constructor.
+        </p>
+      </subsection>
+
+      <subsection name="Properties" id="JavadocNoErrorInThrowsTag_Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td><a id="violateExecutionOnNonTightHtml"/><a href="#violateExecutionOnNonTightHtml">violateExecutionOnNonTightHtml</a></td>
+              <td>Control when to print violations if the Javadoc being examined by this check violates the tight html rules defined at <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
+              <td><a href="../../property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>14.1.0</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="JavadocNoErrorInThrowsTag_Examples">
+        <p id="Example1-config">
+          To configure the check:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="JavadocNoErrorInThrowsTag"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example1-code">
+        Example1:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class Example1 {
+  /**
+   * Valid Javadoc.
+   *
+   * @throws IOException if an input or output exception occurs.
+   * @throws IllegalArgumentException if the argument is invalid.
+   */
+  void validExceptions() throws IOException {
+  }
+
+  /**
+   * Valid explicit Error.
+   *
+   * @throws OutOfMemoryError if memory is exhausted.
+   */
+  void validExplicitError() {
+    throw new OutOfMemoryError("memory exhausted");
+  }
+
+  // violation 5 lines below """Error type 'StackOverflowError' should not be
+  // documented in '@throws' tag."""
+  /**
+   * Invalid Javadoc.
+   *
+   * @throws StackOverflowError if recursion is too deep.
+   */
+  void invalidError() {
+  }
+}
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Example of Usage" id="JavadocNoErrorInThrowsTag_Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocNoErrorInThrowsTag">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="JavadocNoErrorInThrowsTag_Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.no.error.in.throws.tag%22">
+              javadoc.no.error.in.throws.tag
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.parse.rule.error%22">
+              javadoc.parse.rule.error
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unclosedHtml%22">
+              javadoc.unclosedHtml
+            </a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Fully Qualified Name"
+            id="JavadocNoErrorInThrowsTag_Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNoErrorInThrowsTagCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="JavadocNoErrorInThrowsTag_Parent_Module">
+        <p>
+          <a href="../../config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/site/xdoc/checks/javadoc/javadocnoerrorinthrowstag.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocnoerrorinthrowstag.xml.template
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://maven.apache.org/XDOC/2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
+  <head>
+    <title>JavadocNoErrorInThrowsTag</title>
+  </head>
+  <body>
+    <section name="JavadocNoErrorInThrowsTag">
+      <macro name="since">
+        <param name="modulePath"
+               value="src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNoErrorInThrowsTagCheck.java"/>
+      </macro>
+      <macro name="sitetoc">
+        <param name="modulePath"
+               value="src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNoErrorInThrowsTagCheck.java"/>
+      </macro>
+      <subsection name="Description" id="JavadocNoErrorInThrowsTag_Description">
+        <macro name="description">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNoErrorInThrowsTagCheck.java"/>
+        </macro>
+      </subsection>
+
+      <subsection name="Properties" id="JavadocNoErrorInThrowsTag_Properties">
+        <div class="wrapper">
+          <macro name="properties">
+            <param name="modulePath"
+                   value="src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNoErrorInThrowsTagCheck.java"/>
+          </macro>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="JavadocNoErrorInThrowsTag_Examples">
+        <p id="Example1-config">
+          To configure the check:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/Example1.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="Example1-code">
+        Example1:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/Example1.java"/>
+          <param name="type" value="code"/>
+        </macro>
+      </subsection>
+
+      <subsection name="Example of Usage" id="JavadocNoErrorInThrowsTag_Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocNoErrorInThrowsTag">
+            Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="JavadocNoErrorInThrowsTag_Violation_Messages">
+        <macro name="violation-messages">
+          <param name="checkName" value="JavadocNoErrorInThrowsTag"/>
+        </macro>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="../../config.html#Custom_messages">see the documentation</a>
+          to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Fully Qualified Name"
+            id="JavadocNoErrorInThrowsTag_Fully_Qualified_Name">
+        <p>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNoErrorInThrowsTagCheck</p>
+        <p>
+          Use this fully qualified class name in configuration when an exact class reference is
+          required.
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="JavadocNoErrorInThrowsTag_Parent_Module">
+        <macro name="parent-module">
+          <param name="moduleName" value="JavadocNoErrorInThrowsTag"/>
+        </macro>
+      </subsection>
+    </section>
+  </body>
+</document>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNoErrorInThrowsTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNoErrorInThrowsTagCheckTest.java
@@ -1,0 +1,84 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+
+public class JavadocNoErrorInThrowsTagCheckTest extends AbstractModuleTestSupport {
+
+    private static final String MSG_KEY = JavadocNoErrorInThrowsTagCheck.MSG_KEY;
+
+    @Override
+    public String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag";
+    }
+
+    @Test
+    public void testCorrect() throws Exception {
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocNoErrorInThrowsTagCorrect.java"),
+                CommonUtil.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testIncorrect() throws Exception {
+        final String[] expected = {
+            "16:8: " + getCheckMessage(MSG_KEY, "Error", "@throws"),
+            "26:8: " + getCheckMessage(MSG_KEY, "java.lang.Error", "@throws"),
+            "37:8: " + getCheckMessage(MSG_KEY, "OutOfMemoryError", "@throws"),
+            "53:8: " + getCheckMessage(MSG_KEY, "StackOverflowError", "@exception"),
+            "66:8: " + getCheckMessage(MSG_KEY, "com.example.CustomError", "@throws"),
+            "78:12: " + getCheckMessage(MSG_KEY, "AssertionError", "@throws"),
+            "89:8: " + getCheckMessage(MSG_KEY, "Error", "@throws"),
+            "100:8: " + getCheckMessage(MSG_KEY, "Error", "@throws"),
+            "110:8: " + getCheckMessage(MSG_KEY, "Error", "@throws"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocNoErrorInThrowsTagIncorrect.java"), expected);
+    }
+
+    @Test
+    public void testStatefulProcessing() throws Exception {
+        final String[] expected = {
+            "24:8: " + getCheckMessage(MSG_KEY, "Error", "@throws"),
+            "50:8: " + getCheckMessage(MSG_KEY, "CreateError", "@throws"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocNoErrorInThrowsTagStateful.java"), expected);
+    }
+
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "13:4: " + getCheckMessage(MSG_KEY, "AssertionError", "@throws"),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                        "compact/InputJavadocNoErrorInThrowsTagCompactDefault.java"),
+                expected);
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ImmutabilityTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ImmutabilityTest.java
@@ -163,6 +163,7 @@ public class ImmutabilityTest {
     private static final Set<String> SUPPRESSED_CLASSES_FOR_STATELESS_CHECK_RULE = Set.of(
         "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck",
         "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck",
+        "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNoErrorInThrowsTagCheck",
         "com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck",
         "com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck",
         "com.puppycrawl.tools.checkstyle.checks.naming.CatchParameterNameCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -66,6 +66,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                     "JavadocMethod",
                     "JavadocMissingLeadingAsterisk",
                     "JavadocMissingWhitespaceAfterAsterisk",
+                    "JavadocNoErrorInThrowsTag",
                     "JavadocParagraph",
                     "JavadocParamOrder",
                     "JavadocRegexp",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/compact/InputJavadocNoErrorInThrowsTagCompactDefault.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/compact/InputJavadocNoErrorInThrowsTagCompactDefault.java
@@ -1,0 +1,16 @@
+/*
+JavadocNoErrorInThrowsTag
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+// violation 3 lines below "Error type 'AssertionError' should not be documented in '@throws' tag."
+/**
+ * Compact source Javadoc.
+ * @throws AssertionError if an assertion fails.
+ */
+void main() {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/InputJavadocNoErrorInThrowsTagCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/InputJavadocNoErrorInThrowsTagCorrect.java
@@ -1,0 +1,120 @@
+/*
+JavadocNoErrorInThrowsTag
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocnoerrorinthrowstag;
+import java.io.IOException;
+
+public class InputJavadocNoErrorInThrowsTagCorrect {
+    /**
+     * Valid checked and runtime exceptions.
+     *
+     * @throws IOException if an input or output exception occurs.
+     * @throws IllegalArgumentException if the argument is invalid.
+     * @exception NullPointerException if the argument is null.
+     */
+    void validExceptions() throws IOException {
+    }
+
+    /**
+     * Explicit root Error type in method body may be documented.
+     *
+     * @throws Error if a serious problem occurs.
+     */
+    void explicitRootError() {
+        throw new Error("explicit failure");
+    }
+
+    /**
+     * Explicit Error type may be documented with a fully qualified name.
+     *
+     * @throws java.lang.AssertionError if an assertion fails.
+     */
+    void explicitQualifiedErrorTag() {
+        throw new AssertionError("explicit failure");
+    }
+
+    /**
+     * Explicit fully qualified Error type may be documented by simple name.
+     *
+     * @exception ExplicitThrownError if a custom failure occurs.
+     */
+    void explicitQualifiedErrorInBody() {
+        throw new InputJavadocNoErrorInThrowsTagCorrect.ExplicitThrownError("explicit failure");
+    }
+
+    /**
+     * Explicit Error type in constructor body may be documented.
+     *
+     * @throws LinkageError if linkage fails.
+     */
+    InputJavadocNoErrorInThrowsTagCorrect() {
+        throw new LinkageError("explicit failure");
+    }
+
+    record ValidRecord(String value) {
+        /**
+         * Explicit Error type in compact constructor body may be documented.
+         *
+         * @throws AssertionError if value is invalid.
+         */
+        ValidRecord {
+            throw new AssertionError("explicit failure");
+        }
+    }
+
+    /**
+     * Explicit Error type in catch block may be documented.
+     *
+     * @throws AssertionError if recovery fails.
+     */
+    void explicitErrorInCatch() {
+        try {
+            throw new RuntimeException("regular failure");
+        }
+        catch (RuntimeException ex) {
+            throw new AssertionError("explicit failure");
+        }
+    }
+
+    /**
+     * Explicit Error type in finally block may be documented.
+     *
+     * @throws AssertionError if cleanup fails.
+     */
+    void explicitErrorInFinally() {
+        try {
+            return;
+        }
+        finally {
+            throw new AssertionError("explicit failure");
+        }
+    }
+
+    /**
+     * Lowercase suffix does not match Java Error type naming.
+     *
+     * @throws Customerror if a custom exception occurs.
+     */
+    void lowercaseSuffix() throws Customerror {
+    }
+
+    /**
+     * Missing exception name is ignored by this check.
+     *
+     * @throws
+     */
+    void missingThrowsName() {
+    }
+
+    static class Customerror extends Exception {
+    }
+
+    static class ExplicitThrownError extends Error {
+        ExplicitThrownError(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/InputJavadocNoErrorInThrowsTagIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/InputJavadocNoErrorInThrowsTagIncorrect.java
@@ -1,0 +1,120 @@
+/*
+JavadocNoErrorInThrowsTag
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocnoerrorinthrowstag;
+
+public class InputJavadocNoErrorInThrowsTagIncorrect {
+
+    // violation 4 lines below "Error type 'Error' should not be documented in '@throws' tag."
+    /**
+     * Invalid root Error type.
+     *
+     * @throws Error if a serious problem occurs.
+     */
+    void invalidRootError() {
+    }
+
+    // violation 5 lines below """Error type 'java.lang.Error' should not be documented in
+    // '@throws' tag."""
+    /**
+     * Invalid fully qualified root Error type without matching thrown Error.
+     *
+     * @throws java.lang.Error if a serious problem occurs.
+     */
+    void invalidQualifiedRootError() {
+        throw new AssertionError("different failure");
+    }
+
+    // violation 5 lines below """Error type 'OutOfMemoryError' should not be documented in
+    // '@throws' tag."""
+    /**
+     * Invalid caught Error subtype.
+     *
+     * @throws OutOfMemoryError if memory is exhausted.
+     */
+    void invalidCaughtErrorSubtype() {
+        try {
+            throw new OutOfMemoryError("caught failure");
+        }
+        catch (OutOfMemoryError ex) {
+            // ignore
+        }
+    }
+
+    // violation 5 lines below """Error type 'StackOverflowError' should not be documented in
+    // '@exception' tag."""
+    /**
+     * Invalid Error subtype thrown only in lambda body.
+     *
+     * @exception StackOverflowError if recursion is too deep.
+     */
+    void invalidLambdaErrorSubtype() {
+        final Runnable runnable = () -> {
+            throw new StackOverflowError("nested failure");
+        };
+    }
+
+    // violation 5 lines below """Error type 'com.example.CustomError' should not be documented
+    // in '@throws' tag."""
+    /**
+     * Invalid custom Error-like name.
+     *
+     * @throws com.example.CustomError if a custom failure occurs.
+     */
+    void invalidCustomErrorName() {
+    }
+
+    record InvalidRecord(String value) {
+
+        // violation 5 lines below """Error type 'AssertionError' should not be documented in
+        // '@throws' tag."""
+        /**
+         * Invalid Error type in compact constructor.
+         *
+         * @throws AssertionError if value is invalid.
+         */
+        InvalidRecord {
+        }
+
+    }
+
+    // violation 4 lines below "Error type 'Error' should not be documented in '@throws' tag."
+    /**
+     * Invalid Error type thrown through a variable.
+     *
+     * @throws Error if a serious problem occurs.
+     */
+    void invalidErrorThrownByVariable() {
+        final Error error = new Error("indirect failure");
+        throw error;
+    }
+
+    // violation 4 lines below "Error type 'Error' should not be documented in '@throws' tag."
+    /**
+     * Invalid documented Error type with a different thrown type.
+     *
+     * @throws Error if a serious problem occurs.
+     */
+    void invalidDifferentThrownType() {
+        throw new RuntimeException("different failure");
+    }
+
+    // violation 4 lines below "Error type 'Error' should not be documented in '@throws' tag."
+    /**
+     * Invalid Error type thrown only in an anonymous class body.
+     *
+     * @throws Error if a serious problem occurs.
+     */
+    void invalidAnonymousClassError() {
+        new Runnable() {
+            @Override
+            public void run() {
+                throw new Error("nested failure");
+            }
+        };
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/InputJavadocNoErrorInThrowsTagStateful.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/InputJavadocNoErrorInThrowsTagStateful.java
@@ -1,0 +1,65 @@
+/*
+JavadocNoErrorInThrowsTag
+violateExecutionOnNonTightHtml = (default)false
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocnoerrorinthrowstag;
+
+public class InputJavadocNoErrorInThrowsTagStateful {
+
+    /**
+     * Explicit Error type before another method.
+     *
+     * @throws Error if a serious problem occurs.
+     */
+    void explicitRootErrorBeforeInvalidMethod() {
+        throw new Error("explicit failure");
+    }
+
+    // violation 4 lines below "Error type 'Error' should not be documented in '@throws' tag."
+    /**
+     * Invalid Error type after an explicit Error in the previous method.
+     *
+     * @throws Error if a serious problem occurs.
+     */
+    void invalidRootErrorAfterExplicitMethod() {
+    }
+
+    /**
+     * Explicit Error in finally block after a catch may be documented.
+     *
+     * @throws AssertionError if cleanup fails.
+     */
+    void explicitErrorInFinallyWithCatch() {
+        try {
+            throw new RuntimeException("regular failure");
+        }
+        catch (RuntimeException ex) {
+            return;
+        }
+        finally {
+            throw new AssertionError("explicit failure");
+        }
+    }
+
+    // violation 4 lines below "Error type 'CreateError' should not be documented in '@throws' tag."
+    /**
+     * Factory method throw is not a direct throw new.
+     *
+     * @throws CreateError if factory fails.
+     */
+    void invalidFactoryThrownError() {
+        throw CreateError();
+    }
+
+    private CreateError CreateError() {
+        return new CreateError("factory failure");
+    }
+
+    static class CreateError extends Error {
+        CreateError(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNoErrorInThrowsTagCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNoErrorInThrowsTagCheckExamplesTest.java
@@ -1,0 +1,45 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+
+public class JavadocNoErrorInThrowsTagCheckExamplesTest
+        extends AbstractExamplesModuleTestSupport {
+
+    private static final String MSG_KEY = JavadocNoErrorInThrowsTagCheck.MSG_KEY;
+
+    @Override
+    public String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag";
+    }
+
+    @Test
+    public void testExample1() throws Exception {
+        final String[] expected = {
+            "37:6: " + getCheckMessage(MSG_KEY, "StackOverflowError", "@throws"),
+        };
+
+        verifyWithInlineConfigParser(getPath("Example1.java"), expected);
+    }
+
+}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocnoerrorinthrowstag/Example1.java
@@ -1,0 +1,42 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="JavadocNoErrorInThrowsTag"/>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocnoerrorinthrowstag;
+
+import java.io.IOException;
+
+// xdoc section - start
+class Example1 {
+  /**
+   * Valid Javadoc.
+   *
+   * @throws IOException if an input or output exception occurs.
+   * @throws IllegalArgumentException if the argument is invalid.
+   */
+  void validExceptions() throws IOException {
+  }
+
+  /**
+   * Valid explicit Error.
+   *
+   * @throws OutOfMemoryError if memory is exhausted.
+   */
+  void validExplicitError() {
+    throw new OutOfMemoryError("memory exhausted");
+  }
+
+  // violation 5 lines below """Error type 'StackOverflowError' should not be
+  // documented in '@throws' tag."""
+  /**
+   * Invalid Javadoc.
+   *
+   * @throws StackOverflowError if recursion is too deep.
+   */
+  void invalidError() {
+  }
+}
+// xdoc section - end


### PR DESCRIPTION
closes #20792

Contribution PR: https://github.com/checkstyle/contribution/pull/1124

New module config: https://gist.githubusercontent.com/gianmarcoschifone/2fd50663c868c278ded7c43ed78144c8/raw/b7c54d3311044207d685024d4246354761ce3bb6/javadocnoerrorinthrowstag.xml