### PR TITLE
Issue #20954: Rewrite violation comments in InputUnderscoreUsedInNames.java

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputUnderscoreUsedInNames.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter5naming/rule53camelcase/InputUnderscoreUsedInNames.java
@@ -22,32 +22,53 @@ public class InputUnderscoreUsedInNames {
   private String gradle851;
 
   class InnerBad {
-    // violation below ''guava_33_4_7' .* underscores allowed only between adjacent digits.'
+    // violation 4 lines below """Non-constant field name 'guava_33_4_7' must start lowercase,
+    //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+    //  contain only letters, digits or underscores,
+    //  with underscores allowed only between adjacent digits."""
     int guava_33_4_7;
     int guava33_4_7;
 
-    // violation below ''guava33_4_8_' .* underscores allowed only between adjacent digits.'
+    // violation 4 lines below """Non-constant field name 'guava33_4_8_' must start lowercase,
+    //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+    //  contain only letters, digits or underscores,
+    //  with underscores allowed only between adjacent digits."""
     int guava33_4_8_;
     int guava33_4_8;
 
-    // violation below ''jdk_8_90' .* underscores allowed only between adjacent digits.'
+    // violation 4 lines below """Non-constant field name 'jdk_8_90' must start lowercase,
+    //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+    //  contain only letters, digits or underscores,
+    //  with underscores allowed only between adjacent digits."""
     int jdk_8_90;
     int jdk8_90;
 
-    // violation below ''jdk8_91_' .* underscores allowed only between adjacent digits.'
+    // violation 4 lines below """Non-constant field name 'jdk8_91_' must start lowercase,
+    //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+    //  contain only letters, digits or underscores,
+    //  with underscores allowed only between adjacent digits."""
     int jdk8_91_;
     int jdk8_91;
 
-    // violation below ''kotlin_1_9_24' .* underscores allowed only between adjacent digits.'
+    // violation 4 lines below """Non-constant field name 'kotlin_1_9_24' must start lowercase,
+    //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+    //  contain only letters, digits or underscores,
+    //  with underscores allowed only between adjacent digits."""
     int kotlin_1_9_24;
     int kotlin1_9_24;
 
-    // violation below ''kotlin_version1_9_24'.* underscores allowed only between adjacent digits.'
+    // violation 4 lines below """Non-constant field name 'kotlin_version1_9_24'
+    //  must start lowercase, be at least 2 chars, avoid single lowercase letter
+    //  followed by uppercase, contain only letters, digits or underscores,
+    //  with underscores allowed only between adjacent digits."""
     int kotlin_version1_9_24;
 
     int kotlinVersion1_9_24;
 
-    // violation below ''kotlin1_9_25_' .* underscores allowed only between adjacent digits.'
+    // violation 4 lines below """Non-constant field name 'kotlin1_9_25_' must start lowercase,
+    //  be at least 2 chars, avoid single lowercase letter followed by uppercase,
+    //  contain only letters, digits or underscores,
+    //  with underscores allowed only between adjacent digits."""
     int kotlin1_9_25_;
     int kotlin1_9_25;
   }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -306,9 +306,7 @@ public final class InlineConfigParser {
             "checks/coding/noclone/Example1.java",
             "checks/coding/unusedlocalvariable/Example1.java",
             "checks/sizes/recordcomponentnumber/Example2.java",
-            "checks/whitespace/separatorwrap/Example1.java",
-            "com/google/checkstyle/test/chapter5naming/rule53camelcase/"
-                    + "InputUnderscoreUsedInNames.java"
+            "checks/whitespace/separatorwrap/Example1.java"
     );
 
     /**


### PR DESCRIPTION
Issue: #20954

Rewrites the seven paraphrased/`.*`-truncated violation comments in `InputUnderscoreUsedInNames.java` as multiline triple-quoted messages matching `GoogleNonConstantFieldNameCheck`'s real output, and removes the file from `SUPPRESSED_VALIDATE_MESSAGE_FILES` in `InlineConfigParser.java` now that message validation is active for it.

Verified locally with `mvn clean verify` (full build, including the affected `CamelCaseDefinedTest#testCamelCaseNames2` integration test).