### PR TITLE
Issue #21444: fixed false negatives for 3.2 Packaage declaration in google_checks

### DIFF
--- a/config/checkstyle-resources-suppressions.xml
+++ b/config/checkstyle-resources-suppressions.xml
@@ -252,6 +252,8 @@
   <!-- This file must not have a package statement, for testing purposes -->
   <suppress checks="PackageDeclarationCheck"
             files="/InputAstTreeStringPrinterTextBlocksEscapesAreOneChar\.java"/>
+  <suppress checks="PackageDeclaration"
+            files="/it/resources/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement/InputMissingPackageDeclaration\.java"/>
 
   <!-- intentional problem for testing -->
   <suppress checks="FileLength"

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement/PackageStatementTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement/PackageStatementTest.java
@@ -35,4 +35,14 @@ public class PackageStatementTest extends AbstractGoogleModuleTestSupport {
         verifyWithWholeConfig(getPath("InputPackageStatement.java"));
     }
 
+    @Test
+    public void testMissingPackageDeclaration() throws Exception {
+        verifyWithWholeConfig(getPath("InputMissingPackageDeclaration.java"));
+    }
+
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        verifyWithWholeConfig(getNonCompilablePath("InputCompactSourceFile.java"));
+    }
+
 }

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement/InputCompactSourceFile.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement/InputCompactSourceFile.java
@@ -1,0 +1,9 @@
+// non-compiled with javac: Compilable with Java25
+
+// violation below 'Compact source file is not allowed'
+void main() {
+  foo();
+  boolean allowed = false;
+}
+
+void foo() {}

--- a/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement/InputMissingPackageDeclaration.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement/InputMissingPackageDeclaration.java
@@ -1,0 +1,7 @@
+// violation 2 lines below 'Missing package declaration'
+/** Some javadoc. */
+public class InputMissingPackageDeclaration {
+  void method() {
+    int a = 1;
+  }
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -107,6 +107,12 @@
       <property name="allowByTailComment" value="true"/>
       <property name="allowNonPrintableEscapes" value="true"/>
     </module>
+    <module name="PackageDeclaration"/>
+    <module name="MatchXpath">
+      <property name="id" value="CompactSourceFileNotAllowed"/>
+      <property name="query" value="/COMPACT_COMPILATION_UNIT"/>
+      <message key="matchxpath.match" value="Compact source file is not allowed."/>
+    </module>
     <module name="AvoidStarImport"/>
     <module name="OneTopLevelClass"/>
     <module name="NoLineWrap">

--- a/src/site/xdoc/checks/coding/packagedeclaration.xml
+++ b/src/site/xdoc/checks/coding/packagedeclaration.xml
@@ -113,6 +113,10 @@ public class Example2{
       <subsection name="Example of Usage" id="PackageDeclaration_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageDeclaration">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageDeclaration">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/checks/coding/packagedeclaration.xml.template
+++ b/src/site/xdoc/checks/coding/packagedeclaration.xml.template
@@ -65,6 +65,10 @@
       <subsection name="Example of Usage" id="PackageDeclaration_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageDeclaration">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageDeclaration">
             Checkstyle Style</a>
           </li>

--- a/src/site/xdoc/google-style.xml
+++ b/src/site/xdoc/google-style.xml
@@ -391,21 +391,27 @@
                   <br />
                   <br />
                   <span class="wrapper inline">
-                    <img src="images/ok_blue.png" alt="" />
+                    <img src="images/ok_green.png" alt="" />
                   </span>
                   <a href="checks/whitespace/nolinewrap.html#NoLineWrap">NoLineWrap</a>
                   (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">
                     config</a>)
                   <br />
                   <br />
-                  Not covered:
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/coding/packagedeclaration.html#PackageDeclaration">PackageDeclaration</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageDeclaration">
+                  config</a>)
                   <br />
-                  Every source file must have a package declaration.
-                  Compact Source Files should not be used.
-                  Until:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/21444">
-                    #21444
-                  </a>
+                  <br />
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="checks/coding/matchxpath.html#MatchXpath">MatchXpath</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath+CompactSourceFileNotAllowed">
+                  config</a>)
                 </td>
                 <td>
                   <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule32packagestatement">


### PR DESCRIPTION
Issue: #21444 

```
<module name="PackageDeclaration"/>
```
Covers missing package declaration

```
    <module name="MatchXpath">
      <property name="id" value="SourceFileCompactNotAllowed"/>
      <property name="query" value="/COMPACT_COMPILATION_UNIT"/>
      <message key="matchxpath.match" value="Compact source file is not allowed."/>
    </module>
```
Covers compact source file not allowed