### PR TITLE
Issue #21207: make IllegalTokenText default-config example Example 1

### DIFF
--- a/src/site/xdoc/checks/coding/illegaltokentext.xml
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml
@@ -20,10 +20,10 @@
             <input type="checkbox" id="toc-sub-Examples" class="toc-sub-toggle-checkbox" checked="checked"/>
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#IllegalTokenText_Examples">Examples</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
-              <li><a href="#Example1-config" class="toc-sublink">Forbid String literals containing <code>"a href"</code></a></li>
-              <li><a href="#Example2-config" class="toc-sublink">Forbid String literals containing <code>"a href"</code> for the ignoreCase mode</a></li>
-              <li><a href="#Example3-config" class="toc-sublink">Forbid comment content containing <code>"a href"</code></a></li>
-              <li><a href="#Example4-config" class="toc-sublink">With default properties</a></li>
+              <li><a href="#Example1-config" class="toc-sublink">With default properties</a></li>
+              <li><a href="#Example2-config" class="toc-sublink">Forbid String literals containing <code>"a href"</code></a></li>
+              <li><a href="#Example3-config" class="toc-sublink">Forbid String literals containing <code>"a href"</code> for the ignoreCase mode</a></li>
+              <li><a href="#Example4-config" class="toc-sublink">Forbid comment content containing <code>"a href"</code></a></li>
               <li><a href="#Example5-config" class="toc-sublink">With a custom violation message using the <code>message</code> property</a></li>
             </ul>
           </li>
@@ -113,6 +113,36 @@
 
       <subsection name="Examples" id="IllegalTokenText_Examples">
         <p id="Example1-config">
