### PR TITLE
Pull #21416: Fix xdoc IDs for package-info examples

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1521,6 +1521,7 @@ upperell
 urandom
 uri
 url
+usecase
 useenhancedswitch
 userguide
 username

--- a/src/site/xdoc/checks/annotation/packageannotation.xml
+++ b/src/site/xdoc/checks/annotation/packageannotation.xml
@@ -75,7 +75,8 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;
 
 class Example2 {}
 </code></pre></div>
-        <p id="package-info-code">Example of validating package-info.java:</p>
+        <hr class="example-separator"/>
+        <p id="Example3-code">Example of validating package-info.java:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 @Deprecated
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation.example3;

--- a/src/site/xdoc/checks/annotation/packageannotation.xml.template
+++ b/src/site/xdoc/checks/annotation/packageannotation.xml.template
@@ -42,7 +42,8 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/Example2.java"/>
           <param name="type" value="code"/>
         </macro>
-        <p id="package-info-code">Example of validating package-info.java:</p>
+        <hr class="example-separator"/>
+        <p id="Example3-code">Example of validating package-info.java:</p>
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/example3/package-info.java"/>

--- a/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml
+++ b/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml
@@ -18,6 +18,16 @@
           <li>
             <input type="checkbox" id="toc-sub-Examples" class="toc-sub-toggle-checkbox" checked="checked"/>
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#MissingJavadocPackage_Examples">Examples</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#Example1-config" class="toc-sublink">Default configuration</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#MissingJavadocPackage_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">To catch block comments</a></li>
+            </ul>
           </li>
           <li><a href="#MissingJavadocPackage_Example_of_Usage">Example of Usage</a></li>
           <li><a href="#MissingJavadocPackage_Violation_Messages">Violation Messages</a></li>
@@ -46,7 +56,7 @@
       </subsection>
 
       <subsection name="Examples" id="MissingJavadocPackage_Examples">
-        <p id="javadoc-package-info-config">
+        <p id="Example1-config">
             To configure the check:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
@@ -56,19 +66,32 @@
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="javadoc-package-info-code">Example1 of package-info.java:</p>
+        <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 /**
  * Provides API classes
  */
-package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.example1;
 </code></pre></div>
-        <p id="nojavadoc-package-info-code">Example2 of package-info.java:</p>
+      </subsection>
+
+      <subsection name="Use Cases" id="MissingJavadocPackage_Use_Cases">
+        <p id="UseCase1-config">
+            To catch block comments:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MissingJavadocPackage"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="UseCase1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 /*
  * Block comment is not a javadoc
  */
-package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.nojavadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.usecase1;
 // violation above 'Missing javadoc for package-info.java file'
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml.template
+++ b/src/site/xdoc/checks/javadoc/missingjavadocpackage.xml.template
@@ -23,24 +23,35 @@
       </subsection>
 
       <subsection name="Examples" id="MissingJavadocPackage_Examples">
-        <p id="javadoc-package-info-config">
+        <p id="Example1-config">
             To configure the check:
         </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/javadoc/package-info.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/example1/package-info.java"/>
           <param name="type" value="config"/>
         </macro>
-        <p id="javadoc-package-info-code">Example1 of package-info.java:</p>
+        <p id="Example1-code">Example:</p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/javadoc/package-info.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/example1/package-info.java"/>
           <param name="type" value="code"/>
         </macro>
-        <p id="nojavadoc-package-info-code">Example2 of package-info.java:</p>
+      </subsection>
+
+      <subsection name="Use Cases" id="MissingJavadocPackage_Use_Cases">
+        <p id="UseCase1-config">
+            To catch block comments:
+        </p>
         <macro name="example">
           <param name="path"
