### PR TITLE
Issue #13408: Minimum length for name should 3 chars - catchparametername

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -941,7 +941,7 @@
       <property name="format" value="^(?:id|[a-z][a-z0-9][a-zA-Z0-9]+)$"/>
     </module>
     <module name="CatchParameterName">
-      <property name="format" value="^[a-z][a-z][a-zA-Z]+$"/>
+      <property name="format" value="^(e|t|[a-z][a-z][a-zA-Z]+|_)$"/>
     </module>
     <module name="StaticVariableName">
       <property name="format" value="^(?:id|[a-z][a-z0-9][a-zA-Z0-9]+)$"/>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionCatchParameterNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/naming/XpathRegressionCatchParameterNameTest.java
@@ -47,7 +47,7 @@ public class XpathRegressionCatchParameterNameTest extends AbstractXpathTestSupp
 
     @Test
     public void testSimple() throws Exception {
-        final String pattern = "^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$";
+        final String pattern = "^(e|t|[a-z][a-z][a-zA-Z]+|_)$";
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CatchParameterNameCheck.class);
@@ -72,7 +72,7 @@ public class XpathRegressionCatchParameterNameTest extends AbstractXpathTestSupp
 
     @Test
     public void testNested() throws Exception {
-        final String pattern = "^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$";
+        final String pattern = "^(e|t|[a-z][a-z][a-zA-Z]+|_)$";
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CatchParameterNameCheck.class);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheck.java
@@ -34,7 +34,6 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <li>allows names beginning with two lowercase letters followed by at least one uppercase or
  * lowercase letter</li>
  * <li>allows {@code e} abbreviation (suitable for exceptions end errors)</li>
- * <li>allows {@code ex} abbreviation (suitable for exceptions)</li>
  * <li>allows {@code t} abbreviation (suitable for throwables)</li>
  * <li>allows {@code _} for unnamed catch parameters</li>
  * <li>prohibits numbered abbreviations like {@code e1} or {@code t2}</li>
