### PR TITLE
minor: remove unused `getCheckstylePomVersionWithoutSnapshotWithXmlstarlet`

### DIFF
--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -35,11 +35,6 @@ function getCheckstylePomVersionWithoutSnapshot {
   getCheckstylePomVersion | sed "s/-SNAPSHOT//"
 }
 
-function getCheckstylePomVersionWithoutSnapshotWithXmlstarlet {
-  xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 \
-    -t -m pom:project -v pom:version pom.xml | sed "s/-SNAPSHOT//"
-}
-
 function checkout_from {
   CLONE_URL=$1
   TARGET_SHA=$2


### PR DESCRIPTION
Removed `getCheckstylePomVersionWithoutSnapshotWithXmlstarlet` from `util.sh` since it's not used. I believe we introduced it temporarily during summer 2023.

```shell
$ rg --hidden --glob '!.git/' "getCheckstylePomVersionWithoutSnapshotWithXmlstarlet" .
# non-zero exit code, no results found
```