### PR TITLE
Issue #21446: fixed false negative for 2.3.1 Whitespace in google_checks

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/WhitespaceCharactersTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/WhitespaceCharactersTest.java
@@ -40,4 +40,9 @@ public class WhitespaceCharactersTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputFormattedWhitespaceCharacters.java"));
     }
 
+    @Test
+    public void testNonEscapedWhitespaceCharacters() throws Exception {
+        verifyWithWholeConfig(getPath("InputNonEscapedWhitespaceCharacters.java"));
+    }
+
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule231filetab/InputNonEscapedWhitespaceCharacters.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule231filetab/InputNonEscapedWhitespaceCharacters.java
@@ -1,0 +1,168 @@
+package com.google.checkstyle.test.chapter2filebasic.rule231filetab;
+
+/** Some javadoc. */
+public class InputNonEscapedWhitespaceCharacters {
+
+  void rawWhitespace() {
+    String characterTabulationStr = "a	b";
+    // 2 violations above:
+    // 'Whitespace other than the ASCII space must be escaped.'
+    // 'Line contains a tab character.'
+    String lineTabulationStr = "ab";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String formFeedStr = "ab";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String nextLineStr = "ab";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String noBreakSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String oghamSpaceMarkStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String enQuadStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String emQuadStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String enSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String emSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String threePerEmSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String fourPerEmSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String sixPerEmSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String figureSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String punctuationSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String thinSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String hairSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String lineSeparatorStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String paragraphSeparatorStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String narrowNoBreakSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String mediumMathematicalSpaceStr = "a b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    String ideographicSpaceStr = "a　b";
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+
+    char characterTabulationChar = '	';
+    // 2 violations above:
+    // 'Whitespace other than the ASCII space must be escaped.'
+    // 'Line contains a tab character.'
+    char lineTabulationChar = '';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char formFeedChar = '';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char nextLineChar = '';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char noBreakSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char oghamSpaceMarkChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char enQuadChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char emQuadChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char enSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char emSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char threePerEmSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char fourPerEmSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char sixPerEmSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char figureSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char punctuationSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char thinSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char hairSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char lineSeparatorChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char paragraphSeparatorChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char narrowNoBreakSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char mediumMathematicalSpaceChar = ' ';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+    char ideographicSpaceChar = '　';
+    // violation above 'Whitespace other than the ASCII space must be escaped.'
+  }
+
+  void escapedWhitespace() {
+    String characterTabulationStr = "a\tb";
+    String lineTabulationStr = "a\u000Bb";
+    String formFeedStr = "a\fb";
+    String nextLineStr = "a\u0085b";
+    String noBreakSpaceStr = "a\u00A0b";
+    String oghamSpaceMarkStr = "a\u1680b";
+    String enQuadStr = "a\u2000b";
+    String emQuadStr = "a\u2001b";
+    String enSpaceStr = "a\u2002b";
+    String emSpaceStr = "a\u2003b";
+    String threePerEmSpaceStr = "a\u2004b";
+    String fourPerEmSpaceStr = "a\u2005b";
+    String sixPerEmSpaceStr = "a\u2006b";
+    String figureSpaceStr = "a\u2007b";
+    String punctuationSpaceStr = "a\u2008b";
+    String thinSpaceStr = "a\u2009b";
+    String hairSpaceStr = "a\u200Ab";
+    String lineSeparatorStr = "a\u2028b";
+    String paragraphSeparatorStr = "a\u2029b";
+    String narrowNoBreakSpaceStr = "a\u202Fb";
+    String mediumMathematicalSpaceStr = "a\u205Fb";
+    String ideographicSpaceStr = "a\u3000b";
+
+    char characterTabulationChar = '\t';
+    char lineTabulationChar = '\u000B';
+    char formFeedChar = '\f';
+    char nextLineChar = '\u0085';
+    char noBreakSpaceChar = '\u00A0';
+    char oghamSpaceMarkChar = '\u1680';
+    char enQuadChar = '\u2000';
+    char emQuadChar = '\u2001';
+    char enSpaceChar = '\u2002';
+    char emSpaceChar = '\u2003';
+    char threePerEmSpaceChar = '\u2004';
+    char fourPerEmSpaceChar = '\u2005';
+    char sixPerEmSpaceChar = '\u2006';
+    char figureSpaceChar = '\u2007';
+    char punctuationSpaceChar = '\u2008';
+    char thinSpaceChar = '\u2009';
+    char hairSpaceChar = '\u200A';
+    char lineSeparatorChar = '\u2028';
+    char paragraphSeparatorChar = '\u2029';
+    char narrowNoBreakSpaceChar = '\u202F';
+    char mediumMathematicalSpaceChar = '\u205F';
+    char ideographicSpaceChar = '\u3000';
+  }
+
+  void rawWhitespaceInTextBlock() {
+    // violation 2 lines below 'Whitespace other than the ASCII space must be escaped.'
+    String block =
+        """
+        line one
+        line two
+        line　three
+        """;
+  }
+
+  void escapedWhitespaceInTextBlock() {
+    String block =
+        """
+        line\u00A0one
+        line\u2003two
+        line\u3000three
+        """;
+  }
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -78,6 +78,14 @@
     <property name="onCommentFormat" value='.'/>
   </module>
   <module name="TreeWalker">
+    <module name="IllegalTokenText">
+      <property name="id" value="whitespaceCharactersMustBeEscaped"/>
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL, TEXT_BLOCK_CONTENT"/>
+      <property name="format"
+        value="[\u0009\u000B\u000C\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]"/>
+      <property name="message"
+                value="Whitespace other than the ASCII space must be escaped."/>
+    </module>
     <module name="OuterTypeFilename"/>
     <module name="MatchXpath">
       <property name="id" value="singleLineCommentStartWithSpace"/>

--- a/src/site/xdoc/google-style.xml
+++ b/src/site/xdoc/google-style.xml
@@ -244,7 +244,7 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img src="images/ok_blue.png" alt="" />
+                    <img src="images/ok_green.png" alt="" />
                   </span>
                   <a href="checks/whitespace/filetabcharacter.html#FileTabCharacter">
                     FileTabCharacter</a>
@@ -252,15 +252,12 @@
                   config</a>)
                   <br />
                   <br />
