### PR TITLE
Issue #21430: Add checks for Sun Style 6.3 - Placement

### DIFF
--- a/src/it/java/com/sun/checkstyle/test/chapter6declarations/rule63placement/PlacementTest.java
+++ b/src/it/java/com/sun/checkstyle/test/chapter6declarations/rule63placement/PlacementTest.java
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.sun.checkstyle.test.chapter6declarations.rule63placement;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.checkstyle.test.base.AbstractSunModuleTestSupport;
+
+public class PlacementTest extends AbstractSunModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/sun/checkstyle/test/chapter6declarations/rule63placement";
+    }
+
+    @Test
+    public void testPlacementGood() throws Exception {
+        verifyWithWholeConfig(getPath("InputPlacementGood.java"));
+    }
+
+    @Test
+    public void testPlacementBad() throws Exception {
+        verifyWithWholeConfig(getPath("InputPlacementBad.java"));
+    }
+
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter6declarations/rule63placement/InputPlacementBad.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter6declarations/rule63placement/InputPlacementBad.java
@@ -1,0 +1,13 @@
+package com.sun.checkstyle.test.chapter6declarations.rule63placement;
+// violation first line 'Header mismatch.*'
+
+final class InputPlacementBad {
+
+    /** Current count. */
+    private int count;
+
+    void setCount(final int count) { // violation ''count' hides a field'
+        this.count = count;
+    }
+
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter6declarations/rule63placement/InputPlacementGood.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter6declarations/rule63placement/InputPlacementGood.java
@@ -1,0 +1,13 @@
+package com.sun.checkstyle.test.chapter6declarations.rule63placement;
+// violation first line 'Header mismatch.*'
+
+final class InputPlacementGood {
+
+    /** Current count. */
+    private int count;
+
+    void setCount(final int newCount) {
+        count = newCount;
+    }
+
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter6declarations/rule63placement/package-info.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter6declarations/rule63placement/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Test inputs for the placement/hidden field check in Sun style.
+ */
+package com.sun.checkstyle.test.chapter6declarations.rule63placement;

--- a/src/site/xdoc/sun-style.xml
+++ b/src/site/xdoc/sun-style.xml
@@ -567,8 +567,33 @@
                     6.3 Placement
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_blue.png" alt=""/>
+                  </span>
+                  <a href="checks/coding/hiddenfield.html#HiddenField">
+                    HiddenField
+                  </a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+HiddenField">
+                    config
+                  </a>)
+                  <br/>
+                  <br/>
+                  <span class="wrapper inline">
+                    <img src="images/ban_red.png" alt=""/>
+                  </span>
+                  The rule that declarations should be placed only at the
+                  beginning of blocks is a subjective style preference, contrary
+                  to modern Java guidance (delaying declaration until first use
+                  is in fact flagged by Checkstyle's own
+                  <a href="checks/coding/variabledeclarationusagedistance.html#VariableDeclarationUsageDistance">
+                    VariableDeclarationUsageDistance</a> check), so no
+                  Checkstyle check is provided for it.
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/sun/checkstyle/test/chapter6declarations/rule63placement">
+                    samples</a>
+                </td>
               </tr>
               <tr>
                 <td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -192,7 +192,6 @@ public class XdocsPagesTest {
             "FinalClass",
             "FinalParameters",
             "GenericWhitespace",
-            "HiddenField",
             "HideUtilityClassConstructor",
             "IllegalImport",
             "IllegalInstantiation",


### PR DESCRIPTION
Issue #21430

### What
Documents `HiddenField` coverage for Sun Style **6.3 Placement** and adds an integration test suite, per the process described in #20811 and #21430.

### Details
- `src/site/xdoc/sun-style.xml`: fills in the 6.3 coverage row.
  - `HiddenField` (already present and active in `sun_checks.xml` with default configuration) covers the rule to avoid local declarations that hide a higher-level declaration. Marked `ok_blue` (partial) since the section's other rule is not automatable.
  - Notes that the rule to place declarations only at the beginning of blocks is a subjective style preference (the opposite of what modern Java guidance, including Checkstyle's own `VariableDeclarationUsageDistance`, recommends), so no Checkstyle check is provided for it - per maintainer feedback on #21430.
- `src/test/java/.../XdocsPagesTest.java`: removes `HiddenField` from `IGNORED_SUN_MODULES` now that it is documented.
- `src/it/resources/com/sun/checkstyle/test/chapter6declarations/rule63placement/`: new integration test input files (good/bad hidden field).
- `src/it/java/com/sun/checkstyle/test/chapter6declarations/rule63placement/PlacementTest.java`: new integration test class, following the same chapter-wise test structure as sibling PRs.

### Testing
- `XdocsPagesTest` passes (20/20).
- New `PlacementTest` passes (2/2).

Reference: #21430 (child issue), #20811 (parent epic).