### PR TITLE
Issue #20636: narrow LeftCurly short form suppression in openjdk style

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1159,6 +1159,7 @@ qaplug
 qodana
 qualitygates
 Qube
+quebra
 qw
 qwe
 QX
@@ -1213,6 +1214,7 @@ rhs
 rhysd
 rickgiles
 rightcurly
+rivinvaihdon
 Rl
 Rli
 rnveach
@@ -1268,6 +1270,7 @@ Ruslan
 rw
 rx
 sabaka
+salto
 Saludo
 Sameline
 sariflogger
@@ -1329,6 +1332,7 @@ sonarcloud
 sonarqube
 sonarsource
 sonatype
+sonu
 Sopov
 sourcefile
 sourceforge
@@ -1663,6 +1667,7 @@ Yoyodyne
 yq
 yyyy
 Zbbh
+Zeilenumbruch
 zf
 zh
 ZSH

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulebraces/InputBracesLeftCurlyInValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulebraces/InputBracesLeftCurlyInValid.java
@@ -90,4 +90,12 @@ public class InputBracesLeftCurlyInValid {
         } // violation 'should be on the same line'
         while (i > 0);
     }
+
+    boolean testMethod4()
+    { // violation ''{' at column 5 should be on the previous line.'
+        return true;
+    }
+
+    void testMethod5()
+    { System.out.println("hello"); } // violation ''{' at column 5 should be on the previous line.'
 }

--- a/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulebraces/InputBracesLeftCurlyValid.java
+++ b/src/it/resources/com/openjdk/checkstyle/test/chapterformatting/rulebraces/InputBracesLeftCurlyValid.java
@@ -76,4 +76,8 @@ public class InputBracesLeftCurlyValid {
             System.out.println("hello");
         } while (i > 0);
     }
+
+    boolean testMethod4() { return true; }
+
+    void testMethod5() { System.out.println("hello"); }
 }

--- a/src/main/resources/openjdk_checks.xml
+++ b/src/main/resources/openjdk_checks.xml
@@ -325,6 +325,10 @@
     <module name="LeftCurly"/>
     <module name="SuppressionXpathSingleFilter">
       <property name="checks" value="LeftCurly"/>
+      <!-- one phrase per translation of the 'line.break.after' message, see
+           checks/blocks/messages*.properties -->
+      <property name="message"
+                value="line break after|Zeilenumbruch|salto de línea|rivinvaihdon|saut de ligne|改行|quebra de linha|перевод строки|satır sonu|换行"/>
       <property name="query"
                 value="//METHOD_DEF/SLIST[LITERAL_RETURN
                         or EXPR[following-sibling::SEMI[following-sibling::*[self::RCURLY]]]]"/>

--- a/src/site/xdoc/openjdk-style.xml
+++ b/src/site/xdoc/openjdk-style.xml
@@ -526,7 +526,7 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img src="images/ok_blue.png" alt=""/>
+                    <img src="images/ok_green.png" alt=""/>
                   </span>
                   <a href="checks/blocks/leftcurly.html#LeftCurly">LeftCurly</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fopenjdk_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LeftCurly">
@@ -555,15 +555,6 @@
                   Closing braces rule can not be covered until:
                   <a href="https://github.com/checkstyle/checkstyle/issues/7541">
                     #7541
-                  </a>
-                  <br />
-                  <br />
-                  <span class="wrapper inline">
-                    <img src="images/ban_red.png" alt="" />
-                  </span>
-                  False positive present regarding to LeftCurly:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/20636">
-                    #20636
                   </a>
                 </td>
                 <td>


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/20636

The filter that allows the OpenJDK short form only looks at the shape of the method body, so it removes LeftCurly for every method whose body starts with a return or is a single expression statement, no matter where the brace sits. This file reports 6 violations without the filter and none with it:

```java
public boolean braceOnNewLine()
{ return true; }

public boolean twoStatements()
{
    return true;
}
```

The xpath model carries no line information, only `@text`, so the query cannot tell a one line short form from these two. What it can do is stop suppressing the placement message. `should be on the previous line` is not part of the short form exception, only the missing line break after `{` is, so the filter now carries a `message` property the same way the ImportOrder filter a few lines above already does.

Two cases went into the invalid input and the two allowed short forms into the valid one, so both directions are covered.
