### PR TITLE
Issue #20954: Quote UnusedLocalVariable remaining input messages

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -305,20 +305,6 @@ public final class InlineConfigParser {
             "checks/coding/equalshashcode/Example1.java",
             "checks/coding/noclone/Example1.java",
             "checks/coding/unusedlocalvariable/Example1.java",
-            "checks/coding/unusedlocalvariable/InputUnusedLocalVariable3.java",
-            "checks/coding/unusedlocalvariable/"
-                    + "InputUnusedLocalVariableAllowNamedPatternVariables.java",
-            "checks/coding/unusedlocalvariable/"
-                    + "InputUnusedLocalVariablePatternVariables.java",
-            "checks/coding/unusedlocalvariable/"
-                    + "InputUnusedLocalVariablePatternVariables2.java",
-            "checks/coding/unusedlocalvariable/"
-                    + "InputUnusedLocalVariablePatternVariablesAllowUnnamed.java",
-            "checks/coding/unusedlocalvariable/"
-                    + "InputUnusedLocalVariablePatternVariablesCondition.java",
-            "checks/coding/unusedlocalvariable/"
-                    + "InputUnusedLocalVariablePatternVariablesCondition2.java",
-            "checks/coding/unusedlocalvariable/InputUnusedLocalVariableUnnamedTryCatch.java",
             "checks/sizes/recordcomponentnumber/Example2.java",
             "checks/whitespace/separatorwrap/Example1.java",
             "com/google/checkstyle/test/chapter5naming/rule53camelcase/"

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariables.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariables.java
@@ -16,8 +16,8 @@ public class InputUnusedLocalVariablePatternVariables {
 
     void unusedInArrowCase(Shape s) {
         switch (s) {
-            case Circle c    -> process(s); // violation, Unused local variable 'c'
-            case Rectangle r -> process(s); // violation, Unused local variable 'r'
+            case Circle c    -> process(s); // violation 'Unused local variable 'c'.'
+            case Rectangle r -> process(s); // violation 'Unused local variable 'r'.'
             default -> { }
         }
     }
@@ -40,8 +40,8 @@ public class InputUnusedLocalVariablePatternVariables {
 
     void unusedRecordPatternArrow(Box<? extends Shape> box) {
         switch (box) {
-            case Box(Circle c)    -> process(box); // violation, Unused local variable 'c'
-            case Box(Rectangle r) -> process(box); // violation, Unused local variable 'r'
+            case Box(Circle c)    -> process(box); // violation 'Unused local variable 'c'.'
+            case Box(Rectangle r) -> process(box); // violation 'Unused local variable 'r'.'
             default -> { }
         }
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesAllowUnnamed.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesAllowUnnamed.java
@@ -16,8 +16,8 @@ public class InputUnusedLocalVariablePatternVariablesAllowUnnamed {
 
     void unusedNamedPatternVar(Shape s) {
         switch (s) {
-            case Circle    c -> process(s); // violation, unused named local variable 'c'
-            case Rectangle r -> process(s); // violation, unused named local variable 'r'
+            case Circle    c -> process(s); // violation 'Unused named local variable 'c'.'
+            case Rectangle r -> process(s); // violation 'Unused named local variable 'r'.'
         }
         switch (s) {
             case Circle    _ -> process(s);
@@ -27,8 +27,8 @@ public class InputUnusedLocalVariablePatternVariablesAllowUnnamed {
 
     void unusedNamedRecordPattern(Box<? extends Shape> box) {
         switch (box) {
-            case Box(Circle    c) -> process(box); // violation, unused named local variable 'c'
-            case Box(Rectangle r) -> process(box); // violation, unused named local variable 'r'
+            case Box(Circle    c) -> process(box); // violation 'Unused named local variable 'c'.'
+            case Box(Rectangle r) -> process(box); // violation 'Unused named local variable 'r'.'
             default -> {
 
             }
@@ -43,7 +43,7 @@ public class InputUnusedLocalVariablePatternVariablesAllowUnnamed {
     }
 
     void unusedNamedInstanceof(Object obj) {
-        if (obj instanceof String s) { // violation, unused named local variable 's'
+        if (obj instanceof String s) { // violation 'Unused named local variable 's'.'
             System.out.println("it is a string");
         }
         if (obj instanceof String t) {
@@ -54,7 +54,7 @@ public class InputUnusedLocalVariablePatternVariablesAllowUnnamed {
    void namedloops() {
         int[] orderIDs = {34, 45, 23, 27, 15};
         int total = 0;
-        for (int id : orderIDs) { // violation, unused named local variable 'id'
+        for (int id : orderIDs) { // violation 'Unused named local variable 'id'.'
             total++;
         }
         System.out.println("Total: " + total);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesCondition.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesCondition.java
@@ -17,10 +17,10 @@ public class InputUnusedLocalVariablePatternVariablesCondition {
     record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {}
 
     public void patternVariableConditionalStatements(Ball ball) {
-        if (ball instanceof RedBall redBall) { // violation, unused local variable 'redBall'
+        if (ball instanceof RedBall redBall) { // violation 'Unused local variable 'redBall'.'
             process(ball);
         } else if (ball instanceof GreenBall greenBall) {
-            stopProcessing(ball); // violation above, unused local variable 'greenBall'
+            stopProcessing(ball); // violation above 'Unused local variable 'greenBall'.'
         }
         if (ball instanceof RedBall _) {
             process(ball);
@@ -38,7 +38,7 @@ public class InputUnusedLocalVariablePatternVariablesCondition {
     }
 
     public void patternVariableNegatedInstanceofUnused(Ball ball) {
-        if (!(ball instanceof RedBall redBall)) { // violation, unused local variable 'redBall'
+        if (!(ball instanceof RedBall redBall)) { // violation 'Unused local variable 'redBall'.'
             process(ball);
         }
     }
@@ -52,16 +52,16 @@ public class InputUnusedLocalVariablePatternVariablesCondition {
     }
 
     public void patternVariableNegatedInstanceofRecordUnused(Box<? extends Ball> box) {
-        if (!(box instanceof Box(RedBall redBall))) { // violation, unused local variable 'redBall'
+        if (!(box instanceof Box(RedBall redBall))) { // violation 'local variable 'redBall''
             process(box);
         }
     }
 
     public void patternVariableInRecordPatternConditional(Box<? extends Ball> box) {
-        if (box instanceof Box(RedBall redBall)) { // violation, unused local variable 'redBall'
+        if (box instanceof Box(RedBall redBall)) { // violation 'Unused local variable 'redBall'.'
             process(box);
         } else if (box instanceof Box(GreenBall greenBall)) {
-            stopProcessing(box); // violation above, unused local variable 'greenBall'
+            stopProcessing(box); // violation above 'Unused local variable 'greenBall'.'
         }
         if (box instanceof Box(RedBall _)) {
             process(box);
@@ -78,7 +78,7 @@ public class InputUnusedLocalVariablePatternVariablesCondition {
 
     public void patternVariableNestedRecordPatterns(Object o) {
         if (o instanceof Rectangle(ColoredPoint(int p, int x, String c),
-                ColoredPoint lr)) { // violation, unused local variable 'lr'
+                ColoredPoint lr)) { // violation 'Unused local variable 'lr'.'
             System.out.println(p + "" + x + c);
         }
         if (o instanceof Rectangle(ColoredPoint(int p, int x, String c), ColoredPoint _)) {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesCondition2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariablesCondition2.java
@@ -41,7 +41,7 @@ public class InputUnusedLocalVariablePatternVariablesCondition2 {
     }
 
     public void patternVariableUnusedWithNestedBlock(Object o) {
-        if (o instanceof String s) { // violation, unused local variable 's'
+        if (o instanceof String s) { // violation 'Unused local variable 's'.'
             System.out.println("it is a string");
             if (o.hashCode() > 0) {
                 System.out.println("positive hash");
@@ -56,7 +56,7 @@ public class InputUnusedLocalVariablePatternVariablesCondition2 {
     }
 
     public void patternVariableMixedUsage(Object o1, Object o2) {
-        if (o1 instanceof String s1) { // violation, unused local variable 's1'
+        if (o1 instanceof String s1) { // violation 'Unused local variable 's1'.'
             System.out.println("string 1");
         }
         if (o2 instanceof Integer i2) {
@@ -77,7 +77,7 @@ public class InputUnusedLocalVariablePatternVariablesCondition2 {
    void namedloops() {
         int[] orderIDs = {34, 45, 23, 27, 15};
         int total = 0;
-        for (int id : orderIDs) { // violation 'Unused local variable'
+        for (int id : orderIDs) { // violation 'Unused local variable 'id'.'
             total++;
         }
         System.out.println("Total: " + total);
@@ -86,7 +86,7 @@ public class InputUnusedLocalVariablePatternVariablesCondition2 {
    void unnamedloops() {
         int[] orderIDs = {34, 45, 23, 27, 15};
         int total = 0;
-        for (int _ : orderIDs) { // violation, unused named local variable '_'
+        for (int _ : orderIDs) { // violation 'Unused local variable '_'.'
             total++;
         }
         System.out.println("Total: " + total);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableUnnamedTryCatch.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableUnnamedTryCatch.java
@@ -25,7 +25,7 @@ public class InputUnusedLocalVariableUnnamedTryCatch {
         var winners = new ArrayList<Caller>();
         try {
             while (prizes > 0) {
-                Caller _ = q.remove(); // violation, unused local variable '_'
+                Caller _ = q.remove(); // violation 'Unused local variable '_'.'
                 winners.add(q.remove());
                 prizes--;
             }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariable3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariable3.java
@@ -19,7 +19,7 @@ public class InputUnusedLocalVariable3 {
         protected int b = 0;
         public Child(Child d) {
             InputUnusedLocalVariable3.this.super(d);
-            int a = 0; // violation, unused variable 'a'
+            int a = 0; // violation 'Unused local variable 'a'.'
             System.out.println(super.a);
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowNamedPatternVariables.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableAllowNamedPatternVariables.java
@@ -18,27 +18,27 @@ public class InputUnusedLocalVariableAllowNamedPatternVariables {
 
     String whatClass(Object object) {
         return switch (object) {
-            case String ignored -> "A String"; // violation 'Unused local variable'
-            case Integer ignored2 -> "An Integer"; // violation 'Unused local variable'
+            case String ignored -> "A String"; // violation 'Unused local variable 'ignored'.'
+            case Integer ignored2 -> "An Integer"; // violation 'Unused local variable 'ignored2'.'
             default -> "Something Else";
         };
     }
 
     void method(Object object) {
-        int x = 10; // violation 'Unused local variable'
-        if (object instanceof String ignored) { // violation 'Unused local variable'
+        int x = 10; // violation 'Unused local variable 'x'.'
+        if (object instanceof String ignored) { // violation 'Unused local variable 'ignored'.'
             System.out.println("string");
         }
     }
 
     String withrecord(Object object) {
-        return switch (object) { // violation below, unused local variable 'y'
-            case Ignored(int y, int z) -> "record switch"; // violation, unused local variable 'z'
+        return switch (object) { // violation below 'Unused local variable 'y'.'
+            case Ignored(int y, int z) -> "record switch"; // violation 'Unused local variable 'z'.'
             default -> "other";
         };
     }
 
-    String nameWithoutIgnored(Customer customer) { // violation below 'Unused local variable'
+    String nameWithoutIgnored(Customer customer) { // violation below 'ignoredAge'
         if (customer instanceof Person(String name, int ignoredAge)) {
             return name;
         } else if (customer instanceof Company(String companyName)) {
@@ -55,7 +55,7 @@ public class InputUnusedLocalVariableAllowNamedPatternVariables {
     }
 
     boolean isNested(Maybe<?> maybe) {
-        if (maybe instanceof Some(Some<?> inner)) { // violation 'Unused local variable'
+        if (maybe instanceof Some(Some<?> inner)) { // violation 'Unused local variable 'inner'.'
             return true;
         }
         return false;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariables2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariablePatternVariables2.java
@@ -25,7 +25,7 @@ public class InputUnusedLocalVariablePatternVariables2 {
 
     void unusedInColonCase(Object obj) {
         switch (obj) {
-            case String s: // violation, Unused local variable 's'
+            case String s: // violation 'Unused local variable 's'.'
                 System.out.println("string");
                 break;
             default:
@@ -44,7 +44,7 @@ public class InputUnusedLocalVariablePatternVariables2 {
     }
 
     void unusedInstanceof(Object obj) {
-        if (obj instanceof String s) { // violation, Unused local variable 's'
+        if (obj instanceof String s) { // violation 'Unused local variable 's'.'
             System.out.println("it is a string");
         }
     }


### PR DESCRIPTION
Fixes remaining UnusedLocalVariable files from #20954 (except `Example1.java`, which is already covered by another PR).

Violation comments on these inputs used unquoted / paraphrased text, so `InlineConfigParser` never checked the real message and the files stayed in `SUPPRESSED_VALIDATE_MESSAGE_FILES`.

Each comment now uses a quoted substring of the actual check message (`Unused local variable '…'.` or `Unused named local variable '…'.` when `allowUnnamedVariables` is true), and the matching suppression entries are removed.