### PR TITLE
Issue #20954: Quote UnusedLocalVariable xdocs Example1 messages

### DIFF
--- a/src/site/xdoc/checks/coding/unusedlocalvariable.xml
+++ b/src/site/xdoc/checks/coding/unusedlocalvariable.xml
@@ -94,7 +94,7 @@
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
   {
-    int k = 12; // violation, assign and update but never use 'k'
+    int k = 12; // violation 'Unused named local variable 'k'.'
     k++;
   }
 
@@ -104,20 +104,20 @@ public class Example1 {
   }
 
   void method(int b) {
-    int[] arr = {1, 2, 3};  // violation, unused named local variable 'arr'
+    int[] arr = {1, 2, 3};  // violation 'Unused named local variable 'arr'.'
     int[] anotherArr = {1}; // ok, 'anotherArr' is accessed
     anotherArr[0] = 4;
   }
 
   String convertValue(String newValue) {
-    String s = newValue.toLowerCase(); // violation, unused named local variable 's'
+    String s = newValue.toLowerCase(); // violation 'Unused named local variable 's''
     String _ = newValue.toLowerCase(); // ok, '_' is unnamed variable
     return newValue.toLowerCase();
   }
 
   void read() throws IOException {
     BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-    String s; // violation, unused named local variable 's'
+    String s; // violation 'Unused named local variable 's'.'
     while ((s = reader.readLine()) != null) {}
     try (BufferedReader reader1 = // ok, 'reader1' is a resource
                  new BufferedReader(new FileReader("abc.txt"))) {}
@@ -127,7 +127,7 @@ public class Example1 {
 
   void loops() {
     int j = 12;
-    for (int i = 0; j &lt; 11; i++)  // violation, unused named local variable 'i'
+    for (int i = 0; j &lt; 11; i++)  // violation 'Unused named local variable 'i'.'
       for (int p = 0; j &lt; 11; p++) p /= 2;    // ok, 'p' is used
     for (Integer _ : new  int[0]) { } // ok, '_' is unnamed variable
   }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -304,7 +304,6 @@ public final class InlineConfigParser {
     private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of(
             "checks/coding/equalshashcode/Example1.java",
             "checks/coding/noclone/Example1.java",
-            "checks/coding/unusedlocalvariable/Example1.java",
             "checks/sizes/recordcomponentnumber/Example2.java",
             "checks/whitespace/separatorwrap/Example1.java",
             "com/google/checkstyle/test/chapter5naming/rule53camelcase/"

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example1.java
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/Example1.java
@@ -13,7 +13,7 @@ import java.util.function.Predicate;
 // xdoc section - start
 public class Example1 {
   {
-    int k = 12; // violation, assign and update but never use 'k'
+    int k = 12; // violation 'Unused named local variable 'k'.'
     k++;
   }
 
@@ -23,20 +23,20 @@ public class Example1 {
   }
 
   void method(int b) {
-    int[] arr = {1, 2, 3};  // violation, unused named local variable 'arr'
+    int[] arr = {1, 2, 3};  // violation 'Unused named local variable 'arr'.'
     int[] anotherArr = {1}; // ok, 'anotherArr' is accessed
     anotherArr[0] = 4;
   }
 
   String convertValue(String newValue) {
-    String s = newValue.toLowerCase(); // violation, unused named local variable 's'
+    String s = newValue.toLowerCase(); // violation 'Unused named local variable 's''
     String _ = newValue.toLowerCase(); // ok, '_' is unnamed variable
     return newValue.toLowerCase();
   }
 
   void read() throws IOException {
     BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-    String s; // violation, unused named local variable 's'
+    String s; // violation 'Unused named local variable 's'.'
     while ((s = reader.readLine()) != null) {}
     try (BufferedReader reader1 = // ok, 'reader1' is a resource
                  new BufferedReader(new FileReader("abc.txt"))) {}
@@ -46,7 +46,7 @@ public class Example1 {
 
   void loops() {
     int j = 12;
-    for (int i = 0; j < 11; i++)  // violation, unused named local variable 'i'
+    for (int i = 0; j < 11; i++)  // violation 'Unused named local variable 'i'.'
       for (int p = 0; j < 11; p++) p /= 2;    // ok, 'p' is used
     for (Integer _ : new  int[0]) { } // ok, '_' is unnamed variable
   }


### PR DESCRIPTION
#20954 (partial)

Quoted the UnusedLocalVariable xdocs `Example1` violation comments as real message substrings and removed that file from `SUPPRESSED_VALIDATE_MESSAGE_FILES`.

Locally: `./mvnw -Dtest=UnusedLocalVariableCheckExamplesTest test` — 4 tests, 0 failures.