### PR TITLE
minor: remove checkstyle word from `getCheckstylePomVersion`

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -17,7 +17,7 @@ if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1;
 fi
 
-CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot) \
+CURRENT_VERSION=$(getPomVersionWithoutSnapshot) \
   || { echo "Failed to get Checkstyle POM version."; exit 1; }
 echo CURRENT_VERSION="$CURRENT_VERSION"
 

--- a/.ci/no-exception-test.sh
+++ b/.ci/no-exception-test.sh
@@ -6,7 +6,7 @@ source ./.ci/util.sh
 case $1 in
 
 guava-with-google-checks)
-  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+  CS_POM_VERSION="$(getPomVersion)" \
     || { echo "Failed to get Checkstyle POM version."; exit 1; }
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "$CS_POM_VERSION"
@@ -29,7 +29,7 @@ guava-with-google-checks)
   ;;
 
 guava-with-sun-checks)
-  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+  CS_POM_VERSION="$(getPomVersion)" \
     || { echo "Failed to get Checkstyle POM version."; exit 1; }
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "$CS_POM_VERSION"
@@ -140,7 +140,7 @@ openjdk25-with-checks-nonjavadoc-error)
   ;;
 
 no-exception-lucene-and-others-javadoc)
-  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+  CS_POM_VERSION="$(getPomVersion)" \
     || { echo "Failed to get Checkstyle POM version."; exit 1; }
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
@@ -163,7 +163,7 @@ no-exception-lucene-and-others-javadoc)
   ;;
 
 no-exception-cassandra-storm-tapestry-javadoc)
-  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+  CS_POM_VERSION="$(getPomVersion)" \
     || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -185,7 +185,7 @@ no-exception-cassandra-storm-tapestry-javadoc)
   ;;
 
 no-exception-hadoop-apache-groovy-scouter-javadoc)
-  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+  CS_POM_VERSION="$(getPomVersion)" \
     || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -208,7 +208,7 @@ no-exception-hadoop-apache-groovy-scouter-javadoc)
   ;;
 
 no-exception-only-javadoc)
-  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+  CS_POM_VERSION="$(getPomVersion)" \
     || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -230,7 +230,7 @@ no-exception-only-javadoc)
   ;;
 
 no-exception-samples-ant)
-  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+  CS_POM_VERSION="$(getPomVersion)" \
     || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress -B install -Pno-validations
@@ -248,7 +248,7 @@ no-exception-samples-ant)
   ;;
 
 no-exception-samples-gradle)
-  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+  CS_POM_VERSION="$(getPomVersion)" \
     || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress -B install -Pno-validations
@@ -267,7 +267,7 @@ no-exception-samples-gradle)
   ;;
 
 no-exception-samples-maven)
-  CS_POM_VERSION="$(getCheckstylePomVersion)" \
+  CS_POM_VERSION="$(getPomVersion)" \
     || { echo "Failed to get Checkstyle POM version."; exit 1; }
   echo 'CS_POM_VERSION='"${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress -B install -Pno-validations

--- a/.ci/release-close-create-milestone.sh
+++ b/.ci/release-close-create-milestone.sh
@@ -19,7 +19,7 @@ curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
 
 echo "Creation of new milestone ..."
 
-CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot) \
+CURRENT_VERSION=$(getPomVersionWithoutSnapshot) \
   || { echo "Failed to get Checkstyle POM version."; exit 1; }
 echo CURRENT_VERSION="$CURRENT_VERSION"
 

--- a/.ci/release-maven-prepare.sh
+++ b/.ci/release-maven-prepare.sh
@@ -13,7 +13,7 @@ fi
 TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
-CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot) \
+CURRENT_VERSION=$(getPomVersionWithoutSnapshot) \
   || { echo "Failed to get Checkstyle POM version."; exit 1; }
 echo CURRENT_VERSION="$CURRENT_VERSION"
 

--- a/.ci/release-update-xdoc-with-releasenotes.sh
+++ b/.ci/release-update-xdoc-with-releasenotes.sh
@@ -13,7 +13,7 @@ fi
 TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
-CURRENT_VERSION=$(getCheckstylePomVersionWithoutSnapshot) \
+CURRENT_VERSION=$(getPomVersionWithoutSnapshot) \
   || { echo "Failed to get Checkstyle POM version."; exit 1; }
 echo CURRENT_VERSION="$CURRENT_VERSION"
 

--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -27,12 +27,12 @@ function getMavenProperty {
                       --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec
 }
 
