### PR TITLE
Issue #20954: Quote UnusedLocalVariable NestedClasses input messages

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -308,11 +308,6 @@ public final class InlineConfigParser {
             "checks/coding/unusedlocalvariable/Example2.java",
             "checks/coding/unusedlocalvariable/Example4.java",
             "checks/coding/unusedlocalvariable/InputUnusedLocalVariable3.java",
-            "checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses4.java",
-            "checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses5.java",
-            "checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses6.java",
-            "checks/coding/unusedlocalvariable/"
-                    + "InputUnusedLocalVariableNestedClasses7.java",
             "checks/coding/unusedlocalvariable/"
                     + "InputUnusedLocalVariableAllowNamedPatternVariables.java",
             "checks/coding/unusedlocalvariable/"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses4.java
@@ -10,8 +10,8 @@ public class InputUnusedLocalVariableNestedClasses4 {
   int a = 12;
 
   void foo() {
-    int a = 12; // violation, unused variable 'a'
-    int ab = 12; // violation, unused variable 'ab'
+    int a = 12; // violation 'Unused local variable 'a'.'
+    int ab = 12; // violation 'Unused local variable 'ab'.'
 
     class asd {
       Test a = new Test() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses5.java
@@ -10,14 +10,14 @@ public class InputUnusedLocalVariableNestedClasses5 {
   int a = 12;
 
   void foo() {
-    int a = 12; // violation, unused variable 'a'
-    int ab = 12; // violation, unused variable 'ab'
+    int a = 12; // violation 'Unused local variable 'a'.'
+    int ab = 12; // violation 'Unused local variable 'ab'.'
 
     class abc {
       Test a = new Test() {
         void abc() {
           System.out.println(a);
-          int abc = 10; // violation, unused variable 'abc'
+          int abc = 10; // violation 'Unused local variable 'abc'.'
 
           class def {
             Test abc = new Test() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses6.java
@@ -10,8 +10,8 @@ public class InputUnusedLocalVariableNestedClasses6 {
   int a = 12;
 
   void foo() {
-    int a = 12; // violation, unused variable 'a'
-    int ab = 12; // violation, unused variable 'ab'
+    int a = 12; // violation 'Unused local variable 'a'.'
+    int ab = 12; // violation 'Unused local variable 'ab'.'
 
     class abc {
       Test a = new Test() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableNestedClasses7.java
@@ -8,25 +8,25 @@ package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
 
 public class InputUnusedLocalVariableNestedClasses7 {
   void foo() {
-    int a = 12; // violation, unused variable 'a'
-    int ab = 12; // violation, unused variable 'ab'
+    int a = 12; // violation 'Unused local variable 'a'.'
+    int ab = 12; // violation 'Unused local variable 'ab'.'
 
     class Ghi {
       void foo() {
         int a = 12;
-        int ab = 12; // violation, unused variable 'ab'
+        int ab = 12; // violation 'Unused local variable 'ab'.'
         System.out.println(a);
       }
     }
 
     class Def {
       void foo() {
-        int a = 12; // violation, unused variable 'a'
-        int ab = 12; // violation, unused variable 'ab'
+        int a = 12; // violation 'Unused local variable 'a'.'
+        int ab = 12; // violation 'Unused local variable 'ab'.'
 
         class InnerDef {
           void foo() {
-            int a = 12; // violation, unused variable 'a'
+            int a = 12; // violation 'Unused local variable 'a'.'
             int ab = 12;
             System.out.println(ab);
           }


### PR DESCRIPTION
## Description

Part of #20954.

Updates `InputUnusedLocalVariableNestedClasses4` through `NestedClasses7` so violation comments use the real quoted message (`Unused local variable '…'.`) and removes them from `SUPPRESSED_VALIDATE_MESSAGE_FILES`.

## Testing

```
mvn -Dtest=UnusedLocalVariableCheckTest -Djacoco.skip=true test
```

46 tests passed.