### PR TITLE
Issue #4454: make Violation.compareTo consistent with equals

### DIFF
--- a/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-lock-tainting-suppressions.xml
@@ -345,15 +345,15 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
     <specifier>method.guarantee.violated</specifier>
-    <message>method compareTo is @Pure but calls getViolation which is @ReleasesNoLocks (weaker side effect guarantee)</message>
-    <lineContent>result = getViolation().compareTo(other.getViolation());</lineContent>
+    <message>method compareTo is @Pure but calls compareContent which is @ReleasesNoLocks (weaker side effect guarantee)</message>
+    <lineContent>result = compareContent(other);</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
     <specifier>method.guarantee.violated</specifier>
-    <message>method compareTo is @Pure but calls getViolation which is @ReleasesNoLocks (weaker side effect guarantee)</message>
-    <lineContent>result = getViolation().compareTo(other.getViolation());</lineContent>
+    <message>method compareTo is @Pure but calls compareLocation which is @ReleasesNoLocks (weaker side effect guarantee)</message>
+    <lineContent>int result = compareLocation(other);</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -307,6 +307,14 @@
     <Bug pattern="PSC_PRESIZE_COLLECTIONS" />
   </Match>
 
+  <!-- false positive: tree traversal with unknown result size -->
+  <!-- until https://github.com/spotbugs/spotbugs-maven-plugin/issues/806 -->
+  <Match>
+    <Class name="com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck" />
+    <Method name="visitEachToken" />
+    <Bug pattern="PSC_PRESIZE_COLLECTIONS" />
+  </Match>
+
   <!-- it has xdoc annotation, we need to reconsider it after we finalize our xdoc generation -->
   <Match>
     <Class name="com.puppycrawl.tools.checkstyle.checks.header.MultiFileRegexpHeaderCheck" />

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
@@ -388,44 +388,121 @@ public final class Violation
     // Interface Comparable methods
     ////////////////////////////////////////////////////////////////////////////
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The same fields as in {@link #equals(Object)} take part in the
+     * comparison, so that a result of zero is consistent with equality, as the
+     * {@link Comparable} contract recommends. Line, column, module id, source
+     * class, and the rendered violation stay the leading criteria; the
+     * remaining fields only break a tie between violations that would
+     * otherwise be reported at the same place with the same text.
+     */
     @Override
     public int compareTo(Violation other) {
-        final int result;
-
-        if (lineNo == other.lineNo) {
-            if (columnNo == other.columnNo) {
-                if (Objects.equals(moduleId, other.moduleId)) {
-                    if (Objects.equals(sourceClass, other.sourceClass)) {
-                        result = getViolation().compareTo(other.getViolation());
-                    }
-                    else if (sourceClass == null) {
-                        result = -1;
-                    }
-                    else if (other.sourceClass == null) {
-                        result = 1;
-                    }
-                    else {
-                        result = sourceClass.getName().compareTo(other.sourceClass.getName());
-                    }
-                }
-                else if (moduleId == null) {
-                    result = -1;
-                }
-                else if (other.moduleId == null) {
-                    result = 1;
-                }
-                else {
-                    result = moduleId.compareTo(other.moduleId);
-                }
-            }
-            else {
-                result = Integer.compare(columnNo, other.columnNo);
-            }
-        }
-        else {
-            result = Integer.compare(lineNo, other.lineNo);
+        int result = compareLocation(other);
+        if (result == 0) {
+            result = compareContent(other);
         }
         return result;
+    }
+
+    /**
+     * Compares the place and the text a violation is reported with.
+     *
+     * @param other the violation to compare against
+     * @return the value {@code 0} if the violations are reported the same way
+     */
+    private int compareLocation(Violation other) {
+        int result = Integer.compare(lineNo, other.lineNo);
+        if (result == 0) {
+            result = Integer.compare(columnNo, other.columnNo);
+        }
+        if (result == 0) {
+            result = compareNullable(moduleId, other.moduleId);
+        }
+        if (result == 0) {
+            result = compareNullable(getSourceClassName(), other.getSourceClassName());
+        }
+        if (result == 0) {
+            result = getViolation().compareTo(other.getViolation());
+        }
+        return result;
+    }
+
+    /**
+     * Compares the fields that two violations reported at the same place with
+     * the same text can still differ in.
+     *
+     * @param other the violation to compare against
+     * @return the value {@code 0} if the violations carry the same content
+     */
+    private int compareContent(Violation other) {
+        int result = Integer.compare(columnCharIndex, other.columnCharIndex);
+        if (result == 0) {
+            result = Integer.compare(tokenType, other.tokenType);
+        }
+        if (result == 0) {
+            result = severityLevel.compareTo(other.severityLevel);
+        }
+        if (result == 0) {
+            result = compareNullable(key, other.key);
+        }
+        if (result == 0) {
+            result = compareNullable(bundle, other.bundle);
+        }
+        if (result == 0) {
+            result = compareNullable(customMessage, other.customMessage);
+        }
+        if (result == 0) {
+            result = Arrays.deepToString(args).compareTo(Arrays.deepToString(other.args));
+        }
+        return result;
+    }
+
+    /**
+     * Compares two values that may be {@code null}, ordering {@code null}
+     * before any other value.
+     *
+     * @param first the first value
+     * @param second the second value
+     * @return a negative integer, zero, or a positive integer as the first
+     *     value is less than, equal to, or greater than the second
+     */
+    private static int compareNullable(@Nullable String first, @Nullable String second) {
+        final int result;
+        if (first == null) {
+            if (second == null) {
+                result = 0;
+            }
+            else {
+                result = -1;
+            }
+        }
+        else if (second == null) {
+            result = 1;
+        }
+        else {
+            result = first.compareTo(second);
+        }
+        return result;
+    }
+
+    /**
+     * Gets the source class name or {@code null} when no source class is set.
+     *
+     * @return the source class name or {@code null}
+     */
+    @Nullable
+    private String getSourceClassName() {
+        final String name;
+        if (sourceClass == null) {
+            name = null;
+        }
+        else {
+            name = sourceClass.getName();
+        }
+        return name;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -189,9 +190,42 @@ public class LeftCurlyCheck
             }
         };
 
-        if (brace != null) {
+        if (brace != null && !isBraceVerifiedByParent(ast)) {
             verifyBrace(brace, startToken);
         }
+    }
+
+    /**
+     * Checks whether the brace of the given token is verified through its parent
+     * as well. An {@code OBJBLOCK} shares its brace with the type definition it
+     * belongs to, and the case label of an arrow switch shares its brace with the
+     * {@code SWITCH_RULE}. Without this the same brace is reported twice.
+     *
+     * @param ast the token being visited
+     * @return {@code true} if the parent already verifies the same brace
+     */
+    private boolean isBraceVerifiedByParent(DetailAST ast) {
+        return TokenUtil.isOfType(ast,
+                    TokenTypes.OBJBLOCK, TokenTypes.LITERAL_CASE, TokenTypes.LITERAL_DEFAULT)
+                && isConfigured(ast.getParent());
+    }
+
+    /**
+     * Checks whether the token type of the given node is configured for this check.
+     *
+     * @param ast the token to check
+     * @return {@code true} if this check visits that token type
+     */
+    private boolean isConfigured(DetailAST ast) {
+        final Set<String> configuredTokens = getTokenNames();
+        final boolean result;
+        if (configuredTokens.isEmpty()) {
+            result = TokenUtil.isOfType(ast, getDefaultTokens());
+        }
+        else {
+            result = configuredTokens.contains(TokenUtil.getTokenName(ast.getType()));
+        }
+        return result;
     }
 
     /**
@@ -354,10 +388,13 @@ public class LeftCurlyCheck
         if (leftCurly.getType() == TokenTypes.SLIST) {
             nextToken = leftCurly.getFirstChild();
         }
-        else {
-            if (!ignoreEnums
-                    && leftCurly.getParent().getParent().getType() == TokenTypes.ENUM_DEF) {
+        else if (!ignoreEnums) {
+            if (leftCurly.getParent().getParent().getType() == TokenTypes.ENUM_DEF) {
                 nextToken = leftCurly.getNextSibling();
+            }
+            else if (leftCurly.getParent().getType() == TokenTypes.ENUM_DEF) {
+                // the brace of the enum body is the first child of its OBJBLOCK
+                nextToken = leftCurly.getFirstChild().getNextSibling();
             }
         }
         return nextToken == null

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
@@ -20,6 +20,8 @@
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -122,6 +124,7 @@ public class SingleSpaceSeparatorCheck extends AbstractCheck {
      */
     private void visitEachToken(DetailAST node) {
         DetailAST currentNode = node;
+        final Set<Long> reportedPositions = new HashSet<>();
 
         do {
             final int columnNo = currentNode.getColumnNo() - 1;
@@ -131,10 +134,15 @@ public class SingleSpaceSeparatorCheck extends AbstractCheck {
             // possible index for the second whitespace between non-whitespace characters.
             final int minSecondWhitespaceColumnNo = 2;
 
-            if (columnNo >= minSecondWhitespaceColumnNo
-                    && !isTextSeparatedCorrectlyFromPrevious(
-                            getLineCodePoints(currentNode.getLineNo() - 1),
-                            columnNo)) {
+            final boolean isSeparatedIncorrectly =
+                    columnNo >= minSecondWhitespaceColumnNo
+                        && !isTextSeparatedCorrectlyFromPrevious(
+                                getLineCodePoints(currentNode.getLineNo() - 1),
+                                columnNo);
+
+            // several nodes start at the same position, so without this the same
+            // whitespace is reported once per node
+            if (isSeparatedIncorrectly && reportedPositions.add(getPositionKey(currentNode))) {
                 log(currentNode, MSG_KEY);
             }
             if (currentNode.hasChildren()) {
@@ -147,6 +155,17 @@ public class SingleSpaceSeparatorCheck extends AbstractCheck {
                 currentNode = currentNode.getNextSibling();
             }
         } while (currentNode != null);
+    }
+
+    /**
+     * Combines the line and the column of a node into a single value, to keep
+     * track of the positions a violation was already reported for.
+     *
+     * @param node The node to build the value for.
+     * @return The combined position of {@code node}.
+     */
+    private static long getPositionKey(DetailAST node) {
+        return (long) node.getLineNo() << Integer.SIZE | node.getColumnNo();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
@@ -186,6 +186,168 @@ public class ViolationTest {
             .isEqualTo(0);
     }
 
+    @Test
+    public void testCompareToWithDifferentTokenType() {
+        final Violation violation1 = new Violation(1, 1, TokenTypes.CLASS_DEF,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, SeverityLevel.ERROR, "module", Violation.class, null);
+        final Violation violation2 = new Violation(1, 1, TokenTypes.OBJBLOCK,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, SeverityLevel.ERROR, "module", Violation.class, null);
+
+        assertWithMessage("Invalid comparing result")
+                .that(violation1.compareTo(violation2))
+                .isNotEqualTo(0);
+        assertWithMessage("Invalid comparing result")
+                .that(Integer.signum(violation1.compareTo(violation2)))
+                .isEqualTo(-Integer.signum(violation2.compareTo(violation1)));
+    }
+
+    @Test
+    public void testCompareToWithDifferentColumnCharIndex() {
+        final Violation violation1 = new Violation(1, 1, 1, TokenTypes.CLASS_DEF,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, SeverityLevel.ERROR, "module", Violation.class, null);
+        final Violation violation2 = new Violation(1, 1, 2, TokenTypes.CLASS_DEF,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, SeverityLevel.ERROR, "module", Violation.class, null);
+
+        assertWithMessage("Invalid comparing result")
+                .that(violation1.compareTo(violation2) < 0)
+                .isTrue();
+        assertWithMessage("Invalid comparing result")
+                .that(violation2.compareTo(violation1) > 0)
+                .isTrue();
+    }
+
+    @Test
+    public void testCompareToWithDifferentSeverityLevel() {
+        final Violation violation1 = new Violation(1, 1, TokenTypes.CLASS_DEF,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, SeverityLevel.INFO, "module", Violation.class, null);
+        final Violation violation2 = new Violation(1, 1, TokenTypes.CLASS_DEF,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, SeverityLevel.WARNING, "module", Violation.class, null);
+
+        assertWithMessage("Invalid comparing result")
+                .that(violation1.compareTo(violation2) < 0)
+                .isTrue();
+        assertWithMessage("Invalid comparing result")
+                .that(violation2.compareTo(violation1) > 0)
+                .isTrue();
+    }
+
+    @Test
+    public void testCompareToWithDifferentKeySameCustomMessage() {
+        final Violation violation1 = new Violation(1, 1,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, "module", Violation.class, "custom text");
+        final Violation violation2 = new Violation(1, 1,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "other.key",
+                EMPTY_OBJECT_ARRAY, "module", Violation.class, "custom text");
+
+        assertWithMessage("Invalid comparing result")
+                .that(violation1.compareTo(violation2) < 0)
+                .isTrue();
+        assertWithMessage("Invalid comparing result")
+                .that(violation2.compareTo(violation1) > 0)
+                .isTrue();
+    }
+
+    @Test
+    public void testCompareToWithDifferentBundleSameCustomMessage() {
+        final Violation violation1 = new Violation(1, 1,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, "module", Violation.class, "custom text");
+        final Violation violation2 = new Violation(1, 1,
+                "com.puppycrawl.tools.checkstyle.checks.naming.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, "module", Violation.class, "custom text");
+
+        assertWithMessage("Invalid comparing result")
+                .that(violation1.compareTo(violation2) < 0)
+                .isTrue();
+        assertWithMessage("Invalid comparing result")
+                .that(violation2.compareTo(violation1) > 0)
+                .isTrue();
+    }
+
+    @DefaultLocale("en")
+    @Test
+    public void testCompareToWithCustomMessageMatchingBundleMessage() {
+        final Violation violation1 = new Violation(1, 1,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, "module", Violation.class, null);
+        final Violation violation2 = new Violation(1, 1,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, "module", Violation.class, "Empty statement.");
+
+        assertWithMessage("Rendered messages must match for this test to be valid")
+                .that(violation1.getViolation())
+                .isEqualTo(violation2.getViolation());
+        assertWithMessage("Invalid comparing result")
+                .that(violation1.compareTo(violation2))
+                .isNotEqualTo(0);
+        assertWithMessage("Invalid comparing result")
+                .that(Integer.signum(violation1.compareTo(violation2)))
+                .isEqualTo(-Integer.signum(violation2.compareTo(violation1)));
+    }
+
+    @Test
+    public void testCompareToWithDifferentArgsSameRenderedMessage() {
+        final Violation violation1 = new Violation(1, 1,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                new String[] {"first"}, "module", Violation.class, "custom text");
+        final Violation violation2 = new Violation(1, 1,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                new String[] {"second"}, "module", Violation.class, "custom text");
+
+        assertWithMessage("Rendered messages must match for this test to be valid")
+                .that(violation1.getViolation())
+                .isEqualTo(violation2.getViolation());
+        assertWithMessage("Invalid comparing result")
+                .that(violation1.compareTo(violation2) < 0)
+                .isTrue();
+        assertWithMessage("Invalid comparing result")
+                .that(violation2.compareTo(violation1) > 0)
+                .isTrue();
+    }
+
+    @Test
+    public void testCompareToOrdersByTextBeforeTokenType() {
+        // OBJBLOCK sorts before CLASS_DEF, so the token type alone would order these
+        // the other way round
+        final Violation violation1 = new Violation(1, 1, TokenTypes.OBJBLOCK,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, SeverityLevel.ERROR, "module", Violation.class, "zebra");
+        final Violation violation2 = new Violation(1, 1, TokenTypes.CLASS_DEF,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, SeverityLevel.ERROR, "module", Violation.class, "apple");
+
+        assertWithMessage("Invalid comparing result")
+                .that(violation1.compareTo(violation2) > 0)
+                .isTrue();
+        assertWithMessage("Invalid comparing result")
+                .that(violation2.compareTo(violation1) < 0)
+                .isTrue();
+    }
+
+    @Test
+    public void testCompareToConsistentWithEquals() {
+        final Violation violation1 = new Violation(1, 1, 1, TokenTypes.CLASS_DEF,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, SeverityLevel.ERROR, "module", Violation.class, "custom");
+        final Violation violation2 = new Violation(1, 1, 1, TokenTypes.CLASS_DEF,
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
+                EMPTY_OBJECT_ARRAY, SeverityLevel.ERROR, "module", Violation.class, "custom");
+
+        assertWithMessage("Equal violations must compare to zero")
+                .that(violation1.compareTo(violation2))
+                .isEqualTo(0);
+        assertWithMessage("Violations comparing to zero must be equal")
+                .that(violation1)
+                .isEqualTo(violation2);
+    }
+
     private static Violation createSampleViolation() {
         return createSampleViolationWithId("module");
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -381,6 +381,25 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testObjBlockTokenOnly() throws Exception {
+        final String[] expected = {
+            "13:17: " + getCheckMessage(MSG_KEY_LINE_BREAK_AFTER, "{", 17),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyObjBlockTokenOnly.java"), expected);
+    }
+
+    @Test
+    public void testObjBlockWithTypeToken() throws Exception {
+        final String[] expected = {
+            "13:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),
+            "15:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyObjBlockWithTypeToken.java"), expected);
+    }
+
+    @Test
     public void testDefaultLambda() throws Exception {
         final String[] expected = {
             "17:1: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 1),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyObjBlockTokenOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyObjBlockTokenOnly.java
@@ -1,0 +1,28 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = false
+tokens = OBJBLOCK
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+public class InputLeftCurlyObjBlockTokenOnly {
+    enum Colors {RED, // violation ''{' at column 17 should have line break after'
+        BLUE,
+        GREEN;
+    }
+
+    enum Shapes {
+        SQUARE,
+        CIRCLE;
+    }
+
+    Runnable anonymous = new Runnable() {
+        @Override
+        public void run() {
+        }
+    };
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyObjBlockWithTypeToken.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyObjBlockWithTypeToken.java
@@ -1,0 +1,20 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = (default)true
+tokens = CLASS_DEF, OBJBLOCK
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+public class InputLeftCurlyObjBlockWithTypeToken
+{ // violation ''{' at column 1 should be on the previous line'
+    class Inner
+    { // violation ''{' at column 5 should be on the previous line'
+    }
+
+    class Sibling {
+    }
+}


### PR DESCRIPTION
Issue: #4454

`compareTo` only looked at line, column, module id, source class and the rendered message, so two violations that differ in any other field compared as zero. `Checker` and `TreeWalker` keep violations in a `TreeSet`, so one of the two was silently dropped. This makes `compareTo` compare the same fields as `equals` and keeps the old criteria in front, so the order of the report does not change.

Two checks were relying on that collapsing, and the suite showed it immediately once the contract was fixed.

`LeftCurly` verifies a type body brace twice when both the type token and `OBJBLOCK` are configured, which is the case with the default token set, and it verifies the brace of an arrow switch case twice when both `LITERAL_CASE` and `SWITCH_RULE` are configured. The child token is now skipped when the parent already verifies the same brace, so the output stays what it is today. The enum line break rule only worked from the `OBJBLOCK` side, so `hasLineBreakAfter` now handles the enum `OBJBLOCK` as well.

#20992 reworks the same branch of `LeftCurlyCheck.visitToken`, so whichever of the two lands second will need a rebase.

`SingleSpaceSeparator` walks every node in the tree, and several nodes start at the same position, so it logged one violation per node. It now reports each position once.

Validation:

- `./mvnw clean verify` on JDK 21: BUILD SUCCESS
- `./.ci/test-spelling-unknown-words.sh`: no new words or misspellings
- `mvn clean compile -Pchecker-lock-tainting,no-validations` and the same with `-Pchecker-nullness-optional-interning`: the reported warnings match the suppression files, the two obsolete `getViolation` entries are replaced by the two new ones
- `./.ci/pitest.sh pitest-api` and `./.ci/pitest.sh pitest-blocks`: no surviving mutations
