### PR TITLE
Issue #21325: Make TestInputconfiguration a record

### DIFF
--- a/config/qodana.yml
+++ b/config/qodana.yml
@@ -62,6 +62,3 @@ exclude:
   - name: Annotator
     paths:
       - src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocCommentsTokenTypes.java
-  - name: ClassCanBeRecord
-    paths:
-      - src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -239,14 +239,14 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final DefaultConfiguration configWithoutFilters =
                 testInputConfiguration.createConfigurationWithoutFilters();
         final List<TestInputViolation> violationsWithoutFilters =
-                new ArrayList<>(testInputConfiguration.getViolations());
-        violationsWithoutFilters.addAll(testInputConfiguration.getFilteredViolations());
+                new ArrayList<>(testInputConfiguration.violations());
+        violationsWithoutFilters.addAll(testInputConfiguration.filteredViolations());
         Collections.sort(violationsWithoutFilters);
         verifyViolations(configWithoutFilters, filePath, violationsWithoutFilters);
         verify(configWithoutFilters, filePath, expectedUnfiltered);
         final DefaultConfiguration configWithFilters =
                 testInputConfiguration.createConfiguration();
-        verifyViolations(configWithFilters, filePath, testInputConfiguration.getViolations());
+        verifyViolations(configWithFilters, filePath, testInputConfiguration.violations());
         verify(configWithFilters, filePath, expectedFiltered);
     }
 
@@ -264,8 +264,8 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final TestInputConfiguration testInputConfiguration =
                 InlineConfigParser.parseWithXmlHeader(filePath);
         final Configuration xmlConfig =
-                testInputConfiguration.getXmlConfiguration();
-        verifyViolations(xmlConfig, filePath, testInputConfiguration.getViolations());
+                testInputConfiguration.xmlConfiguration();
+        verifyViolations(xmlConfig, filePath, testInputConfiguration.violations());
         verify(xmlConfig, filePath, expected);
     }
 
@@ -307,7 +307,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final DefaultConfiguration parsedConfig =
                 testInputConfiguration.createConfiguration();
         final List<String> actualViolations = getActualViolationsForFile(parsedConfig, filePath);
-        verifyViolations(filePath, testInputConfiguration.getViolations(), actualViolations);
+        verifyViolations(filePath, testInputConfiguration.violations(), actualViolations);
         assertWithMessage("Violations for %s differ.", filePath)
             .that(actualViolations)
             .containsExactlyElementsIn(expected);
@@ -334,8 +334,8 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                 testInputConfiguration1.createConfiguration();
         final TestInputConfiguration testInputConfiguration2 =
                 InlineConfigParser.parse(filePath2);
-        verifyViolations(parsedConfig, filePath1, testInputConfiguration1.getViolations());
-        verifyViolations(parsedConfig, filePath2, testInputConfiguration2.getViolations());
+        verifyViolations(parsedConfig, filePath1, testInputConfiguration1.violations());
+        verifyViolations(parsedConfig, filePath2, testInputConfiguration2.violations());
         verify(createChecker(parsedConfig),
                 new File[] {new File(filePath1), new File(filePath2)},
                 filePath1,
@@ -365,8 +365,8 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final TestInputConfiguration testInputConfiguration2 = InlineConfigParser.parse(filePath2);
         final DefaultConfiguration parsedConfig2 = testInputConfiguration.createConfiguration();
         final File[] inputs = {new File(filePath1), new File(filePath2)};
-        verifyViolations(parsedConfig, filePath1, testInputConfiguration.getViolations());
-        verifyViolations(parsedConfig2, filePath2, testInputConfiguration2.getViolations());
+        verifyViolations(parsedConfig, filePath1, testInputConfiguration.violations());
+        verifyViolations(parsedConfig2, filePath2, testInputConfiguration2.violations());
         verify(createChecker(parsedConfig), inputs, ImmutableMap.of(
             filePath1, expectedFromFile1,
             filePath2, expectedFromFile2));
@@ -415,7 +415,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                 InlineConfigParser.parse(filePath);
         final DefaultConfiguration parsedConfig =
                 testInputConfiguration.createConfiguration();
-        verifyViolations(parsedConfig, filePath, testInputConfiguration.getViolations());
+        verifyViolations(parsedConfig, filePath, testInputConfiguration.violations());
         verify(parsedConfig, filePath, expected);
     }
 
@@ -469,7 +469,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final TestInputConfiguration testInputConfiguration =
                 InlineConfigParser.parseWithXmlHeader(inputFile);
         final Configuration parsedConfig =
-                testInputConfiguration.getXmlConfiguration();
+                testInputConfiguration.xmlConfiguration();
         final List<File> filesToCheck = Collections.singletonList(new File(inputFile));
         final String basePath = Path.of("").toAbsolutePath().toString();
 
@@ -508,7 +508,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final TestInputConfiguration testInputConfiguration =
                 InlineConfigParser.parseWithXmlHeader(inputFile);
         final Configuration parsedConfig =
-                testInputConfiguration.getXmlConfiguration();
+                testInputConfiguration.xmlConfiguration();
         final List<File> filesToCheck = Collections.singletonList(new File(inputFile));
         final String basePath = Path.of("").toAbsolutePath().toString();
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -501,7 +501,7 @@ public final class InlineConfigParser {
             throw new CheckstyleException("Failed to set violations in " + inputFilePath, exc);
         }
 
