### PR TITLE
supplemental: Update references to new java styleguide version

### DIFF
--- a/src/site/xdoc/checks/naming/classtypeparametername.xml
+++ b/src/site/xdoc/checks/naming/classtypeparametername.xml
@@ -113,7 +113,7 @@ class Example2 {
       <subsection name="Use Cases" id="ClassTypeParameterName_Use_Cases">
         <p id="UseCase1-config">
           To configure the check for names that are camel case word with T as suffix
-          (<a href="../../styleguides/google-java-style-20250426/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
+          (<a href="../../styleguides/google-java-style-20260409/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;

--- a/src/site/xdoc/checks/naming/classtypeparametername.xml.template
+++ b/src/site/xdoc/checks/naming/classtypeparametername.xml.template
@@ -65,7 +65,7 @@
       <subsection name="Use Cases" id="ClassTypeParameterName_Use_Cases">
         <p id="UseCase1-config">
           To configure the check for names that are camel case word with T as suffix
-          (<a href="../../styleguides/google-java-style-20250426/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
+          (<a href="../../styleguides/google-java-style-20260409/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
         </p>
         <macro name="example">
           <param name="path"


### PR DESCRIPTION
Issue: #20936
Updating references in checks to new google style guide version

last:
```
atharv@atharv-IdeaPad-3-15IIL05:~/Desktop/oss/checkstyle$ grep -ir "google-java-style-20250426"
grep: .git/index: binary file matches
atharv@atharv-IdeaPad-3-15IIL05:~/Desktop/oss/checkstyle$
```