### PR TITLE
Issue #21309: Automate Website File Change Detection in CI

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -1435,6 +1435,18 @@ git-diff)
   fi
   ;;
 
+website-diff)
+  # Check if any website source files were modified (committed changes only)
+  if git diff --name-only origin/master HEAD 2>/dev/null | grep -q '^src/site/xdoc/'; then
+    echo "Website source files (src/site/xdoc/**) were modified."
+    echo "Please ensure the website is regenerated and committed if needed."
+    echo "Modified files:"
+    git diff --name-only origin/master HEAD | grep '^src/site/xdoc/'
+  else
+    echo "No website source files (src/site/xdoc/**) were modified."
+  fi
+  ;;
+
 git-no-merge-commits)
   MERGE_COMMITS=$(git rev-list --merges master.."$PR_HEAD_SHA")
 

--- a/.github/workflows/website-diff.yml
+++ b/.github/workflows/website-diff.yml
@@ -1,0 +1,108 @@
+#####################################################################################
+# GitHub Action to detect website file changes in PRs.
+#
+# Workflow starts when:
+# 1) pull_request - opened, synchronize, reopened
+#
+# This workflow automatically detects changes in website source files (src/site/xdoc/**)
+# and reports them as a PR comment to alert maintainers that documentation was modified.
+#####################################################################################
+name: Website-Diff
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    paths:
+      - 'src/site/xdoc/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  website-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fetch origin/master
+        run: |
+          git fetch origin master
+
+      - name: Check for website source changes
+        id: check_changes
+        run: |
+          CHANGED_FILES=$(git diff --name-only origin/master HEAD | grep '^src/site/xdoc/' || true)
+
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Website source files were modified."
+
+            # Create report
+            mkdir -p .ci-temp
+            {
+              echo "## Website File Change Detection"
+              echo ""
+              echo "Website source files (src/site/xdoc/**) were modified in this PR."
+              echo ""
+              echo "### Modified files:"
+              echo ""
+              echo '```'
+              echo "$CHANGED_FILES"
+              echo '```'
+              echo ""
+              echo "### Instructions"
+              echo ""
+              echo "- Please ensure the website is regenerated if these"
+              echo "  changes affect the generated output."
+              echo "- Review the source files in src/site/xdoc/ to verify"
+              echo "  the documentation changes are intentional."
+            } > .ci-temp/diff-message.md
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No website source files were modified."
+          fi
+
+      - name: Comment PR with results
+        if: steps.check_changes.outputs.has_changes == 'true'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const message = fs.readFileSync('.ci-temp/diff-message.md', 'utf8');
+
+            // Find existing comment by this workflow
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Website File Change Detection')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: message
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: message
+              });
+            }

--- a/src/site/xdoc/filters/severitymatchfilter.xml
+++ b/src/site/xdoc/filters/severitymatchfilter.xml
@@ -8,6 +8,7 @@
   <body>
     <section name="SeverityMatchFilter">
       <p>Since Checkstyle 3.2</p>
+
       <div class="toc-panel">
   <input type="checkbox" id="toc-toggle" class="toc-toggle-checkbox" checked="checked"/>
   <label for="toc-toggle" class="toc-toggle-arrow" title="Collapse"/>

--- a/src/site/xdoc/filters/severitymatchfilter.xml.template
+++ b/src/site/xdoc/filters/severitymatchfilter.xml.template
@@ -11,6 +11,7 @@
         <param name="modulePath"
                value="src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java"/>
       </macro>
+
       <macro name="sitetoc">
         <param name="modulePath"
                value="src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java"/>


### PR DESCRIPTION
#21309


Implements automated CI detection of website file changes to catch documentation generation issues without manual verification. When PRs modify documentation, CI automatically detects and reports changes in website source files.


### 1. Added `website-diff` function to [.ci/validation.sh]
- New validation function to detect changes in website source files (`src/site/xdoc/**`)
- Compares committed changes against `origin/master` branch
- Lists modified files in human-readable format
- Provides clear instructions for maintainers

### 2. Created [.github/workflows/website-diff.yml]
- New GitHub Actions workflow for automatic PR validation
- Triggers automatically when `src/site/xdoc/**` files are modified in a PR
- Posts a PR comment with:
  - Summary of modified files
  - Clear instructions for maintainers
- Updates existing comments instead of creating duplicates