### PR TITLE
Issue #21330: Move violation hints from trailing comments

### DIFF
--- a/src/site/xdoc/checks/misc/trailingcomment.xml
+++ b/src/site/xdoc/checks/misc/trailingcomment.xml
@@ -147,16 +147,19 @@ public class Example1 {
   int a;
   int b;
   int c;
-  int d; // violation 'Don't use trailing comments.'
+  int d; // ok, SUPPRESS CHECKSTYLE
+  // violation above 'Don't use trailing comments.'
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK */ x &gt; 5) {}
-    int a = 5; // violation 'Don't use trailing comments.'
+    int a = 5; // trailing comment
+    // violation above 'Don't use trailing comments.'
     doSomething(
             "param1"
-    ); // ok, by default such trailing of method/code-block ending is allowed
+    ); // trailing comment
+    // ok above, trailing comment after ');' is allowed by default
 
   }
 
@@ -183,19 +186,22 @@ public class Example1 {
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
-  int a; // violation 'Don't use trailing comments.'
-  int b; // violation 'Don't use trailing comments.'
-  int c; // violation 'Don't use trailing comments.'
-  int d; // violation 'Don't use trailing comments.'
+  int a;
+  int b;
+  int c;
+  int d; // ok, SUPPRESS CHECKSTYLE
+  // violation above 'Don't use trailing comments.'
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK, this comment does not end the line */ x &gt; 5) {}
-    int a = 5; // violation 'Don't use trailing comments.'
+    int a = 5; // trailing comment
+    // violation above 'Don't use trailing comments.'
     doSomething(
             "param1"
-    ); // violation 'Don't use trailing comments.'
+    ); // trailing comment
+    // violation above 'Don't use trailing comments.'
 
   }
 
@@ -227,15 +233,18 @@ public class Example3 {
   int b;
   int c;
   int d; // ok, SUPPRESS CHECKSTYLE
+  // ok above, matches legalComment pattern
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK */ x &gt; 5) {}
-    int a = 5; // violation 'Don't use trailing comments.'
+    int a = 5; // trailing comment
+    // violation above 'Don't use trailing comments.'
     doSomething(
             "param1"
-    ); // ok, by default such trailing of method/code-block ending is allowed
+    ); // trailing comment
+    // ok above, trailing comment after ');' is allowed by default
 
   }
 
@@ -269,7 +278,8 @@ public class UseCase1 {
   int a; // SUPPRESS CHECKSTYLE - OK, comment starts with " SUPPRESS CHECKSTYLE"
   int b; // NOPMD - OK, comment starts with " NOPMD"
   int c; // NOSONAR - OK, comment starts with " NOSONAR"
-  int d; // violation 'Don't use trailing comments.'
+  int d; // some comment - does not match legalComment
+  // violation above 'Don't use trailing comments.'
 }
 </code></pre></div><hr class="example-separator"/>
 
@@ -301,7 +311,8 @@ public class UseCase2 {
     ); // FIXME: handle edge cases - ok, matches legalComment pattern
 
     int b = 10; // trailingcomment - ok, matches legalComment pattern
