### PR TITLE
Issue #21137: add default config example for SuppressionSingleFilter

### DIFF
--- a/src/site/xdoc/filters/suppressionsinglefilter.xml
+++ b/src/site/xdoc/filters/suppressionsinglefilter.xml
@@ -20,13 +20,20 @@
             <input type="checkbox" id="toc-sub-Examples" class="toc-sub-toggle-checkbox" checked="checked"/>
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#SuppressionSingleFilter_Examples">Examples</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
-              <li><a href="#Example1-config" class="toc-sublink">A filter to suppress violations of <code>NoWhitespaceAfter</code> and <code>MagicNumber</code> checks in <code>Example1.java</code> for specific line ranges using <code>SuppressionSingleFilter</code></a></li>
-              <li><a href="#Example2-config" class="toc-sublink">A filter to suppress violations of <code>NoWhitespaceAfter</code> on a specific column in <code>Example2.java</code> using <code>SuppressionSingleFilter</code></a></li>
-              <li><a href="#Example3-config" class="toc-sublink">A filter to suppress violations of <code>RegexpSinglelineCheck</code> in <code>Example3.java</code> using <code>SuppressionSingleFilter</code></a></li>
-              <li><a href="#Example4-config" class="toc-sublink">A filter to suppress violations of <code>NoWhitespaceAfter</code> in <code>Example4.java</code> using <code>SuppressionSingleFilter</code></a></li>
-              <li><a href="#Example5-config" class="toc-sublink">A filter to suppress <code>MagicNumber</code> violations whose message matches <code>100</code> using <code>SuppressionSingleFilter</code></a></li>
-              <li><a href="#Example6-config" class="toc-sublink">A filter to suppress <code>MagicNumber</code> violations on specific line ranges using the <code>lines</code> property</a></li>
-              <li><a href="#Example7-config" class="toc-sublink">A filter to suppress <code>MagicNumber</code> violations using the <code>id</code> property</a></li>
+              <li><a href="#Example1-config" class="toc-sublink">The following example demonstrates the default configuration (no properties) that suppresses all violations</a></li>
+              <li><a href="#Example2-config" class="toc-sublink">A filter to suppress violations of <code>NoWhitespaceAfter</code> and <code>MagicNumber</code> checks in <code>Example2.java</code> for specific line ranges using <code>SuppressionSingleFilter</code></a></li>
+              <li><a href="#Example3-config" class="toc-sublink">A filter to suppress violations of <code>NoWhitespaceAfter</code> on a specific column in <code>Example3.java</code> using <code>SuppressionSingleFilter</code></a></li>
+              <li><a href="#Example4-config" class="toc-sublink">A filter to suppress violations of <code>RegexpSinglelineCheck</code> in <code>Example4.java</code> using <code>SuppressionSingleFilter</code></a></li>
+              <li><a href="#Example5-config" class="toc-sublink">A filter to suppress violations of <code>NoWhitespaceAfter</code> in <code>Example5.java</code> using <code>SuppressionSingleFilter</code></a></li>
+              <li><a href="#Example6-config" class="toc-sublink">A filter to suppress <code>MagicNumber</code> violations whose message matches <code>100</code> using <code>SuppressionSingleFilter</code></a></li>
+              <li><a href="#Example7-config" class="toc-sublink">A filter to suppress <code>MagicNumber</code> violations on specific line ranges using the <code>lines</code> property</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#SuppressionSingleFilter_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">A filter to suppress <code>MagicNumber</code> violations using the <code>id</code> property</a></li>
             </ul>
           </li>
           <li><a href="#SuppressionSingleFilter_Example_of_Usage">Example of Usage</a></li>
@@ -119,11 +126,8 @@
         </div>
       </subsection>
       <subsection name="Examples" id="SuppressionSingleFilter_Examples">
-        <p id="Example1-config">
-          To configure a filter to suppress violations of <code>NoWhitespaceAfter</code> and
-          <code>MagicNumber</code> checks in <code>Example1.java</code> for specific line ranges
-          using <code>SuppressionSingleFilter</code>:
-        </p>
+        <p id="Example1-config">The following example demonstrates the default
+        configuration (no properties) that suppresses all violations:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
@@ -131,12 +135,6 @@
     &lt;module name="MagicNumber"/&gt;
   &lt;/module&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
