### PR TITLE
Issue #20590: Add AvoidInlineConditionals compact source coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheckTest.java
@@ -60,4 +60,15 @@ public class AvoidInlineConditionalsCheckTest
                 .isNotNull();
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "11:28: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                        "compact/InputAvoidInlineConditionalsCompactSourceFile.java"),
+                expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -97,7 +97,6 @@ public class AllChecksCompactSourceCoverageTest {
         "AtclauseOrderCheck",
         "AvoidDoubleBraceInitializationCheck",
         "AvoidEscapedUnicodeCharactersCheck",
-        "AvoidInlineConditionalsCheck",
         "AvoidNestedBlocksCheck",
         "AvoidNoArgumentSuperConstructorCallCheck",
         "AvoidStarImportCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/avoidinlineconditionals/compact/InputAvoidInlineConditionalsCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/avoidinlineconditionals/compact/InputAvoidInlineConditionalsCompactSourceFile.java
@@ -1,0 +1,12 @@
+/*
+AvoidInlineConditionals
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+    boolean condition = true;
+    int result = condition ? 1 : 0; // violation 'Avoid inline conditionals'
+}


### PR DESCRIPTION
Issue: #20590

Adds Java 25 compact-source coverage for `AvoidInlineConditionalsCheck`.

The new input verifies detection of an inline conditional using the default configuration. This also removes the check from the suppression list in `AllChecksCompactSourceCoverageTest`.

Validation:

- `./mvnw clean -Dtest=AvoidInlineConditionalsCheckTest,AllChecksCompactSourceCoverageTest test`
- `./mvnw clean verify`