### PR TITLE
Issue #19548: catch 2-digit octal escapes in google_checks IllegalTokenText

### DIFF
--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequences.java
@@ -59,6 +59,38 @@ public class InputSpecialEscapeSequences {
     String r9 = "\\134"; // violation 'Consider using special escape sequence .*'
   }
 
+  /** Some javadoc. */
+  public void twoDigitOctalWithWarn() {
+    String r1 = "\10"; // violation 'Consider using special escape sequence .*'
+    String r2 = "\11"; // violation 'Consider using special escape sequence .*'
+    String r3 = "\12"; // violation 'Consider using special escape sequence .*'
+    String r4 = "\14"; // violation 'Consider using special escape sequence .*'
+    String r5 = "\15"; // violation 'Consider using special escape sequence .*'
+    String r6 = "\40"; // violation 'Consider using special escape sequence .*'
+    String r7 = "\42"; // violation 'Consider using special escape sequence .*'
+    String r8 = "\47"; // violation 'Consider using special escape sequence .*'
+    char r9 = '\12'; // violation 'Consider using special escape sequence .*'
+  }
+
+  /** Some javadoc. */
+  public void octalEscapeFollowedByNonOctalDigitWithWarn() {
+    String r1 = "\128"; // violation 'Consider using special escape sequence .*'
+    String r2 = "\409"; // violation 'Consider using special escape sequence .*'
+    String r3 = "\0121"; // violation 'Consider using special escape sequence .*'
+    String r4 = "\1345"; // violation 'Consider using special escape sequence .*'
+  }
+
+  /** Octal escapes of ordinary characters have no special escape sequence to suggest. */
+  public void octalEscapeOfOrdinaryCharWithoutWarn() {
+    String r1 = "\101";
+    String r2 = "\110";
+    String r3 = "\127";
+    String r4 = "\147";
+    String r5 = "\157";
+    String r6 = "\0447";
+    String r7 = "\1234";
+  }
+
   class Inner {
     public String wrongEscapeSequences() {
       final String r1 = "\u0008"; // violation 'Consider using special escape sequence'

--- a/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForOctalValues.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/InputSpecialEscapeSequencesInTextBlockForOctalValues.java
@@ -170,6 +170,60 @@ public class InputSpecialEscapeSequencesInTextBlockForOctalValues {
         """;
   }
 
+  private void twoDigitOctalWithWarn() {
+    String r1 = // violation below 'Consider using special escape sequence .*'
+        """
+        \10
+        """;
+    String r2 = // violation below 'Consider using special escape sequence .*'
+        """
+        \11
+        """;
+    String r3 = // violation below 'Consider using special escape sequence .*'
+        """
+        \12
+        """;
+    String r4 = // violation below 'Consider using special escape sequence .*'
+        """
+        \14
+        """;
+    String r5 = // violation below 'Consider using special escape sequence .*'
+        """
+        \15
+        """;
+    String r6 = // violation below 'Consider using special escape sequence .*'
+        """
+        \40
+        """;
+    String r7 = // violation below 'Consider using special escape sequence .*'
+        """
+        \42
+        """;
+    String r8 = // violation below 'Consider using special escape sequence .*'
+        """
+        \47
+        """;
+  }
+
+  private void octalEscapeOfOrdinaryCharWithoutWarn() {
+    String r1 =
+        """
+        \101
+        """;
+    String r2 =
+        """
+        \127
+        """;
+    String r3 =
+        """
+        \157
+        """;
+    String r4 =
+        """
+        \1234
+        """;
+  }
+
   Inner anoInner =
       new Inner() {
         public void specialCharsWithoutWarn1() {

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -98,7 +98,7 @@
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL, TEXT_BLOCK_CONTENT"/>
       <property name="format"
-          value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|20|22|27|5(C|c))|\\(0(10|11|12|14|15|40|42|47)|134)"/>
+          value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|20|22|27|5(C|c))|\\(0(10|11|12|14|15)|(10|11|12|14|15)(?![0-7])|0?(40|42|47)|134)"/>
       <property name="message"
                value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
     </module>


### PR DESCRIPTION
Issue: #19548

The octal branch of the `IllegalTokenText` format in `google_checks.xml` required a leading `0`:

```
\\(0(10|11|12|14|15|40|42|47)|134)
```

Per [JLS 3.10.7](https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.10.7) an octal escape
has 1-, 2- and 3-digit forms, so `\12` and `\012` are both LF. Only the 3-digit spelling was
reported, and the 2-digit spelling of every character that has a special escape sequence
(`\10 \11 \12 \14 \15 \40 \42 \47`) was silently accepted, against
[Google Java Style 2.3.2](https://google.github.io/styleguide/javaguide.html#s2.3.2-special-escape-sequences).

New format:

```
\\(0(10|11|12|14|15)|(10|11|12|14|15)(?![0-7])|0?(40|42|47)|134)
```

Rather than just making the `0` optional, the alternatives are split so that no false positives
are introduced:

- `10|11|12|14|15` can start a 3-digit escape (`\101` is `A`, `\147` is `g`), so the no-leading-zero
  branch is guarded by `(?![0-7])`. The guard is deliberately not applied to the leading-zero
  branch, because the escape there is already 3 digits and a following digit is a literal
  character: `\0121` is LF + `1` and stays a violation.
- `40|42|47` cannot start a 3-digit escape, since the first digit of a 3-digit escape is 0-3.
  `\401` is space + `1`, so no guard is needed and `0?` is enough.
- `134` keeps no `0?`, since `\0134` is `\013` + `4`, not a backslash.

Test coverage added to the existing rule 2.3.2 inputs, for string, char and text block tokens:
the eight 2-digit forms, 2- and 3-digit forms followed by a trailing digit, and octal escapes of
ordinary characters (`\101`, `\110`, `\127`, `\147`, `\157`, `\0447`, `\1234`) that must stay
clean. Reverting only the config change makes the new expectations fail, with exactly the
2-digit lines missing and no unexpected violations elsewhere.

Verified with the whole Google style IT suite (353 tests) plus `AllChecksTest`, `XdocsPagesTest`
and `MainTest`.