-                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/nojavadoc/package-info.java"/>
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/usecase1/package-info.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="UseCase1-code">Example:</p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/usecase1/package-info.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/site/xdoc/checks/whitespace/emptylineseparator.xml
+++ b/src/site/xdoc/checks/whitespace/emptylineseparator.xml
@@ -459,7 +459,7 @@ class Example7 { // violation above ''import' should be separated from previous 
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example8-package-info-code">
+        <p id="Example8-code">
           Example of <code>package-info.java</code> with annotation before
           <code>PACKAGE_DEF</code>:
         </p>
@@ -474,7 +474,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator.pac
 
 import java.lang.Deprecated;
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example9-package-info-code">
+        <p id="Example9-code">
           Example of <code>package-info.java</code> with Javadoc before
           <code>PACKAGE_DEF</code>:
         </p>
@@ -489,7 +489,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator.pac
 // import is present so PACKAGE_DEF is not the last token
 import java.lang.System;
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example10-package-info-code">
+        <p id="Example10-code">
           Example of violation when a configuration block comment precedes
           <code>PACKAGE_DEF</code>:
         </p>
@@ -503,7 +503,7 @@ import java.lang.System;
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator.packageinfo.example10;
 // violation above ''package' should be separated from previous line'
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example11-package-info-code">
+        <p id="Example11-code">
           Example of violation when single-line comment precedes
           <code>PACKAGE_DEF</code>:
         </p>
@@ -518,7 +518,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator.pac
 
 import java.lang.System;
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example12-package-info-code">
+        <p id="Example12-code">
           Example of violation when block comment precedes
           <code>PACKAGE_DEF</code>:
         </p>

--- a/src/site/xdoc/checks/whitespace/emptylineseparator.xml.template
+++ b/src/site/xdoc/checks/whitespace/emptylineseparator.xml.template
@@ -165,7 +165,7 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/Example7.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example8-package-info-code">
+        <p id="Example8-code">
           Example of <code>package-info.java</code> with annotation before
           <code>PACKAGE_DEF</code>:
         </p>
@@ -174,7 +174,7 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/packageinfo/example8/package-info.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example9-package-info-code">
+        <p id="Example9-code">
           Example of <code>package-info.java</code> with Javadoc before
           <code>PACKAGE_DEF</code>:
         </p>
@@ -183,7 +183,7 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/packageinfo/example9/package-info.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example10-package-info-code">
+        <p id="Example10-code">
           Example of violation when a configuration block comment precedes
           <code>PACKAGE_DEF</code>:
         </p>
@@ -192,7 +192,7 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/packageinfo/example10/package-info.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example11-package-info-code">
+        <p id="Example11-code">
           Example of violation when single-line comment precedes
           <code>PACKAGE_DEF</code>:
         </p>
@@ -201,7 +201,7 @@
                  value="resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/packageinfo/example11/package-info.java"/>
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
-        <p id="Example12-package-info-code">
+        <p id="Example12-code">
           Example of violation when block comment precedes
           <code>PACKAGE_DEF</code>:
         </p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -2741,8 +2741,18 @@ public class XdocsPagesTest {
             final String paramValue = item.getAttributes()
                     .getNamedItem("value").getTextContent();
             if ("path".equals(paramName)) {
-                exampleName = paramValue.substring(paramValue.lastIndexOf('/') + 1,
-                        paramValue.lastIndexOf('.'));
+                final int lastSlash = paramValue.lastIndexOf('/');
+                final int lastDot = paramValue.lastIndexOf('.');
+                exampleName = paramValue.substring(lastSlash + 1, lastDot);
+                if ("package-info".equals(exampleName)) {
+                    final int prevSlash = paramValue.lastIndexOf('/', lastSlash - 1);
+                    final String parentDir = paramValue.substring(prevSlash + 1, lastSlash);
+                    if (parentDir.matches("(example|usecase)\\d+")) {
+                        exampleName = parentDir
+                                .replace("example", "Example")
+                                .replace("usecase", "UseCase");
+                    }
+                }
             }
             else if ("type".equals(paramName)) {
                 exampleType = paramValue;
@@ -2752,18 +2762,10 @@ public class XdocsPagesTest {
         final String id = idAttribute.getTextContent();
         final String expectedId = String.format(Locale.ROOT, "%s-%s", exampleName,
                 exampleType);
-        if (expectedId.startsWith("package-info")) {
-            assertWithMessage(
-                "%s: paragraph before example macro should have the expected id value", fileName)
-                .that(id)
-                .endsWith(expectedId);
-        }
-        else {
-            assertWithMessage(
-                "%s: paragraph before example macro should have the expected id value", fileName)
-                .that(id)
-                .isEqualTo(expectedId);
-        }
+        assertWithMessage(
+            "%s: paragraph before example macro should have the expected id value", fileName)
+            .that(id)
+            .isEqualTo(expectedId);
     }
 
     private static Node getPrecedingParagraph(Node macro) {

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckExamplesTest.java
@@ -36,16 +36,16 @@ public class MissingJavadocPackageCheckExamplesTest extends AbstractExamplesModu
     @Test
     public void testExample1() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verifyWithInlineConfigParser(getPath("javadoc/package-info.java"), expected);
+        verifyWithInlineConfigParser(getPath("example1/package-info.java"), expected);
     }
 
     @Test
-    public void testExample2() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expected = {
             "12:1: " + getCheckMessage(MSG_PKG_JAVADOC_MISSING),
         };
 
-        verifyWithInlineConfigParser(getPath("nojavadoc/package-info.java"), expected);
+        verifyWithInlineConfigParser(getPath("usecase1/package-info.java"), expected);
     }
 
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/example1/package-info.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/example1/package-info.java
@@ -9,5 +9,5 @@
 /**
  * Provides API classes
  */
-package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.javadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.example1;
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/usecase1/package-info.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/usecase1/package-info.java
@@ -9,6 +9,6 @@
 /*
  * Block comment is not a javadoc
  */
-package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.nojavadoc;
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage.usecase1;
 // violation above 'Missing javadoc for package-info.java file'
 // xdoc section - end


### PR DESCRIPTION
### Description

This PR fixes handling of `package-info.java` examples in xdoc templates and makes their IDs follow the same convention as all other examples.

The problem was found on the [`MissingJavadocPackage`](https://checkstyle.org/checks/javadoc/missingjavadocpackage.html) documentation page. Its examples were missing from the table of contents because their paragraph IDs did not follow the format expected by the ToC generator:

* `Example\d+-config`
* `Example\d+-code`
* `UseCase\d+-config`
* `UseCase\d+-code`

`package-info.java` examples could not follow this convention cleanly because `XdocsPagesTest` derived the expected example name from the file name. So the test had a special case that only required the paragraph ID to end with `package-info-config` or `package-info-code`.

As a result, package-info examples used IDs such as:

```xml
<p id="Example8-package-info-code">
```

or arbitrary IDs such as:

```xml
<p id="javadoc-package-info-config">
```

These IDs satisfied `XdocsPagesTest`, but they were not recognized as regular examples by the ToC generation logic.

This PR removes that special handling.

For `package-info.java`, `XdocsPagesTest` now derives the example name from its parent directory when that directory follows the existing `exampleN` or `usecaseN` convention:

```text
example1/package-info.java -> Example1
usecase1/package-info.java -> UseCase1
```

The expected paragraph IDs therefore become the same as for normal Java example files:

```text
Example1-config
Example1-code
UseCase1-config
UseCase1-code
```

The test can then require exact equality for all examples instead of keeping a separate `package-info.java` exception.

This PR also:

* updates existing package-info example IDs in `EmptyLineSeparator` and `PackageAnnotation`;
* reorganizes `MissingJavadocPackage` examples into `example1` and `usecase1` directories;
* separates the `MissingJavadocPackage` regular example and use case into the appropriate documentation sections;
* restores the missing `MissingJavadocPackage` example and use-case entries in the table of contents.
