### PR TITLE
Issue #21344: Add manually triggered workflow to deploy master website to AWS

### DIFF
--- a/.ci/site-latest.sh
+++ b/.ci/site-latest.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source ./.ci/util.sh
+
+case $1 in
+
+generate-site)
+  ./mvnw -e --no-transfer-progress clean site \
+    -Pno-validations \
+    -Dmaven.javadoc.skip=false \
+    -Djdepend.skip=false
+  ;;
+
+publish-site)
+  checkForVariable "AWS_BUCKET_NAME"
+  checkForVariable "AWS_REGION"
+
+  aws s3 sync "target/site/" "s3://${AWS_BUCKET_NAME}/website/latest/" --delete
+
+  LINK="https://${AWS_BUCKET_NAME}.s3.${AWS_REGION}.amazonaws.com/website/latest/index.html"
+  echo "Published to '$LINK'"
+  ;;
+
+*)
+  echo "Unexpected argument: $1"
+  exit 1
+  ;;
+
+esac

--- a/.github/workflows/site-latest.yml
+++ b/.github/workflows/site-latest.yml
@@ -1,0 +1,50 @@
+name: "Deploy latest website"
+
+env:
+  AWS_REGION: "us-east-2"
+  AWS_BUCKET_NAME: "checkstyle-diff-reports"
+
+on:
+  workflow_dispatch: null
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-latest-site
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup local maven cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.m2/repository
+          key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5.7.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Generate site
+        run: |
+          ./.ci/site-latest.sh generate-site
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Publish site to AWS S3
+        run: |
+          ./.ci/site-latest.sh publish-site

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ or at [Maven repo](https://repo1.maven.org/maven2/com/puppycrawl/tools/checkstyl
 
 Documentation is available in HTML format, see [Checkstyle checks][checks-docs].
 
+The latest deployed website from `master` is available [here][site-latest].
+
 ## Table of Contents
 
 - [Quick Start](#quick-start)
@@ -273,3 +275,6 @@ https://checkstyle.org/checks.html
 
 [build-instructions]:
 https://github.com/checkstyle/checkstyle/blob/master/docs/BEGINNING_DEVELOPMENT.md
+
+[site-latest]:
+https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/website/latest/index.html

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -403,6 +403,7 @@ esac
 Eslint
 esslingen
 etsy
+euo
 ev
 Evt
 exceptionoverrides


### PR DESCRIPTION
Resolves issue
- #21344

---
Added a new GitHub workflow `site-latest.yml`. It is triggered manually and deploys the latest `master` website to https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/latest/index.html.

### Proof that the changes work
I cannot fully prove that the workflow will work since I do not have an AWS account (nor do I want to spend money on one). I did run the workflow on my fork, and it failed on the `Configure AWS credentials` step as expected.
- https://github.com/stoyanK7/checkstyle/actions/runs/32885453068/job/97924714605

The `aws` step was tested locally using LocalStack and:
```
$ aws --endpoint-url=http://localhost:4566 \
  s3 sync target/site/ s3://test-bucket/website/latest/ --delete
```