### PR TITLE
Issue #21368: Standardize S3 destination paths for uploaded reports

### DIFF
--- a/.ci/diff-report.sh
+++ b/.ci/diff-report.sh
@@ -197,12 +197,12 @@ copy-report-to-aws-s3-bucket)
   FOLDER="${COMMIT_SHA}_$TIME"
   DIFF="./.ci-temp/contribution/checkstyle-tester/reports/diff"
   LINK="https://${AWS_BUCKET_NAME}.s3.${AWS_REGION}.amazonaws.com"
-  aws s3 cp "$DIFF" "s3://${AWS_BUCKET_NAME}/$FOLDER/reports/diff/" \
+  aws s3 cp "$DIFF" "s3://${AWS_BUCKET_NAME}/diff/$FOLDER/" \
     --recursive --storage-class STANDARD_IA --quiet
   if [ -n "$LABEL" ]; then
     echo "$LABEL: " > .ci-temp/message
   fi
-  echo "$LINK/$FOLDER/reports/diff/index.html" >> .ci-temp/message
+  echo "$LINK/diff/$FOLDER/index.html" >> .ci-temp/message
   ;;
 
 process-local-repo-config-files)

--- a/.ci/site.sh
+++ b/.ci/site.sh
@@ -48,10 +48,10 @@ publish-site)
   SITE=".ci-temp/checkstyle/target/site"
   LINK="https://${AWS_BUCKET_NAME}.s3.${AWS_REGION}.amazonaws.com"
   
-  aws s3 cp "$SITE" "s3://${AWS_BUCKET_NAME}/$FOLDER/" --recursive --quiet
-  echo "$LINK/$FOLDER/index.html" > .ci-temp/message
+  aws s3 cp "$SITE" "s3://${AWS_BUCKET_NAME}/website/$FOLDER/" --recursive --quiet
+  echo "$LINK/website/$FOLDER/index.html" > .ci-temp/message
   
-  ./.ci/generate-extra-site-links.sh "$PR_NUMBER" "$LINK/$FOLDER"
+  ./.ci/generate-extra-site-links.sh "$PR_NUMBER" "$LINK/website/$FOLDER"
   
   ./.ci/append-to-github-output.sh "message" "$(cat .ci-temp/message)"
   ;;

--- a/.github/workflows/antlr-report.yml
+++ b/.github/workflows/antlr-report.yml
@@ -221,10 +221,10 @@ jobs:
           LINK="https://${{ env.AWS_BUCKET_NAME }}.s3.${{ env.AWS_REGION }}.amazonaws.com"
 
           aws s3 cp "$DIFF" \
-            "s3://${{ env.AWS_BUCKET_NAME }}/$FOLDER/reports/diff/" \
+            "s3://${{ env.AWS_BUCKET_NAME }}/diff/$FOLDER/" \
             --recursive --storage-class STANDARD_IA --quiet
 
-          echo "ANTLR report: $LINK/$FOLDER/reports/diff/index.html" \
+          echo "ANTLR report: $LINK/diff/$FOLDER/index.html" \
             > .ci-temp/message
 
           ./.ci/append-to-github-output.sh \

--- a/.github/workflows/regression-report.yml
+++ b/.github/workflows/regression-report.yml
@@ -879,14 +879,14 @@ jobs:
           LINK="https://${{ env.AWS_BUCKET_NAME }}.s3.${{ env.AWS_REGION }}.amazonaws.com"
 
           aws s3 cp "$DIFF" \
-            "s3://${{ env.AWS_BUCKET_NAME }}/$FOLDER/reports/diff/" \
+            "s3://${{ env.AWS_BUCKET_NAME }}/diff/$FOLDER/" \
             --recursive --quiet
 
           if [ -n "$LABEL" ]; then
             echo "$LABEL: " > .ci-temp/message
           fi
 
-          echo "$LINK/$FOLDER/reports/diff/index.html" >> .ci-temp/message
+          echo "$LINK/diff/$FOLDER/index.html" >> .ci-temp/message
 
       - name: Set output
         id: out


### PR DESCRIPTION
Resolves issue
- #21368 

---

Standardized AWS S3 upload paths for generated reports and website content.

* Moved website uploads under `website/<generated-folder>`.
* Moved diff, regression, and ANTLR reports under `diff/<generated-folder>`.
* Updated generated report and website links to match the new paths.