-        return testInputConfigBuilder.build().getViolations();
+        return testInputConfigBuilder.build().violations();
     }
 
     public static List<TestInputViolation> getFilteredViolationsFromInputFile(String inputFilePath)
@@ -520,7 +520,7 @@ public final class InlineConfigParser {
             throw new CheckstyleException("Failed to set violations in " + inputFilePath, exc);
         }
 
-        return testInputConfigBuilder.build().getFilteredViolations();
+        return testInputConfigBuilder.build().filteredViolations();
     }
 
     public static TestInputConfiguration parseWithFilteredViolations(String inputFilePath)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
@@ -32,7 +32,10 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
-public final class TestInputConfiguration {
+public record TestInputConfiguration(List<ModuleInputConfiguration> childrenModules,
+                                     List<TestInputViolation> violations,
+                                     List<TestInputViolation> filteredViolations,
+                                     Configuration xmlConfiguration) {
 
     private static final String ROOT_MODULE_NAME = Checker.class.getSimpleName();
 
@@ -65,42 +68,16 @@ public final class TestInputConfiguration {
                 + ".VerifyPositionAfterLastTabFileSet"
     ));
 
-    private final List<ModuleInputConfiguration> childrenModules;
-
-    private final List<TestInputViolation> violations;
-
-    private final List<TestInputViolation> filteredViolations;
-
-    private final Configuration xmlConfiguration;
-
-    private TestInputConfiguration(List<ModuleInputConfiguration> childrenModules,
-                                   List<TestInputViolation> violations,
-                                   List<TestInputViolation> filteredViolations) {
-        this.childrenModules = childrenModules;
-        this.violations = violations;
-        this.filteredViolations = filteredViolations;
-        xmlConfiguration = null;
-    }
-
-    private TestInputConfiguration(List<TestInputViolation> violations,
-                                   List<TestInputViolation> filteredViolations,
-                                   Configuration xmlConfiguration) {
-        childrenModules = null;
-        this.violations = violations;
-        this.filteredViolations = filteredViolations;
-        this.xmlConfiguration = xmlConfiguration;
-    }
-
-    public List<ModuleInputConfiguration> getChildrenModules() {
-        return Collections.unmodifiableList(childrenModules);
-    }
-
-    public List<TestInputViolation> getViolations() {
-        return Collections.unmodifiableList(violations);
-    }
-
-    public List<TestInputViolation> getFilteredViolations() {
-        return Collections.unmodifiableList(filteredViolations);
+    public TestInputConfiguration {
+        if (childrenModules != null) {
+            childrenModules = Collections.unmodifiableList(childrenModules);
+        }
+        if (violations != null) {
+            violations = Collections.unmodifiableList(violations);
+        }
+        if (filteredViolations != null) {
+            filteredViolations = Collections.unmodifiableList(filteredViolations);
+        }
     }
 
     public DefaultConfiguration createConfiguration() {
@@ -121,10 +98,6 @@ public final class TestInputConfiguration {
                 });
         root.addChild(treeWalker);
         return root;
-    }
-
-    public Configuration getXmlConfiguration() {
-        return xmlConfiguration;
     }
 
     public DefaultConfiguration createConfigurationWithoutFilters() {
@@ -190,6 +163,7 @@ public final class TestInputConfiguration {
 
         public TestInputConfiguration buildWithXmlConfiguration() {
             return new TestInputConfiguration(
+                    null,
                     violations,
                     filteredViolations,
                     xmlConfiguration
@@ -200,7 +174,8 @@ public final class TestInputConfiguration {
             return new TestInputConfiguration(
                     childrenModules,
                     violations,
-                    filteredViolations
+                    filteredViolations,
+                    null
             );
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -390,7 +390,7 @@ public class AllChecksCompactSourceCoverageTest {
         }
         for (Path input : inputs) {
             final TestInputConfiguration config = InlineConfigParser.parse(input.toString());
-            for (ModuleInputConfiguration module : config.getChildrenModules()) {
+            for (ModuleInputConfiguration module : config.childrenModules()) {
                 if (checkClassName.equals(module.getModuleName())) {
                     nonDefaultsPerInput.add(module.getNonDefaultProperties().keySet());
                 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -497,7 +497,7 @@ public class XdocsExampleFileTest {
         try {
             final TestInputConfiguration parsed =
                     InlineConfigParser.parse(exampleFile.toString());
-            final List<TestInputViolation> violations = parsed.getViolations();
+            final List<TestInputViolation> violations = parsed.violations();
 
             final boolean hasUnspecifiedMessage = violations.stream()
                     .anyMatch(violation -> violation.message() == null);


### PR DESCRIPTION
close #21325 

### Summary

- Make `TestInputConfiguration.java` a record
- Remove instance fields and getter methods as records implicitly generate them.
- Update getViolations, getXMLConfiguration, etc usages to violations(), xmlConfiguration(),etc.
- Use compact constructor
- Remove `TestInputConfiguration.java` from exclusions in `qodana.yml`