+          To configure the check with default properties:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="IllegalTokenText"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example1-code">Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example1 {
+  public void myTest() {
+
+    String test  = "a href";
+
+    String test2 = "A href";
+    String link = "href";
+    final String quote = """
+            \"""";
+    int num1 = 0;
+    int num2 = 0x111;
+    int num3 = 0X111;
+    int num4 = 010;
+    long num5 = 0L;
+    long num6 = 010L;
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example2-config">
           To configure the check to forbid String literals containing
           <code>&quot;a href&quot;</code>:
         </p>
@@ -126,9 +156,9 @@
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example1-code">Example:</p>
+        <p id="Example2-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example1 {
+public class Example2 {
   public void myTest() {
     // violation below 'Token text matches the illegal pattern 'a href'.'
     String test  = "a href";
@@ -146,7 +176,7 @@ public class Example1 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example2-config">
+        <p id="Example3-config">
           To configure the check to forbid String literals containing
           <code>&quot;a href&quot;</code> for the ignoreCase mode:
         </p>
@@ -161,48 +191,13 @@ public class Example1 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example2-code">Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example2 {
-  public void myTest() {
-    // violation below 'Token text matches the illegal pattern 'a href'.'
-    String test  = "a href";
-    // violation below 'Token text matches the illegal pattern 'a href'.'
-    String test2 = "A href";
-    String link = "href";
-    final String quote = """
-            \"""";
-    int num1 = 0;
-    int num2 = 0x111;
-    int num3 = 0X111;
-    int num4 = 010;
-    long num5 = 0L;
-    long num6 = 010L;
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example3-config">
-          To configure the check to forbid comment content containing
-          <code>&quot;a href&quot;</code>:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="IllegalTokenText"&gt;
-      &lt;property name="tokens" value="COMMENT_CONTENT"/&gt;
-      &lt;property name="format" value="a href"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
         <p id="Example3-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-// violation first line 'Token text matches the illegal pattern 'a href''
-public class Example3 { // violation above 'Token text matches the illegal pattern'
+public class Example3 {
   public void myTest() {
-
+    // violation below 'Token text matches the illegal pattern 'a href'.'
     String test  = "a href";
-
+    // violation below 'Token text matches the illegal pattern 'a href'.'
     String test2 = "A href";
     String link = "href";
     final String quote = """
@@ -217,18 +212,23 @@ public class Example3 { // violation above 'Token text matches the illegal patte
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
-          To configure the check with default properties:
+          To configure the check to forbid comment content containing
+          <code>&quot;a href&quot;</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-    &lt;module name="IllegalTokenText"/&gt;
+    &lt;module name="IllegalTokenText"&gt;
+      &lt;property name="tokens" value="COMMENT_CONTENT"/&gt;
+      &lt;property name="format" value="a href"/&gt;
+    &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
         <p id="Example4-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example4 {
+// violation first line 'Token text matches the illegal pattern 'a href''
+public class Example4 { // violation above 'Token text matches the illegal pattern'
   public void myTest() {
 
     String test  = "a href";

--- a/src/site/xdoc/checks/coding/illegaltokentext.xml.template
+++ b/src/site/xdoc/checks/coding/illegaltokentext.xml.template
@@ -33,8 +33,7 @@
 
       <subsection name="Examples" id="IllegalTokenText_Examples">
         <p id="Example1-config">
-          To configure the check to forbid String literals containing
-          <code>"a href"</code>:
+          To configure the check with default properties:
         </p>
         <macro name="example">
           <param name="path"
@@ -49,7 +48,7 @@
         </macro><hr class="example-separator"/>
         <p id="Example2-config">
           To configure the check to forbid String literals containing
-          <code>"a href"</code> for the ignoreCase mode:
+          <code>"a href"</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -63,8 +62,8 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example3-config">
-          To configure the check to forbid comment content containing
-          <code>"a href"</code>:
+          To configure the check to forbid String literals containing
+          <code>"a href"</code> for the ignoreCase mode:
         </p>
         <macro name="example">
           <param name="path"
@@ -78,7 +77,8 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example4-config">
-          To configure the check with default properties:
+          To configure the check to forbid comment content containing
+          <code>"a href"</code>:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -119,7 +119,6 @@ public class XdocsExampleFileTest {
      * <p>Until: <a href="https://github.com/checkstyle/checkstyle/issues/21207">...</a>
      */
     private static final Set<String> MODULES_WITHOUT_DEFAULT_FIRST_EXAMPLE = Set.of(
-        "checks/coding/illegaltokentext",
         "checks/translation"
     );
 

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckExamplesTest.java
@@ -34,9 +34,7 @@ public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTes
 
     @Test
     public void testExample1() throws Exception {
-        final String[] expected = {
-            "18:20: " + getCheckMessage(MSG_KEY, "a href"),
-        };
+        final String[] expected = {};
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
     }
@@ -44,8 +42,7 @@ public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTes
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "19:20: " + getCheckMessage(MSG_KEY, "a href"),
-            "21:20: " + getCheckMessage(MSG_KEY, "a href"),
+            "18:20: " + getCheckMessage(MSG_KEY, "a href"),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -54,8 +51,8 @@ public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTes
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "1:3: " + getCheckMessage(MSG_KEY, "a href"),
-            "14:3: " + getCheckMessage(MSG_KEY, "a href"),
+            "19:20: " + getCheckMessage(MSG_KEY, "a href"),
+            "21:20: " + getCheckMessage(MSG_KEY, "a href"),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
@@ -63,7 +60,10 @@ public class IllegalTokenTextCheckExamplesTest extends AbstractExamplesModuleTes
 
     @Test
     public void testExample4() throws Exception {
-        final String[] expected = {};
+        final String[] expected = {
+            "1:3: " + getCheckMessage(MSG_KEY, "a href"),
+            "14:3: " + getCheckMessage(MSG_KEY, "a href"),
+        };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example1.java
@@ -1,10 +1,7 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="IllegalTokenText">
-      <property name="tokens" value="STRING_LITERAL"/>
-      <property name="format" value="a href"/>
-    </module>
+    <module name="IllegalTokenText"/>
   </module>
 </module>
 */
@@ -14,10 +11,10 @@ package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
 
 public class Example1 {
   public void myTest() {
-    // violation below 'Token text matches the illegal pattern 'a href'.'
+
     String test  = "a href";
 
-    String test2 = "A href"; // ok, case is sensitive
+    String test2 = "A href";
     String link = "href";
     final String quote = """
             \"""";

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example2.java
@@ -4,7 +4,6 @@
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL"/>
       <property name="format" value="a href"/>
-      <property name="ignoreCase" value="true"/>
     </module>
   </module>
 </module>
@@ -17,8 +16,8 @@ public class Example2 {
   public void myTest() {
     // violation below 'Token text matches the illegal pattern 'a href'.'
     String test  = "a href";
-    // violation below 'Token text matches the illegal pattern 'a href'.'
-    String test2 = "A href";
+
+    String test2 = "A href"; // ok, case is sensitive
     String link = "href";
     final String quote = """
             \"""";

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example3.java
@@ -2,8 +2,9 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="IllegalTokenText">
-      <property name="tokens" value="COMMENT_CONTENT"/>
+      <property name="tokens" value="STRING_LITERAL"/>
       <property name="format" value="a href"/>
+      <property name="ignoreCase" value="true"/>
     </module>
   </module>
 </module>
@@ -11,12 +12,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
 // xdoc section - start
-// violation first line 'Token text matches the illegal pattern 'a href''
-public class Example3 { // violation above 'Token text matches the illegal pattern'
+
+public class Example3 {
   public void myTest() {
-
+    // violation below 'Token text matches the illegal pattern 'a href'.'
     String test  = "a href";
-
+    // violation below 'Token text matches the illegal pattern 'a href'.'
     String test2 = "A href";
     String link = "href";
     final String quote = """

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/Example4.java
@@ -1,15 +1,18 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="IllegalTokenText"/>
+    <module name="IllegalTokenText">
+      <property name="tokens" value="COMMENT_CONTENT"/>
+      <property name="format" value="a href"/>
+    </module>
   </module>
 </module>
 */
 
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
 // xdoc section - start
-
-public class Example4 {
+// violation first line 'Token text matches the illegal pattern 'a href''
+public class Example4 { // violation above 'Token text matches the illegal pattern'
   public void myTest() {
 
     String test  = "a href";


### PR DESCRIPTION
Ref: #21207.

- Reordered examples for `IllegalTokenText` so the default-config example(empty module with no properties) is Example1.
- Removed `checks/coding/illegaltokentext` from `MODULES_WITHOUT_DEFAULT_FIRST_EXAMPLE` in `XdocsExampleFileTest`.

./mvnw clean verify produces success build in local

<img width="882" height="195" alt="image" src="https://github.com/user-attachments/assets/230c6c79-cb84-4432-ae40-5759d87d53e7" />
