### PR TITLE
Issue #21199: Skip module-info.java in JavadocPackageCheck

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1574,6 +1574,7 @@ Wifi
 wiki
 wikipedia
 wiktionary
+withfile
 withgoogle
 wj
 wnd

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
@@ -88,28 +88,31 @@ public class JavadocPackageCheck extends AbstractFileSetCheck {
 
     @Override
     protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
-        // Check if already processed directory
-        final File dir;
-        try {
-            dir = file.getCanonicalFile().getParentFile();
-        }
-        catch (IOException exc) {
-            throw new CheckstyleException(
-                    "Exception while getting canonical path to file " + file.getPath(), exc);
-        }
-        final boolean isDirChecked = !directoriesChecked.add(dir);
-        if (!isDirChecked) {
-            // Check for the preferred file.
-            final Path packageInfo = Path.of(dir.getPath(), "package-info.java");
-            final Path packageHtml = Path.of(dir.getPath(), "package.html");
-
-            if (Files.exists(packageInfo)) {
-                if (Files.exists(packageHtml)) {
-                    log(1, MSG_LEGACY_PACKAGE_HTML);
-                }
+        // module-info.java is not a package member.
+        if (!"module-info.java".equals(file.getName())) {
+            // Check if already processed directory
+            final File dir;
+            try {
+                dir = file.getCanonicalFile().getParentFile();
             }
-            else if (!allowLegacy || !Files.exists(packageHtml)) {
-                log(1, MSG_PACKAGE_INFO);
+            catch (IOException exc) {
+                throw new CheckstyleException(
+                        "Exception while getting canonical path to file " + file.getPath(), exc);
+            }
+            final boolean isDirChecked = !directoriesChecked.add(dir);
+            if (!isDirChecked) {
+                // Check for the preferred file.
+                final Path packageInfo = Path.of(dir.getPath(), "package-info.java");
+                final Path packageHtml = Path.of(dir.getPath(), "package.html");
+
+                if (Files.exists(packageInfo)) {
+                    if (Files.exists(packageHtml)) {
+                        log(1, MSG_LEGACY_PACKAGE_HTML);
+                    }
+                }
+                else if (!allowLegacy || !Files.exists(packageHtml)) {
+                    log(1, MSG_PACKAGE_INFO);
+                }
             }
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
@@ -25,6 +25,7 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck
 
 import java.io.File;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -146,6 +147,27 @@ public class JavadocPackageCheckTest
         verifyWithInlineConfigParser(
                 getPath("annotation" + File.separator + "package-info.java"),
                 expected);
+    }
+
+    @Test
+    public void testModuleInfoFile() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("module-info/default/module-info.java"),
+                expected);
+    }
+
+    @Test
+    public void testModuleInfoDoesNotSkipSiblingJavaFile() throws Exception {
+        final List<String> expectedFromModuleInfo = List.of();
+        final List<String> expectedFromSibling = List.of(
+                "1: " + getCheckMessage(MSG_PACKAGE_INFO));
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("module-info/withfile/module-info.java"),
+                getNonCompilablePath(
+                        "module-info/withfile/InputJavadocPackageModuleInfoWithFile.java"),
+                expectedFromModuleInfo,
+                expectedFromSibling);
     }
 
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/module-info/default/module-info.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/module-info/default/module-info.java
@@ -1,0 +1,15 @@
+/*
+JavadocPackage
+allowLegacy = (default)false
+fileExtensions = (default).java
+
+
+*/
+
+// non-compiled with javac: reference to non existent packages
+
+module com.example.app {
+    requires java.base;
+
+    exports com.example.api;
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/module-info/withfile/InputJavadocPackageModuleInfoWithFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/module-info/withfile/InputJavadocPackageModuleInfoWithFile.java
@@ -1,0 +1,14 @@
+/*
+JavadocPackage
+allowLegacy = (default)false
+fileExtensions = (default).java
+
+
+*/
+// non-compiled with javac: reference to non existent packages
+
+package withfile;
+// violation first line 'Missing package-info.java file'
+
+class InputJavadocPackageModuleInfoWithFile {
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/module-info/withfile/module-info.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/module-info/withfile/module-info.java
@@ -1,0 +1,13 @@
+/*
+JavadocPackage
+allowLegacy = (default)false
+fileExtensions = (default).java
+
+
+*/
+
+// non-compiled with javac: reference to non existent packages
+
+module com.example.app {
+    requires java.base;
+}


### PR DESCRIPTION
Fixes #21199

`JavadocPackage` treats every `.java` file as evidence of a package directory that needs `package-info.java`. `module-info.java` is a modular compilation unit, not a package member (JLS 7.3), so the check reported a false positive on it.

I skip `module-info.java` before the directory is recorded as checked, so a sibling `.java` file in the same directory is still audited.

Locally: `./mvnw -Dtest=JavadocPackageCheckTest,AllTestsTest test` — 12 tests in `JavadocPackageCheckTest`, 0 failures.