### PR TITLE
Issue 21288: fix right curly braces falling out of snippets by reverting back to pre tags

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2139,18 +2139,17 @@ public final class TokenTypes {
      * <p>parses as:</p>
      *
      * {@snippet :
-     * |--LITERAL_SYNCHRONIZED -> synchronized
-     * |   |--LPAREN -> (
-     * |   |--EXPR -> EXPR
-     * |   |   `--LITERAL_THIS -> this
-     * |   |--RPAREN -> )
-     * |   `--SLIST -> {
-     * |       |--EXPR -> EXPR
-     * |       |   `--POST_INC -> ++
-     * |       |       `--IDENT -> x
-     * |       |--SEMI -> ;
-     * |       `--RCURLY -> }
-     * `--RCURLY -> }
+     * LITERAL_SYNCHRONIZED -> synchronized
+     *     |--LPAREN -> (
+     *     |--EXPR -> EXPR
+     *     |   `--LITERAL_THIS -> this
+     *     |--RPAREN -> )
+     *     `--SLIST -> {
+     *         |--EXPR -> EXPR
+     *         |   `--POST_INC -> ++
+     *         |       `--IDENT -> x
+     *         |--SEMI -> ;
+     *         `--RCURLY -> }
      * }
      *
      * @see #MODIFIERS
@@ -6358,45 +6357,44 @@ public final class TokenTypes {
      * <p>parses as:</p>
      * {@snippet :
      * LITERAL_SWITCH -> switch
-     * |   |--LPAREN -> (
-     * |   |--EXPR -> EXPR
-     * |   |   `--IDENT -> o
-     * |   |--RPAREN -> )
-     * |   |--LCURLY -> {
-     * |   |--CASE_GROUP -> CASE_GROUP
-     * |   |   |--LITERAL_CASE -> case
-     * |   |   |   |--PATTERN_DEF -> PATTERN_DEF
-     * |   |   |   |   `--LITERAL_WHEN -> when
-     * |   |   |   |       |--PATTERN_VARIABLE_DEF -> PATTERN_VARIABLE_DEF
-     * |   |   |   |       |   |--MODIFIERS -> MODIFIERS
-     * |   |   |   |       |   |--TYPE -> TYPE
-     * |   |   |   |       |   |   `--IDENT -> String
-     * |   |   |   |       |   `--IDENT -> s
-     * |   |   |   |       `--GT -> >
-     * |   |   |   |           |--METHOD_CALL -> (
-     * |   |   |   |           |   |--DOT -> .
-     * |   |   |   |           |   |   |--IDENT -> s
-     * |   |   |   |           |   |   `--IDENT -> length
-     * |   |   |   |           |   |--ELIST -> ELIST
-     * |   |   |   |           |   `--RPAREN -> )
-     * |   |   |   |           `--NUM_INT -> 4
-     * |   |   |   `--COLON -> :
-     * |   |   `--SLIST -> SLIST
-     * |   |       `--LITERAL_BREAK -> break
-     * |   |           `--SEMI -> ;
-     * |   |--CASE_GROUP -> CASE_GROUP
-     * |   |   |--LITERAL_CASE -> case
-     * |   |   |   |--PATTERN_VARIABLE_DEF -> PATTERN_VARIABLE_DEF
-     * |   |   |   |   |--MODIFIERS -> MODIFIERS
-     * |   |   |   |   |--TYPE -> TYPE
-     * |   |   |   |   |   `--IDENT -> String
-     * |   |   |   |   `--IDENT -> s
-     * |   |   |   `--COLON -> :
-     * |   |   `--SLIST -> SLIST
-     * |   |       `--LITERAL_BREAK -> break
-     * |   |           `--SEMI -> ;
-     * |   `--RCURLY -> }
-     * `--RCURLY -> }
+     *     |--LPAREN -> (
+     *     |--EXPR -> EXPR
+     *     |   `--IDENT -> o
+     *     |--RPAREN -> )
+     *     |--LCURLY -> {
+     *     |--CASE_GROUP -> CASE_GROUP
+     *     |   |--LITERAL_CASE -> case
+     *     |   |   |--PATTERN_DEF -> PATTERN_DEF
+     *     |   |   |   `--LITERAL_WHEN -> when
+     *     |   |   |       |--PATTERN_VARIABLE_DEF -> PATTERN_VARIABLE_DEF
+     *     |   |   |       |   |--MODIFIERS -> MODIFIERS
+     *     |   |   |       |   |--TYPE -> TYPE
+     *     |   |   |       |   |   `--IDENT -> String
+     *     |   |   |       |   `--IDENT -> s
+     *     |   |   |       `--GT -> >
+     *     |   |   |           |--METHOD_CALL -> (
+     *     |   |   |           |   |--DOT -> .
+     *     |   |   |           |   |   |--IDENT -> s
+     *     |   |   |           |   |   `--IDENT -> length
+     *     |   |   |           |   |--ELIST -> ELIST
+     *     |   |   |           |   `--RPAREN -> )
+     *     |   |   |           `--NUM_INT -> 4
+     *     |   |   `--COLON -> :
+     *     |   `--SLIST -> SLIST
+     *     |       `--LITERAL_BREAK -> break
+     *     |           `--SEMI -> ;
+     *     |--CASE_GROUP -> CASE_GROUP
+     *     |   |--LITERAL_CASE -> case
+     *     |   |   |--PATTERN_VARIABLE_DEF -> PATTERN_VARIABLE_DEF
+     *     |   |   |   |--MODIFIERS -> MODIFIERS
+     *     |   |   |   |--TYPE -> TYPE
+     *     |   |   |   |   `--IDENT -> String
+     *     |   |   |   `--IDENT -> s
+     *     |   |   `--COLON -> :
+     *     |   `--SLIST -> SLIST
+     *     |       `--LITERAL_BREAK -> break
+     *     |           `--SEMI -> ;
+     *     `--RCURLY -> }
      * }
      *
      * @see <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-14.html#jls-14.30">
@@ -6476,77 +6474,32 @@ public final class TokenTypes {
      *
      * <p>For example:</p>
      * {@snippet :
-     * record R(Object o){}
      * if (o instanceof R(String s) myRecord) {}
-     * switch (o) {
-     *     case R(String s) myRecord -> {}
-     * }
      * }
      *
      * <p>parses as:</p>
      * {@snippet :
-     * |--RECORD_DEF -> RECORD_DEF
-     * |   |--MODIFIERS -> MODIFIERS
-     * |   |--LITERAL_RECORD -> record
-     * |   |--IDENT -> R
-     * |   |--LPAREN -> (
-     * |   |--RECORD_COMPONENTS -> RECORD_COMPONENTS
-     * |   |   `--RECORD_COMPONENT_DEF -> RECORD_COMPONENT_DEF
-     * |   |       |--ANNOTATIONS -> ANNOTATIONS
-     * |   |       |--TYPE -> TYPE
-     * |   |       |   `--IDENT -> Object
-     * |   |       `--IDENT -> o
-     * |   |--RPAREN -> )
-     * |   `--OBJBLOCK -> OBJBLOCK
-     * |       |--LCURLY -> {
-     * |       `--RCURLY -> }
-     * |--LITERAL_IF -> if
-     * |   |--LPAREN -> (
-     * |   |--EXPR -> EXPR
-     * |   |   `--LITERAL_INSTANCEOF -> instanceof
-     * |   |       |--IDENT -> o
-     * |   |       `--RECORD_PATTERN_DEF -> RECORD_PATTERN_DEF
-     * |   |           |--MODIFIERS -> MODIFIERS
-     * |   |           |--TYPE -> TYPE
-     * |   |           |   `--IDENT -> R
-     * |   |           |--LPAREN -> (
-     * |   |           |--RECORD_PATTERN_COMPONENTS -> RECORD_PATTERN_COMPONENTS
-     * |   |           |   `--PATTERN_VARIABLE_DEF -> PATTERN_VARIABLE_DEF
-     * |   |           |       |--MODIFIERS -> MODIFIERS
-     * |   |           |       |--TYPE -> TYPE
-     * |   |           |       |   `--IDENT -> String
-     * |   |           |       `--IDENT -> s
-     * |   |           |--RPAREN -> )
-     * |   |           `--IDENT -> myRecord
-     * |   |--RPAREN -> )
-     * |   `--SLIST -> {
-     * |       `--RCURLY -> }
-     * |--LITERAL_SWITCH -> switch
-     * |   |--LPAREN -> (
-     * |   |--EXPR -> EXPR
-     * |   |   `--IDENT -> o
-     * |   |--RPAREN -> )
-     * |   |--LCURLY -> {
-     * |   |--SWITCH_RULE -> SWITCH_RULE
-     * |   |   |--LITERAL_CASE -> case
-     * |   |   |   `--RECORD_PATTERN_DEF -> RECORD_PATTERN_DEF
-     * |   |   |       |--MODIFIERS -> MODIFIERS
-     * |   |   |       |--TYPE -> TYPE
-     * |   |   |       |   `--IDENT -> R
-     * |   |   |       |--LPAREN -> (
-     * |   |   |       |--RECORD_PATTERN_COMPONENTS -> RECORD_PATTERN_COMPONENTS
-     * |   |   |       |   `--PATTERN_VARIABLE_DEF -> PATTERN_VARIABLE_DEF
-     * |   |   |       |       |--MODIFIERS -> MODIFIERS
-     * |   |   |       |       |--TYPE -> TYPE
-     * |   |   |       |       |   `--IDENT -> String
-     * |   |   |       |       `--IDENT -> s
-     * |   |   |       |--RPAREN -> )
-     * |   |   |       `--IDENT -> myRecord
-     * |   |   |--LAMBDA -> ->
-     * |   |   `--SLIST -> {
-     * |   |       `--RCURLY -> }
-     * |   `--RCURLY -> }
-     * `--RCURLY -> }
+     * LITERAL_IF -> if
+     *     |--LPAREN -> (
+     *     |--EXPR -> EXPR
+     *     |   `--LITERAL_INSTANCEOF -> instanceof
+     *     |       |--IDENT -> o
+     *     |       `--RECORD_PATTERN_DEF -> RECORD_PATTERN_DEF
+     *     |           |--MODIFIERS -> MODIFIERS
+     *     |           |--TYPE -> TYPE
+     *     |           |   `--IDENT -> R
+     *     |           |--LPAREN -> (
+     *     |           |--RECORD_PATTERN_COMPONENTS -> RECORD_PATTERN_COMPONENTS
+     *     |           |   `--PATTERN_VARIABLE_DEF -> PATTERN_VARIABLE_DEF
+     *     |           |       |--MODIFIERS -> MODIFIERS
+     *     |           |       |--TYPE -> TYPE
+     *     |           |       |   `--IDENT -> String
+     *     |           |       `--IDENT -> s
+     *     |           |--RPAREN -> )
+     *     |           `--IDENT -> myRecord
+     *     |--RPAREN -> )
+     *     `--SLIST -> {
+     *         `--RCURLY -> }
      * }
      *
      * @see <a href="https://openjdk.org/jeps/405">JEP 405: Record Patterns</a>
@@ -6566,8 +6519,6 @@ public final class TokenTypes {
      *
      * <p>For example:</p>
      * {@snippet :
-     * record R(Object o){}
-     * if (o instanceof R(String myComponent)) {}
      * switch (o) {
      *     case R(String myComponent) when "component".equalsIgnoreCase(myComponent) -> {}
      * }
@@ -6575,76 +6526,40 @@ public final class TokenTypes {
      *
      * <p>parses as:</p>
      * {@snippet :
-     * |--RECORD_DEF -> RECORD_DEF
-     * |   |--MODIFIERS -> MODIFIERS
-     * |   |--LITERAL_RECORD -> record
-     * |   |--IDENT -> R
-     * |   |--LPAREN -> (
-     * |   |--RECORD_COMPONENTS -> RECORD_COMPONENTS
-     * |   |   `--RECORD_COMPONENT_DEF -> RECORD_COMPONENT_DEF
-     * |   |       |--ANNOTATIONS -> ANNOTATIONS
-     * |   |       |--TYPE -> TYPE
-     * |   |       |   `--IDENT -> Object
-     * |   |       `--IDENT -> o
-     * |   |--RPAREN -> )
-     * |   `--OBJBLOCK -> OBJBLOCK
-     * |       |--LCURLY -> {
-     * |       `--RCURLY -> }
-     * |--LITERAL_IF -> if
-     * |   |--LPAREN -> (
-     * |   |--EXPR -> EXPR
-     * |   |   `--LITERAL_INSTANCEOF -> instanceof
-     * |   |       |--IDENT -> o
-     * |   |       `--RECORD_PATTERN_DEF -> RECORD_PATTERN_DEF
-     * |   |           |--MODIFIERS -> MODIFIERS
-     * |   |           |--TYPE -> TYPE
-     * |   |           |   `--IDENT -> R
-     * |   |           |--LPAREN -> (
-     * |   |           |--RECORD_PATTERN_COMPONENTS -> RECORD_PATTERN_COMPONENTS
-     * |   |           |   `--PATTERN_VARIABLE_DEF -> PATTERN_VARIABLE_DEF
-     * |   |           |       |--MODIFIERS -> MODIFIERS
-     * |   |           |       |--TYPE -> TYPE
-     * |   |           |       |   `--IDENT -> String
-     * |   |           |       `--IDENT -> myComponent
-     * |   |           `--RPAREN -> )
-     * |   |--RPAREN -> )
-     * |   `--SLIST -> {
-     * |       `--RCURLY -> }
-     * |--LITERAL_SWITCH -> switch
-     * |   |--LPAREN -> (
-     * |   |--EXPR -> EXPR
-     * |   |   `--IDENT -> o
-     * |   |--RPAREN -> )
-     * |   |--LCURLY -> {
-     * |   |--SWITCH_RULE -> SWITCH_RULE
-     * |   |   |--LITERAL_CASE -> case
-     * |   |   |   `--PATTERN_DEF -> PATTERN_DEF
-     * |   |   |       `--LITERAL_WHEN -> when
-     * |   |   |           |--RECORD_PATTERN_DEF -> RECORD_PATTERN_DEF
-     * |   |   |           |   |--MODIFIERS -> MODIFIERS
-     * |   |   |           |   |--TYPE -> TYPE
-     * |   |   |           |   |   `--IDENT -> R
-     * |   |   |           |   |--LPAREN -> (
-     * |   |   |           |   |--RECORD_PATTERN_COMPONENTS -> RECORD_PATTERN_COMPONENTS
-     * |   |   |           |   |   `--PATTERN_VARIABLE_DEF -> PATTERN_VARIABLE_DEF
-     * |   |   |           |   |       |--MODIFIERS -> MODIFIERS
-     * |   |   |           |   |       |--TYPE -> TYPE
-     * |   |   |           |   |       |   `--IDENT -> String
-     * |   |   |           |   |       `--IDENT -> myComponent
-     * |   |   |           |   `--RPAREN -> )
-     * |   |   |           `--METHOD_CALL -> (
-     * |   |   |               |--DOT -> .
-     * |   |   |               |   |--STRING_LITERAL -> "component"
-     * |   |   |               |   `--IDENT -> equalsIgnoreCase
-     * |   |   |               |--ELIST -> ELIST
-     * |   |   |               |   `--EXPR -> EXPR
-     * |   |   |               |       `--IDENT -> myComponent
-     * |   |   |               `--RPAREN -> )
-     * |   |   |--LAMBDA -> ->
-     * |   |   `--SLIST -> {
-     * |   |       `--RCURLY -> }
-     * |   `--RCURLY -> }
-     * `--RCURLY -> }
+     * LITERAL_SWITCH -> switch
+     *     |--LPAREN -> (
+     *     |--EXPR -> EXPR
+     *     |   `--IDENT -> o
+     *     |--RPAREN -> )
+     *     |--LCURLY -> {
+     *     |--SWITCH_RULE -> SWITCH_RULE
+     *     |   |--LITERAL_CASE -> case
+     *     |   |   `--PATTERN_DEF -> PATTERN_DEF
+     *     |   |       `--LITERAL_WHEN -> when
+     *     |   |           |--RECORD_PATTERN_DEF -> RECORD_PATTERN_DEF
+     *     |   |           |   |--MODIFIERS -> MODIFIERS
+     *     |   |           |   |--TYPE -> TYPE
+     *     |   |           |   |   `--IDENT -> R
+     *     |   |           |   |--LPAREN -> (
+     *     |   |           |   |--RECORD_PATTERN_COMPONENTS -> RECORD_PATTERN_COMPONENTS
+     *     |   |           |   |   `--PATTERN_VARIABLE_DEF -> PATTERN_VARIABLE_DEF
+     *     |   |           |   |       |--MODIFIERS -> MODIFIERS
+     *     |   |           |   |       |--TYPE -> TYPE
+     *     |   |           |   |       |   `--IDENT -> String
+     *     |   |           |   |       `--IDENT -> myComponent
+     *     |   |           |   `--RPAREN -> )
+     *     |   |           `--METHOD_CALL -> (
+     *     |   |               |--DOT -> .
+     *     |   |               |   |--STRING_LITERAL -> "component"
+     *     |   |               |   `--IDENT -> equalsIgnoreCase
+     *     |   |               |--ELIST -> ELIST
+     *     |   |               |   `--EXPR -> EXPR
+     *     |   |               |       `--IDENT -> myComponent
+     *     |   |               `--RPAREN -> )
+     *     |   |--LAMBDA -> ->
+     *     |   `--SLIST -> {
+     *     |       `--RCURLY -> }
+     *     `--RCURLY -> }
      * }
      *
      * @see <a href="https://openjdk.org/jeps/405">JEP 405: Record Patterns</a>


### PR DESCRIPTION
Ref #21288

Note, reverting back to `<pre>` means these tokens lose the grey background and copy button that `{@snippet}` provides.

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/4bc8d2cd-2837-4413-aa09-a847fe34eb28" />
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/5d39eff8-a4bc-46fd-bef1-c98d23da4362" />
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/474649d8-f3b1-4a56-b203-397897123347" />
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/11ab0eee-ab3d-4455-8341-2981f48702ef" />
attaching images showing the RCURLY parts for all 4.



below providing one example, where doc sort of missed EXPR, wanted to check if that's fine
<img width="1002" height="433" alt="image" src="https://github.com/user-attachments/assets/6d88ea10-e784-4188-b132-91d8d410dcee" />
<img width="665" height="386" alt="image" src="https://github.com/user-attachments/assets/566a6f15-ee01-4024-9401-32af6831d859" />