-function getCheckstylePomVersion {
+function getPomVersion {
   getMavenProperty project.version
 }
 
-function getCheckstylePomVersionWithoutSnapshot {
-  getCheckstylePomVersion | sed "s/-SNAPSHOT//"
+function getPomVersionWithoutSnapshot {
+  getPomVersion | sed "s/-SNAPSHOT//"
 }
 
 function getCheckstylePomVersionWithoutSnapshotWithXmlstarlet {

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -296,7 +296,7 @@ markdownlint)
   ;;
 
 no-error-kafka)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo "CS_version: ${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -318,7 +318,7 @@ EOF
 
 no-error-pmd)
   export MAVEN_OPTS="-XX:MaxRAMPercentage=90"
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo "CS_version: ${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -348,7 +348,7 @@ no-error-pmd)
   ;;
 
 no-error-hazelcast)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo "CS_version: ${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean package -Passembly,no-validations
   echo "Checkout Hazelcast sources..."
@@ -406,7 +406,7 @@ EOF
   ;;
 
 no-error-xwiki)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   ANTLR4_VERSION="$(getMavenProperty 'antlr4.version')"
   echo "version:${CS_POM_VERSION} antlr4:${ANTLR4_VERSION}"
 
@@ -456,7 +456,7 @@ no-error-xwiki)
   ;;
 
 no-error-test-sbe)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo version:"$CS_POM_VERSION"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -610,7 +610,7 @@ release-dry-run)
 
 assembly-run-all-jar)
   ./mvnw -e --no-transfer-progress clean package -Passembly,no-validations
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo version:"$CS_POM_VERSION"
   mkdir -p .ci-temp
   FOLDER=src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired
@@ -687,7 +687,7 @@ check-since-version)
 
   if [ -f "$NEW_CHECK_FILE" ]; then
     echo "New Check detected: $NEW_CHECK_FILE"
-    CS_RELEASE_VERSION="$(getCheckstylePomVersionWithoutSnapshot)"
+    CS_RELEASE_VERSION="$(getPomVersionWithoutSnapshot)"
     echo "CS Release version: $CS_RELEASE_VERSION"
 
     if [[ $CS_RELEASE_VERSION != *.0 ]]; then
@@ -934,7 +934,7 @@ sonarqube)
   ;;
 
 no-error-pgjdbc)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -949,7 +949,7 @@ no-error-pgjdbc)
   ;;
 
 no-error-orekit)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean package -Passembly,no-validations
   echo "Checkout target sources ..."
@@ -976,7 +976,7 @@ no-error-orekit)
   ;;
 
 no-error-hibernate-search)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -997,7 +997,7 @@ no-error-hibernate-search)
 
 no-error-checkstyles-sevntu)
   set -e
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   ./mvnw -e --no-transfer-progress compile verify -Psevntu \
@@ -1008,7 +1008,7 @@ no-error-checkstyles-sevntu)
 
 no-error-sevntu-checks)
   set -e
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -1025,7 +1025,7 @@ no-error-sevntu-checks)
 
 no-error-checkstyle-openrewrite-recipes)
   set -e
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -1040,7 +1040,7 @@ no-error-checkstyle-openrewrite-recipes)
 
 no-error-contribution)
   set -e
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -1059,7 +1059,7 @@ no-error-contribution)
 
 no-error-methods-distance)
   set -e
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -1072,7 +1072,7 @@ no-error-methods-distance)
   ;;
 
 no-error-equalsverifier)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean package -Passembly,no-validations
   echo "Checkout target sources ..."
@@ -1089,7 +1089,7 @@ no-error-equalsverifier)
 
 no-error-strata)
   set -e
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -1108,7 +1108,7 @@ no-error-strata)
 
 no-error-spring-integration)
   set -e
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -1123,7 +1123,7 @@ no-error-spring-integration)
   ;;
 
 no-error-htmlunit)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean package -Passembly,no-validations
   echo "Checkout target sources ..."
@@ -1144,7 +1144,7 @@ no-error-htmlunit)
   ;;
 
 no-error-spotbugs)
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   ./mvnw -e --no-transfer-progress clean install -Pno-validations
   echo "Checkout target sources ..."
@@ -1161,7 +1161,7 @@ no-error-trino)
   echo "Building checkstyle..."
   ./mvnw -e --no-transfer-progress clean install -Pno-validations -DskipTests
   echo "Resolving Checkstyle version from pom.xml..."
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo "CS_version: ${CS_POM_VERSION}"
   echo "Cloning Trino sources..."
   checkout_from https://github.com/trinodb/trino.git "f45e24a240b089a6499c9bc1a4193b3fa""ba798ef"
