### PR TITLE
Issue #21229: Align AvoidStarImport examples with property count

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -127,7 +127,7 @@
 
   <!-- Suppress forbidden regex messages for avoidstarimport examples -->
   <suppress id="forbiddenRegexpInViolationMessage"
-    files="avoidstarimport/Example[1-6].java"/>
+    files="avoidstarimport/(Example|UseCase)[1-9].java"/>
 
   <suppress checks="CommentsIndentation"
     files="singlespaceseparator/Example[12].java"/>

--- a/src/site/xdoc/checks/imports/avoidstarimport.xml
+++ b/src/site/xdoc/checks/imports/avoidstarimport.xml
@@ -24,9 +24,15 @@
               <li><a href="#Example2-config" class="toc-sublink">So that star imports from packages <code>java.io and java.net</code> as well as static members from class <code>java.lang.Math</code> are allowed</a></li>
               <li><a href="#Example3-config" class="toc-sublink">So that star imports from all packages are allowed</a></li>
               <li><a href="#Example4-config" class="toc-sublink">So that starred static member imports from all packages are allowed</a></li>
-              <li><a href="#Example5-config" class="toc-sublink">So that star imports from packages <code>java.io and java.net</code> are allowed</a></li>
-              <li><a href="#Example6-config" class="toc-sublink">So that star imports from packages <code>java.io and java.net</code> as well as static members imports from all packages are allowed</a></li>
               <li><a href="#Example7-config" class="toc-sublink">According to OpenJDK guidelines, where at most one star import is allowed per file</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#AvoidStarImport_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">So that star imports from packages <code>java.io and java.net</code> are allowed</a></li>
+              <li><a href="#UseCase2-config" class="toc-sublink">So that star imports from packages <code>java.io and java.net</code> as well as static members imports from all packages are allowed</a></li>
             </ul>
           </li>
           <li><a href="#AvoidStarImport_Example_of_Usage">Example of Usage</a></li>
@@ -189,55 +195,6 @@ import static java.lang.Math.*;
 import java.util.*; // violation 'Using the '.*' form of import should be avoided.'
 import java.net.*; // violation 'Using the '.*' form of import should be avoided.'
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example5-config">
-          To configure the check so that star imports from packages
-          <code>java.io and java.net</code> are allowed:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="AvoidStarImport"&gt;
-      &lt;property name="allowClassImports" value="true"/&gt;
-      &lt;property name="excludes" value="java.io,java.net"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example5-code">
-          Example:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-import java.util.Scanner;
-import java.io.*;
-import static java.lang.Math.*; // violation 'form of import should be avoided.'
-import java.util.*;
-import java.net.*;
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example6-config">
-          To configure the check so that star imports from packages
-          <code>java.io and java.net</code> as well as static members imports
-          from all packages are allowed:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="AvoidStarImport"&gt;
-      &lt;property name="allowStaticMemberImports" value="true"/&gt;
-      &lt;property name="excludes" value="java.io,java.net"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example6-code">
-          Example:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-import java.util.Scanner;
-import java.io.*;
-import static java.lang.Math.*;
-import java.util.*; // violation 'Using the '.*' form of import should be avoided.'
-import java.net.*;
-</code></pre></div><hr class="example-separator"/>
         <p id="Example7-config">
           To configure the check according to
           <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-import-statements">
