### PR TITLE
Issue #20954: Quote UnderscoreUsedInNames violation messages

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputUnderscoreUsedInNames.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputUnderscoreUsedInNames.java
@@ -22,32 +22,32 @@ public class InputUnderscoreUsedInNames {
   private String gradle851;
 
   class InnerBad {
-    // violation below ''guava_33_4_7' .* underscores allowed only between adjacent digits.'
+    // violation below "Non-constant field name 'guava_33_4_7'"
     int guava_33_4_7;
     int guava33_4_7;
 
-    // violation below ''guava33_4_8_' .* underscores allowed only between adjacent digits.'
+    // violation below "Non-constant field name 'guava33_4_8_'"
     int guava33_4_8_;
     int guava33_4_8;
 
-    // violation below ''jdk_8_90' .* underscores allowed only between adjacent digits.'
+    // violation below "Non-constant field name 'jdk_8_90'"
     int jdk_8_90;
     int jdk8_90;
 
-    // violation below ''jdk8_91_' .* underscores allowed only between adjacent digits.'
+    // violation below "Non-constant field name 'jdk8_91_'"
     int jdk8_91_;
     int jdk8_91;
 
-    // violation below ''kotlin_1_9_24' .* underscores allowed only between adjacent digits.'
+    // violation below "Non-constant field name 'kotlin_1_9_24'"
     int kotlin_1_9_24;
     int kotlin1_9_24;
 
-    // violation below ''kotlin_version1_9_24'.* underscores allowed only between adjacent digits.'
+    // violation below "Non-constant field name 'kotlin_version1_9_24'"
     int kotlin_version1_9_24;
 
     int kotlinVersion1_9_24;
 
-    // violation below ''kotlin1_9_25_' .* underscores allowed only between adjacent digits.'
+    // violation below "Non-constant field name 'kotlin1_9_25_'"
     int kotlin1_9_25_;
     int kotlin1_9_25;
   }
@@ -56,36 +56,31 @@ public class InputUnderscoreUsedInNames {
 
     void guava_34_4_6() {}
 
-    // violation 2 lines above """Method name 'guava_34_4_6' has invalid underscore
-    // usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'guava_34_4_6'"
 
     void guava34_4_6() {}
 
     void kotlin_2_9_94() {}
 
-    // violation 2 lines above """Method name 'kotlin_2_9_94' has invalid underscore
-    // usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'kotlin_2_9_94'"
 
     void kotlin2_9_94() {}
 
     void gradle_9_5_1() {}
 
-    // violation 2 lines above """Method name 'gradle_9_5_1' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'gradle_9_5_1'"
 
     void gradle9_5_1() {}
 
     void jdk_9_0_392() {}
 
-    // violation 2 lines above """Method name 'jdk_9_0_392' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'jdk_9_0_392'"
 
     void jdk9_0_392() {}
 
     void kotlin_lang1_9_2() {}
 
-    // violation 2 lines above """Method name 'kotlin_lang1_9_2' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'kotlin_lang1_9_2'"
 
     void kotlinLang1_9_2() {}
 
@@ -93,39 +88,33 @@ public class InputUnderscoreUsedInNames {
 
     void jdk_method8_90() {}
 
-    // violation 2 lines above """Method name 'jdk_method8_90' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'jdk_method8_90'"
 
     void jdk_Method8_90() {}
 
-    // violation 2 lines above """Method name 'jdk_Method8_90' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'jdk_Method8_90'"
 
     void jdkMethod8_90() {}
 
     void guava_version33_4_2() {}
 
-    // violation 2 lines above """Method name 'guava_version33_4_2' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'guava_version33_4_2'"
 
     void guava_Version33_4_2() {}
 
-    // violation 2 lines above """Method name 'guava_Version33_4_2' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'guava_Version33_4_2'"
 
     void guavaVersion33_4_2() {}
 
     void kotlin1_9_24_() {}
 
-    // violation 2 lines above """Method name 'kotlin1_9_24_' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'kotlin1_9_24_'"
 
     void kotlin1_9_24() {}
 
     void guava_33_4_5_() {}
 
-    // violation 2 lines above """Method name 'guava_33_4_5_' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'guava_33_4_5_'"
 
     void guava33_4_5() {}
   }
@@ -134,36 +123,31 @@ public class InputUnderscoreUsedInNames {
 
     void testSetCount_zeroToZero_addSupported() {}
 
-    // violation 2 lines above """Method name 'testSetCount_zeroToZero_addSupported' has
-    // invalid underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'testSetCount_zeroToZero_addSupported'"
 
     void testSetCountZeroToZeroAddSupported() {}
 
     void testPutNullValue_supported() {}
 
-    // violation 2 lines above """Method name 'testPutNullValue_supported' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'testPutNullValue_supported'"
 
     void testPutNullValueSupported() {}
 
     void testAddAll_nonEmptyList() {}
 
-    // violation 2 lines above """Method name 'testAddAll_nonEmptyList' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'testAddAll_nonEmptyList'"
 
     void testAddAllNonEmptyList() {}
 
     void testEntrySet_hashCode_size1() {}
 
-    // violation 2 lines above """Method name 'testEntrySet_hashCode_size1' has invalid
-    // underscore usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'testEntrySet_hashCode_size1'"
 
     void testEntrySetHashCodeSize1() {}
 
     void testCount_3() {}
 
-    // violation 2 lines above """Method name 'testCount_3' has invalid underscore
-    // usage, underscores only allowed between adjacent digits."""
+    // violation 2 lines above "Method name 'testCount_3'"
 
     void testCount3() {}
   }
@@ -179,9 +163,7 @@ public class InputUnderscoreUsedInNames {
     @Test
     void testSetCount_ZeroToZero_AddSupported() {}
 
-    // violation 2 lines above """Test method name 'testSetCount_ZeroToZero_AddSupported'
-    // segment must be more than a character, start lowercase, and not have a
-    // single lowercase followed by uppercase, or consecutive uppercase."""
+    // violation 2 lines above "Test method name 'testSetCount_ZeroToZero_AddSupported'"
 
     @Test
     void testPutNullValue_supported() {}
@@ -192,9 +174,7 @@ public class InputUnderscoreUsedInNames {
     @Test
     void testPutNullValue_Supported() {}
 
-    // violation 2 lines above """Test method name 'testPutNullValue_Supported' segment must
-    // be more than a character, start lowercase, and not have a single lowercase followed
-    // by uppercase, or consecutive uppercase."""
+    // violation 2 lines above "Test method name 'testPutNullValue_Supported'"
 
     @Test
     void testAddAll_nonEmptyList() {}
@@ -205,9 +185,7 @@ public class InputUnderscoreUsedInNames {
     @Test
     void testAddAll_NonEmptyList() {}
 
-    // violation 2 lines above """Test method name 'testAddAll_NonEmptyList' segment must
-    // be more than a character, start lowercase, and not have a single lowercase followed
-    // by uppercase, or consecutive uppercase."""
+    // violation 2 lines above "Test method name 'testAddAll_NonEmptyList'"
 
     @Test
     void testEntrySet_hashCode_size1() {}
@@ -218,15 +196,12 @@ public class InputUnderscoreUsedInNames {
     @Test
     void testEntrySet_HashCode_Size1() {}
 
-    // violation 2 lines above """Test method name 'testEntrySet_HashCode_Size1' segment
-    // must be more than a character, start lowercase, and not have a single lowercase
-    // followed by uppercase, or consecutive uppercase."""
+    // violation 2 lines above "Test method name 'testEntrySet_HashCode_Size1'"
 
     @Test
     void testCount_3() {}
 
-    // violation 2 lines above """Test method name 'testCount_3' has invalid
-    // underscore usage, underscore only allowed between letters or between digits"""
+    // violation 2 lines above "Test method name 'testCount_3'"
 
     @Test
     void testCount_number3() {}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -306,9 +306,7 @@ public final class InlineConfigParser {
             "checks/coding/noclone/Example1.java",
             "checks/coding/unusedlocalvariable/Example1.java",
             "checks/sizes/recordcomponentnumber/Example2.java",
-            "checks/whitespace/separatorwrap/Example1.java",
-            "com/google/checkstyle/test/chapter5naming/rule53camelcase/"
-                    + "InputUnderscoreUsedInNames.java"
+            "checks/whitespace/separatorwrap/Example1.java"
     );
 
     /**


### PR DESCRIPTION
 #20954 (partial)

Quoted the Google style `InputUnderscoreUsedInNames` violation comments as real message substrings (no `.*` regex, no triple-quoted wrap) and removed that file from `SUPPRESSED_VALIDATE_MESSAGE_FILES`.

Locally: `./mvnw -Dtest=CamelCaseDefinedTest test` — 3 tests, 0 failures.