### PR TITLE
Issue #21229: Align JavadocPackage examples with property count

### DIFF
--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml
@@ -22,8 +22,14 @@
             <ul class="toc-sublist">
               <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
               <li><a href="#Example2-config" class="toc-sublink">With allowlegacy set to true</a></li>
-              <li><a href="#Example3-config" class="toc-sublink">With allowlegacy set to true</a></li>
               <li><a href="#Example4-config" class="toc-sublink">Only check <code>.properties</code> files for a package documentation file</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#JavadocPackage_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">With allowLegacy set to true when both package-info.java and package.html exist in the same directory</a></li>
             </ul>
           </li>
           <li><a href="#JavadocPackage_Example_of_Usage">Example of Usage</a></li>
@@ -117,33 +123,6 @@ public class Example1 { }
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example2 { } // ok, package.html file is present in directory
 </code></pre></div><hr class="example-separator"/>
-
-        <p id="Example3-config">
-          To configure the check with allowlegacy set to true:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="JavadocPackage"&gt;
-    &lt;property name="allowLegacy" value="true"/&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example3-structure">
-          Directory structure with both package-info.java and package.html
-          file in same directory:<br/><br/>
-          Example3.java<br/><br/>
-          package.html<br/><br/>
-          package-info.java
-        </p>
-        <p id="Example3-code">
-          The legacy configuration (allowLegacy=true) allows the use of package.html files
-          in place of package-info.java but still enforces that only one file
-          (either package-info.java or package.html) exists in a package.
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-// violation first line 'Legacy package.html file should be removed'
-public class Example3 { }
-</code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
           To configure the check to only check <code>.properties</code> files
           for a package documentation file:
@@ -169,6 +148,36 @@ public class Example3 { }
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example4 { } // ok, .java file is not checked
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Use Cases" id="JavadocPackage_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check with allowLegacy set to true when both
+          package-info.java and package.html exist in the same directory:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="JavadocPackage"&gt;
+    &lt;property name="allowLegacy" value="true"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="UseCase1-structure">
+          Directory structure with both package-info.java and package.html
+          file in same directory:<br/><br/>
+          UseCase1.java<br/><br/>
+          package.html<br/><br/>
+          package-info.java
+        </p>
+        <p id="UseCase1-code">
+          The legacy configuration (allowLegacy=true) allows the use of package.html files
+          in place of package-info.java but still enforces that only one file
+          (either package-info.java or package.html) exists in a package.
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+// violation first line 'Legacy package.html file should be removed'
+public class UseCase1 { }
 </code></pre></div>
       </subsection>
 

--- a/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
+++ b/src/site/xdoc/checks/javadoc/javadocpackage.xml.template
@@ -76,32 +76,6 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacy/Example2.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-
-        <p id="Example3-config">
-          To configure the check with allowlegacy set to true:
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacywithboth/Example3.java"/>
-          <param name="type" value="config"/>
-        </macro>
-        <p id="Example3-structure">
-          Directory structure with both package-info.java and package.html
-          file in same directory:<br/>
-          Example3.java<br/>
-          package.html<br/>
-          package-info.java
-        </p>
-        <p id="Example3-code">
-          The legacy configuration (allowLegacy=true) allows the use of package.html files
-          in place of package-info.java but still enforces that only one file
-          (either package-info.java or package.html) exists in a package.
-        </p>
-        <macro name="example">
-          <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacywithboth/Example3.java"/>
-          <param name="type" value="code"/>
-        </macro><hr class="example-separator"/>
         <p id="Example4-config">
           To configure the check to only check <code>.properties</code> files
           for a package documentation file:
@@ -126,6 +100,35 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/extensions/Example4.java"/>
+          <param name="type" value="code"/>
+        </macro>
+      </subsection>
+
+      <subsection name="Use Cases" id="JavadocPackage_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check with allowLegacy set to true when both
+          package-info.java and package.html exist in the same directory:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacywithboth/UseCase1.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="UseCase1-structure">
+          Directory structure with both package-info.java and package.html
+          file in same directory:<br/>
+          UseCase1.java<br/>
+          package.html<br/>
+          package-info.java
+        </p>
+        <p id="UseCase1-code">
+          The legacy configuration (allowLegacy=true) allows the use of package.html files
+          in place of package-info.java but still enforces that only one file
+          (either package-info.java or package.html) exists in a package.
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacywithboth/UseCase1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -166,7 +166,6 @@ public class XdocsExamplesAstConsistencyTest {
      * Until: <a href="https://github.com/checkstyle/checkstyle/issues/21229">...</a>
      */
     private static final Set<String> EXAMPLE_COUNT_SUPPRESSED_MODULES = Set.of(
-            "checks/javadoc/javadocpackage",
             "checks/whitespace/emptylineseparator",
             "filters/suppresswarningsfilter"
     );

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckExamplesTest.java
@@ -50,13 +50,13 @@ public class JavadocPackageCheckExamplesTest extends AbstractExamplesModuleTestS
     }
 
     @Test
-    public void testExample3() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expected = {
             "1: " + getCheckMessage(MSG_LEGACY_PACKAGE_HTML),
 
         };
 
-        verifyWithInlineConfigParser(getPath("legacywithboth/Example3.java"), expected);
+        verifyWithInlineConfigParser(getPath("legacywithboth/UseCase1.java"), expected);
     }
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacywithboth/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocpackage/legacywithboth/UseCase1.java
@@ -8,5 +8,5 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocpackage.legacywithboth;
 // xdoc section - start
 // violation first line 'Legacy package.html file should be removed'
-public class Example3 { }
+public class UseCase1 { }
 // xdoc section - end


### PR DESCRIPTION
Issue: #21229

`JavadocPackage` has two example-covered properties (`allowLegacy` and
`fileExtensions`), so `testExampleCountMatchesPropertyCount` expects 3
AST-matching examples (default + one per property). The module had 4
structurally identical Java examples.

Examples now has the default config, one example for `allowLegacy`, and
one example for `fileExtensions`. The extra combination (allowLegacy
with both `package-info.java` and `package.html` present) is kept under
Use Cases as UseCase1.

Other modules listed in #21229 are left for separate PRs.

## Testing

Executed:

- `mvn test -Dtest=JavadocPackageCheckExamplesTest`
  - JavadocPackageCheckExamplesTest 4/4
- `mvn test -Dtest=XdocsExamplesAstConsistencyTest,XdocsExampleFileTest,XdocsPagesTest`
  - XdocsExamplesAstConsistencyTest 5/5
  - XdocsExampleFileTest 5/5
  - XdocsPagesTest 20/20