### PR TITLE
Issue #21308: Avoid hardcoded module counts in XmlMetaReaderTest

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1182,6 +1182,7 @@ reportyml
 requiredtags
 requireemptylinebeforeblocktaggroup
 requirethis
+Rescanning
 resourceleak
 Rethrown
 returncount

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
@@ -20,41 +20,90 @@
 package com.puppycrawl.tools.checkstyle.meta;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 
 public class XmlMetaReaderTest extends AbstractPathTestSupport {
+
+    /** Modules that intentionally ship no metadata file. */
+    private static final Set<String> MODULES_WITHOUT_METADATA = Set.of(
+            "com.puppycrawl.tools.checkstyle.Checker",
+            "com.puppycrawl.tools.checkstyle.TreeWalker"
+    );
+
+    /** Plain scan result, shared to avoid repeating an expensive classpath scan. */
+    private static final List<ModuleDetails> ALL_MODULES =
+            XmlMetaReader.readAllModulesIncludingThirdPartyIfAny();
 
     @Override
     public String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/meta/xmlmetareader";
     }
 
+    /**
+     * Verifies that metadata for every checkstyle module can be located on the classpath
+     * and parsed.
+     *
+     * <p>This is "contains at least", not "contains exactly", because this test's own input
+     * files live inside the scanned package and are therefore picked up by the scan. The
+     * reverse direction, metadata files with no matching module, is covered by
+     * {@code MetadataGeneratorUtilTest}.
+     *
+     * <p>When running this test directly from an IDE, run {@code ./mvnw process-classes}
+     * first to generate the metadata files under {@code target/classes}.
+     *
+     * @throws Exception if the attempt to read class path resources failed
+     */
     @Test
-    public void test() {
-        assertThat(XmlMetaReader.readAllModulesIncludingThirdPartyIfAny()).hasSize(234);
+    public void testAllModulesHaveMetadata() throws Exception {
+        final Set<String> expected = CheckUtil.getCheckstyleModules().stream()
+                .map(Class::getName)
+                .filter(name -> !MODULES_WITHOUT_METADATA.contains(name))
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        assertWithMessage("Metadata should be readable for every checkstyle module")
+                .that(fullNames(ALL_MODULES))
+                .containsAtLeastElementsIn(expected);
     }
 
     @Test
     public void testDuplicatePackage() {
-        assertThat(XmlMetaReader
-                .readAllModulesIncludingThirdPartyIfAny("com.puppycrawl.tools.checkstyle.meta"))
-                .hasSize(234);
+        final List<ModuleDetails> actual = XmlMetaReader
+                .readAllModulesIncludingThirdPartyIfAny("com.puppycrawl.tools.checkstyle.meta");
+
+        assertWithMessage("Rescanning a scanned package should not duplicate modules")
+                .that(actual)
+                .hasSize(ALL_MODULES.size());
+        assertWithMessage("Rescanning a scanned package should not change the modules")
+                .that(fullNames(actual))
+                .containsExactlyElementsIn(fullNames(ALL_MODULES));
     }
 
     @Test
     public void testBadPackage() {
-        assertThat(XmlMetaReader.readAllModulesIncludingThirdPartyIfAny("DOES.NOT.EXIST"))
-                .hasSize(234);
+        final List<ModuleDetails> actual =
+                XmlMetaReader.readAllModulesIncludingThirdPartyIfAny("DOES.NOT.EXIST");
+
+        assertWithMessage("A nonexistent third party package should not add modules")
+                .that(actual)
+                .hasSize(ALL_MODULES.size());
+        assertWithMessage("A nonexistent third party package should not change the modules")
+                .that(fullNames(actual))
+                .containsExactlyElementsIn(fullNames(ALL_MODULES));
     }
 
     @Test
@@ -63,8 +112,8 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
         try (InputStream is = Files.newInputStream(Path.of(path))) {
             final ModuleDetails result = XmlMetaReader.read(is, ModuleType.CHECK);
             checkModuleProps(result, ModuleType.CHECK, "Some description for check",
-                "com.puppycrawl.tools.checkstyle.checks.misc.InputCheck",
-                "com.puppycrawl.tools.checkstyle.TreeWalker");
+                    "com.puppycrawl.tools.checkstyle.checks.misc.InputCheck",
+                    "com.puppycrawl.tools.checkstyle.TreeWalker");
             assertThat(result.getName()).isEqualTo("InputCheck");
             final List<String> violationMessageKeys = result.getViolationMessageKeys();
             assertThat(violationMessageKeys).hasSize(1);
@@ -73,13 +122,13 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
             assertThat(props).hasSize(2);
             final ModulePropertyDetails prop1 = props.getFirst();
             checkProperty(prop1, "propertyOne", "java.lang.String",
-                "propertyOneDefaultValue",
-                "Property wrapped\n            description.");
+                    "propertyOneDefaultValue",
+                    "Property wrapped\n            description.");
             assertThat(prop1.getValidationType()).isNull();
 
             final ModulePropertyDetails prop2 = props.get(1);
             checkProperty(prop2, "propertyTwo", "java.lang.String[]",
-                "", "Property two desc");
+                    "", "Property two desc");
             assertThat(prop2.getValidationType()).isEqualTo("tokenTypesSet");
         }
     }
@@ -90,9 +139,9 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
         try (InputStream is = Files.newInputStream(Path.of(path))) {
             final ModuleDetails result = XmlMetaReader.read(is, ModuleType.CHECK);
             checkModuleProps(result, ModuleType.CHECK,
-                "Some description for check with no properties",
-                "com.puppycrawl.tools.checkstyle.checks.misc.InputCheckNoProps",
-                "com.puppycrawl.tools.checkstyle.TreeWalker");
+                    "Some description for check with no properties",
+                    "com.puppycrawl.tools.checkstyle.checks.misc.InputCheckNoProps",
+                    "com.puppycrawl.tools.checkstyle.TreeWalker");
             assertThat(result.getName()).isEqualTo("InputCheckNoProps");
             final List<String> violationMessageKeys = result.getViolationMessageKeys();
             assertThat(violationMessageKeys).hasSize(2);