@@ -262,6 +219,58 @@ import java.io.*;
 import static java.lang.Math.*; // violation 'Only '1' star import is allowed per file.'
 import java.util.*; // violation 'Only '1' star import is allowed per file.'
 import java.net.*; // violation 'Only '1' star import is allowed per file.'
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Use Cases" id="AvoidStarImport_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check so that star imports from packages
+          <code>java.io and java.net</code> are allowed:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="AvoidStarImport"&gt;
+      &lt;property name="allowClassImports" value="true"/&gt;
+      &lt;property name="excludes" value="java.io,java.net"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="UseCase1-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+import java.util.Scanner;
+import java.io.*;
+import static java.lang.Math.*; // violation 'form of import should be avoided.'
+import java.util.*;
+import java.net.*;
+</code></pre></div><hr class="example-separator"/>
+        <p id="UseCase2-config">
+          To configure the check so that star imports from packages
+          <code>java.io and java.net</code> as well as static members imports
+          from all packages are allowed:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="AvoidStarImport"&gt;
+      &lt;property name="allowStaticMemberImports" value="true"/&gt;
+      &lt;property name="excludes" value="java.io,java.net"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="UseCase2-code">
+          Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+import java.util.Scanner;
+import java.io.*;
+import static java.lang.Math.*;
+import java.util.*; // violation 'Using the '.*' form of import should be avoided.'
+import java.net.*;
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/imports/avoidstarimport.xml.template
+++ b/src/site/xdoc/checks/imports/avoidstarimport.xml.template
@@ -107,41 +107,6 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/Example4.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example5-config">
-          To configure the check so that star imports from packages
-          <code>java.io and java.net</code> are allowed:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/Example5.java"/>
-          <param name="type" value="config"/>
-        </macro>
-        <p id="Example5-code">
-          Example:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/Example5.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-        <p id="Example6-config">
-          To configure the check so that star imports from packages
-          <code>java.io and java.net</code> as well as static members imports
-          from all packages are allowed:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/Example6.java"/>
-          <param name="type" value="config"/>
-        </macro>
-        <p id="Example6-code">
-          Example:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/Example6.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
         <p id="Example7-config">
           To configure the check according to
           <a href="https://cr.openjdk.org/~alundblad/styleguide/index-v6.html#toc-import-statements">
@@ -159,6 +124,44 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/Example7.java"/>
+          <param name="type" value="code"/>
+        </macro>
+      </subsection>
+
+      <subsection name="Use Cases" id="AvoidStarImport_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check so that star imports from packages
+          <code>java.io and java.net</code> are allowed:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/UseCase1.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="UseCase1-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/UseCase1.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
+        <p id="UseCase2-config">
+          To configure the check so that star imports from packages
+          <code>java.io and java.net</code> as well as static members imports
+          from all packages are allowed:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/UseCase2.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="UseCase2-code">
+          Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/UseCase2.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -166,7 +166,6 @@ public class XdocsExamplesAstConsistencyTest {
      * Until: <a href="https://github.com/checkstyle/checkstyle/issues/21229">...</a>
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
-            "checks/imports/avoidstarimport",
             "checks/javadoc/atclauseorder",
             "checks/javadoc/javadocblocktaglocation",
             "checks/javadoc/javadocpackage",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckExamplesTest.java
@@ -75,21 +75,21 @@ public class AvoidStarImportCheckExamplesTest extends AbstractExamplesModuleTest
     }
 
     @Test
-    public void testExample5() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expected = {
             "17:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.*"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
     @Test
-    public void testExample6() throws Exception {
+    public void testUseCase2() throws Exception {
         final String[] expected = {
             "18:17: " + getCheckMessage(MSG_KEY, "java.util.*"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase2.java"), expected);
     }
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/UseCase1.java
@@ -19,4 +19,4 @@ import java.util.*;
 import java.net.*;
 // xdoc section - end
 
-class Example5 {}
+class UseCase1 {}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/UseCase2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/UseCase2.java
@@ -19,4 +19,4 @@ import java.util.*; // violation 'Using the '.*' form of import should be avoide
 import java.net.*;
 // xdoc section - end
 
-class Example6 {}
+class UseCase2 {}


### PR DESCRIPTION
Issue: #21229

`AvoidStarImport` documents four properties (`allowClassImports`,
`allowStaticMemberImports`, `excludes`, `maxAllowedStarImports`), so
`testExampleCountMatchesPropertyCount` expects 5 AST-matching examples
(default + one per property). The module had 7 structurally identical
Java examples.

Examples now has the default config plus one example per property. The
extra combination configurations (`allowClassImports` + `excludes`, and
`allowStaticMemberImports` + `excludes`) are kept under Use Cases as
UseCase1 and UseCase2.

Other modules listed in #21229 are left for separate PRs.

## Testing

Executed:

- `mvn test -Dtest=AvoidStarImportCheckExamplesTest,XdocsExamplesAstConsistencyTest,XdocsExampleFileTest,XdocsPagesTest`
  - AvoidStarImportCheckExamplesTest 7/7
  - XdocsExamplesAstConsistencyTest 5/5
  - XdocsExampleFileTest 5/5
  - XdocsPagesTest 20/20