### PR TITLE
Issue #19803: Move IllegalToken BlockCommentEnd violation above Javadoc

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -314,8 +314,6 @@
             files="/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsSingle1\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="/com/puppycrawl/tools/checkstyle/checks/coding/illegalthrows/InputIllegalThrowsNotIgnoreOverriddenMethod\.java"/>
-  <suppress id="violationBetweenJavadocAndMethod"
-            files="/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/InputIllegalTokensCheckBlockCommentEnd\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumberDefault3\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheckTest.java
@@ -100,7 +100,7 @@ public class IllegalTokenCheckTest
 
         final String[] expected = {
             "6:1: " + getCheckMessage(MSG_KEY, "*/"),
-            "12:2: " + getCheckMessage(MSG_KEY, "*/"),
+            "13:2: " + getCheckMessage(MSG_KEY, "*/"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputIllegalTokensCheckBlockCommentEnd.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/InputIllegalTokensCheckBlockCommentEnd.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltoken/InputIllegalTokensCheckBlockCommentEnd.java
@@ -7,9 +7,10 @@ tokens = BLOCK_COMMENT_END
 
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltoken;
 
+// violation 3 lines below 'Using '\*\/' is not allowed'
 /**
  * Test for illegal tokens
- */ // violation 'Using '\*\/' is not allowed'
+ */
 public class InputIllegalTokensCheckBlockCommentEnd
 {
     public void methodWithPreviouslyIllegalTokens()


### PR DESCRIPTION
Issue: #19803

Moved the violation comment in `InputIllegalTokensCheckBlockCommentEnd.java` above the Javadoc (was on the same line as `*/`), updated the expected line in `IllegalTokenCheckTest`, and removed the related `violationBetweenJavadocAndMethod` suppression.

Testing: `./mvnw clean verify` passed locally.

Continues #19803