### PR TITLE
Issue #21229: Align JavadocBlockTagLocation examples with property count

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml
@@ -22,7 +22,13 @@
             <ul class="toc-sublist">
               <li><a href="#Example1-config" class="toc-sublink">The default check</a></li>
               <li><a href="#Example2-config" class="toc-sublink">Verify tags from JEP 8068562 only</a></li>
-              <li><a href="#Example3-config" class="toc-sublink">Verify all default tags and some custom tags in addition</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#JavadocBlockTagLocation_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">Verify all default tags and some custom tags in addition</a></li>
             </ul>
           </li>
           <li><a href="#JavadocBlockTagLocation_Example_of_Usage">Example of Usage</a></li>
@@ -163,8 +169,11 @@ class Example2 {
     return 0;
   }
 }
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example3-config">
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Use Cases" id="JavadocBlockTagLocation_Use_Cases">
+        <p id="UseCase1-config">
           To configure the check to verify all default tags and some custom tags in addition:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
@@ -182,9 +191,9 @@ class Example2 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example3-code">Example:</p>
+        <p id="UseCase1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-class Example3 {
+class UseCase1 {
   /**
    * Escaped tag &amp;#64;version (OK)
    * Plain text with {@code @see} (OK)

--- a/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocblocktaglocation.xml.template
@@ -66,19 +66,22 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example2.java"/>
           <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-        <p id="Example3-config">
+        </macro>
+      </subsection>
+
+      <subsection name="Use Cases" id="JavadocBlockTagLocation_Use_Cases">
+        <p id="UseCase1-config">
           To configure the check to verify all default tags and some custom tags in addition:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example3.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/UseCase1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example3-code">Example:</p>
+        <p id="UseCase1-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/Example3.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/UseCase1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -167,7 +167,6 @@ public class XdocsExamplesAstConsistencyTest {
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
             "checks/javadoc/atclauseorder",
-            "checks/javadoc/javadocblocktaglocation",
             "checks/javadoc/javadocpackage",
             "checks/lineending",
             "checks/sizes/linelength",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckExamplesTest.java
@@ -49,13 +49,13 @@ public class JavadocBlockTagLocationCheckExamplesTest extends AbstractExamplesMo
     }
 
     @Test
-    public void testExample3() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expected = {
             "25: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "version"),
             "30: " + getCheckMessage(MSG_BLOCK_TAG_LOCATION, "noinspection"),
         };
 
-        verifyWithInlineConfigParser(getPath("Example3.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocblocktaglocation/UseCase1.java
@@ -17,7 +17,7 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocblocktaglocation;
 
 // xdoc section - start
-class Example3 {
+class UseCase1 {
   /**
    * Escaped tag &#64;version (OK)
    * Plain text with {@code @see} (OK)


### PR DESCRIPTION
Issue: #21229

`JavadocBlockTagLocation` documents one example-covered property
(`tags`; `violateExecutionOnNonTightHtml` is ignored), so
`testExampleCountMatchesPropertyCount` expects 2 AST-matching examples
(default + one per property). The module had 3 structurally identical
Java examples.

Examples now has the default config plus one example for `tags`. The
extra combination configuration (default tags plus custom tags) is kept
under Use Cases as UseCase1.

Other modules listed in #21229 are left for separate PRs.

## Testing

Executed:

- `mvn test -Dtest=JavadocBlockTagLocationCheckExamplesTest,XdocsExamplesAstConsistencyTest,XdocsExampleFileTest,XdocsPagesTest`
  - JavadocBlockTagLocationCheckExamplesTest 3/3
  - XdocsExamplesAstConsistencyTest 5/5
  - XdocsExampleFileTest 5/5
  - XdocsPagesTest 20/20