### PR TITLE
Table of contents macro should fail if it cannot not show all use cases

### DIFF
--- a/src/site/xdoc/checks/annotation/packageannotation.xml
+++ b/src/site/xdoc/checks/annotation/packageannotation.xml
@@ -23,6 +23,13 @@
               <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
             </ul>
           </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#PackageAnnotation_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">Show a class without violation</a></li>
+            </ul>
+          </li>
           <li><a href="#PackageAnnotation_Example_of_Usage">Example of Usage</a></li>
           <li><a href="#PackageAnnotation_Violation_Messages">Violation Messages</a></li>
           <li><a href="#PackageAnnotation_Fully_Qualified_Name">Fully Qualified Name</a></li>
@@ -69,13 +76,25 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;
 
 public class Example1 {}
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example2-code">Example of class without violation:</p>
+      </subsection>
+
+      <subsection name="Use Cases" id="PackageAnnotation_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check to show a class without violation:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="PackageAnnotation"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="UseCase1-code">Example of class without violation:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;
 
-class Example2 {}
-</code></pre></div>
-        <hr class="example-separator"/>
+class UseCase1 {}
+</code></pre></div><hr class="example-separator"/>
         <p id="Example3-code">Example of validating package-info.java:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 @Deprecated

--- a/src/site/xdoc/checks/annotation/packageannotation.xml.template
+++ b/src/site/xdoc/checks/annotation/packageannotation.xml.template
@@ -36,13 +36,23 @@
                  value="resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/Example1.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example2-code">Example of class without violation:</p>
+      </subsection>
+
+      <subsection name="Use Cases" id="PackageAnnotation_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check to show a class without violation:
+        </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/Example2.java"/>
-          <param name="type" value="code"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/UseCase1.java"/>
+          <param name="type" value="config"/>
         </macro>
-        <hr class="example-separator"/>
+        <p id="UseCase1-code">Example of class without violation:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/UseCase1.java"/>
+          <param name="type" value="code"/>
+        </macro><hr class="example-separator"/>
         <p id="Example3-code">Example of validating package-info.java:</p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -2983,6 +2983,71 @@ public class XdocsPagesTest {
                 .isEmpty();
     }
 
