### PR TITLE
Issue #21460: Merge duplicate Surefire `argLine` configuration elements

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -103,6 +103,7 @@
   <suppress checks="ClassDataAbstractionCoupling"
              files="XpathFileGeneratorAuditListenerTest\.java"/>
   <suppress checks="ClassFanOutComplexity" files="/Main\.java"/>
+  <suppress checks="ClassFanOutComplexity" files="MainTest\.java"/>
   <suppress checks="ClassFanOutComplexity" files="CheckerTest\.java"/>
   <suppress checks="ClassFanOutComplexity" files="Checker\.java"/>
   <suppress checks="ClassFanOutComplexity" files="AbstractAutomaticBean\.java"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1813,7 +1813,6 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.6.0</version>
         <configuration>
-          <argLine>-Dfile.encoding=UTF-8 ${surefire.options}</argLine>
           <systemPropertyVariables>
             <jacoco-agent.destfile>${project.build.directory}/jacoco.exec</jacoco-agent.destfile>
             <!-- Virtual AWT driver for GUI unit tests -->
@@ -1824,6 +1823,7 @@
             </java.awt.graphicsenv>
           </systemPropertyVariables>
           <argLine>
+            -Dfile.encoding=UTF-8 ${surefire.options}
             --add-exports=java.desktop/java.awt=ALL-UNNAMED
             --add-exports=java.desktop/java.awt.peer=ALL-UNNAMED
             --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junitpioneer.jupiter.DefaultLocale;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -68,6 +69,7 @@ import com.puppycrawl.tools.checkstyle.internal.testmodules.TestRootModuleChecke
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.ChainedPropertyUtil;
 
+@DefaultLocale("en")
 @ExtendWith({SystemErrGuard.class, SystemOutGuard.class})
 public class MainTest {
 


### PR DESCRIPTION
Issue #21460.

The `maven-surefire-plugin` configuration declared two sibling `argLine` elements. Maven does not merge or concatenate duplicate sibling configuration elements for a scalar Mojo parameter; only one survives, silently discarding the `-Dfile.encoding=UTF-8 ${surefire.options}` value contributed by the first element.