### PR TITLE
minor: add `--quiet` option to all `aws` CLI calls

### DIFF
--- a/.ci/diff-report.sh
+++ b/.ci/diff-report.sh
@@ -198,7 +198,7 @@ copy-report-to-aws-s3-bucket)
   DIFF="./.ci-temp/contribution/checkstyle-tester/reports/diff"
   LINK="https://${AWS_BUCKET_NAME}.s3.${AWS_REGION}.amazonaws.com"
   aws s3 cp "$DIFF" "s3://${AWS_BUCKET_NAME}/$FOLDER/reports/diff/" \
-    --recursive --storage-class STANDARD_IA
+    --recursive --storage-class STANDARD_IA --quiet
   if [ -n "$LABEL" ]; then
     echo "$LABEL: " > .ci-temp/message
   fi

--- a/.ci/site-latest.sh
+++ b/.ci/site-latest.sh
@@ -17,7 +17,7 @@ publish-site)
   checkForVariable "AWS_BUCKET_NAME"
   checkForVariable "AWS_REGION"
 
-  aws s3 sync "target/site/" "s3://${AWS_BUCKET_NAME}/website/latest/" --delete
+  aws s3 sync "target/site/" "s3://${AWS_BUCKET_NAME}/website/latest/" --delete --quiet
 
   LINK="https://${AWS_BUCKET_NAME}.s3.${AWS_REGION}.amazonaws.com/website/latest/index.html"
   echo "Published to '$LINK'"

--- a/.ci/site.sh
+++ b/.ci/site.sh
@@ -48,7 +48,7 @@ publish-site)
   SITE=".ci-temp/checkstyle/target/site"
   LINK="https://${AWS_BUCKET_NAME}.s3.${AWS_REGION}.amazonaws.com"
   
-  aws s3 cp "$SITE" "s3://${AWS_BUCKET_NAME}/$FOLDER/" --recursive
+  aws s3 cp "$SITE" "s3://${AWS_BUCKET_NAME}/$FOLDER/" --recursive --quiet
   echo "$LINK/$FOLDER/index.html" > .ci-temp/message
   
   ./.ci/generate-extra-site-links.sh "$PR_NUMBER" "$LINK/$FOLDER"

--- a/.github/workflows/antlr-report.yml
+++ b/.github/workflows/antlr-report.yml
@@ -222,7 +222,7 @@ jobs:
 
           aws s3 cp "$DIFF" \
             "s3://${{ env.AWS_BUCKET_NAME }}/$FOLDER/reports/diff/" \
-            --recursive --storage-class STANDARD_IA
+            --recursive --storage-class STANDARD_IA --quiet
 
           echo "ANTLR report: $LINK/$FOLDER/reports/diff/index.html" \
             > .ci-temp/message

--- a/.github/workflows/regression-report.yml
+++ b/.github/workflows/regression-report.yml
@@ -880,7 +880,7 @@ jobs:
 
           aws s3 cp "$DIFF" \
             "s3://${{ env.AWS_BUCKET_NAME }}/$FOLDER/reports/diff/" \
-            --recursive
+            --recursive --quiet
 
           if [ -n "$LABEL" ]; then
             echo "$LABEL: " > .ci-temp/message


### PR DESCRIPTION
## Summary
Added the `--quiet` option to all `aws` CLI calls.

From [AWS CLI docs](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html#options):
> `--quiet` (boolean) Does not display the operations performed from the specified command.

## Why change?

Noticed in https://github.com/checkstyle/checkstyle/issues/21344#issuecomment-5425378086.

When uploading to AWS S3 via `cp` or `sync`, as we do, the tool shows a progress report of the upload. This pollutes our logs with thousands of lines of upload progress information. For example https://github.com/checkstyle/checkstyle/actions/runs/32946361704/job/98110570716#step:5:12476.
```text
upload: .ci-temp/checkstyle/target/site/xref/overview-frame.html to s3://checkstyle-diff-reports/636e8fb_20260826082436/xref/overview-frame.html
Completed 107.9 MiB/107.9 MiB (3.8 MiB/s) with 4 file(s) remaining
Completed 107.9 MiB/107.9 MiB (3.8 MiB/s) with 4 file(s) remaining
upload: .ci-temp/checkstyle/target/site/xref/com/puppycrawl/tools/checkstyle/xpath/package-frame.html to s3://checkstyle-diff-reports/636e8fb_20260826082436/xref/com/puppycrawl/tools/checkstyle/xpath/package-frame.html
Completed 107.9 MiB/107.9 MiB (3.8 MiB/s) with 3 file(s) remaining
Completed 107.9 MiB/107.9 MiB (3.8 MiB/s) with 3 file(s) remaining
```

We enforce such non-polluting behaviour with our `./mvnw` calls by requiring `--no-transfer-progress`. We should do the same with `aws`:
https://github.com/checkstyle/checkstyle/blob/3ce3b5268ab48e03510b9c0c9d38fd659f82530d/config/checkstyle-non-main-files-checks.xml#L64-L66