-    &lt;property name="checks" value="NoWhitespaceAfter|MagicNumber"/&gt;
-    &lt;property name="files" value="Example1.java"/&gt;
-    &lt;property name="lines" value="1,5-100"/&gt;
-  &lt;/module&gt;
-  &lt;module name="SuppressionSingleFilter"&gt;
-    &lt;property name="message" value="Missing a Javadoc comment for"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -162,8 +160,50 @@ public class Example1 {
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example2-config">
+          To configure a filter to suppress violations of <code>NoWhitespaceAfter</code> and
+          <code>MagicNumber</code> checks in <code>Example2.java</code> for specific line ranges
+          using <code>SuppressionSingleFilter</code>:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="NoWhitespaceAfter"/&gt;
+    &lt;module name="MagicNumber"/&gt;
+  &lt;/module&gt;
+  &lt;module name="SuppressionSingleFilter"&gt;
+    &lt;property name="checks" value="NoWhitespaceAfter|MagicNumber"/&gt;
+    &lt;property name="files" value="Example2.java"/&gt;
+    &lt;property name="lines" value="1,5-100"/&gt;
+  &lt;/module&gt;
+  &lt;module name="SuppressionSingleFilter"&gt;
+    &lt;property name="message" value="Missing a Javadoc comment for"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example2-code">
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example2 {
+  // filtered violation below ''5' is a magic number'
+  private int MyVariable = 5;
+
+  public void exampleMethod(int a, int b) {
+    int value = 100; // filtered violation ''100' is a magic number'
+
+    Integer. parseInt("3"); // filtered violation ''.' is followed by whitespace'
+  }
+
+  public void printExample() {
+    int [] x; // filtered violation ''int' is followed by whitespace'
+    System.out.println(
+            "example"
+    );
+  }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example3-config">
           To configure a filter to suppress violations of <code>NoWhitespaceAfter</code>
-          on a specific column in <code>Example2.java</code> using
+          on a specific column in <code>Example3.java</code> using
           <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
@@ -172,16 +212,16 @@ public class Example1 {
     &lt;module name="NoWhitespaceAfter"/&gt;
   &lt;/module&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
-    &lt;property name="files" value="Example2.java"/&gt;
+    &lt;property name="files" value="Example3.java"/&gt;
     &lt;property name="checks" value="NoWhitespaceAfter"/&gt;
     &lt;property name="columns" value="12"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example2-code">
+        <p id="Example3-code">
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example2 {
+public class Example3 {
 
   private int MyVariable = 5;
 
@@ -199,9 +239,9 @@ public class Example2 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example3-config">
+        <p id="Example4-config">
           To configure a filter to suppress violations of <code>RegexpSinglelineCheck</code>
-          in <code>Example3.java</code> using <code>SuppressionSingleFilter</code>:
+          in <code>Example4.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -209,15 +249,15 @@ public class Example2 {
     &lt;property name="format" value="example"/&gt;
   &lt;/module&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
-    &lt;property name="files" value="Example3.java"/&gt;
+    &lt;property name="files" value="Example4.java"/&gt;
     &lt;property name="checks" value="RegexpSinglelineCheck"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example3-code">
+        <p id="Example4-code">
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example3 {
+public class Example4 {
 
   private int MyVariable = 5;
   // filtered violation below 'Line matches the illegal pattern'
@@ -235,9 +275,9 @@ public class Example3 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example4-config">
+        <p id="Example5-config">
           To configure a filter to suppress violations of <code>NoWhitespaceAfter</code>
-          in <code>Example4.java</code> using <code>SuppressionSingleFilter</code>:
+          in <code>Example5.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
@@ -247,15 +287,15 @@ public class Example3 {
     &lt;/module&gt;
   &lt;/module&gt;
   &lt;module name="SuppressionSingleFilter"&gt;
-    &lt;property name="files" value="Example4.java"/&gt;
+    &lt;property name="files" value="Example5.java"/&gt;
     &lt;property name="id" value="customMemberName"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example4-code">
+        <p id="Example5-code">
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example4 {
+public class Example5 {
   // filtered violation below 'Name 'MyVariable' must match pattern'
   private int MyVariable = 5;
 
@@ -273,7 +313,7 @@ public class Example4 {
   }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example5-config">
+        <p id="Example6-config">
           To configure a filter to suppress <code>MagicNumber</code> violations
           whose message matches <code>100</code> using <code>SuppressionSingleFilter</code>:
         </p>
@@ -288,46 +328,11 @@ public class Example4 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example5-code">
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example5 {
-  // violation below ''5' is a magic number'
-  private int MyVariable = 5;
-
-  public void exampleMethod(int a, int b) {
-    int value = 100; // filtered violation ''100' is a magic number'
-
-    Integer. parseInt("3");
-  }
-
-  public void printExample() {
-    int [] x;
-    System.out.println(
-            "example"
-    );
-  }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example6-config">
-          To configure a filter to suppress <code>MagicNumber</code> violations
-          on specific line ranges using the <code>lines</code> property:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="MagicNumber"/&gt;
-  &lt;/module&gt;
-  &lt;module name="SuppressionSingleFilter"&gt;
-    &lt;property name="lines" value="1,5-100"/&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
         <p id="Example6-code">
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example6 {
-  // filtered violation below ''5' is a magic number'
+  // violation below ''5' is a magic number'
   private int MyVariable = 5;
 
   public void exampleMethod(int a, int b) {
@@ -346,6 +351,43 @@ public class Example6 {
 </code></pre></div><hr class="example-separator"/>
         <p id="Example7-config">
           To configure a filter to suppress <code>MagicNumber</code> violations
+          on specific line ranges using the <code>lines</code> property:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="MagicNumber"/&gt;
+  &lt;/module&gt;
+  &lt;module name="SuppressionSingleFilter"&gt;
+    &lt;property name="lines" value="1,5-100"/&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example7-code">
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example7 {
+  // filtered violation below ''5' is a magic number'
+  private int MyVariable = 5;
+
+  public void exampleMethod(int a, int b) {
+    int value = 100; // filtered violation ''100' is a magic number'
+
+    Integer. parseInt("3");
+  }
+
+  public void printExample() {
+    int [] x;
+    System.out.println(
+            "example"
+    );
+  }
+}
+</code></pre></div>
+      </subsection>
+      <subsection name="Use Cases" id="SuppressionSingleFilter_Use_Cases">
+        <p id="UseCase1-config">
+          To configure a filter to suppress <code>MagicNumber</code> violations
           using the <code>id</code> property:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
@@ -360,10 +402,10 @@ public class Example6 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example7-code">
+        <p id="UseCase1-code">
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example7 {
+public class UseCase1 {
   // filtered violation below ''5' is a magic number'
   private int MyVariable = 5;
 

--- a/src/site/xdoc/filters/suppressionsinglefilter.xml.template
+++ b/src/site/xdoc/filters/suppressionsinglefilter.xml.template
@@ -36,11 +36,8 @@
         </div>
       </subsection>
       <subsection name="Examples" id="SuppressionSingleFilter_Examples">
-        <p id="Example1-config">
-          To configure a filter to suppress violations of <code>NoWhitespaceAfter</code> and
-          <code>MagicNumber</code> checks in <code>Example1.java</code> for specific line ranges
-          using <code>SuppressionSingleFilter</code>:
-        </p>
+        <p id="Example1-config">The following example demonstrates the default
+        configuration (no properties) that suppresses all violations:</p>
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example1.java"/>
@@ -54,9 +51,9 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example2-config">
-          To configure a filter to suppress violations of <code>NoWhitespaceAfter</code>
-          on a specific column in <code>Example2.java</code> using
-          <code>SuppressionSingleFilter</code>:
+          To configure a filter to suppress violations of <code>NoWhitespaceAfter</code> and
+          <code>MagicNumber</code> checks in <code>Example2.java</code> for specific line ranges
+          using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -71,8 +68,9 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example3-config">
-          To configure a filter to suppress violations of <code>RegexpSinglelineCheck</code>
-          in <code>Example3.java</code> using <code>SuppressionSingleFilter</code>:
+          To configure a filter to suppress violations of <code>NoWhitespaceAfter</code>
+          on a specific column in <code>Example3.java</code> using
+          <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -87,7 +85,7 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example4-config">
-          To configure a filter to suppress violations of <code>NoWhitespaceAfter</code>
+          To configure a filter to suppress violations of <code>RegexpSinglelineCheck</code>
           in <code>Example4.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
@@ -103,8 +101,8 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example5-config">
-          To configure a filter to suppress <code>MagicNumber</code> violations
-          whose message matches <code>100</code> using <code>SuppressionSingleFilter</code>:
+          To configure a filter to suppress violations of <code>NoWhitespaceAfter</code>
+          in <code>Example5.java</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -120,7 +118,7 @@
         </macro><hr class="example-separator"/>
         <p id="Example6-config">
           To configure a filter to suppress <code>MagicNumber</code> violations
-          on specific line ranges using the <code>lines</code> property:
+          whose message matches <code>100</code> using <code>SuppressionSingleFilter</code>:
         </p>
         <macro name="example">
           <param name="path"
@@ -136,7 +134,7 @@
         </macro><hr class="example-separator"/>
         <p id="Example7-config">
           To configure a filter to suppress <code>MagicNumber</code> violations
-          using the <code>id</code> property:
+          on specific line ranges using the <code>lines</code> property:
         </p>
         <macro name="example">
           <param name="path"
@@ -148,6 +146,24 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example7.java"/>
+          <param name="type" value="code"/>
+        </macro>
+      </subsection>
+      <subsection name="Use Cases" id="SuppressionSingleFilter_Use_Cases">
+        <p id="UseCase1-config">
+          To configure a filter to suppress <code>MagicNumber</code> violations
+          using the <code>id</code> property:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/UseCase1.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="UseCase1-code">
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/UseCase1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -154,7 +154,6 @@ public class XdocsExamplesAstConsistencyTest {
             "checks/descendanttoken",
             "checks/imports/importcontrol",
             "filters/severitymatchfilter",
-            "filters/suppressionsinglefilter",
             "filters/suppressionxpathfilter",
             "filters/suppresswithplaintextcommentfilter"
     );

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilterExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilterExamplesTest.java
@@ -40,11 +40,11 @@ public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample1() throws Exception {
         final String[] expectedWithoutFilter = {
-            "21:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "5"),
-            "24:17: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "100"),
-            "26:12: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+            "15:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "5"),
+            "18:17: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "100"),
+            "20:12: " + getCheckMessage(NoWhitespaceAfterCheck.class,
                     NoWhitespaceAfterCheck.MSG_KEY, "."),
-            "30:9: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+            "24:9: " + getCheckMessage(NoWhitespaceAfterCheck.class,
                     NoWhitespaceAfterCheck.MSG_KEY, "int"),
         };
         final String[] expectedWithFilter = {};
@@ -56,6 +56,22 @@ public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample2() throws Exception {
         final String[] expectedWithoutFilter = {
+            "21:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "5"),
+            "24:17: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "100"),
+            "26:12: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "."),
+            "30:9: " + getCheckMessage(NoWhitespaceAfterCheck.class,
+                    NoWhitespaceAfterCheck.MSG_KEY, "int"),
+        };
+        final String[] expectedWithFilter = {};
+
+        verifyFilterWithInlineConfigParser(getPath("Example2.java"),
+                expectedWithoutFilter, expectedWithFilter);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expectedWithoutFilter = {
             "22:12: " + getCheckMessage(NoWhitespaceAfterCheck.class,
                     NoWhitespaceAfterCheck.MSG_KEY, "."),
             "26:9: " + getCheckMessage(NoWhitespaceAfterCheck.class,
@@ -66,19 +82,6 @@ public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleT
                     NoWhitespaceAfterCheck.MSG_KEY, "int"),
         };
 
-        verifyFilterWithInlineConfigParser(getPath("Example2.java"),
-                expectedWithoutFilter, expectedWithFilter);
-    }
-
-    @Test
-    public void testExample3() throws Exception {
-        final String[] expectedWithoutFilter = {
-            "4: " + getCheckMessage(RegexpCheck.class, MSG_ILLEGAL_REGEXP, "example"),
-            "19: " + getCheckMessage(RegexpCheck.class, MSG_ILLEGAL_REGEXP, "example"),
-            "28: " + getCheckMessage(RegexpCheck.class, MSG_ILLEGAL_REGEXP, "example"),
-        };
-        final String[] expectedWithFilter = {};
-
         verifyFilterWithInlineConfigParser(getPath("Example3.java"),
                 expectedWithoutFilter, expectedWithFilter);
     }
@@ -86,8 +89,9 @@ public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample4() throws Exception {
         final String[] expectedWithoutFilter = {
-            "18:15: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern",
-                    "MyVariable", "^[a-z][a-zA-Z0-9]*$"),
+            "4: " + getCheckMessage(RegexpCheck.class, MSG_ILLEGAL_REGEXP, "example"),
+            "19: " + getCheckMessage(RegexpCheck.class, MSG_ILLEGAL_REGEXP, "example"),
+            "28: " + getCheckMessage(RegexpCheck.class, MSG_ILLEGAL_REGEXP, "example"),
         };
         final String[] expectedWithFilter = {};
 
@@ -98,12 +102,10 @@ public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample5() throws Exception {
         final String[] expectedWithoutFilter = {
-            "16:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "5"),
-            "19:17: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "100"),
+            "18:15: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern",
+                    "MyVariable", "^[a-z][a-zA-Z0-9]*$"),
         };
-        final String[] expectedWithFilter = {
-            "16:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "5"),
-        };
+        final String[] expectedWithFilter = {};
 
         verifyFilterWithInlineConfigParser(getPath("Example5.java"),
                 expectedWithoutFilter, expectedWithFilter);
@@ -112,10 +114,12 @@ public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample6() throws Exception {
         final String[] expectedWithoutFilter = {
-            "15:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "5"),
-            "18:17: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "100"),
+            "16:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "5"),
+            "19:17: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "100"),
         };
-        final String[] expectedWithFilter = {};
+        final String[] expectedWithFilter = {
+            "16:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "5"),
+        };
 
         verifyFilterWithInlineConfigParser(getPath("Example6.java"),
                 expectedWithoutFilter, expectedWithFilter);
@@ -124,12 +128,24 @@ public class SuppressionSingleFilterExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample7() throws Exception {
         final String[] expectedWithoutFilter = {
+            "15:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "5"),
+            "18:17: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "100"),
+        };
+        final String[] expectedWithFilter = {};
+
+        verifyFilterWithInlineConfigParser(getPath("Example7.java"),
+                expectedWithoutFilter, expectedWithFilter);
+    }
+
+    @Test
+    public void testUseCase1() throws Exception {
+        final String[] expectedWithoutFilter = {
             "17:28: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "5"),
             "20:17: " + getCheckMessage(MagicNumberCheck.class, MSG_KEY, "100"),
         };
         final String[] expectedWithFilter = {};
 
-        verifyFilterWithInlineConfigParser(getPath("Example7.java"),
+        verifyFilterWithInlineConfigParser(getPath("UseCase1.java"),
                 expectedWithoutFilter, expectedWithFilter);
     }
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example2.java
@@ -2,28 +2,32 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="NoWhitespaceAfter"/>
+    <module name="MagicNumber"/>
   </module>
   <module name="SuppressionSingleFilter">
+    <property name="checks" value="NoWhitespaceAfter|MagicNumber"/>
     <property name="files" value="Example2.java"/>
-    <property name="checks" value="NoWhitespaceAfter"/>
-    <property name="columns" value="12"/>
+    <property name="lines" value="1,5-100"/>
+  </module>
+  <module name="SuppressionSingleFilter">
+    <property name="message" value="Missing a Javadoc comment for"/>
   </module>
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section - start
 public class Example2 {
-
+  // filtered violation below ''5' is a magic number'
   private int MyVariable = 5;
 
   public void exampleMethod(int a, int b) {
-    int value = 100;
-    // filtered violation below ''.' is followed by whitespace'
-    Integer. parseInt("3");
+    int value = 100; // filtered violation ''100' is a magic number'
+
+    Integer. parseInt("3"); // filtered violation ''.' is followed by whitespace'
   }
 
   public void printExample() {
-    int [] x; // violation ''int' is followed by whitespace'
+    int [] x; // filtered violation ''int' is followed by whitespace'
     System.out.println(
             "example"
     );

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example3.java
@@ -1,31 +1,31 @@
 /*xml
 <module name="Checker">
-  <module name="RegexpSingleline">
-    <property name="format" value="example"/>
+  <module name="TreeWalker">
+    <module name="NoWhitespaceAfter"/>
   </module>
   <module name="SuppressionSingleFilter">
     <property name="files" value="Example3.java"/>
-    <property name="checks" value="RegexpSinglelineCheck"/>
+    <property name="checks" value="NoWhitespaceAfter"/>
+    <property name="columns" value="12"/>
   </module>
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
-// filtered violation 9 lines above 'Line matches the illegal pattern'
 // xdoc section - start
 public class Example3 {
 
   private int MyVariable = 5;
-  // filtered violation below 'Line matches the illegal pattern'
+
   public void exampleMethod(int a, int b) {
     int value = 100;
-
+    // filtered violation below ''.' is followed by whitespace'
     Integer. parseInt("3");
   }
 
   public void printExample() {
-    int [] x;
+    int [] x; // violation ''int' is followed by whitespace'
     System.out.println(
-            "example" // filtered violation 'Line matches the illegal pattern'
+            "example"
     );
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example4.java
@@ -1,22 +1,21 @@
 /*xml
 <module name="Checker">
-  <module name="TreeWalker">
-    <module name="MemberName">
-      <property name="id" value="customMemberName"/>
-    </module>
+  <module name="RegexpSingleline">
+    <property name="format" value="example"/>
   </module>
   <module name="SuppressionSingleFilter">
     <property name="files" value="Example4.java"/>
-    <property name="id" value="customMemberName"/>
+    <property name="checks" value="RegexpSinglelineCheck"/>
   </module>
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
+// filtered violation 9 lines above 'Line matches the illegal pattern'
 // xdoc section - start
 public class Example4 {
-  // filtered violation below 'Name 'MyVariable' must match pattern'
-  private int MyVariable = 5;
 
+  private int MyVariable = 5;
+  // filtered violation below 'Line matches the illegal pattern'
   public void exampleMethod(int a, int b) {
     int value = 100;
 
@@ -26,7 +25,7 @@ public class Example4 {
   public void printExample() {
     int [] x;
     System.out.println(
-            "example"
+            "example" // filtered violation 'Line matches the illegal pattern'
     );
   }
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example5.java
@@ -1,22 +1,24 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="MagicNumber"/>
+    <module name="MemberName">
+      <property name="id" value="customMemberName"/>
+    </module>
   </module>
   <module name="SuppressionSingleFilter">
-    <property name="checks" value="MagicNumber"/>
-    <property name="message" value="100"/>
+    <property name="files" value="Example5.java"/>
+    <property name="id" value="customMemberName"/>
   </module>
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section - start
 public class Example5 {
-  // violation below ''5' is a magic number'
+  // filtered violation below 'Name 'MyVariable' must match pattern'
   private int MyVariable = 5;
 
   public void exampleMethod(int a, int b) {
-    int value = 100; // filtered violation ''100' is a magic number'
+    int value = 100;
 
     Integer. parseInt("3");
   }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example6.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example6.java
@@ -4,14 +4,15 @@
     <module name="MagicNumber"/>
   </module>
   <module name="SuppressionSingleFilter">
-    <property name="lines" value="1,5-100"/>
+    <property name="checks" value="MagicNumber"/>
+    <property name="message" value="100"/>
   </module>
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section - start
 public class Example6 {
-  // filtered violation below ''5' is a magic number'
+  // violation below ''5' is a magic number'
   private int MyVariable = 5;
 
   public void exampleMethod(int a, int b) {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example7.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/Example7.java
@@ -1,12 +1,10 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="MagicNumber">
-      <property name="id" value="customMagicNumber"/>
-    </module>
+    <module name="MagicNumber"/>
   </module>
   <module name="SuppressionSingleFilter">
-    <property name="id" value="customMagicNumber"/>
+    <property name="lines" value="1,5-100"/>
   </module>
 </module>
 */

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/filters/suppressionsinglefilter/UseCase1.java
@@ -1,27 +1,29 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="NoWhitespaceAfter"/>
-    <module name="MagicNumber"/>
+    <module name="MagicNumber">
+      <property name="id" value="customMagicNumber"/>
+    </module>
   </module>
   <module name="SuppressionSingleFilter">
+    <property name="id" value="customMagicNumber"/>
   </module>
 </module>
 */
 package com.puppycrawl.tools.checkstyle.filters.suppressionsinglefilter;
 // xdoc section - start
-public class Example1 {
+public class UseCase1 {
   // filtered violation below ''5' is a magic number'
   private int MyVariable = 5;
 
   public void exampleMethod(int a, int b) {
     int value = 100; // filtered violation ''100' is a magic number'
 
-    Integer. parseInt("3"); // filtered violation ''.' is followed by whitespace'
+    Integer. parseInt("3");
   }
 
   public void printExample() {
-    int [] x; // filtered violation ''int' is followed by whitespace'
+    int [] x;
     System.out.println(
             "example"
     );


### PR DESCRIPTION
Adds a zero-property `SuppressionSingleFilter` example and removes `filters/suppressionsinglefilter` from `EXAMPLE_DEFAULT_CONFIG_SUPPRESSED_MODULES`.

One suppression, per https://github.com/checkstyle/checkstyle/issues/21137.