### PR TITLE
Issue #20954: Quote UnusedLocalVariable messages in Example2 and Example4

### DIFF
--- a/src/site/xdoc/checks/coding/unusedlocalvariable.xml
+++ b/src/site/xdoc/checks/coding/unusedlocalvariable.xml
@@ -157,7 +157,7 @@ public class Example1 {
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 {
   {
-    int k = 12; // violation, assign and update but never use 'k'
+    int k = 12; // violation 'Unused local variable 'k'.'
     k++;
   }
 
@@ -167,20 +167,20 @@ public class Example2 {
   }
 
   void method(int b) {
-    int[] arr = {1, 2, 3};  // violation, unused local variable 'arr'
+    int[] arr = {1, 2, 3};  // violation 'Unused local variable 'arr'.'
     int[] anotherArr = {1}; // ok, 'anotherArr' is accessed
     anotherArr[0] = 4;
   }
 
   String convertValue(String newValue) {
-    String s = newValue.toLowerCase(); // violation, unused local variable 's'
-    String _ = newValue.toLowerCase(); // violation, unused local variable '_'
+    String s = newValue.toLowerCase(); // violation 'Unused local variable 's'.'
+    String _ = newValue.toLowerCase(); // violation 'Unused local variable '_'.'
     return newValue.toLowerCase();
   }
 
   void read() throws IOException {
     BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-    String s; // violation, unused local variable 's'
+    String s; // violation 'Unused local variable 's'.'
     while ((s = reader.readLine()) != null) {}
     try (BufferedReader reader1 = // ok, 'reader1' is a resource
                  new BufferedReader(new FileReader("abc.txt"))) {}
@@ -190,9 +190,9 @@ public class Example2 {
 
   void loops() {
     int j = 12;
-    for (int i = 0; j &lt; 11; i++)  // violation, unused local variable 'i'
+    for (int i = 0; j &lt; 11; i++)  // violation 'Unused local variable 'i'.'
       for (int p = 0; j &lt; 11; p++) p /= 2;   // ok, 'p' is used
-    for (Integer _ : new  int[0]) { } // violation, unused local variable '_'
+    for (Integer _ : new  int[0]) { } // violation 'Unused local variable '_'.'
   }
 
   void lambdas() {
@@ -260,7 +260,7 @@ public class Example4 {
   static final class Circle extends Shape {}
   static final class Rect extends Shape {}
   void patternVariables(Object obj, Shape s) {
-    if (obj instanceof String str) { // violation, unused local variable 'str'
+    if (obj instanceof String str) { // violation 'Unused local variable 'str'.'
       System.out.println("string");
     }
     if (obj instanceof String t) { // ok, 't' is used

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -305,8 +305,6 @@ public final class InlineConfigParser {
             "checks/coding/equalshashcode/Example1.java",
             "checks/coding/noclone/Example1.java",
             "checks/coding/unusedlocalvariable/Example1.java",
-            "checks/coding/unusedlocalvariable/Example2.java",
-            "checks/coding/unusedlocalvariable/Example4.java",
             "checks/coding/unusedlocalvariable/InputUnusedLocalVariable3.java",
             "checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses4.java",
             "checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses5.java",

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example2.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example2.java
@@ -14,7 +14,7 @@ import java.util.function.Predicate;
 // xdoc section - start
 public class Example2 {
   {
-    int k = 12; // violation, assign and update but never use 'k'
+    int k = 12; // violation 'Unused local variable 'k'.'
     k++;
   }
 
@@ -24,20 +24,20 @@ public class Example2 {
   }
 
   void method(int b) {
-    int[] arr = {1, 2, 3};  // violation, unused local variable 'arr'
+    int[] arr = {1, 2, 3};  // violation 'Unused local variable 'arr'.'
     int[] anotherArr = {1}; // ok, 'anotherArr' is accessed
     anotherArr[0] = 4;
   }
 
   String convertValue(String newValue) {
-    String s = newValue.toLowerCase(); // violation, unused local variable 's'
-    String _ = newValue.toLowerCase(); // violation, unused local variable '_'
+    String s = newValue.toLowerCase(); // violation 'Unused local variable 's'.'
+    String _ = newValue.toLowerCase(); // violation 'Unused local variable '_'.'
     return newValue.toLowerCase();
   }
 
   void read() throws IOException {
     BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-    String s; // violation, unused local variable 's'
+    String s; // violation 'Unused local variable 's'.'
     while ((s = reader.readLine()) != null) {}
     try (BufferedReader reader1 = // ok, 'reader1' is a resource
                  new BufferedReader(new FileReader("abc.txt"))) {}
@@ -47,9 +47,9 @@ public class Example2 {
 
   void loops() {
     int j = 12;
-    for (int i = 0; j < 11; i++)  // violation, unused local variable 'i'
+    for (int i = 0; j < 11; i++)  // violation 'Unused local variable 'i'.'
       for (int p = 0; j < 11; p++) p /= 2;   // ok, 'p' is used
-    for (Integer _ : new  int[0]) { } // violation, unused local variable '_'
+    for (Integer _ : new  int[0]) { } // violation 'Unused local variable '_'.'
   }
 
   void lambdas() {

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example4.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example4.java
@@ -16,7 +16,7 @@ public class Example4 {
   static final class Circle extends Shape {}
   static final class Rect extends Shape {}
   void patternVariables(Object obj, Shape s) {
-    if (obj instanceof String str) { // violation, unused local variable 'str'
+    if (obj instanceof String str) { // violation 'Unused local variable 'str'.'
       System.out.println("string");
     }
     if (obj instanceof String t) { // ok, 't' is used


### PR DESCRIPTION
## Description

Part of #20954.

Updates `Example2` and `Example4` for `UnusedLocalVariable` so violation comments use the real quoted message text (`Unused local variable '…'.`) instead of paraphrased notes. Removes both files from `SUPPRESSED_VALIDATE_MESSAGE_FILES` so message validation runs again.

## Testing

```
mvn -Dtest=UnusedLocalVariableCheckExamplesTest -Djacoco.skip=true clean test
```

All 4 tests in `UnusedLocalVariableCheckExamplesTest` passed.