### PR TITLE
Issue #21119: Fix examples with duplicate violation behavior - annota…

### DIFF
--- a/src/site/xdoc/checks/annotation/annotationlocation.xml
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml
@@ -25,7 +25,7 @@
               <li><a href="#Example2-config" class="toc-sublink">Use the following configuration to allow multiple annotations on the same line</a></li>
               <li><a href="#Example3-config" class="toc-sublink">Use the following configuration to allow only one and only parameterized annotation on the same line</a></li>
               <li><a href="#Example4-config" class="toc-sublink">Use the following configuration to only validate annotations on methods to allow one single parameterless annotation on the same line</a></li>
-              <li><a href="#Example5-config" class="toc-sublink">Use the following configuration to forbid multiple annotations on the same line</a></li>
+              <li><a href="#Example5-config" class="toc-sublink">Use the following configuration to forbid single parameterless annotation on the same line</a></li>
             </ul>
           </li>
           <li><a href="#AnnotationLocation_Example_of_Usage">Example of Usage</a></li>
@@ -322,13 +322,14 @@ class Example4 {
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example5-config">
-          Use the following configuration to forbid multiple annotations on the same line:
+          Use the following configuration to forbid single parameterless
+          annotation on the same line:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="AnnotationLocation"&gt;
-      &lt;property name="allowSamelineMultipleAnnotations" value="false"/&gt;
+      &lt;property name="allowSamelineSingleParameterlessAnnotation" value="false"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -339,7 +340,7 @@ class Example5 {
   @Nonnull
   private boolean field1;
   @Override public int hashCode() { return 1; }
-
+  // violation above 'Annotation 'Override' should be alone on line'
   @Nonnull
   private boolean field2;
   @Override
@@ -350,7 +351,7 @@ class Example5 {
   // violation above 'Annotation 'SuppressWarnings' should be alone on line'
   @SuppressWarnings("deprecation") public int foo() { return 1; }
   // violation above 'Annotation 'SuppressWarnings' should be alone on line'
-  @Nonnull @Mock DataLoader loader3;
+  @Nonnull @Mock DataLoader loader3; // violation ''Nonnull' should be alone on line'
   // violation above 'Annotation 'Mock' should be alone on line'
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/annotation/annotationlocation.xml.template
+++ b/src/site/xdoc/checks/annotation/annotationlocation.xml.template
@@ -100,7 +100,8 @@
             <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example5-config">
-          Use the following configuration to forbid multiple annotations on the same line:
+          Use the following configuration to forbid single parameterless
+          annotation on the same line:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -99,7 +99,6 @@ public class XdocsExampleFileTest {
      * <a href="https://github.com/checkstyle/checkstyle/issues/21072">...</a>
      */
     private static final Set<String> SUPPRESSED_UNIQUENESS_CHECK_MODULES = Set.of(
-        "checks/annotation/annotationlocation/",
         "checks/coding/hiddenfield/",
         "checks/coding/returncount/",
         "checks/imports/avoidstarimport/",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationExamplesTest.java
@@ -76,8 +76,10 @@ public class AnnotationLocationExamplesTest extends AbstractExamplesModuleTestSu
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
+            "20:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Override"),
             "28:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
             "30:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "32:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Nonnull"),
             "32:12: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Mock"),
         };
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/Example5.java
@@ -2,7 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="AnnotationLocation">
-      <property name="allowSamelineMultipleAnnotations" value="false"/>
+      <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
     </module>
   </module>
 </module>
@@ -18,7 +18,7 @@ class Example5 {
   @Nonnull
   private boolean field1;
   @Override public int hashCode() { return 1; }
-
+  // violation above 'Annotation 'Override' should be alone on line'
   @Nonnull
   private boolean field2;
   @Override
@@ -29,7 +29,7 @@ class Example5 {
   // violation above 'Annotation 'SuppressWarnings' should be alone on line'
   @SuppressWarnings("deprecation") public int foo() { return 1; }
   // violation above 'Annotation 'SuppressWarnings' should be alone on line'
-  @Nonnull @Mock DataLoader loader3;
+  @Nonnull @Mock DataLoader loader3; // violation ''Nonnull' should be alone on line'
   // violation above 'Annotation 'Mock' should be alone on line'
 }
 // xdoc section - end


### PR DESCRIPTION
#21119 

`Example1`: Default configuration (no properties set)
`Example5`: Explicitly set `allowSamelineMultipleAnnotations="false"` (which is already the default)
This caused the `testAllModuleExamplesAreBehaviorallyUnique `test to fail.

Modified `Example5 `to demonstrate a different configuration by setting `allowSamelineSingleParameterlessAnnotation="false" ` instead. This changes the violations produced.