### PR TITLE
Issue #21119: Remove already-fixed avoidstarimport/patternvariablename suppressions

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -101,11 +101,9 @@ public class XdocsExampleFileTest {
     private static final Set<String> SUPPRESSED_UNIQUENESS_CHECK_MODULES = Set.of(
         "checks/coding/hiddenfield/",
         "checks/coding/returncount/",
-        "checks/imports/avoidstarimport/",
         "checks/javadoc/javadocvariable/",
         "checks/javadoc/missingjavadoctype/",
         "checks/naming/illegalidentifiername/",
-        "checks/naming/patternvariablename/",
         "checks/outertypefilename/",
         "checks/regexp/regexpmultiline/",
         "checks/regexp/regexpsingleline/"


### PR DESCRIPTION
## Description

Removes `checks/imports/avoidstarimport/` and `checks/naming/patternvariablename/`
from `SUPPRESSED_UNIQUENESS_CHECK_MODULES` in `XdocsExampleFileTest`, two of the
modules listed in #21119.

Both were already made behaviorally unique by the earlier "align examples with
property count" PRs (#43762aaf49 / #d1e3e49f73, tracked under #21229), but the
suppression entries were never cleaned up afterward.

## Testing

- `testAllModuleExamplesAreBehaviorallyUnique` passes for both modules without
  the suppression.
- `./mvnw -Dexec.skip=true clean test -Dtest=XdocsExampleFileTest` — 5/5 green.