### PR TITLE
Issue #21119: Fix duplicate violation behavior in examples: returncount

### DIFF
--- a/src/site/xdoc/checks/coding/returncount.xml
+++ b/src/site/xdoc/checks/coding/returncount.xml
@@ -23,7 +23,7 @@
               <li><a href="#Example1-config" class="toc-sublink">So that it doesn't allow more than three return statements per method (ignoring the <code>equals()</code> method)</a></li>
               <li><a href="#Example2-config" class="toc-sublink">So that it doesn't allow any return statements per void method</a></li>
               <li><a href="#Example3-config" class="toc-sublink">So that it doesn't allow more than 2 return statements per method (ignoring the <code>equals()</code> method) and more than 1 return statements per void method</a></li>
-              <li><a href="#Example4-config" class="toc-sublink">So that it doesn't allow more than three return statements per method for all methods</a></li>
+              <li><a href="#Example4-config" class="toc-sublink">So that it doesn't allow more than three return statements per method, ignoring the <code>signB()</code> method</a></li>
               <li><a href="#Example5-config" class="toc-sublink">So that it doesn't allow any return statements in constructors, more than one return statement in all lambda expressions and more than two return statements in methods</a></li>
             </ul>
           </li>
@@ -262,14 +262,15 @@ public class Example3 {
 </code></pre></div><hr class="example-separator"/>
         <p id="Example4-config">
           To configure the check so that it doesn't allow more than three
-          return statements per method for all methods:
+          return statements per method, ignoring the <code>signB()</code>
+          method:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
     &lt;module name="ReturnCount"&gt;
       &lt;property name="max" value="3"/&gt;
-      &lt;property name="format" value="^$"/&gt;
+      &lt;property name="format" value="^signB$"/&gt;
     &lt;/module&gt;
   &lt;/module&gt;
 &lt;/module&gt;
@@ -287,7 +288,7 @@ public class Example4 {
         if (x &lt; -2) { return -1; }
         return 0;
     }
-    // violation below 'max allowed for non-void methods/lambdas is 3'
+    // ok below, because 'signB' is ignored by 'format'
     public int signB(int x) {
         if (x &lt; -2) { return -1; }
         if (x == 0) { return 0; }

--- a/src/site/xdoc/checks/coding/returncount.xml.template
+++ b/src/site/xdoc/checks/coding/returncount.xml.template
@@ -87,7 +87,8 @@
         </macro><hr class="example-separator"/>
         <p id="Example4-config">
           To configure the check so that it doesn't allow more than three
-          return statements per method for all methods:
+          return statements per method, ignoring the <code>signB()</code>
+          method:
         </p>
         <macro name="example">
           <param name="path"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java
@@ -100,7 +100,6 @@ public class XdocsExampleFileTest {
      */
     private static final Set<String> SUPPRESSED_UNIQUENESS_CHECK_MODULES = Set.of(
         "checks/coding/hiddenfield/",
-        "checks/coding/returncount/",
         "checks/javadoc/javadocvariable/",
         "checks/javadoc/missingjavadoctype/",
         "checks/naming/illegalidentifiername/",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckExamplesTest.java
@@ -25,6 +25,7 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck.MSG
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractExamplesModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class ReturnCountCheckExamplesTest extends AbstractExamplesModuleTestSupport {
 
@@ -64,9 +65,7 @@ public class ReturnCountCheckExamplesTest extends AbstractExamplesModuleTestSupp
 
     @Test
     public void testExample4() throws Exception {
-        final String[] expected = {
-            "26:5: " + getCheckMessage(MSG_KEY, 4, 3),
-        };
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example4.java
@@ -3,7 +3,7 @@
   <module name="TreeWalker">
     <module name="ReturnCount">
       <property name="max" value="3"/>
-      <property name="format" value="^$"/>
+      <property name="format" value="^signB$"/>
     </module>
   </module>
 </module>
@@ -22,7 +22,7 @@ public class Example4 {
         if (x < -2) { return -1; }
         return 0;
     }
-    // violation below 'max allowed for non-void methods/lambdas is 3'
+    // ok below, because 'signB' is ignored by 'format'
     public int signB(int x) {
         if (x < -2) { return -1; }
         if (x == 0) { return 0; }


### PR DESCRIPTION
## Description

#21119

```
Module 'returncount': examples [Example1.java, Example4.java] produce identical violations
(26:max allowed for non-void methods/lambdas is 3).
```

Fixes the collision and removes `checks/coding/returncount/` from
`SUPPRESSED_UNIQUENESS_CHECK_MODULES`.

### Root cause

`Example4` set `format="^$"`, a pattern that matches no real method name,
intending to show the `max=3` restriction applying to every method (i.e.
without the default `equals()` exemption). Since the shared example source has
no method named `equals`, this had no observable effect versus `Example1`'s
implicit default — both flag the same single violation on `signB`.

### Fix

Kept `max="3"` and pointed `format` at `^signB$`, so the example filters out
the only violation the shared source produces at that limit. `Example4` now
demonstrates what `format` actually does — exempt a named method from the
`max` restriction — instead of using a pattern with no visible effect, and
its (empty) violation set is distinct from every sibling example.

### Files changed

- `src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example4.java`
- `src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckExamplesTest.java`
- `src/site/xdoc/checks/coding/returncount.xml.template` (updated `Example4-config` prose)
- `src/site/xdoc/checks/coding/returncount.xml` (regenerated)
- `src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExampleFileTest.java` — removed `"checks/coding/returncount/"` from `SUPPRESSED_UNIQUENESS_CHECK_MODULES`

## Testing

- `./mvnw -Dexec.skip=true clean test -Dtest=ReturnCountCheckExamplesTest,XdocsExampleFileTest,XdocsExamplesAstConsistencyTest,XdocsPagesTest` — 36/36 green.
