### PR TITLE
Issue #15032: add LeftCurly input for switch pattern when guards

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -684,4 +684,18 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
                 getPath("InputLeftCurlySwitchMutation.java"), expected);
     }
 
+    @Test
+    public void testSwitchWhen() throws Exception {
+        final String[] expected = {
+            "17:13: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 13),
+            "22:13: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 13),
+            "28:13: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 13),
+            "40:13: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 13),
+            "49:13: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 13),
+            "52:13: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 13),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlySwitchWhen.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlySwitchWhen.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlySwitchWhen.java
@@ -1,0 +1,65 @@
+/*
+LeftCurly
+option = (default)eol
+ignoreEnums = (default)true
+tokens = LITERAL_CASE, LITERAL_DEFAULT
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+public class InputLeftCurlySwitchWhen {
+
+    void testSwitchRules(Object obj) {
+        switch (obj) {
+            case ColoredPoint(int x, int y, String c) when (x >= 2) ->
+            { // violation ''{' at column 13 should be on the previous line'
+                y++;
+            }
+            case ColoredPoint(int x, int y, String c)
+                    when (x == 3) ->
+            { // violation ''{' at column 13 should be on the previous line'
+                y++;
+            }
+            case ColoredPoint(int x, int y, String c)
+                    when (x == 1)
+                    ->
+            { // violation ''{' at column 13 should be on the previous line'
+                y++;
+            }
+            case ColoredPoint(int x, int y, String c) when (x == 0) -> {
+                y++;
+            }
+            case Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight)
+                    when (upperLeft != null) -> {
+                lowerRight.hashCode();
+            }
+            case String s when (s.isEmpty()) -> { }
+            default ->
+            { // violation ''{' at column 13 should be on the previous line'
+                obj.hashCode();
+            }
+        }
+    }
+
+    void testSwitchStatements(Object obj) {
+        switch (obj) {
+            case ColoredPoint(int x, int y, String c) when (x >= 2) :
+            { } break; // violation ''{' at column 13 should be on the previous line'
+            case ColoredPoint(int x, int y, String c)
+                    when (x == 1) :
+            { } break; // violation ''{' at column 13 should be on the previous line'
+            case ColoredPoint(int x, int y, String c)
+                    when (x == 0) : { }
+                break;
+            case String s when (s.isEmpty()) : { }
+                break;
+            default : { }
+        }
+    }
+
+    record ColoredPoint(int p, int x, String c) { }
+
+    record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) { }
+}


### PR DESCRIPTION
Fixes #15032

Issue #15032 is labelled `input update`: the CLI run in the report confirms `LeftCurly` already handles `when`-guarded patterns correctly, and the ask was to lock that behaviour in with a test input.

> We can add a simple test input and move on here. — @nrmancuso

### What is added

`InputLeftCurlySwitchWhen.java` (`src/test/resources/`, so it is compiled by the build) covering `LITERAL_CASE` and `LITERAL_DEFAULT` with the default `eol` option:

- arrow-form `case` rules where the guard and `->` sit on the same line, on a wrapped line, and on a line of their own, each with `{` pushed to the next line — 3 violations
- `default ->` with `{` on the next line — 1 violation
- colon-form `case` labels with guards, both inline and wrapped, followed by `{ } break;` on the next line — 2 violations
- correctly formatted counterparts for each shape (guarded record pattern, wrapped guard, nested record pattern, `case String s when ...`), which produce no violations

Named record components are used instead of the `_` unnamed patterns from the issue report so that the input compiles under the project's Java 21 release level and can live alongside the other compilable inputs.

The reported columns and the `should be on the previous line` message match the original CLI output in the issue.