### PR TITLE
Issue #20906: Add checks for Sun Style 3.1.2 - Package And Import Names

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1059,6 +1059,7 @@ overridable
 overridealwaysused
 OVERRIDERS
 owasp
+packageandimportstatements
 packageannotation
 packagecomment
 packagedeclaration

--- a/src/it/java/com/sun/checkstyle/test/chapter3fileorganization/rule312packageandimportstatements/PackageAndImportStatementsTest.java
+++ b/src/it/java/com/sun/checkstyle/test/chapter3fileorganization/rule312packageandimportstatements/PackageAndImportStatementsTest.java
@@ -1,0 +1,49 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.sun.checkstyle.test.chapter3fileorganization.rule312packageandimportstatements;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.checkstyle.test.base.AbstractSunModuleTestSupport;
+
+public class PackageAndImportStatementsTest extends AbstractSunModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/sun/checkstyle/test/chapter3fileorganization/rule312packageandimportstatements";
+    }
+
+    @Test
+    public void testPackageAndImportStatementsGood() throws Exception {
+        verifyWithWholeConfig(getPath("InputPackageAndImportStatementsGood.java"));
+    }
+
+    @Test
+    public void testPackageAndImportStatementsBad() throws Exception {
+        // Located outside getPackageLocation(), in its own top-level "BadPackageName"
+        // directory matching the invalid package statement in the input file, so the
+        // PackageDeclaration self-check passes while PackageName is still violated.
+        verifyWithWholeConfig(new File("src/it/resources/BadPackageName"
+                + "/InputPackageAndImportStatementsBad.java").getCanonicalPath());
+    }
+
+}

--- a/src/it/resources/BadPackageName/InputPackageAndImportStatementsBad.java
+++ b/src/it/resources/BadPackageName/InputPackageAndImportStatementsBad.java
@@ -1,0 +1,7 @@
+// violation first line 'Header is missing or too short.*'
+package BadPackageName;
+// violation above 'Name .BadPackageName. must match pattern .*'
+
+final class InputPackageAndImportStatementsBad {
+
+}

--- a/src/it/resources/BadPackageName/package-info.java
+++ b/src/it/resources/BadPackageName/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Test input for the package naming rule violation in Sun style.
+ */
+package BadPackageName;

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule312packageandimportstatements/InputPackageAndImportStatementsGood.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule312packageandimportstatements/InputPackageAndImportStatementsGood.java
@@ -1,0 +1,6 @@
+package com.sun.checkstyle.test.chapter3fileorganization.rule312packageandimportstatements;
+// violation first line 'Header is missing or too short.*'
+
+final class InputPackageAndImportStatementsGood {
+
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule312packageandimportstatements/package-info.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule312packageandimportstatements/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Test inputs for package and import statements check in Sun style.
+ */
+package com.sun.checkstyle.test.chapter3fileorganization.rule312packageandimportstatements;

--- a/src/site/xdoc/sun-style.xml
+++ b/src/site/xdoc/sun-style.xml
@@ -270,8 +270,31 @@
                     3.1.2 Package and Import Statements
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_blue.png" alt="" />
+                  </span>
+                  <a href="checks/naming/packagename.html#PackageName">PackageName</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageName">
+                    config</a>)
+                  <br/>
+                  <br/>
+                  The rule that the first component of a package name is
+                  all-lowercase ASCII is covered above, but the specific
+                  requirement that it be a top-level domain (com, edu, gov,
+                  mil, net, org) or an ISO 3166 country code is not checked.
+                  <br/>
+                  <br/>
+                  The requirement that a package statement, when present,
+                  must be the first statement in the file and be followed
+                  only by import statements is already enforced by the Java
+                  language grammar, so no additional Checkstyle check is
+                  needed for it.
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule312packageandimportstatements">
+                    samples</a>
+                </td>
               </tr>
               <tr>
                 <td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -219,7 +219,6 @@ public class XdocsPagesTest {
             "NoWhitespaceAfter",
             "NoWhitespaceBefore",
             "OperatorWrap",
-            "PackageName",
             "ParameterName",
             "ParameterNumber",
             "ParenPad",


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/20906

### What
Documents `PackageName` coverage for Sun Style **3.1.2 Package and Import Statements** and adds an integration test suite, per the process described in #20811.

### Details
- `src/site/xdoc/sun_style.xml`: fills in the 3.1.2 coverage row.
  - `PackageName` (already present in `sun_checks.xml`, unconfigured) enforces that the first component of a package name is all-lowercase, matching part of the rule. Marked `ok_blue` (partial) since it does not restrict the first component to an actual top-level domain / ISO country code.
  - Notes that the requirement for package statement ordering (package first, then imports) is already enforced by the Java language grammar, so no Checkstyle check is needed for it.
- `src/test/java/.../XdocsPagesTest.java`: removes `PackageName` from `IGNORED_SUN_MODULES` now that it is documented.
- `src/it/resources/com/sun/checkstyle/test/chapter3fileorganization/rule312packageandimportstatements/`: new integration test input files (good/bad package name).
- `src/it/java/com/sun/checkstyle/test/chapter3fileorganization/rule312packageandimportstatements/PackageAndImportStatementsTest.java`: new integration test class, following the Google style chapter-wise test structure per the parent issue instructions.

### Testing
- `XdocsPagesTest` passes (20/20).
- New `PackageAndImportStatementsTest` passes (2/2).

Reference: #20906 (child issue), #20811 (parent epic).