+    @Test
+    public void testAllExamplesPresentInGeneratedToc() throws Exception {
+        final List<Path> templates = collectAllXmlTemplatesUnderSrcSite();
+
+        assertWithMessage("Expected to find at least one xdoc template under src/site")
+                .that(templates)
+                .isNotEmpty();
+
+        final List<String> failures = new ArrayList<>();
+
+        for (final Path template : templates) {
+            final String content = Files.readString(template);
+            final String fileName = template.getFileName().toString();
+
+            failures.addAll(validateTocMacroCanExtractAllExamples(fileName, content));
+        }
+
+        assertWithMessage("TOC macro failed to extract all examples:\n%s",
+                String.join("\n", failures))
+                .that(failures)
+                .isEmpty();
+    }
+
+    /**
+     * Validates that the TocMacro can extract all Example/UseCase ids from the
+     * template. This uses the same ANCHOR_PATTERN as TocMacro to detect cases
+     * where the macro would silently fail to extract some examples.
+     *
+     * @param fileName the file name, for failure messages.
+     * @param content the full template source text.
+     * @return the list of failure messages.
+     */
+    private static List<String> validateTocMacroCanExtractAllExamples(String fileName,
+            String content) throws Exception {
+        final List<String> failures = new ArrayList<>();
+
+        final Pattern anchorPattern = Pattern.compile(
+                "<p\\s+id=\"((?:Example|UseCase)\\d+)-(config|raw)\"[^>]*>\\s*(.*?)\\s*</p>",
+                Pattern.DOTALL);
+
+        final Set<String> exampleIdsInContent = findAllExampleAndUseCaseIds(content);
+        final Set<String> exampleIdsExtractedByMacro = new TreeSet<>();
+
+        final Matcher matcher = anchorPattern.matcher(content);
+        while (matcher.find()) {
+            final String anchorId = matcher.group(1);
+            exampleIdsExtractedByMacro.add(anchorId);
+        }
+
+        final Set<String> missingFromMacro = new TreeSet<>(exampleIdsInContent);
+        missingFromMacro.removeAll(exampleIdsExtractedByMacro);
+
+        if (!missingFromMacro.isEmpty()) {
+            failures.add(String.format(Locale.ROOT,
+                    "%s: TOC macro failed to extract the following examples: %s. "
+                            + "The ToC macro could not match these example IDs "
+                            + "with its ANCHOR_PATTERN. "
+                            + "Check that each example has a <p id=\"ExampleN-config\"> or "
+                            + "<p id=\"UseCaseN-config\"> paragraph with proper formatting.",
+                    fileName, missingFromMacro));
+        }
+
+        return failures;
+    }
+
     /**
      * Validates that every Example/UseCase id found in the template has a
      * matching descriptive paragraph immediately before its example macro,
@@ -3054,8 +3119,8 @@ public class XdocsPagesTest {
 
     /**
      * Finds every {@code ExampleN}/{@code UseCaseN} id declared via a
-     * {@code -config} paragraph anywhere in the template, regardless of
-     * whether it matches the extraction pattern -- used to detect ids that
+     * {@code -config} paragraph anywhere in the template,
+     * regardless of whether it matches the extraction pattern -- used to detect ids that
      * exist but silently fail extraction.
      *
      * @param content the full template source text.
@@ -3067,9 +3132,12 @@ public class XdocsPagesTest {
         final Set<String> result = new TreeSet<>();
         final NodeList paragraphs = doc.getElementsByTagName("p");
 
+        final Pattern idPattern = Pattern.compile(
+                "^((?:Example|UseCase)\\d+)-config$");
+
         for (int index = 0; index < paragraphs.getLength(); index++) {
             final Element paragraph = (Element) paragraphs.item(index);
-            final Matcher idMatcher = EXAMPLE_ID_PATTERN.matcher(paragraph.getAttribute("id"));
+            final Matcher idMatcher = idPattern.matcher(paragraph.getAttribute("id"));
             if (idMatcher.matches()) {
                 result.add(idMatcher.group(1));
             }

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheckExamplesTest.java
@@ -43,10 +43,10 @@ public class PackageAnnotationCheckExamplesTest extends AbstractExamplesModuleTe
     }
 
     @Test
-    public void testExample2() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verifyWithInlineConfigParser(getPath("Example2.java"), expected);
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
     }
 
     @Test

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/UseCase1.java
@@ -9,5 +9,5 @@
 // xdoc section - start
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;
 
-class Example2 {}
+class UseCase1 {}
 // xdoc section - end


### PR DESCRIPTION

https://github.com/checkstyle/checkstyle/issues/21436

fixes: https://github.com/checkstyle/checkstyle-files-generator/issues/32
This PR adds a new test `testAllExamplesPresentInGeneratedToc ` to `XdocsPagesTest.java` that validates the Table of Contents (ToC) macro can extract all example descriptions from xdoc template files.

The `TocMacro `uses a specific regex pattern (`ANCHOR_PATTERN`) to extract example titles from paragraphs with IDs like `ExampleN-config` or `UseCaseN-config.` When template files use IDs that don't match this pattern (e.g., `UseCaseN-package-info-config`), the macro silently fails to extract those examples, resulting in missing entries in the generated ToC.

This test prevents such silent failures by:

- Scanning all` .xml.template` files under` src/site/xdoc`
- Finding all example IDs declared with `-config` or `-package-info-config` suffixes
- Attempting to extract them using the same `ANCHOR_PATTERN `as the TocMacro
- Failing with a clear error message if any IDs cannot be extracted

```
Prajapati\.m2\repository\org\xmlresolver\xmlresolver\5.3.3\xmlresolver-5.3.3.jar;C:\Users\Smita 
TOC-extractable description problems found:
emptylineseparator.xml.template: the following Example/UseCase ids have a config paragraph that TocMacro's extraction pattern cannot match (paragraph must immediately precede a <macro name="example"> with a 'path' param): [UseCase3, UseCase4, UseCase5, UseCase6, UseCase7]
expected to be empty
but was: [emptylineseparator.xml.template: the following Example/UseCase ids have a config paragraph that TocMacro's extraction pattern cannot match (paragraph must immediately precede a <macro name="example"> with a 'path' param): [UseCase3, UseCase4, UseCase5, UseCase6, UseCase7]]

	at com.puppycrawl.tools.checkstyle.internal.XdocsPagesTest.testAllExampleAndUseCaseParagraphsHaveDescriptiveText(XdocsPagesTest.java:2981)


TOC macro failed to extract all examples:
emptylineseparator.xml.template: TOC macro failed to extract the following examples: [UseCase3, UseCase4, UseCase5, UseCase6, UseCase7]. The ToC macro could not match these example IDs with its ANCHOR_PATTERN. Check that each example has a <p id="ExampleN-config"> or <p id="UseCaseN-config"> paragraph with proper formatting.
expected to be empty
but was: [emptylineseparator.xml.template: TOC macro failed to extract the following examples: [UseCase3, UseCase4, UseCase5, UseCase6, UseCase7]. The ToC macro could not match these example IDs with its ANCHOR_PATTERN. Check that each example has a <p id="ExampleN-config"> or <p id="UseCaseN-config"> paragraph with proper formatting.]

	at com.puppycrawl.tools.checkstyle.internal.XdocsPagesTest.testAllExamplesPresentInGeneratedToc(XdocsPagesTest.java:3004)


Process finished with exit code -1
```
