### PR TITLE
Issue #21311: add javadoc handler for package def

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheck.java
@@ -19,8 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import java.util.Optional;
-
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -86,58 +84,10 @@ public class MissingJavadocPackageCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (CheckUtil.isPackageInfo(getFilePath()) && !hasJavadoc(ast)) {
+        if (CheckUtil.isPackageInfo(getFilePath())
+                && JavadocUtil.getAttachedJavadocCommentForPackage(ast) == null) {
             log(ast, MSG_PKG_JAVADOC_MISSING);
         }
-    }
-
-    /**
-     * Checks that there is javadoc before ast.
-     * Because of <a href="https://github.com/checkstyle/checkstyle/issues/4392">parser bug</a>
-     * parser can place javadoc comment either as previous sibling of package definition
-     * or (if there is annotation between package def and javadoc) inside package definition tree.
-     * So we should look for javadoc in both places.
-     *
-     * @param ast {@link TokenTypes#PACKAGE_DEF} token to check
-     * @return true if there is javadoc, false otherwise
-     */
-    private static boolean hasJavadoc(DetailAST ast) {
-        final boolean hasJavadocBefore = ast.getPreviousSibling() != null
-            && isJavadoc(ast.getPreviousSibling());
-        return hasJavadocBefore || hasJavadocAboveAnnotation(ast);
-    }
-
-    /**
-     * Checks javadoc existence in annotations list.
-     *
-     * @param ast package def
-     * @return true if there is a javadoc, false otherwise
-     */
-    private static boolean hasJavadocAboveAnnotation(DetailAST ast) {
-        final Optional<DetailAST> firstAnnotationChild = Optional.of(ast.getFirstChild())
-            .map(DetailAST::getFirstChild)
-            .map(DetailAST::getFirstChild);
-        boolean result = false;
-        if (firstAnnotationChild.isPresent()) {
-            for (DetailAST child = firstAnnotationChild.orElseThrow(); child != null;
-                 child = child.getNextSibling()) {
-                if (isJavadoc(child)) {
-                    result = true;
-                    break;
-                }
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Checks that ast is a javadoc comment.
-     *
-     * @param ast token to check
-     * @return true if ast is a javadoc comment, false otherwise
-     */
-    private static boolean isJavadoc(DetailAST ast) {
-        return ast.getType() == TokenTypes.BLOCK_COMMENT_BEGIN && JavadocUtil.isJavadocComment(ast);
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.utils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
@@ -134,6 +135,43 @@ public final class JavadocUtil {
         while (result == null && child.getType() != TokenTypes.IDENT) {
             result = findJavadocComment(child);
             child = child.getNextSibling();
+        }
+        return result;
+    }
+
+    /**
+     * Returns the Javadoc block comment attached to the given package AST node.
+     * Because of <a href="https://github.com/checkstyle/checkstyle/issues/4392">parser bug</a>
+     * parser can place javadoc comment either as previous sibling of package definition
+     * or (if there is annotation between package def and javadoc) inside package definition tree.
+     * So we should look for javadoc in both places.
+     *
+     * @param ast the package declaration AST node
+     * @return the attached Javadoc block comment, or {@code null} if none is found
+     */
+    @Nullable
+    public static DetailAST getAttachedJavadocCommentForPackage(final DetailAST ast) {
+        DetailAST result = null;
+        if (ast.getPreviousSibling() != null
+                && ast.getPreviousSibling().getType() == TokenTypes.BLOCK_COMMENT_BEGIN
+                && isJavadocComment(ast.getPreviousSibling())) {
+            result = ast.getPreviousSibling();
+        }
+        else {
+            final Optional<DetailAST> firstAnnotationChild =
+                Optional.ofNullable(ast.getFirstChild())
+                    .map(DetailAST::getFirstChild)
+                    .map(DetailAST::getFirstChild);
+            if (firstAnnotationChild.isPresent()) {
+                for (DetailAST child = firstAnnotationChild.orElseThrow(); child != null;
+                     child = child.getNextSibling()) {
+                    if (child.getType() == TokenTypes.BLOCK_COMMENT_BEGIN
+                            && isJavadocComment(child)) {
+                        result = child;
+                        break;
+                    }
+                }
+            }
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
@@ -20,9 +20,11 @@
 package com.puppycrawl.tools.checkstyle.utils;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck.MSG_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_EXPECTED_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_RETURN_EXPECTED;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck.MSG_JAVADOC_MISSING;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck.MSG_PKG_JAVADOC_MISSING;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
@@ -39,11 +41,13 @@ import com.puppycrawl.tools.checkstyle.api.JavadocCommentsTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.LineColumn;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocTag;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.utils.BlockTagUtil;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.utils.InlineTagUtil;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.utils.TagInfo;
@@ -374,6 +378,87 @@ public class JavadocUtilTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testFindFirstToken() {
+        final JavadocNodeImpl parent = new JavadocNodeImpl();
+        final JavadocNodeImpl firstTextNode = createJavadocNode(JavadocCommentsTokenTypes.TEXT);
+        final JavadocNodeImpl tagNameNode = createJavadocNode(JavadocCommentsTokenTypes.TAG_NAME);
+
+        parent.addChild(firstTextNode);
+        parent.addChild(tagNameNode);
+
+        final DetailNode result =
+            JavadocUtil.findFirstToken(parent, JavadocCommentsTokenTypes.TEXT);
+
+        assertWithMessage("Invalid node")
+            .that(result)
+            .isEqualTo(firstTextNode);
+    }
+
+    @Test
+    public void testIsTag() {
+        final JavadocNodeImpl parent = new JavadocNodeImpl();
+
+        assertWithMessage("Should return false")
+            .that(JavadocUtil.isTag(parent, "myTag"))
+            .isFalse();
+
+        final JavadocNodeImpl tagStart =
+            createJavadocNode(JavadocCommentsTokenTypes.HTML_TAG_START);
+        parent.addChild(tagStart);
+
+        final JavadocNodeImpl tagName = createJavadocNode(JavadocCommentsTokenTypes.TAG_NAME);
+        tagName.setText("myTag");
+        tagStart.addChild(tagName);
+
+        assertWithMessage("Should return true")
+            .that(JavadocUtil.isTag(parent, "myTag"))
+            .isTrue();
+
+        assertWithMessage("Should return false")
+            .that(JavadocUtil.isTag(parent, "otherTag"))
+            .isFalse();
+    }
+
+    @Test
+    public void testGetNextSibling() {
+        final JavadocNodeImpl parent = new JavadocNodeImpl();
+        final JavadocNodeImpl first = createJavadocNode(JavadocCommentsTokenTypes.TEXT);
+        final JavadocNodeImpl second = createJavadocNode(JavadocCommentsTokenTypes.NEWLINE);
+        final JavadocNodeImpl third = createJavadocNode(JavadocCommentsTokenTypes.TAG_NAME);
+
+        parent.addChild(first);
+        parent.addChild(second);
+        parent.addChild(third);
+
+        assertWithMessage("Should find NEWLINE")
+            .that(JavadocUtil.getNextSibling(first, JavadocCommentsTokenTypes.NEWLINE))
+            .isEqualTo(second);
+
+        assertWithMessage("Should find TAG_NAME")
+            .that(JavadocUtil.getNextSibling(first, JavadocCommentsTokenTypes.TAG_NAME))
+            .isEqualTo(third);
+
+        assertWithMessage("Should return null")
+            .that(JavadocUtil.getNextSibling(first, JavadocCommentsTokenTypes.HTML_TAG_START))
+            .isNull();
+    }
+
+    @Test
+    public void testGetTagName() {
+        final JavadocNodeImpl parent = new JavadocNodeImpl();
+        final JavadocNodeImpl tagStart =
+            createJavadocNode(JavadocCommentsTokenTypes.HTML_TAG_START);
+        final JavadocNodeImpl tagName = createJavadocNode(JavadocCommentsTokenTypes.TAG_NAME);
+        tagName.setText("myTag");
+        tagStart.addChild(tagName);
+        parent.addChild(tagStart);
+
+        assertWithMessage("Should return myTag")
+            .that(JavadocUtil.getTagName(parent))
+            .isEqualTo("myTag");
+    }
+
+    @Test
     public void testGetAllNodesOfType() {
         final JavadocNodeImpl parent = new JavadocNodeImpl();
         final JavadocNodeImpl firstTextNode = createJavadocNode(JavadocCommentsTokenTypes.TEXT);
@@ -473,6 +558,7 @@ public class JavadocUtilTest extends AbstractModuleTestSupport {
                     MSG_EXPECTED_TAG, "@param", "value"),
             "40: " + getCheckMessage(JavadocMethodCheck.class, MSG_RETURN_EXPECTED),
             "60: " + getCheckMessage(JavadocMethodCheck.class, MSG_RETURN_EXPECTED),
+            "82: " + getCheckMessage(JavadocMethodCheck.class, MSG_RETURN_EXPECTED),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocUtilMethodDefComments.java"), expected);
@@ -551,6 +637,58 @@ public class JavadocUtilTest extends AbstractModuleTestSupport {
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocUtilEnumConstantDefComments.java"), expected);
+    }
+
+    @Test
+    public void testGetAttachedJavadocCommentForPackagePreviousSiblingIsJavadoc()
+            throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("pkgisjavadoc/package-info.java"), expected);
+    }
+
+    @Test
+    public void testGetAttachedJavadocCommentForPackagePreviousSiblingNotJavadoc()
+            throws Exception {
+        final String[] expected = {
+            "10:1: " + getCheckMessage(MissingJavadocPackageCheck.class,
+                    MSG_PKG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("pkgnotjavadoc/package-info.java"), expected);
+    }
+
+    @Test
+    public void testGetAttachedJavadocCommentForPackageInsideAnnotation()
+            throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("pkgannotationisjavadoc/package-info.java"), expected);
+    }
+
+    @Test
+    public void testGetAttachedJavadocCommentForPackageInsideAnnotationNotJavadoc()
+            throws Exception {
+        final String[] expected = {
+            "11:1: " + getCheckMessage(MissingJavadocPackageCheck.class,
+                    MSG_PKG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("pkgannotationnotjavadoc/package-info.java"), expected);
+    }
+
+    @Test
+    public void testGetAttachedJavadocCommentForTypeDefinitions() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocUtilTypeDefComments.java"), expected);
+    }
+
+    @Test
+    public void testGetAttachedJavadocCommentForModuleDefinitions() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("modulejavadoc/module-info.java"), expected);
     }
 
     private static JavadocTags getJavadocTags(TextBlock textBlock, JavadocTagType tagType) {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/utils/javadocutil/modulejavadoc/module-info.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/utils/javadocutil/modulejavadoc/module-info.java
@@ -1,0 +1,11 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck
+
+
+*/
+
+/**
+ * valid javadoc
+ */
+module com.example.app {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilMethodDefComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilMethodDefComments.java
@@ -60,4 +60,26 @@ class InputJavadocUtilMethodDefComments {
     int danglingReal() { // violation '@return tag should be present and have description'
         return 1;
     }
+
+    /**
+     * First javadoc.
+     */
+    // single line comment
+    /**
+     * Second javadoc.
+     * @return ignored
+     */
+    int singleLineCommentBetween() {
+        return 1;
+    }
+
+    /**
+     * Javadoc comment.
+     */
+    /*
+     * Non-javadoc block comment.
+     */
+    int blockCommentBetween() { // violation '@return tag should be present and have description'
+        return 1;
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilTypeDefComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/InputJavadocUtilTypeDefComments.java
@@ -1,3 +1,9 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.utils.javadocutil;
 
 /**classComment*/

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/pkgannotationisjavadoc/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/pkgannotationisjavadoc/package-info.java
@@ -1,0 +1,11 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck
+
+
+*/
+
+/**
+ * valid javadoc
+ */
+@Deprecated
+package com.puppycrawl.tools.checkstyle.utils.javadocutil.pkgannotationisjavadoc;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/pkgannotationnotjavadoc/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/pkgannotationnotjavadoc/package-info.java
@@ -1,0 +1,11 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck
+
+
+*/
+
+/*
+ not javadoc
+ */
+@Deprecated
+package com.puppycrawl.tools.checkstyle.utils.javadocutil.pkgannotationnotjavadoc; // violation 'Missing javadoc for package-info.java file.'

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/pkgisjavadoc/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/pkgisjavadoc/package-info.java
@@ -1,0 +1,10 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck
+
+
+*/
+
+/**
+ * valid javadoc
+ */
+package com.puppycrawl.tools.checkstyle.utils.javadocutil.pkgisjavadoc;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/pkgnotjavadoc/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/javadocutil/pkgnotjavadoc/package-info.java
@@ -1,0 +1,10 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck
+
+
+*/
+
+/*
+ not javadoc
+ */
+package com.puppycrawl.tools.checkstyle.utils.javadocutil.pkgnotjavadoc; // violation 'Missing javadoc for package-info.java file.'


### PR DESCRIPTION
fixes: #21311 

This PR adds a new util method `getAttachedJavadocCommentForPackage` to get the Javadoc comment attached to a `PACKAGE_DEF` considering the two possible positions, as the previous sibling or as the child of preceeding `ANNOTATION_DEF`.