### PR TITLE
Issue #21207: Remove now-empty MODULES_WITHOUT_DEFAULT_FIRST_EXAMPLE collection

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -111,14 +111,6 @@ public class XdocsExampleFileTest {
         "checks/regexp/regexpsingleline/"
     );
 
-    /**
-     * Modules whose numerically-first example (Example1) is not the default-config
-     * example, temporarily suppressed pending reordering or renumbering of examples.
-     *
-     * <p>Until: <a href="https://github.com/checkstyle/checkstyle/issues/21207">...</a>
-     */
-    private static final Set<String> MODULES_WITHOUT_DEFAULT_FIRST_EXAMPLE = Set.of();
-
     @Test
     public void testAllCheckPropertiesAreUsedInXdocsExamples() throws Exception {
         final Map<String, Set<String>> usedPropertiesByCheck =
@@ -586,12 +578,11 @@ public class XdocsExampleFileTest {
 
             final String moduleName = XdocsExamplesAstConsistencyTest
                 .toModuleClassSimpleName(dir.getFileName().toString());
-            final String relativePath = XdocsExamplesAstConsistencyTest.XDOCS_ROOT
-                .relativize(dir).toString().replace(File.separatorChar, '/');
 
             if (moduleName != null && !examples.isEmpty()
-                && !XdocsExamplesAstConsistencyTest.isModuleWithNoProperties(examples)
-                && !MODULES_WITHOUT_DEFAULT_FIRST_EXAMPLE.contains(relativePath)) {
+                && !XdocsExamplesAstConsistencyTest.isModuleWithNoProperties(examples)) {
+                final String relativePath = XdocsExamplesAstConsistencyTest.XDOCS_ROOT
+                    .relativize(dir).toString().replace(File.separatorChar, '/');
                 final String xmlModuleName =
                     XdocsExamplesAstConsistencyTest.stripCheckSuffix(moduleName);
                 checkDefaultConfigExampleOrder(examples, xmlModuleName,


### PR DESCRIPTION
## Summary
- Follow-up to bfc9dfa3af per romani's review comment: since `MODULES_WITHOUT_DEFAULT_FIRST_EXAMPLE` in `XdocsExampleFileTest` is now `Set.of()` (empty), remove the unused collection field, its javadoc, and its usage in `processDirectoryForDefaultConfigOrderCheck`.

Closes #21207

## Test plan
- [x] `./mvnw test -Dtest=com.puppycrawl.tools.checkstyle.internal.XdocsExampleFileTest` — 5/5 tests pass