### PR TITLE
Issue #21119: make FileTabCharacter examples behaviorally unique

### DIFF
--- a/src/site/xdoc/checks/whitespace/filetabcharacter.xml
+++ b/src/site/xdoc/checks/whitespace/filetabcharacter.xml
@@ -131,16 +131,16 @@ class Example2 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="FileTabCharacter"&gt;
-    &lt;property name="fileExtensions" value="java, xml"/&gt;
+    &lt;property name="fileExtensions" value="xml"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example3-code">Example - Test.java:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example3 {
-  int a; // violation 'File contains tab characters'
+  int a; // ok, no check performed on java file extension
 
-  public void foo (int arg) { // ok, only first occurrence in file reported
+  public void foo (int arg) { // ok, java is not specified in check config
     a = arg; // ok, indented using spaces
   }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -110,8 +110,7 @@ public class XdocsExampleFileTest {
         "checks/outertypefilename/",
         "checks/regexp/regexpmultiline/",
         "checks/regexp/regexpsingleline/",
-        "checks/trailingcomment/",
-        "checks/whitespace/filetabcharacter/"
+        "checks/trailingcomment/"
     );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterExamplesTest.java
@@ -55,9 +55,7 @@ public class FileTabCharacterExamplesTest extends AbstractExamplesModuleTestSupp
 
     @Test
     public void testExample3() throws Exception {
-        final String[] expected = {
-            "15:1: " + getCheckMessage(MSG_FILE_CONTAINS_TAB),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example3.java
@@ -1,7 +1,7 @@
 /*xml
 <module name="Checker">
   <module name="FileTabCharacter">
-    <property name="fileExtensions" value="java, xml"/>
+    <property name="fileExtensions" value="xml"/>
   </module>
 </module>
 
@@ -12,9 +12,9 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.filetabcharacter;
 
 // xdoc section - start
 class Example3 {
-	int a; // violation 'File contains tab characters'
+	int a; // ok, no check performed on java file extension
 
-	public void foo (int arg) { // ok, only first occurrence in file reported
+	public void foo (int arg) { // ok, java is not specified in check config
     a = arg; // ok, indented using spaces
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example4.xml
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example4.xml
@@ -1,7 +1,7 @@
 /*xml
 <module name="Checker">
   <module name="FileTabCharacter">
-    <property name="fileExtensions" value="java, xml"/>
+    <property name="fileExtensions" value="xml"/>
   </module>
 </module>
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example5.html
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/Example5.html
@@ -1,7 +1,7 @@
 /*xml
 <module name="Checker">
   <module name="FileTabCharacter">
-    <property name="fileExtensions" value="java, xml"/>
+    <property name="fileExtensions" value="xml"/>
   </module>
 </module>
 


### PR DESCRIPTION
Issue: #21119

Configure the FileTabCharacter file-extension example for XML only, so the Java example demonstrates excluded-extension behavior while XML is checked and HTML remains ignored. Remove the uniqueness suppression and update the generated documentation and tests.

Validation:
- `./mvnw -Dtest=FileTabCharacterExamplesTest,XdocsExampleFileTest,XdocsExamplesAstConsistencyTest test`
- `./mvnw clean verify` passes after temporarily correcting the current master module-count assertions in `XmlMetaReaderTest` from 233 to 234; without that unrelated correction, current master fails the same three assertions.