-    int c = 15; // violation 'Don't use trailing comments.'
+    int c = 15; // some comment - does not match legalComment
+    // violation above 'Don't use trailing comments.'
   }
 
   private static void doSomething(String param) {

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
@@ -36,7 +36,7 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
     public void testExample1() throws Exception {
         final String[] expected = {
             "16:10: " + getCheckMessage(MSG_KEY),
-            "22:16: " + getCheckMessage(MSG_KEY),
+            "23:16: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -45,12 +45,9 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample2() throws Exception {
         final String[] expected = {
-            "15:10: " + getCheckMessage(MSG_KEY),
-            "16:10: " + getCheckMessage(MSG_KEY),
-            "17:10: " + getCheckMessage(MSG_KEY),
             "18:10: " + getCheckMessage(MSG_KEY),
-            "24:16: " + getCheckMessage(MSG_KEY),
-            "27:8: " + getCheckMessage(MSG_KEY),
+            "25:16: " + getCheckMessage(MSG_KEY),
+            "29:8: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example2.java"), expected);
@@ -59,7 +56,7 @@ public class TrailingCommentCheckExamplesTest extends AbstractExamplesModuleTest
     @Test
     public void testExample3() throws Exception {
         final String[] expected = {
-            "24:16: " + getCheckMessage(MSG_KEY),
+            "25:16: " + getCheckMessage(MSG_KEY),
         };
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example1.java
@@ -13,16 +13,19 @@ public class Example1 {
   int a;
   int b;
   int c;
-  int d; // violation 'Don't use trailing comments.'
+  int d; // ok, SUPPRESS CHECKSTYLE
+  // violation above 'Don't use trailing comments.'
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK */ x > 5) {}
-    int a = 5; // violation 'Don't use trailing comments.'
+    int a = 5; // trailing comment
+    // violation above 'Don't use trailing comments.'
     doSomething(
             "param1"
-    ); // ok, by default such trailing of method/code-block ending is allowed
+    ); // trailing comment
+    // ok above, trailing comment after ');' is allowed by default
 
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example2.java
@@ -12,19 +12,22 @@ package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
 
 // xdoc section - start
 public class Example2 {
-  int a; // violation 'Don't use trailing comments.'
-  int b; // violation 'Don't use trailing comments.'
-  int c; // violation 'Don't use trailing comments.'
-  int d; // violation 'Don't use trailing comments.'
+  int a;
+  int b;
+  int c;
+  int d; // ok, SUPPRESS CHECKSTYLE
+  // violation above 'Don't use trailing comments.'
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK, this comment does not end the line */ x > 5) {}
-    int a = 5; // violation 'Don't use trailing comments.'
+    int a = 5; // trailing comment
+    // violation above 'Don't use trailing comments.'
     doSomething(
             "param1"
-    ); // violation 'Don't use trailing comments.'
+    ); // trailing comment
+    // violation above 'Don't use trailing comments.'
 
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
@@ -16,15 +16,18 @@ public class Example3 {
   int b;
   int c;
   int d; // ok, SUPPRESS CHECKSTYLE
+  // ok above, matches legalComment pattern
 
   public static void main(String[] args) {
     int x = 10;
 
     if (/* OK */ x > 5) {}
-    int a = 5; // violation 'Don't use trailing comments.'
+    int a = 5; // trailing comment
+    // violation above 'Don't use trailing comments.'
     doSomething(
             "param1"
-    ); // ok, by default such trailing of method/code-block ending is allowed
+    ); // trailing comment
+    // ok above, trailing comment after ');' is allowed by default
 
   }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase1.java
@@ -15,6 +15,7 @@ public class UseCase1 {
   int a; // SUPPRESS CHECKSTYLE - OK, comment starts with " SUPPRESS CHECKSTYLE"
   int b; // NOPMD - OK, comment starts with " NOPMD"
   int c; // NOSONAR - OK, comment starts with " NOSONAR"
-  int d; // violation 'Don't use trailing comments.'
+  int d; // some comment - does not match legalComment
+  // violation above 'Don't use trailing comments.'
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase2.java
@@ -22,7 +22,8 @@ public class UseCase2 {
     ); // FIXME: handle edge cases - ok, matches legalComment pattern
 
     int b = 10; // trailingcomment - ok, matches legalComment pattern
-    int c = 15; // violation 'Don't use trailing comments.'
+    int c = 15; // some comment - does not match legalComment
+    // violation above 'Don't use trailing comments.'
   }
 
   private static void doSomething(String param) {


### PR DESCRIPTION
# Issue #21330: Trailing comment examples should have violation hint comments to be not trailing

## Problem

The examples for the `TrailingComment` check used the violation marker itself as the
trailing comment:

```java
public class Example1 {
  int a;
  int b;
  int c;
  int d; // violation 'Don't use trailing comments.'
}
```

`// violation '...'` serves two purposes at once. It labels the flagged line for readers
of the generated documentation, and it is parsed by `InlineConfigParser` to build the
expected violations for the test. For every other check that is harmless. For this check
it is circular: the marker *is* a trailing comment, so it is the thing causing the
violation. Delete it and `int d;` becomes identical to `int a;` and nothing is flagged.

The result is that the rendered documentation shows four identical field declarations
where only the fourth is an error, with no visible difference other than test scaffolding
that a reader has no way to recognize as such. The example demonstrates nothing about the
rule.

## Solution

Give the code a real trailing comment and move the marker onto its own line, where it is
no longer trailing anything:

```java
  int d; // trailing comment
  // violation above 'Don't use trailing comments.'
```

`UseCase3.java` already used this form and is unchanged.

## Why the examples were restructured rather than patched line by line

Adding a marker line only where a violation exists desynchronizes the example files, and
two existing tests reject that:

- `XdocsExamplesAstConsistencyTest` compares `Example\d+.java` files structurally, and
  `StructuralAstNode.equals` includes the node's line number within the rendered section.
  Example1 had two violations, Example2 six and Example3 one, so inserting a marker after
  each would move `public static void main` to a different relative line in each file.
- The same test compares the list of comments that are not markers. `isIgnoredComment`
  only skips comments beginning with `ok`, `violation`, `filtered violation`,
  `xdoc section`, an `N violations` count, or a quoted continuation. A comment reading
  `// trailing comment` is therefore compared as content and must be identical across all
  three examples.

Example1, Example2 and Example3 are now identical in code and in trailing comments, and
differ only in configuration. That satisfies both constraints and is closer to what these
examples are meant to show: the same input under different settings producing different
results.

One consequence is worth calling out. `int d; // ok, SUPPRESS CHECKSTYLE` is legal in
Example3, whose `legalComment` matches it, and a violation in Example1 and Example2, which
configure no `legalComment`. The same line now demonstrates the property directly.

`UseCase*.java` files are excluded from both tests (they filter on `Example\d+\.java`), so
those took the straightforward change.

## Files changed

```
src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example1.java
src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example2.java
src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/Example3.java
src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase1.java
src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/UseCase2.java
src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckExamplesTest.java
src/site/xdoc/checks/misc/trailingcomment.xml
```

`UseCase3.java` is unchanged. `trailingcomment.xml` is regenerated by
`./mvnw process-classes`, not edited by hand.

### Expected violations

| Example | Before | After |
|---|---|---|
| Example1 | `16:10`, `22:16` | `13:10`, `17:10`, `24:16` |
| Example2 | `15:10`, `16:10`, `17:10`, `18:10`, `24:16`, `27:8` | `15:10`, `19:10`, `26:16`, `30:8` |
| Example3 | `24:16` | `15:10`, `26:16` |
| UseCase1 | `18:10` | unchanged |
| UseCase2 | `25:17` | unchanged |
| UseCase3 | `24:10` | unchanged |

## Verification

`./mvnw verify` — 1310 tests run, 0 failures. `TrailingCommentCheckExamplesTest`,
`XdocsExamplesAstConsistencyTest`, `XdocsExampleFileTest` and `XdocsPagesTest` all pass.