### PR TITLE
Issue #21478: fix IndexOutOfBoundsException in SuppressWarningsCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -298,10 +298,13 @@ public class SuppressWarningsCheck extends AbstractCheck {
                 condStack.push(getCondRight(currentCond));
                 condStack.push(getCondLeft(currentCond));
             }
-            else {
+            else if (currentCond.getType() == TokenTypes.STRING_LITERAL) {
                 final String warningText = removeQuotes(currentCond.getText());
                 logMatch(currentCond, warningText);
             }
+            // else: unsupported forms inside a ternary branch (string concatenation,
+            // casts, constant references, etc.) cannot be resolved to a literal value.
+            // These are silently skipped.
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckTest.java
@@ -1018,8 +1018,8 @@ public class SuppressWarningsCheckTest extends AbstractModuleTestSupport {
 
         final String[] expected = {
             "31:34: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, ""),
-            "38:23: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, ""),
-            "46:5: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, ""),
+            "40:23: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, ""),
+            "48:5: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, ""),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsHolder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsHolder.java
@@ -34,11 +34,13 @@ com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarnings.InputSuppress
     int h;
     @SuppressWarnings((String) "UN_U")
     int i;
+    @SuppressWarnings(true ? "un" + "used" : "unchecked")
+    int j;
     // violation below 'The warning '' cannot be suppressed at this location'
     @SuppressWarnings({})
-    int j;
-    @SuppressWarnings({UN_U})
     int k;
+    @SuppressWarnings({UN_U})
+    int l;
 }
 
 class CustomSuppressWarnings {


### PR DESCRIPTION
fixes: #21478 

Fixes the `StringIndexOutOfBoundsException` in `SuppressWarningsCheck` by silently skipping the unsupported forms inside a ternary branch following the existing approach.