### PR TITLE
Issue #21229: Align DesignForExtension examples with property count

### DIFF
--- a/src/site/xdoc/checks/design/designforextension.xml
+++ b/src/site/xdoc/checks/design/designforextension.xml
@@ -23,7 +23,13 @@
               <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
               <li><a href="#Example2-config" class="toc-sublink">Allow methods which have @Override annotations to be designed for extension.</a></li>
               <li><a href="#Example3-config" class="toc-sublink">Allow methods which contain a specified comment text pattern in their javadoc to be designed for extension.</a></li>
-              <li><a href="#Example4-config" class="toc-sublink">Allow methods which contain a specified comment text pattern in their javadoc which can span multiple lines to be designed for extension.</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#DesignForExtension_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">Allow methods which contain a specified comment text pattern in their javadoc which can span multiple lines to be designed for extension.</a></li>
             </ul>
           </li>
           <li><a href="#DesignForExtension_Example_of_Usage">Example of Usage</a></li>
@@ -345,8 +351,11 @@ public abstract class Example3 {
     return "";
   }
 }
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example4-config">
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Use Cases" id="DesignForExtension_Use_Cases">
+        <p id="UseCase1-config">
           To configure the check to allow methods which contain a specified comment text pattern in
           their javadoc which can span multiple lines to be designed for extension.
         </p>
@@ -360,9 +369,9 @@ public abstract class Example3 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example4-code">Example:</p>
+        <p id="UseCase1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public abstract class Example4 {
+public abstract class UseCase1 {
   private int bar;
 
   // violation below ''m1' does not have javadoc that explains how to do that safely'

--- a/src/site/xdoc/checks/design/designforextension.xml.template
+++ b/src/site/xdoc/checks/design/designforextension.xml.template
@@ -75,20 +75,23 @@
           <param name="path"
                    value="resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example3.java"/>
             <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-        <p id="Example4-config">
+        </macro>
+      </subsection>
+
+      <subsection name="Use Cases" id="DesignForExtension_Use_Cases">
+        <p id="UseCase1-config">
           To configure the check to allow methods which contain a specified comment text pattern in
           their javadoc which can span multiple lines to be designed for extension.
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example4.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/UseCase1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example4-code">Example:</p>
+        <p id="UseCase1-code">Example:</p>
         <macro name="example">
           <param name="path"
-                   value="resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/Example4.java"/>
+                   value="resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/UseCase1.java"/>
             <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -166,7 +166,6 @@ public class XdocsExamplesAstConsistencyTest {
      * Until: <a href="https://github.com/checkstyle/checkstyle/issues/21229">...</a>
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
-            "checks/design/designforextension",
             "checks/imports/avoidstarimport",
             "checks/javadoc/atclauseorder",
             "checks/javadoc/javadocblocktaglocation",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckExamplesTest.java
@@ -67,15 +67,15 @@ public class DesignForExtensionCheckExamplesTest extends AbstractExamplesModuleT
     }
 
     @Test
-    public void testExample4() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expected = {
-            "18:3: " + getCheckMessage(MSG_KEY, "Example4", "m1"),
-            "21:3: " + getCheckMessage(MSG_KEY, "Example4", "m2"),
-            "38:3: " + getCheckMessage(MSG_KEY, "Example4", "m7"),
-            "46:3: " + getCheckMessage(MSG_KEY, "Example4", "toString"),
+            "18:3: " + getCheckMessage(MSG_KEY, "UseCase1", "m1"),
+            "21:3: " + getCheckMessage(MSG_KEY, "UseCase1", "m2"),
+            "38:3: " + getCheckMessage(MSG_KEY, "UseCase1", "m7"),
+            "46:3: " + getCheckMessage(MSG_KEY, "UseCase1", "toString"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/UseCase1.java
@@ -11,7 +11,7 @@
 package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
 
 // xdoc section - start
-public abstract class Example4 {
+public abstract class UseCase1 {
   private int bar;
 
   // violation below ''m1' does not have javadoc that explains how to do that safely'


### PR DESCRIPTION
Issue: #21229

`DesignForExtension` documents two properties (`ignoredAnnotations`,
`requiredJavadocPhrase`), so `testExampleCountMatchesPropertyCount`
expects 3 AST-matching examples (default + one per property). The module
had 4 structurally identical Java examples (default, `ignoredAnnotations`,
single-line `requiredJavadocPhrase`, and multiline `requiredJavadocPhrase`).

Examples now has the default config plus one example per property. The extra
multiline `requiredJavadocPhrase` configuration is kept under Use Cases as
UseCase1.

Other modules listed in #21229 are left for separate PRs.

## Testing

Executed:

- `mvn test -Dtest=DesignForExtensionCheckExamplesTest,XdocsExamplesAstConsistencyTest,XdocsExampleFileTest,XdocsPagesTest`
  - DesignForExtensionCheckExamplesTest 4/4
  - XdocsExamplesAstConsistencyTest 5/5
  - XdocsExampleFileTest 5/5
  - XdocsPagesTest 20/20