### PR TITLE
Issue #19803: move HideUtilityClassConstructor violation comment

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -349,8 +349,6 @@
             files="/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionOverridableMethods\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionOverridableMethods\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorIgnoreAnnotationByFullyQualifiedName\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocleadingasteriskalign/InputJavadocLeadingAsteriskAlignIncorrect\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheckTest.java
@@ -160,7 +160,7 @@ public class HideUtilityClassConstructorCheckTest
     @Test
     public void testIgnoreAnnotatedByFullQualifier() throws Exception {
         final String[] expected = {
-            "9:1: " + getCheckMessage(MSG_KEY),
+            "10:1: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputHideUtilityClassConstructor"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorIgnoreAnnotationByFullyQualifiedName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/hideutilityclassconstructor/InputHideUtilityClassConstructorIgnoreAnnotationByFullyQualifiedName.java
@@ -6,7 +6,8 @@ ignoreAnnotatedBy = java.lang.Deprecated
 
 package com.puppycrawl.tools.checkstyle.checks.design.hideutilityclassconstructor;
 
-@Deprecated // violation, should not have a public or default constructor
+// violation below 'Utility classes should not have a public or default constructor.'
+@Deprecated
 public class InputHideUtilityClassConstructorIgnoreAnnotationByFullyQualifiedName {
   public static void func() {}
 }


### PR DESCRIPTION
Issue: #19803

Move the HideUtilityClassConstructor violation comment before the annotated class declaration, update the expected line, and remove the now-unneeded input suppression.

Validation:
- `./mvnw -Dtest=HideUtilityClassConstructorCheckTest test`
- `./mvnw clean verify` passes after temporarily correcting the current master module-count assertions in `XmlMetaReaderTest` from 233 to 234; without that unrelated correction, current master fails the same three assertions.