### PR TITLE
Issue #21480: Add javadoc on why testEmptyFile does not use inline config

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckTest.java
@@ -142,6 +142,12 @@ public class PackageDeclarationCheckTest extends AbstractModuleTestSupport {
                 expected);
     }
 
+    /**
+     * Cannot use verifyWithInlineConfigParser because the input file has to stay
+     * empty to cover the case of a file without any content. Inline config parser
+     * requires a config comment as the first line of the input file, and adding it
+     * would make the file non-empty.
+     */
     @SuppressForbidden
     @Test
     public void testEmptyFile() throws Exception {


### PR DESCRIPTION
Issue #21480

As requested in the issue discussion, documents why `PackageDeclarationCheckTest#testEmptyFile` still uses the old-style `verify` instead of `verifyWithInlineConfigParser`, so the conversion is not reinvented later.

`InputPackageDeclarationEmptyFile.java` is a 1-byte file, and the whole point of the test is a file with no content. `InlineConfigParser` requires a config comment as the first line of the input, so converting the test fails with:

```
com.puppycrawl.tools.checkstyle.api.CheckstyleException: Config comment not specified properly in
  .../packagedeclaration/InputPackageDeclarationEmptyFile.java
Caused by: com.puppycrawl.tools.checkstyle.api.CheckstyleException: Config not specified on top.
  Expected "/*xml" or "/*" (Java-comment style) as the first line.
```

Adding that comment would make the file non-empty and defeat the test, so the javadoc records this.

Javadoc phrasing follows the existing precedent in `XMLLoggerTest` and `SuppressWithPlainTextCommentFilterTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)