### PR TITLE
Issue #21229: Align PatternVariableName examples with property count

### DIFF
--- a/src/site/xdoc/checks/naming/patternvariablename.xml
+++ b/src/site/xdoc/checks/naming/patternvariablename.xml
@@ -22,7 +22,6 @@
             <ul class="toc-sublist">
               <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
               <li><a href="#Example2-config" class="toc-sublink">An example of how to configure the check for names that have a lower case letter, followed by letters and digits, optionally separated by underscore</a></li>
-              <li><a href="#Example3-config" class="toc-sublink">An example of how to configure the check with different format for final and non-final pattern variables</a></li>
             </ul>
           </li>
           <li>
@@ -30,6 +29,7 @@
             <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#PatternVariableName_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
               <li><a href="#UseCase1-config" class="toc-sublink">An example of how to configure the check to that all variables have 3 or more chars in name</a></li>
+              <li><a href="#UseCase2-config" class="toc-sublink">An example of how to configure the check with different format for final and non-final pattern variables</a></li>
             </ul>
           </li>
           <li><a href="#PatternVariableName_Example_of_Usage">Example of Usage</a></li>
@@ -118,8 +118,38 @@ class Example2 {
 
   }
 }
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Use Cases" id="PatternVariableName_Use_Cases">
+        <p id="UseCase1-config">
+          An example of how to configure the check to that all variables have 3 or more
+          chars in name:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="PatternVariableName"&gt;
+      &lt;property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="UseCase1-code">Code Example:</p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+class UseCase1 {
+  void foo(Object o1){
+    if (o1 instanceof String STRING) {}
+    // violation above 'Name 'STRING' must match pattern*.'
+    if (o1 instanceof Integer num) {}
+    if (o1 instanceof Integer num_1) {}
+
+    if (o1 instanceof Integer n) {}
+    // violation above 'Name 'n' must match pattern*.'
+  }
+}
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example3-config">
+        <p id="UseCase2-config">
           An example of how to configure the check with different format for final and non-final
           pattern variables:
         </p>
@@ -150,9 +180,9 @@ class Example2 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example3-code">Code Example:</p>
+        <p id="UseCase2-code">Code Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example3 {
+class UseCase2 {
   void foo(Object o1){
     if (o1 instanceof String STRING) {}
     // violation above 'Name 'STRING' must match pattern*.'
@@ -161,36 +191,6 @@ class Example3 {
     // violation above 'Name 'num_1' must match pattern*.'
     if (o1 instanceof Integer n) {}
 
-  }
-}
-</code></pre></div>
-      </subsection>
-
-      <subsection name="Use Cases" id="PatternVariableName_Use_Cases">
-        <p id="UseCase1-config">
-          An example of how to configure the check to that all variables have 3 or more
-          chars in name:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="PatternVariableName"&gt;
-      &lt;property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="UseCase1-code">Code Example:</p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class UseCase1 {
-  void foo(Object o1){
-    if (o1 instanceof String STRING) {}
-    // violation above 'Name 'STRING' must match pattern*.'
-    if (o1 instanceof Integer num) {}
-    if (o1 instanceof Integer num_1) {}
-
-    if (o1 instanceof Integer n) {}
-    // violation above 'Name 'n' must match pattern*.'
   }
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/naming/patternvariablename.xml.template
+++ b/src/site/xdoc/checks/naming/patternvariablename.xml.template
@@ -61,21 +61,6 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example2.java"/>
           <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-        <p id="Example3-config">
-          An example of how to configure the check with different format for final and non-final
-          pattern variables:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example3.java"/>
-          <param name="type" value="config"/>
-        </macro>
-        <p id="Example3-code">Code Example:</p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/Example3.java"/>
-          <param name="type" value="code"/>
         </macro>
       </subsection>
 
@@ -93,6 +78,21 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/UseCase1.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="UseCase2-config">
+          An example of how to configure the check with different format for final and non-final
+          pattern variables:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/UseCase2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="UseCase2-code">Code Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/UseCase2.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -172,7 +172,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/javadoc/javadocblocktaglocation",
             "checks/javadoc/javadocpackage",
             "checks/lineending",
-            "checks/naming/patternvariablename",
             "checks/sizes/linelength",
             "checks/whitespace/emptylineseparator",
             "filters/suppresswarningsfilter"

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckExamplesTest.java
@@ -71,14 +71,14 @@ public class PatternVariableNameCheckExamplesTest extends AbstractExamplesModule
     }
 
     @Test
-    public void testExample3() throws Exception {
+    public void testUseCase2() throws Exception {
 
         final String[] expected = {
             "37:30: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", "^([a-z][a-zA-Z0-9]*|_)$"),
             "40:31: " + getCheckMessage(MSG_INVALID_PATTERN, "num_1", "^([a-z][a-zA-Z0-9]*|_)$"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase2.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/UseCase2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/UseCase2.java
@@ -32,7 +32,7 @@
 package com.puppycrawl.tools.checkstyle.checks.naming.patternvariablename;
 
 // xdoc section - start
-class Example3 {
+class UseCase2 {
   void foo(Object o1){
     if (o1 instanceof String STRING) {}
     // violation above 'Name 'STRING' must match pattern*.'


### PR DESCRIPTION
Issue: #21229

`PatternVariableName` documents one property (`format`), so
`testExampleCountMatchesPropertyCount` expects 2 AST-matching examples
(default + one per property). The module had 3 structurally identical
Java examples (default, custom `format`, and dual-module final/non-final
with xpath filters).

Examples now has the default config plus the `format` example. The extra
final/non-final xpath configuration is kept under Use Cases as UseCase2.

Other modules listed in #21229 are left for separate PRs.

## Testing

Executed:

- `mvn clean test -Dtest=PatternVariableNameCheckExamplesTest,XdocsExamplesAstConsistencyTest,XdocsExampleFileTest,XdocsPagesTest`
  - PatternVariableNameCheckExamplesTest 4/4
  - XdocsExamplesAstConsistencyTest 5/5
  - XdocsExampleFileTest 5/5
  - XdocsPagesTest 20/20