### PR TITLE
Issue #21229: Align AtclauseOrder examples with property count

### DIFF
--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml
@@ -23,7 +23,13 @@
               <li><a href="#Example1-config" class="toc-sublink">The default check</a></li>
               <li><a href="#Example2-config" class="toc-sublink">Such that it checks in the custom order</a></li>
               <li><a href="#Example3-config" class="toc-sublink">Such that it targets only enums</a></li>
-              <li><a href="#Example4-config" class="toc-sublink">Such that it targets only classes, with a custom tag order</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#AtclauseOrder_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">Such that it targets only classes, with a custom tag order</a></li>
             </ul>
           </li>
           <li><a href="#AtclauseOrder_Example_of_Usage">Example of Usage</a></li>
@@ -274,8 +280,11 @@ public class Example3 {
   }
 
 }
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example4-config">
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Use Cases" id="AtclauseOrder_Use_Cases">
+        <p id="UseCase1-config">
             To configure the check such that it targets only classes, with a
             custom tag order:
         </p>
@@ -292,7 +301,7 @@ public class Example3 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example4-code">
+        <p id="UseCase1-code">
           Results in the following violation, as only the class-level javadoc is
           checked and its tags do not follow the custom order:
         </p>
@@ -313,7 +322,7 @@ public class Example3 {
 * @serialField field Object Field description.
 * @serialData
 */
-public class Example4 {
+public class UseCase1 {
   class Valid implements Serializable {}
 
   // ok below, ENUM_DEF is not checked because target is CLASS_DEF

--- a/src/site/xdoc/checks/javadoc/atclauseorder.xml.template
+++ b/src/site/xdoc/checks/javadoc/atclauseorder.xml.template
@@ -79,23 +79,26 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example3.java"/>
           <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
-        <p id="Example4-config">
+        </macro>
+      </subsection>
+
+      <subsection name="Use Cases" id="AtclauseOrder_Use_Cases">
+        <p id="UseCase1-config">
             To configure the check such that it targets only classes, with a
             custom tag order:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example4.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/UseCase1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example4-code">
+        <p id="UseCase1-code">
           Results in the following violation, as only the class-level javadoc is
           checked and its tags do not follow the custom order:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/Example4.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/UseCase1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -166,7 +166,6 @@ public class XdocsExamplesAstConsistencyTest {
      * Until: <a href="https://github.com/checkstyle/checkstyle/issues/21229">...</a>
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
-            "checks/javadoc/atclauseorder",
             "checks/javadoc/javadocpackage",
             "checks/lineending",
             "checks/sizes/linelength",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckExamplesTest.java
@@ -76,7 +76,7 @@ public class AtclauseOrderCheckExamplesTest extends AbstractExamplesModuleTestSu
     }
 
     @Test
-    public void testExample4() throws Exception {
+    public void testUseCase1() throws Exception {
         final String tagOrder = "[@version, @author, @param, @return"
             + ", @throws, @exception,"
             + " @see, @since, @serial, @serialField, @serialData]";
@@ -85,7 +85,7 @@ public class AtclauseOrderCheckExamplesTest extends AbstractExamplesModuleTestSu
             "23: " + getCheckMessage(MSG_KEY, tagOrder),
         };
 
-        verifyWithInlineConfigParser(getPath("Example4.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/UseCase1.java
@@ -31,7 +31,7 @@ import java.io.Serializable;
 * @serialField field Object Field description.
 * @serialData
 */
-public class Example4 {
+public class UseCase1 {
   class Valid implements Serializable {}
 
   // ok below, ENUM_DEF is not checked because target is CLASS_DEF


### PR DESCRIPTION
Issue: #21229

`AtclauseOrder` documents two properties (`target`, `tagOrder`), so the example-count test expects 3 AST-matching examples (default + one per property). The module had 4 structurally identical Java examples.

Examples now has the default config, `tagOrder`, and `target`. The extra combination (`target=CLASS_DEF` + custom `tagOrder`) is kept under Use Cases as UseCase1.

Other modules listed in #21229 are left for separate PRs.

## Testing

`./mvnw clean verify` passed locally.