### PR TITLE
Issue #20776: enable PMD ExhaustiveSwitchHasDefault

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -9,8 +9,6 @@
   </description>
 
   <rule ref="category/java/bestpractices.xml">
-    <!-- until https://github.com/checkstyle/checkstyle/issues/20776 -->
-    <exclude name="ExhaustiveSwitchHasDefault"/>
     <!-- Clashes with CommentDefaultAccessModifier. We do not like package and protected
          visibility, they are HACK in design and illusion of protection of method from outside.
          Keeping them public is ok. -->

--- a/src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java
@@ -146,7 +146,6 @@ public abstract class AbstractIndentationTestSupport extends AbstractGoogleModul
      * @return true if comment is consistent based on expected indent level, actual indent level
      *     and if comment is a warn comment else it returns false.
      * @throws IllegalArgumentException if comment type is unknown and cannot determine consistency.
-     * @throws IllegalStateException if cannot determine that comment is consistent(default case).
      */
     private static boolean isCommentConsistent(String comment) {
         final int indentInComment = getIndentFromComment(comment);
@@ -161,8 +160,6 @@ public abstract class AbstractIndentationTestSupport extends AbstractGoogleModul
                 isNonStrictCommentConsistent(comment, indentInComment, isWarnComment);
             case UNKNOWN ->
                     throw new IllegalArgumentException("Cannot determine comment consistent");
-            default ->
-                    throw new IllegalStateException("Cannot determine comment is consistent");
         };
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModelTest.java
@@ -59,21 +59,14 @@ public class MainFrameModelTest extends AbstractModuleTestSupport {
     @Test
     public void testParseModeEnum() {
         for (final ParseMode parseMode : ParseMode.values()) {
-            switch (parseMode) {
-                case PLAIN_JAVA -> assertWithMessage("Invalid toString result")
-                        .that(parseMode.toString())
-                        .isEqualTo("Plain Java");
-
-                case JAVA_WITH_COMMENTS -> assertWithMessage("Invalid toString result")
-                        .that(parseMode.toString())
-                        .isEqualTo("Java with comments");
-
-                case JAVA_WITH_JAVADOC_AND_COMMENTS -> assertWithMessage("Invalid toString result")
-                        .that(parseMode.toString())
-                        .isEqualTo("Java with comments and Javadocs");
-
-                default -> assertWithMessage("Unexpected enum value").fail();
-            }
+            final String expected = switch (parseMode) {
+                case PLAIN_JAVA -> "Plain Java";
+                case JAVA_WITH_COMMENTS -> "Java with comments";
+                case JAVA_WITH_JAVADOC_AND_COMMENTS -> "Java with comments and Javadocs";
+            };
+            assertWithMessage("Invalid toString result")
+                    .that(parseMode.toString())
+                    .isEqualTo(expected);
         }
     }
 


### PR DESCRIPTION
Issue: #20776

PMD released the fix for [pmd/pmd#5514](https://github.com/pmd/pmd/issues/5514) (via [pmd/pmd#6822](https://github.com/pmd/pmd/pull/6822)) in `7.27.0`, which is the PMD version already used in this project. This enables the previously excluded `ExhaustiveSwitchHasDefault` rule.

Changes:
- `config/pmd.xml`: remove the temporary `<exclude name="ExhaustiveSwitchHasDefault"/>` and its `until #20776` comment.
- `AbstractIndentationTestSupport.java`: remove the unreachable `default ->` branch of the `switch` over `CommentType` (all four enum constants are already handled) and drop the now-stale `@throws IllegalStateException` javadoc line.
- `MainFrameModelTest.testParseModeEnum`: remove the unreachable `default -> fail(...)` branch of the `switch` over `ParseMode` (all three enum constants are already handled).

Verification:
- `./mvnw clean test-compile pmd:check` → `BUILD SUCCESS` with PMD 7.27.0.
- `./mvnw clean test -Dtest=MainFrameModelTest` → 12/12 pass.