### PR TITLE
Issue #20954: Quote NoClone xdocs Example1 message

### DIFF
--- a/src/site/xdoc/checks/coding/noclone.xml
+++ b/src/site/xdoc/checks/coding/noclone.xml
@@ -156,7 +156,7 @@ System.out.println(s2 instanceof Square); //true
         <p id="Example1-code">Example: </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
-  public Example1 clone() {return null;} // violation, overrides the clone method
+  public Example1 clone() {return null;} // violation 'Avoid using clone method.'
   public static Object clone(Object o) {return null;}
   public static Example1 clone(Example1 same) {return null;}
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -303,7 +303,6 @@ public final class InlineConfigParser {
      */
     private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of(
             "checks/coding/equalshashcode/Example1.java",
-            "checks/coding/noclone/Example1.java",
             "checks/sizes/recordcomponentnumber/Example2.java",
             "checks/whitespace/separatorwrap/Example1.java"
     );

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/noclone/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/noclone/Example1.java
@@ -9,7 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.noclone;
 
 // xdoc section - start
 public class Example1 {
-  public Example1 clone() {return null;} // violation, overrides the clone method
+  public Example1 clone() {return null;} // violation 'Avoid using clone method.'
   public static Object clone(Object o) {return null;}
   public static Example1 clone(Example1 same) {return null;}
 }


### PR DESCRIPTION
Fixes #20954 (NoClone slice). Re-implements abandoned #20981.

Quote the real Checkstyle message on noclone/Example1.java, regenerate noclone.xml, and drop that file from SUPPRESSED_VALIDATE_MESSAGE_FILES. Leaves equalshashcode (#21212) and separatorwrap/recordcomponentnumber (#21244) alone.

NoCloneCheckExamplesTest, NoCloneCheckTest, XdocsExampleFileTest, XdocsExamplesAstConsistencyTest: 13 run, 0 failures.