### PR TITLE
dependency: bump pmd version to 7.27.0, fix ReturnEmptyCollectionRath…

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -8223,17 +8223,6 @@
     <message>incompatible types in return.</message>
     <lineContent>return result;</lineContent>
     <details>
-      type of expression: @Initialized @Nullable List&lt;@Initialized @NonNull String&gt;
-      method return type: @Initialized @NonNull List&lt;@Initialized @NonNull String&gt;
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return result;</lineContent>
-    <details>
       type of expression: @Initialized @Nullable ModuleDetails
       method return type: @Initialized @NonNull ModuleDetails
     </details>

--- a/config/pmd-main.xml
+++ b/config/pmd-main.xml
@@ -74,4 +74,15 @@
                    //MethodDeclaration[@Name='visitToken']"/>
     </properties>
   </rule>
+
+  <rule ref="category/java/errorprone.xml/ReturnEmptyCollectionRatherThanNull">
+    <properties>
+      <!-- DetailAstImpl#getHiddenBefore/getHiddenAfter if we convert it to List.of, it
+             prevents us from reaching full Pit mutant coverage which we value
+               more than list.of. -->
+      <property name="violationSuppressXPath"
+               value="//ClassDeclaration[@SimpleName='DetailAstImpl']
+                        //MethodDeclaration[@Name='getHiddenBefore' or @Name='getHiddenAfter']"/>
+    </properties>
+  </rule>
 </ruleset>

--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -221,4 +221,18 @@
                     //MethodDeclaration[@Name='loadFilterSet']"/>
     </properties>
   </rule>
+
+  <rule ref="category/java/errorprone.xml/ReturnEmptyCollectionRatherThanNull">
+    <properties>
+      <!-- MainTest#testListFilesDirectoryWithNull intentionally overrides
+           File#listFiles() to return null, simulating the real JDK contract
+           (File#listFiles() returns null on I/O error). This is required to
+           test Main#listFiles' null-handling branch and must not be changed
+           to an empty array. -->
+      <property name="violationSuppressXPath"
+               value="//ClassDeclaration[@SimpleName='MainTest']
+                        //MethodDeclaration[@Name='testListFilesDirectoryWithNull']
+                        //MethodDeclaration[@Name='listFiles']"/>
+    </properties>
+  </rule>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
     <site.plugin.version>3.22.0</site.plugin.version>
     <spotbugs.plugin.version>4.10.4.0</spotbugs.plugin.version>
     <pmd.plugin.version>3.28.0</pmd.plugin.version>
-    <pmd.version>7.26.0</pmd.version>
+    <pmd.version>7.27.0</pmd.version>
     <jacoco.plugin.version>0.8.15</jacoco.plugin.version>
     <mockito.version>5.2.0</mockito.version>
     <slf4j.version>2.0.18</slf4j.version>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
@@ -209,8 +209,11 @@ public final class XmlMetaReader {
     private static List<String> getListContentByAttribute(Element element, String listParent,
                                                          String listOption, String attribute) {
         final List<Element> children = getDirectChildsByTag(element, listParent);
-        List<String> result = null;
-        if (!children.isEmpty()) {
+        final List<String> result;
+        if (children.isEmpty()) {
+            result = List.of();
+        }
+        else {
             final NodeList nodeList = children.getFirst().getElementsByTagName(listOption);
             final int nodeListLength = nodeList.getLength();
             final List<String> listContent = new ArrayList<>(nodeListLength);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -553,8 +553,11 @@ public class XdocsExampleFileTest {
             }
         }
 
-        int[] result = null;
-        if (startLine != -1 && endLine != -1) {
+        final int[] result;
+        if (startLine == -1 && endLine == -1) {
+            result = new int[0];
+        }
+        else {
             result = new int[] {startLine, endLine};
         }
         return result;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1711,13 +1711,16 @@ public class XdocsPagesTest {
     }
 
     private static Set<String> getListById(Node subSection, String id) {
-        Set<String> result = null;
+        final Set<String> result;
         final Node node = XmlUtil.findChildElementById(subSection, id);
         if (node != null) {
             result = XmlUtil.getChildrenElements(node)
                     .stream()
                     .map(Node::getTextContent)
                     .collect(Collectors.toUnmodifiableSet());
+        }
+        else {
+            result = Set.of();
         }
         return result;
     }


### PR DESCRIPTION
Closes https://github.com/checkstyle/checkstyle/pull/21420
bump pmd.version from 7.26.0 to 7.27.0
Fixes ReturnEmptyCollectionRatherThanNull rule warning.
Also suppresses the same rule in `MainTest#testListFilesDirectoryWithNull()`.
It must return null `not an empty array` to simulate `File#listFiles()` real null on I/O error contract and keep `jacco` branch coverage 100.