### PR TITLE
config: Ignore stray jacoco.exec that can land at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ nb-configuration.xml
 target
 bin
 
+# JaCoCo offline instrumentation can write this to the repo root instead of target/
+/jacoco.exec
+
 # Maven Wrapper (modern setup — do not include jar/downloader)
 .mvn/wrapper/maven-wrapper.jar
 .mvn/wrapper/MavenWrapperDownloader.java


### PR DESCRIPTION
## Summary
- Adds `/jacoco.exec` to `.gitignore`. JaCoCo's offline instrumentation destfile is normally under `target/` (already ignored), but it can also be written to the repo root, where it isn't covered by any existing pattern.
- Found this because such a file was accidentally committed on an unrelated branch via `git add -A` during local testing - a one-line gitignore fix prevents recurrence.

## Test plan
- [x] `.gitignore`-only change, no build/test impact.