### PR TITLE
Issue #21477: Add LineLength to cover Sun style rule 4.1

### DIFF
--- a/src/it/java/com/sun/checkstyle/test/chapter4indentation/rule41linelength/LineLengthTest.java
+++ b/src/it/java/com/sun/checkstyle/test/chapter4indentation/rule41linelength/LineLengthTest.java
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.sun.checkstyle.test.chapter4indentation.rule41linelength;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.checkstyle.test.base.AbstractSunModuleTestSupport;
+
+public class LineLengthTest extends AbstractSunModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/sun/checkstyle/test/chapter4indentation/rule41linelength";
+    }
+
+    @Test
+    public void testLineLengthValid() throws Exception {
+        verifyWithWholeConfig(getPath("InputLineLengthValid.java"));
+    }
+
+    @Test
+    public void testLineLengthTooLong() throws Exception {
+        verifyWithWholeConfig(getPath("InputLineLengthTooLong.java"));
+    }
+
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule41linelength/InputLineLengthTooLong.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule41linelength/InputLineLengthTooLong.java
@@ -1,0 +1,28 @@
+package com.sun.checkstyle.test.chapter4indentation.rule41linelength;
+
+// violation first line 'Header mismatch'
+
+/**
+ * Test input with lines longer than 80 characters.
+ */
+public final class InputLineLengthTooLong {
+
+    /** Dummy constant. */
+    private static final String LONG_CONSTANT = "This is a very long string literal for testing.";
+    // violation above 'Line is longer than 80 characters (found 98).'
+
+    /**
+     * Dummy method.
+     *
+     * @param firstParameter dummy first parameter.
+     * @param secondParameter dummy second parameter.
+     * @return combined value.
+     */
+    public int methodWithVeryLongName(final int firstParameter, final int secondParameter) {
+        // violation above 'Line is longer than 80 characters (found 92).'
+        final String veryLongResultMessage = "This is a very long message for testing purposes.";
+        // violation above 'Line is longer than 80 characters (found 97).'
+        return firstParameter + secondParameter;
+    }
+
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule41linelength/InputLineLengthValid.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule41linelength/InputLineLengthValid.java
@@ -1,0 +1,20 @@
+package com.sun.checkstyle.test.chapter4indentation.rule41linelength;
+
+// violation first line 'Header mismatch'
+
+/**
+ * Test input with all lines within 80 characters, this very line is exactly 80.
+ */
+public final class InputLineLengthValid {
+
+    /**
+     * Dummy method.
+     *
+     * @param value dummy parameter.
+     * @return doubled value.
+     */
+    public int method(final int value) {
+        return 2 * value;
+    }
+
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule41linelength/package-info.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule41linelength/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Test inputs for line length check in Sun style.
+ */
+package com.sun.checkstyle.test.chapter4indentation.rule41linelength;

--- a/src/site/xdoc/sun-style.xml
+++ b/src/site/xdoc/sun-style.xml
@@ -335,8 +335,22 @@
                     4.1 Line Length
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="checks/sizes/linelength.html#LineLength">
+                    LineLength
+                  </a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineLength">
+                    config
+                  </a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule41linelength">
+                    samples
+                  </a>
+                </td>
               </tr>
               <tr>
                 <td>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -202,7 +202,6 @@ public class XdocsPagesTest {
             "JavadocType",
             "JavadocVariable",
             "LeftCurly",
-            "LineLength",
             "LocalFinalVariableName",
             "LocalVariableName",
             "MagicNumber",


### PR DESCRIPTION
Issue: #21477
Parent: #20811

### What

Documents `LineLength` coverage for Sun Style 4.1 Line Length and adds an
integration test suite, per #20811.

`LineLength` is already present in `sun_checks.xml` (default max 80, matching
the rule), so there is no config change:

- `src/site/xdoc/sun-style.xml`: filled the `???` row for 4.1
  (`ok_green` + LineLength check/config/samples links).
- New IT suite `chapter4indentation/rule41linelength` (valid + too-long inputs,
  chapterwise test structure).
- Removed `LineLength` from `IGNORED_SUN_MODULES` in `XdocsPagesTest`.

The 70-character documentation note in the rule is guidance for examples, not
enforceable code — no check for it (as stated in the approved issue).

### Testing

- `XdocsPagesTest` passes (20/20).
- New `LineLengthTest` passes (2/2); full Sun IT package passes (23/23).
- Spelling check (`test-spelling-unknown-words.sh`) clean, no whitelist change.
