### PR TITLE
minor: fix href for google style coverage page 4.6.1 Vertical Whitespace

### DIFF
--- a/src/site/xdoc/google-style.xml
+++ b/src/site/xdoc/google-style.xml
@@ -1007,7 +1007,7 @@
                   </a>
                 </td>
                 <td>
-                  <a href="styleguides/google-java-style-20260409/javaguide.html#s4.6.1-vertical-whitespace (blank lines)">
+                  <a href="styleguides/google-java-style-20260409/javaguide.html#s4.6.1-vertical-whitespace">
                     4.6.1 Vertical Whitespace: Blank Lines</a>
                 </td>
                 <td>


### PR DESCRIPTION
Issue: #20936

Fixes href for section 4.6.1 Vertical Whitespace: Blank Lines
ref: https://github.com/checkstyle/checkstyle/blob/0bfa5972ff36ef3501f6684814dd43c4abb0e062/src/site/resources/styleguides/google-java-style-20260409/javaguide.html#L527