### PR TITLE
Issue #21480: Migrate MultipleStringLiterals multi-input test to inline config

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckTest.java
@@ -22,15 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck.MSG_KEY;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
@@ -69,14 +66,8 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testMultipleInputs() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(MultipleStringLiteralsCheck.class);
-        checkConfig.addProperty("allowedDuplicates", "2");
-
         final String firstInput = getPath("InputMultipleStringLiterals3.java");
         final String secondInput = getPath("InputMultipleStringLiteralsNoWarnings.java");
-
-        final File[] inputs = {new File(firstInput), new File(secondInput)};
 
         final List<String> expectedFirstInput = Arrays.asList(
             "15:16: " + getCheckMessage(MSG_KEY, "\"StringContents\"", 3),
@@ -84,9 +75,8 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
         );
         final List<String> expectedSecondInput = Arrays.asList(CommonUtil.EMPTY_STRING_ARRAY);
 
-        verify(createChecker(checkConfig), inputs,
-            ImmutableMap.of(firstInput, expectedFirstInput,
-                secondInput, expectedSecondInput));
+        verifyWithInlineConfigParser(firstInput, secondInput,
+                expectedFirstInput, expectedSecondInput);
     }
 
     @Test


### PR DESCRIPTION
Issue: #21480

Migrate `MultipleStringLiteralsCheckTest.testMultipleInputs` to the existing two-file `verifyWithInlineConfigParser` overload. Both inputs already specify the same configuration. This keeps both files in one checker run and preserves their expected violations while also validating embedded violation comments.

Remove the redundant Java configuration, file array, and unused imports. This addresses only the MultipleStringLiterals portion of the umbrella issue.

Validation: Java 21 `mvn -B -ntp clean verify` passed, including 6,787 unit/example tests (2 skipped), 1,347 integration tests, and all configured quality checks. The focused class run passed all 10 tests.

AI assistance: Codex prepared the test migration, ran local validation, and drafted this description.
