### PR TITLE
Issue #21229: Align NewlineAtEndOfFile examples with property count

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -166,7 +166,7 @@
 
   <!-- No new line by design to show violation -->
   <suppress checks="NewlineAtEndOfFile"
-    files="newlineatendoffile/Example\d+.*"/>
+    files="newlineatendoffile/(Example|UseCase)\d+.*"/>
 
   <!-- We need to maintain indentation on xml part -->
   <suppress checks="LineLength"

--- a/src/site/xdoc/checks/misc/newlineatendoffile.xml
+++ b/src/site/xdoc/checks/misc/newlineatendoffile.xml
@@ -23,7 +23,13 @@
               <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
               <li><a href="#Example3-config" class="toc-sublink">Always use Unix-style line separators</a></li>
               <li><a href="#Example4-config" class="toc-sublink">Work only on Java, XML and Cpp files</a></li>
-              <li><a href="#Example5-config" class="toc-sublink">Special message if line separator is defined</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#NewlineAtEndOfFile_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">Special message if line separator is defined</a></li>
             </ul>
           </li>
           <li><a href="#NewlineAtEndOfFile_Example_of_Usage">Example of Usage</a></li>
@@ -181,9 +187,11 @@ int main() { // ⤶
         <p id="Example6-code">Text file <code>Example6.txt</code>:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 Sample txt file. // ok, this file is not specified in the config.
-</code></pre></div><hr class="example-separator"/>
+</code></pre></div>
+      </subsection>
 
-        <p id="Example5-config">Special message if line separator is defined:</p>
+      <subsection name="Use Cases" id="NewlineAtEndOfFile_Use_Cases">
+        <p id="UseCase1-config">Special message if line separator is defined:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="NewlineAtEndOfFile"&gt;
@@ -191,9 +199,9 @@ Sample txt file. // ok, this file is not specified in the config.
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example5-code">Example:</p>
+        <p id="UseCase1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example5 { // ⤶
+public class UseCase1 { // ⤶
 // ⤶
 } // violation first line 'File does not end with a newline 'crlf'.'
 </code></pre></div>

--- a/src/site/xdoc/checks/misc/newlineatendoffile.xml.template
+++ b/src/site/xdoc/checks/misc/newlineatendoffile.xml.template
@@ -96,18 +96,20 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/Example6.txt"/>
           <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
+        </macro>
+      </subsection>
 
-        <p id="Example5-config">Special message if line separator is defined:</p>
+      <subsection name="Use Cases" id="NewlineAtEndOfFile_Use_Cases">
+        <p id="UseCase1-config">Special message if line separator is defined:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/Example5.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/UseCase1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example5-code">Example:</p>
+        <p id="UseCase1-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/Example5.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/UseCase1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -173,7 +173,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/javadoc/javadocpackage",
             "checks/lineending",
             "checks/naming/patternvariablename",
-            "checks/newlineatendoffile",
             "checks/sizes/linelength",
             "checks/whitespace/emptylineseparator",
             "filters/suppresswarningsfilter"

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckExamplesTest.java
@@ -70,12 +70,12 @@ public class NewlineAtEndOfFileCheckExamplesTest extends AbstractExamplesModuleT
     }
 
     @Test
-    public void testExample5() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expected = {
             "1: " + getCheckMessage(MSG_KEY_NO_NEWLINE_EOF_WITH_SEPARATOR, "crlf"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/UseCase1.java
@@ -8,7 +8,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.newlineatendoffile;
 // xdoc section - start
-public class Example5 { // ⤶
+public class UseCase1 { // ⤶
 // ⤶
 } // violation first line 'File does not end with a newline 'crlf'.'
 // xdoc section - end


### PR DESCRIPTION
Issue: #21229

`NewlineAtEndOfFile` documents two properties (`fileExtensions` and
`lineSeparator`), so `testExampleCountMatchesPropertyCount` expects 3
AST-matching examples (default + one per property). The module had 4
structurally identical Java examples (default ok, default violation,
`lineSeparator=lf`, and `lineSeparator=crlf`).

Examples now has the default config pair plus the Unix-style
`lineSeparator` example. The extra `lineSeparator=crlf` special-message
example is kept under Use Cases.

Other modules listed in #21229 are left for separate PRs.

## Testing

Executed:

- `mvn test -Dtest=NewlineAtEndOfFileCheckExamplesTest,XdocsExamplesAstConsistencyTest,XdocsExampleFileTest,XdocsPagesTest`
  - NewlineAtEndOfFileCheckExamplesTest 6/6
  - XdocsExamplesAstConsistencyTest 5/5
  - XdocsExampleFileTest 5/5
  - XdocsPagesTest 20/20