-                  Not covered:
-                  <br />
-                  All whitespace characters other than the ASCII horizontal space (0x20)
-                  and the line terminator sequence must be escaped in char and string
-                  literals and in text blocks.
-                  Until:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/21446">
-                    #21446
-                  </a>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/coding/illegaltokentext.html#IllegalTokenText">IllegalTokenText</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalTokenText+whitespaceCharactersMustBeEscaped">
+                  config</a>)
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule231filetab">


### PR DESCRIPTION
Issue: #21446 

refer: https://en.wikipedia.org/wiki/Whitespace_character

### What `format` covers

`value="[\u0009\u000B\u000C\u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]"`

The set is every Unicode `White_Space=yes` character except the ASCII space and the
line terminator sequence, per [2.3.1](https://google.github.io/styleguide/javaguide.html#s2.3.1-whitespace-characters).
Order and names follow [Whitespace character](https://en.wikipedia.org/wiki/Whitespace_character).

[JLS §3.4](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-3.4) defines
`LineTerminator` as LF, CR, or CR LF — nothing else — and `InputCharacter` as any Unicode
input character *but not CR or LF*. So LF and CR cannot appear raw in a character literal
([§3.10.4](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-3.10.4)) or a
string literal ([§3.10.5](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-3.10.5)),
and in a text block ([§3.10.6](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-3.10.6))
they are the line terminator sequence that 2.3.1 exempts. Every other whitespace character
is an ordinary `InputCharacter` and is therefore in scope — including U+0085, U+2028 and
U+2029, which are Unicode line breaks but not Java line terminators.

| Code point | Name | Regex token | Covered |
|---|---|---|:---:|
| U+0009 | character tabulation | `\u0009` | yes |
| U+000A | line feed | — | no |
| U+000B | line tabulation | `\u000B` | yes |
| U+000C | form feed | `\u000C` | yes |
| U+000D | carriage return | — | no |
| U+0020 | space | — | no |
| U+0085 | next line | `\u0085` | yes |
| U+00A0 | no-break space | `\u00A0` | yes |
| U+1680 | ogham space mark | `\u1680` | yes |
| U+2000 | en quad | `\u2000-\u200A` | yes |
| U+2001 | em quad | `\u2000-\u200A` | yes |
| U+2002 | en space | `\u2000-\u200A` | yes |
| U+2003 | em space | `\u2000-\u200A` | yes |
| U+2004 | three-per-em space | `\u2000-\u200A` | yes |
| U+2005 | four-per-em space | `\u2000-\u200A` | yes |
| U+2006 | six-per-em space | `\u2000-\u200A` | yes |
| U+2007 | figure space | `\u2000-\u200A` | yes |
| U+2008 | punctuation space | `\u2000-\u200A` | yes |
| U+2009 | thin space | `\u2000-\u200A` | yes |
| U+200A | hair space | `\u2000-\u200A` | yes |
| U+2028 | line separator | `\u2028` | yes |
| U+2029 | paragraph separator | `\u2029` | yes |
| U+202F | narrow no-break space | `\u202F` | yes |
| U+205F | medium mathematical space | `\u205F` | yes |
| U+3000 | ideographic space | `\u3000` | yes |

The eleven code points U+2000–U+200A are contiguous, hence the range rather than
eleven separate escapes. It stops at U+200A because U+200B is `White_Space=no`.