### PR TITLE
Issue checkstyle#20954: Quote violation messages in EqualsHashCode Example1

### DIFF
--- a/src/site/xdoc/checks/coding/equalshashcode.xml
+++ b/src/site/xdoc/checks/coding/equalshashcode.xml
@@ -60,14 +60,14 @@
         <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
-  public int hashCode() { // violation, no valid 'equals'
+  public int hashCode() { // violation 'Definition of 'hashCode()' without corresponding definition of 'equals()'.'
     return 0;
   }
   public boolean equals(String o) { return false; }
 }
 
 class ExampleNoHashCode {
-  public boolean equals(Object o) { // violation, no 'hashCode'
+  public boolean equals(Object o) { // violation 'Definition of 'equals()' without corresponding definition of 'hashCode()'.'
     return false;
   }
   public boolean equals(String o) { return false; }
@@ -90,13 +90,13 @@ class ExampleBothMethods2 {
 
 class ExampleNoValidHashCode {
   public static int hashCode(int i) { return 0; }
-  public boolean equals(Object o) { // violation, no valid 'hashCode'
+  public boolean equals(Object o) { // violation 'Definition of 'equals()' without corresponding definition of 'hashCode()'.'
     return false;
   }
 }
 
 class ExampleNoValidEquals {
-  public int hashCode() { // violation, no valid 'equals'
+  public int hashCode() { // violation 'Definition of 'hashCode()' without corresponding definition of 'equals()'.'
     return 0;
   }
   public static boolean equals(Object o, Object o2) { return false; }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -302,7 +302,6 @@ public final class InlineConfigParser {
      * <a href="https://github.com/checkstyle/checkstyle/issues/20954">#20954</a>
      */
     private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of(
-            "checks/coding/equalshashcode/Example1.java",
             "checks/coding/noclone/Example1.java",
             "checks/sizes/recordcomponentnumber/Example2.java",
             "checks/whitespace/separatorwrap/Example1.java"

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode/Example1.java
@@ -8,14 +8,14 @@
 package com.puppycrawl.tools.checkstyle.checks.coding.equalshashcode;
 // xdoc section - start
 class Example1 {
-  public int hashCode() { // violation, no valid 'equals'
+  public int hashCode() { // violation 'Definition of 'hashCode()' without corresponding definition of 'equals()'.'
     return 0;
   }
   public boolean equals(String o) { return false; }
 }
 
 class ExampleNoHashCode {
-  public boolean equals(Object o) { // violation, no 'hashCode'
+  public boolean equals(Object o) { // violation 'Definition of 'equals()' without corresponding definition of 'hashCode()'.'
     return false;
   }
   public boolean equals(String o) { return false; }
@@ -38,13 +38,13 @@ class ExampleBothMethods2 {
 
 class ExampleNoValidHashCode {
   public static int hashCode(int i) { return 0; }
-  public boolean equals(Object o) { // violation, no valid 'hashCode'
+  public boolean equals(Object o) { // violation 'Definition of 'equals()' without corresponding definition of 'hashCode()'.'
     return false;
   }
 }
 
 class ExampleNoValidEquals {
-  public int hashCode() { // violation, no valid 'equals'
+  public int hashCode() { // violation 'Definition of 'hashCode()' without corresponding definition of 'equals()'.'
     return 0;
   }
   public static boolean equals(Object o, Object o2) { return false; }


### PR DESCRIPTION
Fixes the violation message comments in EqualsHashCode's Example1.java 
to use the real, quoted checkstyle output instead of paraphrased text, 
and removes it from SUPPRESSED_VALIDATE_MESSAGE_FILES.

Related to #20954

`mvn test -Dtest=EqualsHashCodeCheckExamplesTest` passes locally.