@@ -108,15 +157,15 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
         try (InputStream is = Files.newInputStream(Path.of(path))) {
             final ModuleDetails result = XmlMetaReader.read(is, ModuleType.FILTER);
             checkModuleProps(result, ModuleType.FILTER, "Description for filter",
-                "com.puppycrawl.tools.checkstyle.filters.SomeFilter",
-                "com.puppycrawl.tools.checkstyle.TreeWalker");
+                    "com.puppycrawl.tools.checkstyle.filters.SomeFilter",
+                    "com.puppycrawl.tools.checkstyle.TreeWalker");
             assertThat(result.getName()).isEqualTo("SomeFilter");
             assertThat(result.getViolationMessageKeys()).isEmpty();
             final List<ModulePropertyDetails> props = result.getProperties();
             assertThat(props).hasSize(1);
             final ModulePropertyDetails prop1 = props.getFirst();
             checkProperty(prop1, "propertyOne", "java.util.regex.Pattern",
-                "propertyDefaultValue", "Property description.");
+                    "propertyDefaultValue", "Property description.");
             assertThat(prop1.getValidationType()).isNull();
         }
     }
@@ -127,9 +176,9 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
         try (InputStream is = Files.newInputStream(Path.of(path))) {
             final ModuleDetails result = XmlMetaReader.read(is, ModuleType.FILEFILTER);
             checkModuleProps(result, ModuleType.FILEFILTER,
-                "File filter description",
-                "com.puppycrawl.tools.checkstyle.filefilters.FileFilter",
-                "com.puppycrawl.tools.checkstyle.Checker");
+                    "File filter description",
+                    "com.puppycrawl.tools.checkstyle.filefilters.FileFilter",
+                    "com.puppycrawl.tools.checkstyle.Checker");
             assertThat(result.getName()).isEqualTo("FileFilter");
             assertThat(result.getViolationMessageKeys()).isEmpty();
             final List<ModulePropertyDetails> props = result.getProperties();
@@ -140,7 +189,7 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
             assertThat(prop1.getDefaultValue()).isNull();
             assertThat(prop1.getValidationType()).isNull();
             assertThat(prop1.getDescription())
-                .isEqualTo("Define regular expression to match the file name against.");
+                    .isEqualTo("Define regular expression to match the file name against.");
         }
     }
 
@@ -149,6 +198,12 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
         try (InputStream is = IOUtils.toInputStream("", StandardCharsets.UTF_8)) {
             assertThat(XmlMetaReader.read(is, null)).isNull();
         }
+    }
+
+    private static Set<String> fullNames(List<ModuleDetails> modules) {
+        return modules.stream()
+                .map(ModuleDetails::getFullQualifiedName)
+                .collect(Collectors.toCollection(TreeSet::new));
     }
 
     private static void checkModuleProps(ModuleDetails result, ModuleType moduleType,


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/21308


## Solution

Remove the literal by asserting the invariant each test was really trying to express.

| Test | Invariant now asserted |
|---|---|
| `test` → `testAllModulesHaveMetadata` | Every module from `CheckUtil.getCheckstyleModules()` has metadata that `XmlMetaReader` can locate and parse |
| `testDuplicatePackage` | Rescanning an already scanned package adds no modules and no duplicates |
| `testBadPackage` | A nonexistent third-party package changes nothing |

All three are now self-maintaining: adding a Check requires no edit to this file.

### Details

- **`testAllModulesHaveMetadata`** compares fully-qualified names against
  `CheckUtil.getCheckstyleModules()`, minus `Checker` and `TreeWalker`, which ship no
  metadata file. This mirrors the exemption list already present in
  `MetadataGeneratorUtilTest`.

- **FQN rather than simple name.** Both production consumers key metadata by
  fully-qualified name — `SarifLogger.loadModuleMetadata()` and `InlineConfigParser` each
  build a `Map<FQN, ModuleDetails>`. Using FQNs tests the field those callers depend on
  and avoids the "strip trailing `Check`" heuristic in `CheckUtil.getSimpleNames`.

- **`containsAtLeastElementsIn`, not `containsExactlyElementsIn`.** This test's four input
  files sit inside the scanned package, so they always appear in the scan result. They
  cannot be relocated: `AllTestsTest.verifyInputFile` requires every resource to live in a
  sub-package of its test class, and this test class is in
  `com.puppycrawl.tools.checkstyle.meta`. The opposite direction — a metadata file with no
  corresponding module — is already covered by `MetadataGeneratorUtilTest`, which asserts
  exact set equality against the filesystem. The reasoning is recorded in a javadoc so it
  isn't "tightened" later.

- **Explicit size assertion retained.** `testDuplicatePackage` and `testBadPackage` each
  assert `hasSize(ALL_MODULES.size())` on the raw `List` in addition to comparing FQN
  sets. Comparing sets alone would not detect duplicate entries, which is the property
  those tests exist to protect; the size comparison preserves it without a literal.

- **`ALL_MODULES` static field.** The plain scan is performed once and reused. Each call
  to `readAllModulesIncludingThirdPartyIfAny()` is a Reflections classpath scan plus a DOM
  parse of every metadata file, and the tests previously repeated it per test method.

- **Javadoc** notes the `./mvnw process-classes` prerequisite for running from an IDE,
  matching the note already on `MetadataGeneratorUtilTest`.