@@ -1175,7 +1175,7 @@ no-error-trino)
 
 no-exception-struts)
   export MAVEN_OPTS="-XX:MaxRAMPercentage=90"
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "${CS_POM_VERSION}"
   checkout_from https://github.com/checkstyle/contribution
@@ -1193,7 +1193,7 @@ no-exception-struts)
 no-exception-checkstyle-sevntu)
   export MAVEN_OPTS="-Xmx4g"
   set -e
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "${CS_POM_VERSION}"
   checkout_from https://github.com/checkstyle/contribution
@@ -1212,7 +1212,7 @@ no-exception-checkstyle-sevntu)
 no-exception-checkstyle-sevntu-javadoc)
   export MAVEN_OPTS="-Xmx4g"
   set -e
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "${CS_POM_VERSION}"
   checkout_from https://github.com/checkstyle/contribution
@@ -1231,7 +1231,7 @@ no-exception-checkstyle-sevntu-javadoc)
 
 no-exception-guava)
   export MAVEN_OPTS="-Xmx4g"
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   checkout_from https://github.com/checkstyle/contribution
@@ -1248,7 +1248,7 @@ no-exception-guava)
 
 no-exception-hibernate-orm)
   export MAVEN_OPTS="-Xmx4g"
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   checkout_from https://github.com/checkstyle/contribution
@@ -1265,7 +1265,7 @@ no-exception-hibernate-orm)
 
 no-exception-spotbugs)
   export MAVEN_OPTS="-Xmx4g"
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "${CS_POM_VERSION}"
   checkout_from https://github.com/checkstyle/contribution
@@ -1282,7 +1282,7 @@ no-exception-spotbugs)
 
 no-exception-spoon)
   export MAVEN_OPTS="-Xmx4g"
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "${CS_POM_VERSION}"
   checkout_from https://github.com/checkstyle/contribution
@@ -1299,7 +1299,7 @@ no-exception-spoon)
 
 no-exception-spring-framework)
   export MAVEN_OPTS="-Xmx4g"
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "${CS_POM_VERSION}"
   checkout_from https://github.com/checkstyle/contribution
@@ -1316,7 +1316,7 @@ no-exception-spring-framework)
 
 no-exception-hbase)
   export MAVEN_OPTS="-Xmx4g"
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   checkout_from https://github.com/checkstyle/contribution
@@ -1333,7 +1333,7 @@ no-exception-hbase)
 
 no-exception-Pmd-elasticsearch-lombok-ast)
   export MAVEN_OPTS="-Xmx4g"
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "${CS_POM_VERSION}"
   checkout_from https://github.com/checkstyle/contribution
@@ -1352,7 +1352,7 @@ no-exception-Pmd-elasticsearch-lombok-ast)
 
 no-exception-alot-of-projects)
   export MAVEN_OPTS="-Xmx4g"
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   echo CS_version: "${CS_POM_VERSION}"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   checkout_from https://github.com/checkstyle/contribution
@@ -1377,7 +1377,7 @@ no-warning-imports-guava)
   PROJECTS=checks-import-order/projects-to-test-imports-guava.properties
   CONFIG=checks-import-order/checks-imports-error-guava.xml
   REPORT=reports/guava/site/index.html
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "${CS_POM_VERSION}"
   checkout_from https://github.com/checkstyle/contribution
@@ -1403,7 +1403,7 @@ no-warning-imports-java-design-patterns)
   PROJECTS=checks-import-order/projects-to-test-imports-java-design-patterns.properties
   CONFIG=checks-import-order/checks-imports-error-java-design-patterns.xml
   REPORT=reports/java-design-patterns/site/index.html
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
+  CS_POM_VERSION="$(getPomVersion)"
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo CS_version: "${CS_POM_VERSION}"
   checkout_from https://github.com/checkstyle/contribution


### PR DESCRIPTION
Resolves https://github.com/checkstyle/checkstyle-files-generator/pull/18#discussion_r3843658018:
> We need to rename method to drop `Checkstyle` word.
> we can, there might be some name collision back in time, if not present now, we can update.

Renamed:
- `getCheckstylePomVersion` to `getPomVersion`
- `getCheckstylePomVersionWithoutSnapshot` to `getPomVersionWithoutSnapshot`