### PR TITLE
Issue #20954: Quote ClassNamesWithUnderscore violation messages

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule522classnames/InputClassNamesWithUnderscore.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule522classnames/InputClassNamesWithUnderscore.java
@@ -2,15 +2,15 @@ package com.google.checkstyle.test.chapter5naming.rule522classnames;
 
 class InputClassNamesWithUnderscore {
 
-  class ConvertToKotlinVersion_ {} // violation 'Type name '.*' must match pattern'
+  class ConvertToKotlinVersion_ {} // violation "Type name '.*' must match pattern"
 
-  class ConvertToKotlinVersion_1_9_24 {} // violation 'Type name '.*' must match pattern'
+  class ConvertToKotlinVersion_1_9_24 {} // violation "Type name '.*' must match pattern"
 
   class ConvertToKotlinVersion1_9_24 {}
 
-  class ConvertToKotlinVersion1_9_24_ {} // violation 'Type name '.*' must match pattern'
+  class ConvertToKotlinVersion1_9_24_ {} // violation "Type name '.*' must match pattern"
 
   class ConvertToKotlinVersion10_0 {}
 
-  class ConvertToKotlinVersion__ {} // violation 'Type name '.*' must match pattern'
+  class ConvertToKotlinVersion__ {} // violation "Type name '.*' must match pattern"
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -321,8 +321,6 @@ public final class InlineConfigParser {
             "checks/coding/unusedlocalvariable/InputUnusedLocalVariableUnnamedTryCatch.java",
             "checks/sizes/recordcomponentnumber/Example2.java",
             "checks/whitespace/separatorwrap/Example1.java",
-            "com/google/checkstyle/test/chapter5naming/rule522classnames/"
-                    + "InputClassNamesWithUnderscore.java",
             "com/google/checkstyle/test/chapter5naming/rule53camelcase/"
                     + "InputUnderscoreUsedInNames.java",
             "com/openjdk/checkstyle/test/chapterformatting/"


### PR DESCRIPTION
Issue: #20954

Updates the violation comments in InputClassNamesWithUnderscore.java to use double-quoted message text and removes the corresponding message-validation suppression.

Testing:
- `mvn -Dit.test=ClassNamesTest verify` (BUILD SUCCESS)