@@ -51,7 +50,7 @@ public class CatchParameterNameCheck extends AbstractNameCheck {
      * Creates a new {@code CatchParameterNameCheck} instance.
      */
     public CatchParameterNameCheck() {
-        super("^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$");
+        super("^(e|t|[a-z][a-z][a-zA-Z]+|_)$");
     }
 
     @Override

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/CatchParameterNameCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/CatchParameterNameCheck.xml
@@ -15,7 +15,6 @@
  &lt;li&gt;allows names beginning with two lowercase letters followed by at least one uppercase or
  lowercase letter&lt;/li&gt;
  &lt;li&gt;allows &lt;code&gt;e&lt;/code&gt; abbreviation (suitable for exceptions end errors)&lt;/li&gt;
- &lt;li&gt;allows &lt;code&gt;ex&lt;/code&gt; abbreviation (suitable for exceptions)&lt;/li&gt;
  &lt;li&gt;allows &lt;code&gt;t&lt;/code&gt; abbreviation (suitable for throwables)&lt;/li&gt;
  &lt;li&gt;allows &lt;code&gt;_&lt;/code&gt; for unnamed catch parameters&lt;/li&gt;
  &lt;li&gt;prohibits numbered abbreviations like &lt;code&gt;e1&lt;/code&gt; or &lt;code&gt;t2&lt;/code&gt;&lt;/li&gt;
@@ -24,7 +23,7 @@
  &lt;li&gt;prohibits any other characters than letters&lt;/li&gt;
  &lt;/ul&gt;</description>
          <properties>
-            <property default-value="^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$"
+            <property default-value="^(e|t|[a-z][a-z][a-zA-Z]+|_)$"
                       name="format"
                       type="java.util.regex.Pattern">
                <description>Sets the pattern to match valid identifiers.</description>

--- a/src/site/xdoc/checks/naming/catchparametername.xml
+++ b/src/site/xdoc/checks/naming/catchparametername.xml
@@ -43,7 +43,6 @@
         <li>allows names beginning with two lowercase letters followed by at least one uppercase or
           lowercase letter</li>
         <li>allows <code>e</code> abbreviation (suitable for exceptions end errors)</li>
-        <li>allows <code>ex</code> abbreviation (suitable for exceptions)</li>
         <li>allows <code>t</code> abbreviation (suitable for throwables)</li>
         <li>allows <code>_</code> for unnamed catch parameters</li>
         <li>prohibits numbered abbreviations like <code>e1</code> or <code>t2</code></li>
@@ -67,7 +66,7 @@
               <td><a id="format"/><a href="#format">format</a></td>
               <td>Sets the pattern to match valid identifiers.</td>
               <td><a href="../../property-types.html#Pattern">Pattern</a></td>
-              <td><code>^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$</code></td>
+              <td><code>^(e|t|[a-z][a-z][a-zA-Z]+|_)$</code></td>
               <td>6.14</td>
             </tr>
           </table>
@@ -95,6 +94,7 @@ public class Example1 {
     } catch (ArithmeticException e) {
 
     } catch (ArrayIndexOutOfBoundsException ex) {
+      // violation above 'Name 'ex' must match pattern'
     } catch (IndexOutOfBoundsException e123) {
       // violation above 'Name 'e123' must match pattern'
     } catch (NullPointerException ab) {
@@ -134,6 +134,7 @@ public class Example2 {
     } catch (ArithmeticException e) {
       // violation above 'Name 'e' must match pattern'
     } catch (ArrayIndexOutOfBoundsException ex) {
+
     } catch (IndexOutOfBoundsException e123) {
 
     } catch (NullPointerException ab) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheckTest.java
@@ -66,9 +66,10 @@ public class CatchParameterNameCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testDefaultConfigurationOnFileWithViolations() throws Exception {
-        final String defaultFormat = "^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$";
+        final String defaultFormat = "^(e|t|[a-z][a-z][a-zA-Z]+|_)$";
 
         final String[] expected = {
+            "16:28: " + getCheckMessage(MSG_INVALID_PATTERN, "ex", defaultFormat),
             "25:28: " + getCheckMessage(MSG_INVALID_PATTERN, "exception1", defaultFormat),
             "35:39: " + getCheckMessage(MSG_INVALID_PATTERN, "ie", defaultFormat),
             "38:28: " + getCheckMessage(MSG_INVALID_PATTERN, "iException", defaultFormat),
@@ -106,7 +107,7 @@ public class CatchParameterNameCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testCatchParameterNameUnnamed() throws Exception {
-        final String defaultFormat = "^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$";
+        final String defaultFormat = "^(e|t|[a-z][a-z][a-zA-Z]+|_)$";
 
         final String[] expected = {
             "18:28: " + getCheckMessage(MSG_INVALID_PATTERN, "__", defaultFormat),

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/InputCatchParameterName.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/InputCatchParameterName.java
@@ -1,6 +1,6 @@
 /*
 CatchParameterName
-format = (default)^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$
+format = (default)^(e|t|[a-z][a-z][a-zA-Z]+|_)$
 
 
 */
@@ -13,7 +13,7 @@ public class InputCatchParameterName {
         } catch (Exception e) {
         }
         try {
-        } catch (Exception ex) {
+        } catch (Exception ex) { // violation 'Name 'ex' must match pattern'
         }
         try {
         } catch (Error | Exception err) {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/InputCatchParameterNameUnnamed.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/InputCatchParameterNameUnnamed.java
@@ -1,6 +1,6 @@
 /*
 CatchParameterName
-format = (default)^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$
+format = (default)^(e|t|[a-z][a-z][a-zA-Z]+|_)$
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/InputCatchParameterNameSimple2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/InputCatchParameterNameSimple2.java
@@ -1,6 +1,6 @@
 /*
 CatchParameterName
-format = (default)^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$
+format = (default)^(e|t|[a-z][a-z][a-zA-Z]+|_)$
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/InputCatchParameterNameSimpleOne1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/InputCatchParameterNameSimpleOne1.java
@@ -1,6 +1,6 @@
 /*
 CatchParameterName
-format = (default)^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$
+format = (default)^(e|t|[a-z][a-z][a-zA-Z]+|_)$
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/InputCatchParameterNameSimpleOne2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/InputCatchParameterNameSimpleOne2.java
@@ -1,6 +1,6 @@
 /*
 CatchParameterName
-format = (default)^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$
+format = (default)^(e|t|[a-z][a-z][a-zA-Z]+|_)$
 
 
 */

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheckExamplesTest.java
@@ -27,7 +27,7 @@ import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
 
 public class CatchParameterNameCheckExamplesTest extends AbstractExamplesModuleTestSupport {
 
-    private static final String CATCH_PARAM_NAME_PATTERN_1 = "^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$";
+    private static final String CATCH_PARAM_NAME_PATTERN_1 = "^(e|t|[a-z][a-z][a-zA-Z]+|_)$";
     private static final String CATCH_PARAM_NAME_PATTERN_2 = "^[a-z][a-zA-Z0-9]+$";
 
     @Override
@@ -38,13 +38,15 @@ public class CatchParameterNameCheckExamplesTest extends AbstractExamplesModuleT
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "19:40: " + getCheckMessage(MSG_INVALID_PATTERN, "e123",
+            "18:45: " + getCheckMessage(MSG_INVALID_PATTERN, "ex",
                     CATCH_PARAM_NAME_PATTERN_1),
-            "21:35: " + getCheckMessage(MSG_INVALID_PATTERN, "ab",
+            "20:40: " + getCheckMessage(MSG_INVALID_PATTERN, "e123",
                     CATCH_PARAM_NAME_PATTERN_1),
-            "24:35: " + getCheckMessage(MSG_INVALID_PATTERN, "aBC",
+            "22:35: " + getCheckMessage(MSG_INVALID_PATTERN, "ab",
                     CATCH_PARAM_NAME_PATTERN_1),
-            "27:24: " + getCheckMessage(MSG_INVALID_PATTERN, "EighthException",
+            "25:35: " + getCheckMessage(MSG_INVALID_PATTERN, "aBC",
+                    CATCH_PARAM_NAME_PATTERN_1),
+            "28:24: " + getCheckMessage(MSG_INVALID_PATTERN, "EighthException",
                     CATCH_PARAM_NAME_PATTERN_1),
         };
 
@@ -56,9 +58,9 @@ public class CatchParameterNameCheckExamplesTest extends AbstractExamplesModuleT
         final String[] expected = {
             "18:34: " + getCheckMessage(MSG_INVALID_PATTERN, "e",
                     CATCH_PARAM_NAME_PATTERN_2),
-            "29:24: " + getCheckMessage(MSG_INVALID_PATTERN, "EighthException",
+            "30:24: " + getCheckMessage(MSG_INVALID_PATTERN, "EighthException",
                     CATCH_PARAM_NAME_PATTERN_2),
-            "31:24: " + getCheckMessage(MSG_INVALID_PATTERN, "t",
+            "32:24: " + getCheckMessage(MSG_INVALID_PATTERN, "t",
                     CATCH_PARAM_NAME_PATTERN_2),
         };
 

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/Example1.java
@@ -16,6 +16,7 @@ public class Example1 {
     } catch (ArithmeticException e) {
 
     } catch (ArrayIndexOutOfBoundsException ex) {
+      // violation above 'Name 'ex' must match pattern'
     } catch (IndexOutOfBoundsException e123) {
       // violation above 'Name 'e123' must match pattern'
     } catch (NullPointerException ab) {

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/naming/catchparametername/Example2.java
@@ -18,6 +18,7 @@ public class Example2 {
     } catch (ArithmeticException e) {
       // violation above 'Name 'e' must match pattern'
     } catch (ArrayIndexOutOfBoundsException ex) {
+
     } catch (IndexOutOfBoundsException e123) {
 
     } catch (NullPointerException ab) {


### PR DESCRIPTION
#13408 

**Changes:**
- Updated `CatchParameterNameCheck` default regex pattern from `^(e|t|ex|[a-z][a-z][a-zA-Z]+|_)$` to `^(e|t|[a-z][a-z][a-zA-Z]+|_)$`
- Removed `ex` (2-character abbreviation) from allowed catch parameter names
- Updated Javadoc documentation to reflect the new pattern
- Updated all test files to account for the new violation on `ex`
- Updated xdocs-examples files and tests
- Updated metadata XML file


```
[INFO] Reflections took 81 ms to scan 1 urls, producing 241 keys and 241 values
[INFO] [checkstyle] Running Checkstyle  on 2609 files
[ERROR] [checkstyle] [ERROR] C:\Users\Smita Prajapati\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\internal\XdocsExampleFileTest.java:171:40: Name 'ex' must match pattern '^[a-z][a-z][a-zA-Z]+$'. [CatchParameterName]
[INFO]      [echo] Checkstyle finished (checkstyl
```