### PR TITLE
Issue #20590: Add InnerAssignment compact source coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheckTest.java
@@ -49,6 +49,16 @@ public class InnerAssignmentCheckTest
     }
 
     @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "11:44: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("compact/InputInnerAssignmentCompactSourceFile.java"),
+                expected);
+    }
+
+    @Test
     public void testMethod() throws Exception {
         final String[] expected = {
             "73:22: " + getCheckMessage(MSG_KEY),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -144,7 +144,6 @@ public class AllChecksCompactSourceCoverageTest {
         "ImportControlCheck",
         "ImportOrderCheck",
         "IndentationCheck",
-        "InnerAssignmentCheck",
         "InterfaceIsTypeCheck",
         "InterfaceMemberImpliedModifierCheck",
         "InterfaceTypeParameterNameCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/innerassignment/compact/InputInnerAssignmentCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/innerassignment/compact/InputInnerAssignmentCompactSourceFile.java
@@ -1,0 +1,12 @@
+/*
+InnerAssignment
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+    int value;
+    String result = Integer.toString(value = 2); // violation 'Inner assignments should be avoided'
+}


### PR DESCRIPTION
Issue: #20590

Adds Java 25 compact-source coverage for `InnerAssignmentCheck`.

The input verifies that an assignment used as a method argument reports the expected violation with the default configuration. This also removes the check from the suppression list in `AllChecksCompactSourceCoverageTest`.

Validation:

- `./mvnw clean -Dtest=InnerAssignmentCheckTest,AllChecksCompactSourceCoverageTest test`
- `./mvnw clean verify`