### PR TITLE
Issue #15049: add CommentsIndentation input for switch when guards

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -420,4 +420,21 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
                 getPath("InputCommentsIndentationStartOfMethodCallChainNpe.java"), expected);
     }
 
+    @Test
+    public void testCommentsInSwitchWithWhenGuards() throws Exception {
+        final String[] expected = {
+            "15:20: " + getCheckMessage(MSG_KEY_SINGLE, 16, 19, 20),
+            "17:18: " + getCheckMessage(MSG_KEY_SINGLE, 18, 17, 16),
+            "21:22: " + getCheckMessage(MSG_KEY_BLOCK, 24, 21, 12),
+            "25:14: " + getCheckMessage(MSG_KEY_SINGLE, 26, 13, 12),
+            "34:20: " + getCheckMessage(MSG_KEY_SINGLE, 35, 19, 20),
+            "36:29: " + getCheckMessage(MSG_KEY_SINGLE, 37, 28, 20),
+            "40:22: " + getCheckMessage(MSG_KEY_BLOCK, 43, 21, 12),
+            "44:14: " + getCheckMessage(MSG_KEY_SINGLE, "43, 45", 13, "12, 12"),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputCommentsIndentationSwitchWhen.java"),
+            expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationSwitchWhen.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationSwitchWhen.java
@@ -1,0 +1,75 @@
+/*
+CommentsIndentation
+tokens = (default)SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;
+
+public class InputCommentsIndentationSwitchWhen {
+
+    void testColonSwitch(Object obj) {
+        switch (obj) {
+            case ColoredPoint(int a, int b, boolean c)
+                   // violation '.* incorrect .* level 19, expected is 20,.* as line 16.'
+                    when (a >= b) :
+                 // violation '.* incorrect .* level 17, expected is 16,.* as line 18.'
+                { } break;
+            case ColoredPoint(int a, int b, boolean c) when (b >= 100) // comment 3
+                    :
+                     /* // violation '.* incorrect .* level 21, expected is 12,.* as line 24.'
+                      *
+                      */
+            { }
+             // violation '.* incorrect .* level 13, expected is 12,.* as line 26.'
+            break;
+            default : System.out.println("none"); // comment 6
+        }
+    }
+
+    void testArrowSwitch(Object obj) {
+        switch (obj) {
+            case ColoredPoint(int a, int b, boolean c)
+                   // violation '.* incorrect .* level 19, expected is 20,.* as line 35.'
+                    when (a >= b)
+                            // violation '.* incorrect .* level 28, expected is 20,.* as line 37.'
+                    -> { }
+            case ColoredPoint(int a, int b, boolean c) when (b >= 100) // comment 3
+                    ->
+                     /* // violation '.* incorrect .* level 21, expected is 12,.* as line 43.'
+                      *
+                      */
+            { }
+             // violation '.* incorrect .* level 13, expected is 12, 12,.* as line 43, 45.'
+            default -> System.out.println("none");
+        }
+    }
+
+    void testProperlyIndentedComments(Object obj) {
+        switch (obj) {
+            // comment
+            case ColoredPoint(int a, int b, boolean c)
+                    // comment
+                    when (a >= b)
+                    // comment
+                    -> {
+                // comment
+                System.out.println(a);
+                // comment
+            }
+            // comment
+            case ColoredPoint(int a, int b, boolean c) when (b >= 100) ->
+                    /* comment
+                     *
+                     */
+                    System.out.println(b);
+            // comment
+            default -> {
+            }
+            // comment
+        }
+    }
+
+    record ColoredPoint(int p, int x, boolean c) { }
+}


### PR DESCRIPTION
Fixes #15049

Issue #15049 is labelled `input update`: `CommentsIndentation` already behaves correctly around `when`-guarded patterns, and the ask was to capture the reported example as a test case.

> Let's add this example as a new test case for this check, there is lots of weird stuff here that might prove useful during regression testing. — @nrmancuso

> When we add inputs, we should have bad and properly formatted examples. — @rnveach

### What is added

`InputCommentsIndentationSwitchWhen.java` reproduces the exact layout from the issue report and asserts the same 8 violations the CLI run produced:

- `testColonSwitch` — comments between a record pattern and its `when` guard, between the guard and `:`, a block comment between `:` and the block, and a comment before a trailing `break;` (4 violations)
- `testArrowSwitch` — the same four positions in arrow form, where the last one resolves against two candidate lines and yields the `expected is 12, 12, ... as line 43, 45` form (4 violations)
- `testProperlyIndentedComments` — the correctly formatted counterpart of every position above, including comments before `case`, around a wrapped `when` guard, inside and after a rule block, before `default`, and at the end of the switch; this method produces no violations

Named record components replace the `_` unnamed patterns from the report so the input compiles under the project's Java 21 release level.

As is the convention for this check, each intentionally misindented comment carries its own `// violation` annotation, so the annotations are the violating comments rather than extra ones that would shift the results.