### PR TITLE
Issue #21229: Align SuppressWarningsFilter examples with property count

### DIFF
--- a/src/site/xdoc/filters/suppresswarningsfilter.xml
+++ b/src/site/xdoc/filters/suppresswarningsfilter.xml
@@ -20,7 +20,13 @@
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#SuppressWarningsFilter_Examples">Examples</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
               <li><a href="#Example1-config" class="toc-sublink">Example of suppression by name of Check in annotation</a></li>
-              <li><a href="#Example2-config" class="toc-sublink">Example of suppression by prefix "checkstyle:"</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#SuppressWarningsFilter_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">Example of suppression by prefix "checkstyle:"</a></li>
             </ul>
           </li>
           <li><a href="#SuppressWarningsFilter_Example_of_Usage">Example of Usage</a></li>
@@ -96,7 +102,8 @@ public class Example1 {
   }
 }
 </code></pre></div>
-        <hr class="example-separator"/>
+      </subsection>
+      <subsection name="Use Cases" id="SuppressWarningsFilter_Use_Cases">
         <p>
           It is possible to specify an ID of checks, so that it can be leveraged by the
           SuppressWarningsFilter to skip validations. The following examples show how to skip
@@ -104,7 +111,7 @@ public class Example1 {
           just <code>@SuppressWarnings(&quot;&lt;ID&gt;&quot;)</code> annotation, where ID is the ID of checks
           you want to suppress.
         </p>
-        <p id="Example2-config">Example of suppression by prefix &quot;checkstyle:&quot;:</p>
+        <p id="UseCase1-config">Example of suppression by prefix &quot;checkstyle:&quot;:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
@@ -119,11 +126,11 @@ public class Example1 {
   &lt;module name="SuppressWarningsFilter" /&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example2-code">Java code:</p>
+        <p id="UseCase1-code">Java code:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 package com.puppycrawl.tools.checkstyle.filters.suppresswarningsfilter;
 // violation 9 lines above 'use SLF4J instead.'
-public class Example2 {
+public class UseCase1 {
 
   @SuppressWarnings("memberName")
   int J;

--- a/src/site/xdoc/filters/suppresswarningsfilter.xml.template
+++ b/src/site/xdoc/filters/suppresswarningsfilter.xml.template
@@ -40,7 +40,8 @@
                  value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/Example1.java"/>
           <param name="type" value="code"/>
         </macro>
-        <hr class="example-separator"/>
+      </subsection>
+      <subsection name="Use Cases" id="SuppressWarningsFilter_Use_Cases">
         <p>
           It is possible to specify an ID of checks, so that it can be leveraged by the
           SuppressWarningsFilter to skip validations. The following examples show how to skip
@@ -48,16 +49,16 @@
           just <code>@SuppressWarnings("&lt;ID&gt;")</code> annotation, where ID is the ID of checks
           you want to suppress.
         </p>
-        <p id="Example2-config">Example of suppression by prefix "checkstyle:":</p>
+        <p id="UseCase1-config">Example of suppression by prefix "checkstyle:":</p>
         <macro name="example">
           <param name="path"
-               value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/Example2.java"/>
+               value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/UseCase1.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="Example2-code">Java code:</p>
+        <p id="UseCase1-code">Java code:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/Example2.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/UseCase1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -166,8 +166,7 @@ public class XdocsExamplesAstConsistencyTest {
      * Until: <a href="https://github.com/checkstyle/checkstyle/issues/21229">...</a>
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
-            "checks/whitespace/emptylineseparator",
-            "filters/suppresswarningsfilter"
+            "checks/whitespace/emptylineseparator"
     );
 
     /**

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterExamplesTest.java
@@ -60,7 +60,7 @@ public class SuppressWarningsFilterExamplesTest extends AbstractExamplesModuleTe
     }
 
     @Test
-    public void testExample2() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expectedWithoutFilter = {
             "9: Dont use System.out/err, use SLF4J instead.",
             "32: Dont use System.out/err, use SLF4J instead.",
@@ -72,7 +72,7 @@ public class SuppressWarningsFilterExamplesTest extends AbstractExamplesModuleTe
             "36: Dont use System.out/err, use SLF4J instead.",
         };
 
-        verifyFilterWithInlineConfigParser(getPath("Example2.java"),
+        verifyFilterWithInlineConfigParser(getPath("UseCase1.java"),
                 expectedWithoutFilter, expectedWithFilter);
     }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppresswarningsfilter/UseCase1.java
@@ -16,7 +16,7 @@
 // xdoc section - start
 package com.puppycrawl.tools.checkstyle.filters.suppresswarningsfilter;
 // violation 9 lines above 'use SLF4J instead.'
-public class Example2 {
+public class UseCase1 {
 
   @SuppressWarnings("memberName")
   int J;


### PR DESCRIPTION
Moved the extra SuppressWarningsFilter example to Use Cases so the example count matches the property count.

Fixes #21229 for `filters/suppresswarningsfilter`.