### PR TITLE
Issue #19415: Fix IndentationCheck false positive for double-brace init

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
@@ -75,8 +75,13 @@ public class SlistHandler extends BlockParentHandler {
         //  preceded by a switch
 
         final IndentLevel result;
+        // Same-line double-brace init shares the anonymous class indent so
+        // the inner SLIST does not add another basicOffset on top of it.
+        if (isSameLineDoubleBraceInit()) {
+            result = getParent().getIndent();
+        }
         // if our parent is a block handler we want to be transparent
-        if (getParent() instanceof BlockParentHandler
+        else if (getParent() instanceof BlockParentHandler
                 && !(getParent() instanceof SlistHandler)
             || child instanceof SlistHandler
                 && getParent() instanceof CaseHandler) {
@@ -136,6 +141,21 @@ public class SlistHandler extends BlockParentHandler {
         final DetailAST parentNode = getMainAst().getParent();
         return parentNode.getType() == TokenTypes.CASE_GROUP
             && TokenUtil.areOnSameLine(getMainAst(), parentNode);
+    }
+
+    /**
+     * Checks if this handler is the instance initializer of a double-brace
+     * initialization whose brace is on the same line as the anonymous class
+     * brace, such as {@code new HashMap<>() {{ put(...); }}}.
+     *
+     * @return true if this is a same-line double-brace instance initializer
+     */
+    private boolean isSameLineDoubleBraceInit() {
+        final DetailAST ast = getMainAst();
+        final DetailAST objBlock = ast.getParent();
+        return ast.getType() == TokenTypes.INSTANCE_INIT
+                && objBlock.getParent().getType() == TokenTypes.LITERAL_NEW
+                && TokenUtil.areOnSameLine(ast, objBlock);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -3079,7 +3079,6 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             getPath("InputIndentationAnonymousClassInMethodCurlyOnNewLine.java"), expected);
     }
 
-    // until #19415
     @Test
     public void testDoubleBraceInit() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
@@ -3091,20 +3090,28 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("throwsIndent", "4");
         checkConfig.addProperty("arrayInitIndent", "4");
         final String[] expected = {
-            "27:13: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 12, "16, 20"),
-            "28:13: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 12, "16, 20"),
-            "29:9: " + getCheckMessage(MSG_ERROR_MULTI, "block rcurly", 8, "12, 16"),
-            "35:17: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 16, "20, 24"),
-            "36:13: " + getCheckMessage(MSG_ERROR_MULTI, "block rcurly", 12, "16, 20"),
-            "42:13: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 12, "16, 20"),
-            "43:9: " + getCheckMessage(MSG_ERROR_MULTI, "block rcurly", 8, "12, 16"),
-            "56:13: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 12, "16, 20"),
-            "57:9: " + getCheckMessage(MSG_ERROR_MULTI, "block rcurly", 8, "12, 16"),
-            "63:17: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 16, "20, 24"),
-            "64:17: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 16, "20, 24"),
-            "65:13: " + getCheckMessage(MSG_ERROR_MULTI, "block rcurly", 12, "16, 20"),
+            "64:7: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 6, "12, 16"),
+            "65:29: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 28, "12, 16"),
         };
         verifyWarns(checkConfig, getPath("InputIndentationDoubleBraceInit.java"), expected);
+    }
+
+    @Test
+    public void testDoubleBraceInit2() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        checkConfig.addProperty("arrayInitIndent", "4");
+        final String[] expected = {
+            "50:29: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 28, "20, 24"),
+            "51:29: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "block", 28, "20, 24"),
+            "52:25: " + getCheckMessage(MSG_ERROR_MULTI, "block rcurly", 24, "16, 20"),
+        };
+        verifyWarns(checkConfig, getPath("InputIndentationDoubleBraceInit2.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationDoubleBraceInit.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationDoubleBraceInit.java
@@ -1,8 +1,6 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
 
 import java.util.HashMap;                                               //indent:0 exp:0
-import java.util.HashSet;                                               //indent:0 exp:0
-import java.util.ArrayList;                                             //indent:0 exp:0
 import java.util.Map;                                                   //indent:0 exp:0
 
 /**                                                                     //indent:0 exp:0
@@ -21,26 +19,30 @@ import java.util.Map;                                                   //indent
 public class InputIndentationDoubleBraceInit {                          //indent:0 exp:0
 
     private final FluentCallChain configLog = new FluentCallChain();    //indent:4 exp:4
-    // behavior until #19415                                            //indent:4 exp:4
+
+    {                                                                   //indent:4 exp:4
+        configLog.readToEnd();                                          //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+
     void test() {                                                       //indent:4 exp:4
         var map = new HashMap<>() {{                                    //indent:8 exp:8
-            put("KEY1", "VALUE1");                                      //indent:12 exp:16,20 warn
-            put("KEY2", "VALUE2");                                      //indent:12 exp:16,20 warn
-        }};                                                             //indent:8 exp:12,16 warn
+            put("KEY1", "VALUE1");                                      //indent:12 exp:12
+            put("KEY2", "VALUE2");                                      //indent:12 exp:12
+        }};                                                             //indent:8 exp:8
     }                                                                   //indent:4 exp:4
 
     void testNestedInIf() {                                             //indent:4 exp:4
         if (true) {                                                     //indent:8 exp:8
             var map = new HashMap<>() {{                                //indent:12 exp:12
-                put("KEY1", "VALUE1");                                  //indent:16 exp:20,24 warn
-            }};                                                         //indent:12 exp:16,20 warn
+                put("KEY1", "VALUE1");                                  //indent:16 exp:16
+            }};                                                         //indent:12 exp:12
         }                                                               //indent:8 exp:8
     }                                                                   //indent:4 exp:4
 
     Map<String, String> testReturnDoubleBrace() {                       //indent:4 exp:4
         return new HashMap<>() {{                                       //indent:8 exp:8
-            put("KEY1", "VALUE1");                                      //indent:12 exp:16,20 warn
-        }};                                                             //indent:8 exp:12,16 warn
+            put("KEY1", "VALUE1");                                      //indent:12 exp:12
+        }};                                                             //indent:8 exp:8
     }                                                                   //indent:4 exp:4
 
     void testSeparateLineInit() {                                       //indent:4 exp:4
@@ -53,67 +55,18 @@ public class InputIndentationDoubleBraceInit {                          //indent
 
     void testMethodArgDoubleBrace() {                                   //indent:4 exp:4
         System.out.println(new HashMap<>() {{                           //indent:8 exp:8
-            put("KEY1", "VALUE1");                                      //indent:12 exp:16,20 warn
-        }});                                                            //indent:8 exp:12,16 warn
+            put("KEY1", "VALUE1");                                      //indent:12 exp:12
+        }});                                                            //indent:8 exp:8
     }                                                                   //indent:4 exp:4
 
-    void testWrappedMethodArgDoubleBrace() {                            //indent:4 exp:4
-        accept("first",                                                 //indent:8 exp:8
-            new HashMap<>() {{                                          //indent:12 exp:12
-                put("KEY1", "VALUE1");                                  //indent:16 exp:20,24 warn
-                put("KEY2", "VALUE2");                                  //indent:16 exp:20,24 warn
-            }});                                                        //indent:12 exp:16,20 warn
-    }                                                                   //indent:4 exp:4
-
-    void testNestedMethodArgDoubleBrace() {                             //indent:4 exp:4
-        accept(expectReadToEnd(new HashMap<>() {{                       //indent:8 exp:8
-                    put("KEY1", "VALUE1");                              //indent:20 exp:20
-                    put("KEY2", "VALUE2");                              //indent:20 exp:20
-                }}));                                                   //indent:16 exp:16
-    }                                                                   //indent:4 exp:4
-
-    void testChainedMethodArgDoubleBrace() {                            //indent:4 exp:4
-        foo()                                                           //indent:8 exp:8
-            .accept(new HashMap<>() {{                                  //indent:12 exp:12
-                        put("KEY1", "VALUE1");                          //indent:24 exp:24
-                        put("KEY2", "VALUE2");                          //indent:24 exp:24
-                    }})                                                 //indent:20 exp:20
-            .bar();                                                     //indent:12 exp:12
-    }                                                                   //indent:4 exp:4
-
-    void testKafkaStyleDoubleBrace() {                                  //indent:4 exp:4
-        foo()                                                           //indent:8 exp:8
-                .doAnswer(expectReadToEnd(new HashMap<>() {{            //indent:16 exp:16
-                            put("KEY1", "VALUE1");                      //indent:28 exp:28
-                            put("KEY2", "VALUE2");                      //indent:28 exp:28
-                        }}))                                            //indent:24 exp:24
-                .when(configLog).readToEnd();                           //indent:16 exp:16
-    }                                                                   //indent:4 exp:4
-
-    private void accept(String name, Map<String, String> values) {}     //indent:4 exp:4
-    private void accept(Object value) {}                                //indent:4 exp:4
-    private Map<String, String> expectReadToEnd(                        //indent:4 exp:4
-            Map<String, String> values) {                               //indent:12 exp:12
-        return values;                                                  //indent:8 exp:8
-    }                                                                   //indent:4 exp:4
-    private FluentCallChain foo() {                                     //indent:4 exp:4
-        return new FluentCallChain();                                   //indent:8 exp:8
+    void testWrongInnerIndent() {                                       //indent:4 exp:4
+        var map = new HashMap<>() {{                                    //indent:8 exp:8
+      put("KEY1", "VALUE1");                                            //indent:6 exp:12,16 warn
+                            put("KEY2", "VALUE2");                      //indent:28 exp:12,16 warn
+        }};                                                             //indent:8 exp:8
     }                                                                   //indent:4 exp:4
 
     private static final class FluentCallChain {                        //indent:4 exp:4
-
-        private FluentCallChain accept(Map<String, String> values) {    //indent:8 exp:8
-            return this;                                                //indent:12 exp:12
-        }                                                               //indent:8 exp:8
-        private FluentCallChain bar() {                                 //indent:8 exp:8
-            return this;                                                //indent:12 exp:12
-        }                                                               //indent:8 exp:8
-        private FluentCallChain doAnswer(Object answer) {               //indent:8 exp:8
-            return this;                                                //indent:12 exp:12
-        }                                                               //indent:8 exp:8
-        private FluentCallChain when(FluentCallChain chain) {           //indent:8 exp:8
-            return this;                                                //indent:12 exp:12
-        }                                                               //indent:8 exp:8
         private void readToEnd() {}                                     //indent:8 exp:8
     }                                                                   //indent:4 exp:4
 }                                                                       //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationDoubleBraceInit2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationDoubleBraceInit2.java
@@ -1,0 +1,81 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
+
+import java.util.HashMap;                                               //indent:0 exp:0
+import java.util.Map;                                                   //indent:0 exp:0
+
+/**                                                                     //indent:0 exp:0
+ * This test-input is intended to be checked using following            //indent:1 exp:1
+ * configuration:                                                       //indent:1 exp:1
+ *                                                                      //indent:1 exp:1
+ * arrayInitIndent = 4                                                  //indent:1 exp:1
+ * basicOffset = 4                                                      //indent:1 exp:1
+ * braceAdjustment = 0                                                  //indent:1 exp:1
+ * caseIndent = 4                                                       //indent:1 exp:1
+ * forceStrictCondition = false                                         //indent:1 exp:1
+ * lineWrappingIndentation = 4                                          //indent:1 exp:1
+ * tabWidth = 4                                                         //indent:1 exp:1
+ * throwsIndent = 4                                                     //indent:1 exp:1
+ */                                                                     //indent:1 exp:1
+public class InputIndentationDoubleBraceInit2 {                         //indent:0 exp:0
+
+    private final FluentCallChain configLog = new FluentCallChain();    //indent:4 exp:4
+
+    void testWrappedMethodArgDoubleBrace() {                            //indent:4 exp:4
+        accept("first",                                                 //indent:8 exp:8
+            new HashMap<>() {{                                          //indent:12 exp:12
+                put("KEY1", "VALUE1");                                  //indent:16 exp:16
+                put("KEY2", "VALUE2");                                  //indent:16 exp:16
+            }});                                                        //indent:12 exp:12
+    }                                                                   //indent:4 exp:4
+
+    void testNestedMethodArgDoubleBrace() {                             //indent:4 exp:4
+        accept(expectReadToEnd(new HashMap<>() {{                       //indent:8 exp:8
+            put("KEY1", "VALUE1");                                      //indent:12 exp:12
+            put("KEY2", "VALUE2");                                      //indent:12 exp:12
+        }}));                                                           //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+
+    void testChainedMethodArgDoubleBrace() {                            //indent:4 exp:4
+        foo()                                                           //indent:8 exp:8
+            .accept(new HashMap<>() {{                                  //indent:12 exp:12
+                put("KEY1", "VALUE1");                                  //indent:16 exp:16
+                put("KEY2", "VALUE2");                                  //indent:16 exp:16
+            }})                                                         //indent:12 exp:12
+            .bar();                                                     //indent:12 exp:12
+    }                                                                   //indent:4 exp:4
+
+    void testKafkaStyleDoubleBrace() {                                  //indent:4 exp:4
+        foo()                                                           //indent:8 exp:8
+                .doAnswer(expectReadToEnd(new HashMap<>() {{            //indent:16 exp:16
+                            put("KEY1", "VALUE1");                      //indent:28 exp:20,24 warn
+                            put("KEY2", "VALUE2");                      //indent:28 exp:20,24 warn
+                        }}))                                            //indent:24 exp:16,20 warn
+                .when(configLog).readToEnd();                           //indent:16 exp:16
+    }                                                                   //indent:4 exp:4
+
+    private void accept(String name, Map<String, String> values) {}     //indent:4 exp:4
+    private void accept(Object value) {}                                //indent:4 exp:4
+    private Map<String, String> expectReadToEnd(                        //indent:4 exp:4
+            Map<String, String> values) {                               //indent:12 exp:12
+        return values;                                                  //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+    private FluentCallChain foo() {                                     //indent:4 exp:4
+        return new FluentCallChain();                                   //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+
+    private static final class FluentCallChain {                        //indent:4 exp:4
+        private FluentCallChain accept(Map<String, String> values) {    //indent:8 exp:8
+            return this;                                                //indent:12 exp:12
+        }                                                               //indent:8 exp:8
+        private FluentCallChain bar() {                                 //indent:8 exp:8
+            return this;                                                //indent:12 exp:12
+        }                                                               //indent:8 exp:8
+        private FluentCallChain doAnswer(Object answer) {               //indent:8 exp:8
+            return this;                                                //indent:12 exp:12
+        }                                                               //indent:8 exp:8
+        private FluentCallChain when(FluentCallChain chain) {           //indent:8 exp:8
+            return this;                                                //indent:12 exp:12
+        }                                                               //indent:8 exp:8
+        private void readToEnd() {}                                     //indent:8 exp:8
+    }                                                                   //indent:4 exp:4
+}                                                                       //indent:0 exp:0


### PR DESCRIPTION
Issue: #19415

`IndentationCheck` reported false positives for compact double-brace
initialization such as `new HashMap<>() {{ put(...); }}`.

The handler chain is `NewHandler` -> `ObjectBlockHandler` ->
`INSTANCE_INIT` `SlistHandler` -> `SLIST` `SlistHandler`. The inner
`SLIST` added another `basicOffset` on top of the anonymous class
children indent, so statements at column 12 were expected at 16/20.

Same-line double-brace init now uses the anonymous class indent as the
base, so inner statements are expected at that level plus `basicOffset`
and are still checked. Separate-line instance initializers are unchanged.

## Testing

Executed:

- `mvn surefire:test -Dtest=IndentationCheckTest#testDoubleBraceInit`
  - 1/1
- `mvn surefire:test -Dtest=IndentationCheckTest`
  - IndentationCheckTest 225/225