### PR TITLE
Issue #21229: Align LineEnding examples with property count

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -204,8 +204,6 @@
   <suppress checks="LineLength"
             files="lineending/Example3.java"/>
   <suppress checks="LineLength"
-            files="lineending/Example4.java"/>
-  <suppress checks="LineLength"
             files="overloadmethodsdeclarationorder/Example2.java"/>
 
   <!-- Exclude canonical names list longer than 85 characters  -->

--- a/src/site/xdoc/checks/misc/lineending.xml
+++ b/src/site/xdoc/checks/misc/lineending.xml
@@ -23,7 +23,13 @@
               <li><a href="#Example1-config" class="toc-sublink">Enforce LF (Unix-style) line endings</a></li>
               <li><a href="#Example2-config" class="toc-sublink">Enforce CRLF (Windows-style) line endings</a></li>
               <li><a href="#Example3-config" class="toc-sublink">Enforce CR line endings for Java files only</a></li>
-              <li><a href="#Example4-config" class="toc-sublink">Enforce CR line endings for TXT files only</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#LineEnding_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">Enforce CR line endings for TXT files only</a></li>
             </ul>
           </li>
           <li><a href="#LineEnding_Example_of_Usage">Example of Usage</a></li>
@@ -135,9 +141,11 @@ public class Example3 {  // ␊ // violation 'Expected line ending for file is C
     int x = 1; // ␊           // violation 'Expected line ending for file is CR, but LF is detected.'
   } // ␊                      // violation 'Expected line ending for file is CR, but LF is detected.'
 } // ␊                        // violation 'Expected line ending for file is CR, but LF is detected.'
-</code></pre></div><hr class="example-separator"/>
+</code></pre></div>
+      </subsection>
 
-        <p id="Example4-config">
+      <subsection name="Use Cases" id="LineEnding_Use_Cases">
+        <p id="UseCase1-config">
           To configure the check to enforce CR line endings for TXT files only:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
@@ -148,11 +156,11 @@ public class Example3 {  // ␊ // violation 'Expected line ending for file is C
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example4-code">
+        <p id="UseCase1-code">
           Example (Java file with LF line endings - no violations, as only TXT files are checked):
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example4 {  // ␊ // ok, only .txt files are checked
+public class UseCase1 {  // ␊ // ok, only .txt files are checked
   public void method() { // ␊ // ok, only .txt files are checked
     int x = 1; // ␊           // ok, only .txt files are checked
   } // ␊                      // ok, only .txt files are checked

--- a/src/site/xdoc/checks/misc/lineending.xml.template
+++ b/src/site/xdoc/checks/misc/lineending.xml.template
@@ -82,22 +82,24 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/lineending/Example3.java"/>
           <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
+        </macro>
+      </subsection>
 
-        <p id="Example4-config">
+      <subsection name="Use Cases" id="LineEnding_Use_Cases">
+        <p id="UseCase1-config">
           To configure the check to enforce CR line endings for TXT files only:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/lineending/Example4.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/lineending/UseCase1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example4-code">
+        <p id="UseCase1-code">
           Example (Java file with LF line endings - no violations, as only TXT files are checked):
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/lineending/Example4.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/lineending/UseCase1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -169,7 +169,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/javadoc/atclauseorder",
             "checks/javadoc/javadocblocktaglocation",
             "checks/javadoc/javadocpackage",
-            "checks/lineending",
             "checks/sizes/linelength",
             "checks/whitespace/emptylineseparator",
             "filters/suppresswarningsfilter"

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/LineEndingCheckExampleTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/LineEndingCheckExampleTest.java
@@ -85,11 +85,11 @@ public class LineEndingCheckExampleTest extends AbstractExamplesModuleTestSuppor
     }
 
     @Test
-    public void testExample4() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verifyWithInlineConfigParser(
-                getPath("Example4.java"), expected
+                getPath("UseCase1.java"), expected
         );
     }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/lineending/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/lineending/UseCase1.java
@@ -8,7 +8,7 @@
 */
 package com.puppycrawl.tools.checkstyle.checks.lineending;
 // xdoc section - start
-public class Example4 {  // ␊ // ok, only .txt files are checked
+public class UseCase1 {  // ␊ // ok, only .txt files are checked
   public void method() { // ␊ // ok, only .txt files are checked
     int x = 1; // ␊           // ok, only .txt files are checked
   } // ␊                      // ok, only .txt files are checked


### PR DESCRIPTION
Issue: #21229

`LineEnding` documents two properties (`fileExtensions`, `lineEnding`), so the example-count test expects 3 AST-matching examples (default + one per property). The module had 4 structurally identical Java examples.

Examples now has the default config, `lineEnding`, and `fileExtensions`. The extra combination (`lineEnding` + `fileExtensions=java`) is kept under Use Cases as UseCase1.

Other modules listed in #21229 are left for separate PRs.

## Testing

`./mvnw clean verify` passed locally.