### PR TITLE
Issue #20954: Remove constructor order message suppression

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -308,10 +308,7 @@ public final class InlineConfigParser {
             "checks/sizes/recordcomponentnumber/Example2.java",
             "checks/whitespace/separatorwrap/Example1.java",
             "com/google/checkstyle/test/chapter5naming/rule53camelcase/"
-                    + "InputUnderscoreUsedInNames.java",
-            "com/openjdk/checkstyle/test/chapterformatting/"
-                    + "ruleorderofconstructorsandoverloadedmethods/"
-                    + "InputOrderOfConstructorsAndOverloadedMethodsOne.java"
+                    + "InputUnderscoreUsedInNames.java"
     );
 
     /**


### PR DESCRIPTION
Issue: #20954

Removes the obsolete violation-message validation suppression for
`InputOrderOfConstructorsAndOverloadedMethodsOne.java`.

The existing violation comments now pass strict message validation.

Validation:
- `./mvnw clean test`
- `./mvnw clean verify`