### PR TITLE
Issue #21229: Align LineLength examples with property count

### DIFF
--- a/config/checkstyle-examples-suppressions.xml
+++ b/config/checkstyle-examples-suppressions.xml
@@ -182,7 +182,7 @@
   <suppress checks="LineLength"
     files="suppresswithplaintextcommentfilter/UseCase1.java"/>
   <suppress checks="LineLength"
-    files="linelength/Example\d+.*"/>
+    files="linelength/(Example|UseCase)\d+.*"/>
   <!-- it prints user regexp -->
   <suppress checks="LineLength"
             files="regexponfilename/Example[2].java"/>

--- a/src/site/xdoc/checks/sizes/linelength.xml
+++ b/src/site/xdoc/checks/sizes/linelength.xml
@@ -24,8 +24,14 @@
               <li><a href="#Example2-config" class="toc-sublink">Accept lines up to 120 characters long</a></li>
               <li><a href="#Example3-config" class="toc-sublink">Ignore lines that begin with <code>" * "</code>code, followed by just one word, such as within a Javadoc comment</a></li>
               <li><a href="#Example4-config" class="toc-sublink">Only validate xml and property files and ignore other extensions</a></li>
-              <li><a href="#Example5-config" class="toc-sublink">Check to validate <code>import</code> statements</a></li>
-              <li><a href="#Example6-config" class="toc-sublink">To prevent this check from flagging lines in text-blocks, with side effects</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#LineLength_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">Check to validate <code>import</code> statements</a></li>
+              <li><a href="#UseCase2-config" class="toc-sublink">To prevent this check from flagging lines in text-blocks, with side effects</a></li>
             </ul>
           </li>
           <li><a href="#LineLength_Example_of_Usage">Example of Usage</a></li>
@@ -274,9 +280,11 @@ class Example4 {
         """;
   }
 }
-</code></pre></div><hr class="example-separator"/>
+</code></pre></div>
+      </subsection>
 
-        <p id="Example5-config">
+      <subsection name="Use Cases" id="LineLength_Use_Cases">
+        <p id="UseCase1-config">
           To configure check to validate <code>import</code> statements:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
@@ -288,7 +296,7 @@ class Example4 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example5-code">
+        <p id="UseCase1-code">
           Example:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
@@ -300,7 +308,7 @@ import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_K
  * This is a short Javadoc comment.
  * ThisJavadocCommentIsAReallyLongWordThatExceedsDefaultLineLimitOfEightyCharacters.
  */
-class Example5 {
+class UseCase1 {
   // violation 3 lines above 'Line is longer'
   void testMethod(String str) {
     str = MSG_KEY;
@@ -319,7 +327,7 @@ class Example5 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example6-config">
+        <p id="UseCase2-config">
           To prevent this check from flagging lines in text-blocks, with
           <a href="https://github.com/checkstyle/checkstyle/issues/17707">side effects</a>:
         </p>
@@ -336,7 +344,7 @@ class Example5 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example6-code">
+        <p id="UseCase2-code">
           Example:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
@@ -348,7 +356,7 @@ import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_K
  * This is a short Javadoc comment.
  * ThisJavadocCommentIsAReallyLongWordThatExceedsDefaultLineLimitOfEightyCharacters.
  */
-class Example6 {
+class UseCase2 {
 
   void testMethod(String str) {
     str = MSG_KEY;

--- a/src/site/xdoc/checks/sizes/linelength.xml.template
+++ b/src/site/xdoc/checks/sizes/linelength.xml.template
@@ -107,39 +107,41 @@
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example4.java"/>
           <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
+        </macro>
+      </subsection>
 
-        <p id="Example5-config">
+      <subsection name="Use Cases" id="LineLength_Use_Cases">
+        <p id="UseCase1-config">
           To configure check to validate <code>import</code> statements:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example5.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/UseCase1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example5-code">
+        <p id="UseCase1-code">
           Example:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example5.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/UseCase1.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example6-config">
+        <p id="UseCase2-config">
           To prevent this check from flagging lines in text-blocks, with
           <a href="https://github.com/checkstyle/checkstyle/issues/17707">side effects</a>:
         </p>
         <macro name="example">
           <param name="path"
-               value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java"/>
+               value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/UseCase2.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example6-code">
+        <p id="UseCase2-code">
           Example:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/Example6.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/UseCase2.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -167,7 +167,6 @@ public class XdocsExamplesAstConsistencyTest {
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
             "checks/javadoc/javadocpackage",
-            "checks/sizes/linelength",
             "checks/whitespace/emptylineseparator",
             "filters/suppresswarningsfilter"
     );

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckExamplesTest.java
@@ -70,7 +70,7 @@ public class LineLengthCheckExamplesTest extends AbstractExamplesModuleTestSuppo
     }
 
     @Test
-    public void testExample5() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expected = {
             "11: " + getCheckMessage(MSG_KEY, 60, 64),
             "17: " + getCheckMessage(MSG_KEY, 60, 84),
@@ -79,15 +79,15 @@ public class LineLengthCheckExamplesTest extends AbstractExamplesModuleTestSuppo
             "33: " + getCheckMessage(MSG_KEY, 60, 89),
         };
 
-        verifyWithInlineConfigParser(getPath("Example5.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
     @Test
-    public void testExample6() throws Exception {
+    public void testUseCase2() throws Exception {
         final String[] expected = {
             "29: " + getCheckMessage(MSG_KEY, 84, 92),
         };
-        verifyWithInlineConfigParser(getPath("Example6.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase2.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/UseCase1.java
@@ -16,7 +16,7 @@ import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_K
  * This is a short Javadoc comment.
  * ThisJavadocCommentIsAReallyLongWordThatExceedsDefaultLineLimitOfEightyCharacters.
  */
-class Example5 {
+class UseCase1 {
   // violation 3 lines above 'Line is longer'
   void testMethod(String str) {
     str = MSG_KEY;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/UseCase2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/UseCase2.java
@@ -20,7 +20,7 @@ import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_K
  * This is a short Javadoc comment.
  * ThisJavadocCommentIsAReallyLongWordThatExceedsDefaultLineLimitOfEightyCharacters.
  */
-class Example6 {
+class UseCase2 {
 
   void testMethod(String str) {
     str = MSG_KEY;


### PR DESCRIPTION
Issue: #21229

`LineLength` documents three properties (`fileExtensions`, `ignorePattern`, `max`), so the example-count test expects 4 AST-matching examples. Examples 1–4 stay under Examples (default, max, ignorePattern, fileExtensions). The combo ignorePattern+max and the SuppressWithPlainTextCommentFilter case move to Use Cases as UseCase1 and UseCase2.

Continues #21229.

## Testing

`./mvnw clean verify` passed locally.