### PR TITLE
Issue #19803: Move AnnotationUseStyle violation comments above annotations

### DIFF
--- a/config/checkstyle-input-suppressions.xml
+++ b/config/checkstyle-input-suppressions.xml
@@ -290,16 +290,6 @@
             files="/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrectOne\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"
             files="/com/puppycrawl/tools/checkstyle/checks/annotation/annotationonsameline/InputAnnotationOnSameLineCheckTokensOnMethodAndVar\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleCompactNoArray\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleDifferentStyles\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleExpanded\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleNoTrailingComma\.java"/>
-  <suppress id="violationBetweenAnnotationAndMethod"
-            files="/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleWithTrailingCommaIgnore\.java"/>
   <suppress id="violationBetweenJavadocAndMethod"
             files="/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadDeprecated\.java"/>
   <suppress id="violationBetweenAnnotationAndMethod"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
@@ -105,20 +105,20 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testDefault() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "14:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "21:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "23:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "29:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "30:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "35:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "42:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "45:5: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "53:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "55:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "59:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "88:32: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "91:40: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "15:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "16:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "24:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "26:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "34:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "35:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "40:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "47:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "51:5: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "60:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "63:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "68:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "97:32: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "100:40: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
         };
 
         verifyWithInlineConfigParser(
@@ -164,16 +164,16 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testStyleExpanded() throws Exception {
         final String[] expected = {
-            "14:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "21:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "29:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "35:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "48:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "50:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "67:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "72:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "15:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "23:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "32:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "39:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "53:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "56:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "74:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
             "80:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "84:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "89:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "94:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
         };
 
         verifyWithInlineConfigParser(
@@ -197,15 +197,15 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testStyleCompactNoArray() throws Exception {
         final String[] expected = {
-            "13:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "14:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "21:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "29:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "30:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "35:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "52:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "54:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "58:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "15:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "16:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "23:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "33:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "34:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "39:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "57:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "60:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "65:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
         };
 
         verifyWithInlineConfigParser(
@@ -215,19 +215,19 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testCommaAlwaysViolations() throws Exception {
         final String[] expected = {
-            "12:20: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "15:30: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "20:40: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "24:45: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "28:55: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "38:22: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "38:36: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "42:21: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "42:30: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "47:39: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "47:49: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "52:21: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "52:41: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "13:20: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "17:30: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "22:40: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "26:45: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "30:55: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "43:22: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "43:36: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "44:21: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "44:30: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "49:39: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "49:49: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "54:21: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "54:41: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
         };
 
         verifyWithInlineConfigParser(
@@ -264,10 +264,10 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTrailingArrayIgnore() throws Exception {
         final String[] expected = {
-            "15:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "23:13: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "35:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "42:9: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "16:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "24:13: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "36:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "43:9: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleCompactNoArray.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleCompactNoArray.java
@@ -9,9 +9,11 @@ trailingArrayComma = ignore
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
+// violation 3 lines below 'Annotation style must be 'COMPACT_NO_ARRAY''
+// violation 3 lines below 'Annotation style must be 'COMPACT_NO_ARRAY''
 @Deprecated
-@SomeArraysDiffStyle(pooches={DOGS.LEO}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
-@SuppressWarnings({""}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+@SomeArraysDiffStyle(pooches={DOGS.LEO})
+@SuppressWarnings({""})
 public class InputAnnotationUseStyleCompactNoArray
 {
 
@@ -25,9 +27,11 @@ class Dep6 {
 
 }
 
+// violation 3 lines below 'Annotation style must be 'COMPACT_NO_ARRAY''
+// violation 3 lines below 'Annotation style must be 'COMPACT_NO_ARRAY''
 @Deprecated
-@SomeArraysDiffStyle(pooches={DOGS.LEO}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
-@SuppressWarnings({""}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+@SomeArraysDiffStyle(pooches={DOGS.LEO})
+@SuppressWarnings({""})
 enum SON6 {
 
     // violation 2 lines below 'Annotation style must be 'COMPACT_NO_ARRAY''
@@ -49,13 +53,16 @@ enum DOGS6 {
 @interface SomeArrays6 {
     @Another("") //compact
     String[] um() default {};
-    @Another({""}) //compact // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+    // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+    @Another({""}) //compact
     String[] duh() default {};
-    @Another(value={""}) //expanded // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+    // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+    @Another(value={""}) //expanded
     DOGS[] pooches();
 }
 
-@Another(value={""}) //expanded // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+// violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+@Another(value={""}) //expanded
 enum E6 {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleDifferentStyles.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleDifferentStyles.java
@@ -9,25 +9,30 @@ trailingArrayComma = (default)never
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
+// violation 3 lines below 'Annotation style must be 'COMPACT_NO_ARRAY''
+// violation 3 lines below 'Annotation style must be 'COMPACT_NO_ARRAY''
 @Deprecated
-@SomeArraysDiffStyle(pooches={DOGS.LEO}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
-@SuppressWarnings({""}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+@SomeArraysDiffStyle(pooches={DOGS.LEO})
+@SuppressWarnings({""})
 public class InputAnnotationUseStyleDifferentStyles
 {
 
 }
 
-// violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+// violation 2 lines below 'Annotation style must be 'COMPACT_NO_ARRAY''
+// violation 3 lines below 'Annotation cannot have closing parenthesis'
 @SomeArraysDiffStyle(pooches={DOGS.LEO},um={}, duh={"ignore"})
 @SuppressWarnings("") //compact_no_array
-@Deprecated() // violation 'Annotation cannot have closing parenthesis'
+@Deprecated()
 class Dep {
 
 }
 
+// violation 3 lines below 'Annotation style must be 'COMPACT_NO_ARRAY''
+// violation 3 lines below 'Annotation style must be 'COMPACT_NO_ARRAY''
 @Deprecated
-@SomeArraysDiffStyle(pooches={DOGS.LEO}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY'
-@SuppressWarnings({""}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+@SomeArraysDiffStyle(pooches={DOGS.LEO})
+@SuppressWarnings({""})
 enum SON {
 
     // violation 2 lines below 'Annotation style must be 'COMPACT_NO_ARRAY''
@@ -42,7 +47,8 @@ enum SON {
 @InputAnnotationUseStyleCustomAnnotation3()
 enum DOGS {
 
-    @Deprecated() // violation 'Annotation cannot have closing parenthesis'
+    // violation below 'Annotation cannot have closing parenthesis'
+    @Deprecated()
     LEO,
     HERBIE
 }
@@ -50,13 +56,16 @@ enum DOGS {
 @interface SomeArraysDiffStyle {
     @Another("") //compact
     String[] um() default {};
-    @Another({""}) //compact // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+    // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+    @Another({""}) //compact
     String[] duh() default {};
-    @Another(value={""}) //expanded // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+    // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+    @Another(value={""}) //expanded
     DOGS[] pooches();
 }
 
-@Another(value={""}) //expanded // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+// violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+@Another(value={""}) //expanded
 enum E {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleExpanded.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleExpanded.java
@@ -9,30 +9,34 @@ trailingArrayComma = ignore
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
+// violation 3 lines below 'Annotation style must be 'EXPANDED''
 @Deprecated
 @SomeArraysDiffStyle(pooches={DOGS.LEO})
-@SuppressWarnings({""}) // violation 'Annotation style must be 'EXPANDED''
+@SuppressWarnings({""})
 public class InputAnnotationUseStyleExpanded
 {
 
 }
 
+// violation 2 lines below 'Annotation style must be 'EXPANDED''
 @SomeArraysDiffStyle(pooches={DOGS.LEO}, um={}, duh={"ignore"})
-@SuppressWarnings("") //compact_no_array // violation 'Annotation style must be 'EXPANDED''
+@SuppressWarnings("") //compact_no_array
 @Deprecated()
 class Dep4 {
 
 }
 
+// violation 3 lines below 'Annotation style must be 'EXPANDED''
 @Deprecated
 @SomeArraysDiffStyle(pooches={DOGS.LEO})
-@SuppressWarnings({""}) // violation 'Annotation style must be 'EXPANDED''
+@SuppressWarnings({""})
 enum SON4 {
 
+    // violation 4 lines below 'Annotation style must be 'EXPANDED''
     @Deprecated
     @SomeArraysDiffStyle(pooches={DOGS.LEO}, um={""}, duh={"ignore"})
     @APooch(dog=DOGS.HERBIE)
-    @Another("") //compact_no_array // violation 'Annotation style must be 'EXPANDED''
+    @Another("") //compact_no_array
     ETHAN
 }
 
@@ -45,9 +49,11 @@ enum DOGS4 {
 }
 
 @interface SomeArrays4 {
-    @Another("") //compact // violation 'Annotation style must be 'EXPANDED''
+    // violation below 'Annotation style must be 'EXPANDED''
+    @Another("") //compact
     String[] um() default {};
-    @Another({""}) //compact // violation 'Annotation style must be 'EXPANDED''
+    // violation below 'Annotation style must be 'EXPANDED''
+    @Another({""}) //compact
     String[] duh() default {};
     @Another(value={""}) //expanded
     DOGS[] pooches();
@@ -64,12 +70,14 @@ enum E4 {
 
 @interface Another4 {
     String[] value() default {};
-    @Another({"foo", "bar"}) //compact style // violation 'Annotation style must be 'EXPANDED''
+    // violation below 'Annotation style must be 'EXPANDED''
+    @Another({"foo", "bar"}) //compact style
     String value1() default "";
 }
 
+// violation 2 lines below 'Annotation style must be 'EXPANDED''
 @SomeArraysDiffStyle(pooches = {})
-@Another({}) // violation 'Annotation style must be 'EXPANDED''
+@Another({})
 class Closing4 {
     static final String UN_U = "UN_U";
 
@@ -77,11 +85,13 @@ class Closing4 {
     int d;
 }
 
-@AnnotationWithAnnotationValue(@Another) // violation 'Annotation style must be 'EXPANDED''
+// violation below 'Annotation style must be 'EXPANDED''
+@AnnotationWithAnnotationValue(@Another)
 class Example13 {}
 @AnnotationWithAnnotationValue(value = @Another)
 class Example14 {}
-@AnnotationWithAnnotationValue(@Another()) // violation 'Annotation style must be 'EXPANDED''
+// violation below 'Annotation style must be 'EXPANDED''
+@AnnotationWithAnnotationValue(@Another())
 class Example15 {}
 @AnnotationWithAnnotationValue(value = @Another())
 class Example16 {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleNoTrailingComma.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleNoTrailingComma.java
@@ -9,10 +9,12 @@ trailingArrayComma = ALWAYS
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
-@SuppressWarnings({}) // violation 'Annotation array values must contain trailing comma'
+// violation below 'Annotation array values must contain trailing comma'
+@SuppressWarnings({})
 public class InputAnnotationUseStyleNoTrailingComma
 {
-  @SuppressWarnings({"common"}) // violation 'Annotation array values must contain trailing comma'
+  // violation below 'Annotation array values must contain trailing comma'
+  @SuppressWarnings({"common"})
   public void foo() {
 
       /** Suppress warnings */
@@ -32,13 +34,13 @@ public class InputAnnotationUseStyleNoTrailingComma
           }
       };
   }
-  // 2 violations 3 lines below:
+  // 2 violations 6 lines below:
+  // 'Annotation array values must contain trailing comma.'
+  // 'Annotation array values must contain trailing comma.'
+  // 2 violations 4 lines below:
   // 'Annotation array values must contain trailing comma.'
   // 'Annotation array values must contain trailing comma.'
   @Test2(value={"foo"}, more={"bar"})
-  // 2 violations 3 lines below:
-  // 'Annotation array values must contain trailing comma.'
-  // 'Annotation array values must contain trailing comma.'
   @Pooches2(tokens={},other={})
   enum P {
       // 2 violations 3 lines below:

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleWithTrailingCommaIgnore.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleWithTrailingCommaIgnore.java
@@ -12,7 +12,8 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
 public class InputAnnotationUseStyleWithTrailingCommaIgnore
 {
-    @SuppressWarnings({"common",}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+    // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+    @SuppressWarnings({"common",})
     public void foo() {
 
 


### PR DESCRIPTION
Issue: #19803

Moved AnnotationUseStyle violation comments above annotations in the 5 suppressed inputs (CompactNoArray, DifferentStyles, Expanded, NoTrailingComma, WithTrailingCommaIgnore), updated expected lines in AnnotationUseStyleCheckTest, and removed the related violationBetweenAnnotationAndMethod suppressions.

Testing: `./mvnw clean verify` passed locally.

Continues #19803