### PR TITLE
Issue #21454: enable treatTryResourcesAsStatement in google_checks

### DIFF
--- a/config/google-java-format/excluded/compilable-input-paths.txt
+++ b/config/google-java-format/excluded/compilable-input-paths.txt
@@ -24,6 +24,7 @@ src/it/resources/com/google/checkstyle/test/chapter4formatting/rule42blockindent
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLine.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLine2.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLineEdgeCases.java
+src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLineTryResources.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputColumnLimit.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputTextBlockColumnLimit.java
 src/it/resources/com/google/checkstyle/test/chapter4formatting/rule44columnlimit/InputColumnLimitEdgeCase.java

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java
@@ -60,4 +60,14 @@ public class OneStatementPerLineTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputFormattedOneStatementPerLineEdgeCases.java"));
     }
 
+    @Test
+    public void testOneStatementTryResourcesInput() throws Exception {
+        verifyWithWholeConfig(getPath("InputOneStatementPerLineTryResources.java"));
+    }
+
+    @Test
+    public void testOneStatementTryResourcesInputFormatted() throws Exception {
+        verifyWithWholeConfig(getPath("InputFormattedOneStatementPerLineTryResources.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputFormattedOneStatementPerLineTryResources.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputFormattedOneStatementPerLineTryResources.java
@@ -1,0 +1,51 @@
+package com.google.checkstyle.test.chapter4formatting.rule43onestatement;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PipedOutputStream;
+
+/** Some javadoc. */
+public class InputFormattedOneStatementPerLineTryResources {
+
+  /** Some javadoc. */
+  public void singleResource() throws IOException {
+    try (OutputStream s1 = new PipedOutputStream()) {
+      s1.flush();
+    }
+  }
+
+  /** Some javadoc. */
+  public void oneResourcePerLine() throws IOException {
+    try (OutputStream s1 = new PipedOutputStream();
+        OutputStream s2 = new PipedOutputStream()) {
+      s1.flush();
+    }
+  }
+
+  /** Some javadoc. */
+  public void multipleResourcesOnSameLine() throws IOException {
+    try (OutputStream s1 = new PipedOutputStream();
+        OutputStream s2 = new PipedOutputStream()) {
+      s1.flush();
+    }
+  }
+
+  /** Some javadoc. */
+  public void lastTwoResourcesOnSameLine() throws IOException {
+    try (OutputStream s1 = new PipedOutputStream();
+        OutputStream s2 = new PipedOutputStream();
+        OutputStream s3 = new PipedOutputStream()) {
+      s1.flush();
+    }
+  }
+
+  /** Some javadoc. */
+  public void nestedTryResources() throws IOException {
+    try (OutputStream s1 = new PipedOutputStream()) {
+      try (OutputStream s2 = new PipedOutputStream();
+          OutputStream s3 = new PipedOutputStream()) {
+        s2.flush();
+      }
+    }
+  }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLineTryResources.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement/InputOneStatementPerLineTryResources.java
@@ -1,0 +1,51 @@
+package com.google.checkstyle.test.chapter4formatting.rule43onestatement;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PipedOutputStream;
+
+/** Some javadoc. */
+public class InputOneStatementPerLineTryResources {
+
+  /** Some javadoc. */
+  public void singleResource() throws IOException {
+    try (OutputStream s1 = new PipedOutputStream()) {
+      s1.flush();
+    }
+  }
+
+  /** Some javadoc. */
+  public void oneResourcePerLine() throws IOException {
+    try (OutputStream s1 = new PipedOutputStream();
+        OutputStream s2 = new PipedOutputStream()) {
+      s1.flush();
+    }
+  }
+
+  /** Some javadoc. */
+  public void multipleResourcesOnSameLine() throws IOException {
+    // violation below 'Only one statement per line allowed.'
+    try (OutputStream s1 = new PipedOutputStream(); OutputStream s2 = new PipedOutputStream()) {
+      s1.flush();
+    }
+  }
+
+  /** Some javadoc. */
+  public void lastTwoResourcesOnSameLine() throws IOException {
+    try (OutputStream s1 = new PipedOutputStream();
+        OutputStream s2 = new PipedOutputStream(); OutputStream s3 = new PipedOutputStream()) {
+      // violation above 'Only one statement per line allowed.'
+      s1.flush();
+    }
+  }
+
+  /** Some javadoc. */
+  public void nestedTryResources() throws IOException {
+    try (OutputStream s1 = new PipedOutputStream()) {
+      // violation below 'Only one statement per line allowed.'
+      try (OutputStream s2 = new PipedOutputStream(); OutputStream s3 = new PipedOutputStream()) {
+        s2.flush();
+      }
+    }
+  }
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -224,7 +224,9 @@
     </module>
     <module name="ArrayBracketNoWhitespace"/>
     <module name="SingleSpaceSeparator"/>
-    <module name="OneStatementPerLine"/>
+    <module name="OneStatementPerLine">
+      <property name="treatTryResourcesAsStatement" value="true"/>
+    </module>
     <module name="MultipleVariableDeclarations"/>
     <module name="ArrayTypeStyle"/>
     <module name="JavadocLeadingAsteriskAlign"/>

--- a/src/site/xdoc/google-style.xml
+++ b/src/site/xdoc/google-style.xml
@@ -878,22 +878,12 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img src="images/ok_blue.png" alt="" />
+                    <img src="images/ok_green.png" alt="" />
                   </span>
                   <a href="checks/coding/onestatementperline.html#OneStatementPerLine">
                     OneStatementPerLine</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
                   config</a>)
-                  <br />
-                  <br />
-                  Not covered:
-                  <br />
-                  False negative for multiple resource declarations on the same line
-                  in a try-with-resources statement.
-                  Until:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/21454">
-                    #21454
-                  </a>
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule43onestatement">


### PR DESCRIPTION
## Description

Fixes #21454.

[4.3 One statement per line](https://google.github.io/styleguide/javaguide.html#s4.3-one-statement-per-line)
requires each statement to be followed by a line break, but multiple resource
declarations on a single line in a try-with-resources statement were not
flagged.

### Root cause

`google_checks.xml` configured `OneStatementPerLine` with defaults, and
`treatTryResourcesAsStatement` is `false` by default, so resource declarations
were never treated as statements.

```
$ cat Test2.java
...
    try (OutputStream s1 = new PipedOutputStream(); OutputStream s2 = new PipedOutputStream();) {
    }

$ java -jar checkstyle-14.1.0-all.jar -c /google_checks.xml Test2.java
Starting audit...
Audit done.
```

### Fix

Enabled the property:

```diff
-    <module name="OneStatementPerLine"/>
+    <module name="OneStatementPerLine">
+      <property name="treatTryResourcesAsStatement" value="true"/>
+    </module>
```

This is consistent with the style guide rather than merely satisfying the
report: `google-java-format` always splits a multi-resource list onto separate
lines (as shown by the formatter output in the issue), so the single-line form
is non-conforming.

### Files changed

- `src/main/resources/google_checks.xml` — enable the property.
- `src/it/resources/.../rule43onestatement/InputOneStatementPerLineTryResources.java` —
  new dedicated input for try-with-resources coverage: the flagged single-line
  forms (including a trailing pair and a nested `try`), plus compliant
  single-resource and one-per-line forms to guard against over-flagging.
- `src/it/resources/.../rule43onestatement/InputFormattedOneStatementPerLineTryResources.java` —
  violation-free formatted counterpart.
- `src/it/java/.../rule43onestatement/OneStatementPerLineTest.java` — two tests
  for the new inputs.
- `config/google-java-format/excluded/compilable-input-paths.txt` — exclude the
  intentionally unformatted input.
- `src/site/xdoc/google-style.xml` — removed the now-obsolete "Not covered ...
  Until #21454" note from rule 4.3.

## Testing

- All `com.google.checkstyle.test.**` tests pass — no fallout in the existing corpus.
- Verified the new coverage actually guards the fix: reverting only the
  `google_checks.xml` change makes
  `chapter4formatting.rule43onestatement.OneStatementPerLineTest` fail on
  exactly the new single-line cases.
- `XdocsPagesTest` and `AllChecksTest` pass, covering the style coverage page edit.

Note: the violation is reported at column 53 (start of the second resource)
rather than column 51 as quoted in the issue description.
