### PR TITLE
Issue #21480: Convert PackageDeclarationCheckTest#testBeginTreeClear to embedded config

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckTest.java
@@ -23,12 +23,12 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck.MSG_KEY_MISMATCH;
 import static com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck.MSG_KEY_MISSING;
 
-import java.io.File;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
@@ -186,19 +186,13 @@ public class PackageDeclarationCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testBeginTreeClear() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(PackageDeclarationCheck.class);
-        final String[] expected = {
-            "8:1: " + getCheckMessage(MSG_KEY_MISSING),
-        };
-        final Checker checker = createChecker(checkConfig);
         final String fileName1 = getPath("InputPackageDeclarationPlain.java");
         final String fileName2 = getPath("InputPackageDeclarationNoPackage.java");
-        final File[] files = {
-            new File(fileName1),
-            new File(fileName2),
-        };
-        verify(checker, files, fileName2, expected);
+        final List<String> expected1 = Collections.emptyList();
+        final List<String> expected2 = List.of(
+            "8:1: " + getCheckMessage(MSG_KEY_MISSING));
+
+        verifyWithInlineConfigParser(fileName1, fileName2, expected1, expected2);
     }
 
 }


### PR DESCRIPTION
## Summary
- Converts `PackageDeclarationCheckTest#testBeginTreeClear` from the old-style `verify(checker, files, path, expected)` (built via `createModuleConfig`) to `verifyWithInlineConfigParser(filePath1, filePath2, expectedFromFile1, expectedFromFile2)`.
- Both input files (`InputPackageDeclarationPlain.java`, `InputPackageDeclarationNoPackage.java`) already carry an embedded config from earlier conversions in this same test class, so no input-file edits were needed — this was one of the "18 easiest wins" call sites flagged in #21480.
- `testEmptyFile` (the other remaining old-style call in this class) is intentionally left untouched: its input is a genuinely empty (1-byte) file, and embedding a config comment would defeat the point of that test case — same category as the `NewlineAtEndOfFileCheckTest` exception noted on #21480.

Part of #21480.

## Test plan
- [x] `PackageDeclarationCheckTest` — 15/15 pass
- [x] `./mvnw clean verify` — clean