### PR TITLE
Issue #19803: Move AnnotationLocation violation comments

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -107,10 +107,6 @@
             files="/filters/suppresswithnearbytextfilter/InputSuppressWithNearbyTextFilterNearbyTextPatternUrlLineLengthSuppression.java"/>
   <!-- until https://github.com/checkstyle/checkstyle/issues/19803 -->
   <suppress id="violationBetweenAnnotationAndMethod"
-            files="/checks/annotation/annotationlocation/InputAnnotationLocationRecordsAndCompactCtors\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="/checks/annotation/annotationlocation/inputs/package-info\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
             files="/checks/annotation/suppresswarnings/InputSuppressWarningsCompact2\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="/checks/annotation/suppresswarnings/InputSuppressWarningsCompact3\.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -264,8 +264,8 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPackage() throws Exception {
         final String[] expected = {
-            "12:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "PackageAnnotation", 2, 0),
-            "14:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "PackageAnnotation"),
+            "14:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "PackageAnnotation", 2, 0),
+            "15:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "PackageAnnotation"),
         };
         verifyWithInlineConfigParser(
                 getPath("inputs/package-info.java"), expected);
@@ -324,7 +324,7 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
             "30:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
             "37:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
             "49:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
-            "59:34: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "60:34: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationLocationRecordsAndCompactCtors.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationRecordsAndCompactCtors.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationRecordsAndCompactCtors.java
@@ -56,8 +56,9 @@ public class InputAnnotationLocationRecordsAndCompactCtors {
      * @return
      */
     public record MyRecord7() {
+        // violation below 'Annotation 'SuppressWarnings' should be alone on line.'
         record MyInnerRecord () {@SuppressWarnings("Annotation")public MyInnerRecord {
-            } // violation above 'Annotation 'SuppressWarnings' should be alone on line.'
+            }
         }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/inputs/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/inputs/package-info.java
@@ -8,8 +8,8 @@ tokens = PACKAGE_DEF
 
 */
 
+// violation 3 lines below '.* incorrect .* level 2, .* should be 0.'
+// violation 3 lines below 'Annotation 'PackageAnnotation' should be alone on line.'
 @PackageAnnotation(value = "foo")
-  @PackageAnnotation // violation '.* incorrect .* level 2, .* should be 0.'
-// violation below 'Annotation 'PackageAnnotation' should be alone on line.'
+  @PackageAnnotation
 @PackageAnnotation("bar") package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation.inputs;
-


### PR DESCRIPTION
Issue: #19803

Moves violation comments outside the annotated code in the remaining
`AnnotationLocation` input files.

Removes the corresponding `violationBetweenAnnotationAndMethod`
suppressions and updates affected expected line numbers.

Validation:
- `./mvnw clean -Dtest=AnnotationLocationCheckTest test`
- `./mvnw clean verify`