### PR TITLE
Issue #6020: fix indentation of wrapped arguments in chained calls

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -54,6 +54,19 @@ public class LineWrappingHandler {
     }
 
     /**
+     * The list of token types that open an indentation scope of their own. A node
+     * separated from a call by one of them, such as a statement in the body of a
+     * lambda passed as an argument, is not wrapped relative to that call.
+     *
+     * @see #getWrappedLineIndent(DetailAST, int, int)
+     */
+    private static final int[] SCOPE_BOUNDARY_LIST = {
+        TokenTypes.SLIST,
+        TokenTypes.OBJBLOCK,
+        TokenTypes.LAMBDA,
+    };
+
+    /**
      * The list of ignored token types for being checked by lineWrapping indentation
      * inside {@code checkIndentation()} as these tokens are checked for lineWrapping
      * inside their dedicated handlers.
@@ -156,9 +169,58 @@ public class LineWrappingHandler {
                 logWarningMessage(node, firstNodeIndent);
             }
             else if (!TokenUtil.isOfType(currentType, IGNORED_LIST)) {
-                logWarningMessage(node, currentIndent);
+                logWarningMessage(node, getWrappedLineIndent(node, currentIndent, indentLevel));
             }
         }
+    }
+
+    /**
+     * Returns the indentation a wrapped line should use. Arguments of a chained call
+     * which starts on a line of its own are wrapped relative to that line, not
+     * relative to the first line of the whole expression:
+     * {@code
+     *     new Builder()
+     *             .foo(1
+     *                     + 1)
+     *             .foo(1 + 1);
+     * }
+     *
+     * <p>Here {@code + 1} continues the arguments of the call on the {@code .foo(1}
+     * line, so it is wrapped from that line rather than from the
+     * {@code new Builder()} one. A call sharing a line with the expression it is
+     * invoked on is not a chain link in this sense, as its arguments are already
+     * wrapped relative to the right line.</p>
+     *
+     * <p>Only {@code forceStrictCondition} mode is treated this way. Without it the
+     * property is a lower bound for the whole expression, and raising it per chain
+     * link would report code that has always been accepted.</p>
+     *
+     * @param node the first node on the line being checked.
+     * @param currentIndent the indentation wrapped lines of the expression use.
+     * @param indentLevel indentation all wrapped lines should use.
+     * @return the indentation expected for {@code node}.
+     */
+    private IndentLevel getWrappedLineIndent(DetailAST node, int currentIndent,
+            int indentLevel) {
+        IndentLevel result = new IndentLevel(currentIndent);
+        DetailAST child = node;
+        DetailAST parent = node.getParent();
+        while (parent != null
+                && !TokenUtil.isOfType(parent.getType(), SCOPE_BOUNDARY_LIST)) {
+            if (child.getType() == TokenTypes.ELIST
+                    && parent.getType() == TokenTypes.METHOD_CALL) {
+                final DetailAST dot = parent.findFirstToken(TokenTypes.DOT);
+                if (dot != null && indentCheck.isForceStrictCondition()
+                        && expandedTabsColumnNo(dot) == getLineStart(dot)) {
+                    result = new IndentLevel(new IndentLevel(getLineStart(dot)),
+                            indentCheck.getBasicOffset(), indentLevel);
+                }
+                break;
+            }
+            child = parent;
+            parent = parent.getParent();
+        }
+        return result;
     }
 
     /**
@@ -414,6 +476,33 @@ public class LineWrappingHandler {
             index++;
         }
         return CommonUtil.lengthExpandedTabs(line, index, indentCheck.getIndentationTabWidth());
+    }
+
+    /**
+     * Logs warning message if indentation is incorrect.
+     *
+     * @param currentNode
+     *            current node which probably invoked a violation.
+     * @param currentIndent
+     *            correct indentation.
+     */
+    private void logWarningMessage(DetailAST currentNode, IndentLevel currentIndent) {
+        final int columnNo = expandedTabsColumnNo(currentNode);
+        final boolean isViolation;
+        if (indentCheck.isForceStrictCondition()) {
+            isViolation = !currentIndent.isAcceptable(columnNo);
+        }
+        else {
+            isViolation = currentIndent.isGreaterThan(columnNo);
+        }
+        if (isViolation) {
+            String messageKey = IndentationCheck.MSG_ERROR;
+            if (currentIndent.isMultiLevel()) {
+                messageKey = IndentationCheck.MSG_ERROR_MULTI;
+            }
+            indentCheck.indentationLog(currentNode, messageKey,
+                    currentNode.getText(), columnNo, currentIndent);
+        }
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1790,6 +1790,48 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testChainedMethodCallWrappedArguments() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "true");
+        checkConfig.addProperty("lineWrappingIndentation", "8");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String fileName =
+                getPath("InputIndentationChainedMethodCallWrappedArguments.java");
+        final String[] expected = {
+            "41:17: " + getCheckMessage(MSG_ERROR_MULTI, "+", 16, "20, 24"),
+            "43:17: " + getCheckMessage(MSG_ERROR_MULTI, "+", 16, "20, 24"),
+            "45:17: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 16, 20),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
+    public void testChainedMethodCallWrappedArgumentsSingleLevel() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+
+        checkConfig.addProperty("arrayInitIndent", "4");
+        checkConfig.addProperty("basicOffset", "4");
+        checkConfig.addProperty("braceAdjustment", "0");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("forceStrictCondition", "true");
+        checkConfig.addProperty("lineWrappingIndentation", "4");
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("throwsIndent", "4");
+        final String fileName =
+                getPath("InputIndentationChainedMethodCallWrappedArguments2.java");
+        final String[] expected = {
+            "22:13: " + getCheckMessage(MSG_ERROR, "+", 12, 16),
+        };
+        verifyWarns(checkConfig, fileName, expected);
+    }
+
+    @Test
     public void testInvalidArrayInitWithTrueStrictCondition()
             throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodCallWrappedArguments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodCallWrappedArguments.java
@@ -1,0 +1,54 @@
+/* Config:                                                                  //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration: //indent:1 exp:1
+ *                                                                          //indent:1 exp:1
+ * arrayInitIndent = 4                                                      //indent:1 exp:1
+ * basicOffset = 4                                                          //indent:1 exp:1
+ * braceAdjustment = 0                                                      //indent:1 exp:1
+ * caseIndent = 4                                                           //indent:1 exp:1
+ * forceStrictCondition = true                                              //indent:1 exp:1
+ * lineWrappingIndentation = 8                                              //indent:1 exp:1
+ * tabWidth = 4                                                             //indent:1 exp:1
+ * throwsIndent = 4                                                         //indent:1 exp:1
+ *                                                                          //indent:1 exp:1
+ */                                                                         //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
+
+class InputIndentationChainedMethodCallWrappedArguments {                   //indent:0 exp:0
+
+    void lastCallOnSingleLine() {                                           //indent:4 exp:4
+        new Builder()                                                       //indent:8 exp:8
+                .foo(1                                                      //indent:16 exp:16
+                        + 1)                                                //indent:24 exp:24
+                .foo(1                                                      //indent:16 exp:16
+                        + 1)                                                //indent:24 exp:24
+                .foo(1 + 1);                                                //indent:16 exp:16
+    }                                                                       //indent:4 exp:4
+
+    void lastCallWrapped() {                                                //indent:4 exp:4
+        new Builder()                                                       //indent:8 exp:8
+                .foo(1                                                      //indent:16 exp:16
+                        + 1)                                                //indent:24 exp:24
+                .foo(1                                                      //indent:16 exp:16
+                        + 1)                                                //indent:24 exp:24
+                .foo(1                                                      //indent:16 exp:16
+                        + 1);                                               //indent:24 exp:24
+    }                                                                       //indent:4 exp:4
+
+    void argumentsNotWrappedFarEnough() {                                   //indent:4 exp:4
+        new Builder()                                                       //indent:8 exp:8
+                .foo(1                                                      //indent:16 exp:16
+                + 1)                                                        //indent:16 exp:20,24 warn
+                .foo(1                                                      //indent:16 exp:16
+                + 1)                                                        //indent:16 exp:20,24 warn
+                .foo(1                                                      //indent:16 exp:16
+                + 1);                                                       //indent:16 exp:20 warn
+    }                                                                       //indent:4 exp:4
+
+    private static final class Builder {                                    //indent:4 exp:4
+
+        Builder foo(int number) {                                           //indent:8 exp:8
+            return this;                                                    //indent:12 exp:12
+        }                                                                   //indent:8 exp:8
+    }                                                                       //indent:4 exp:4
+}                                                                           //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodCallWrappedArguments2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethodCallWrappedArguments2.java
@@ -1,0 +1,33 @@
+/* Config:                                                                  //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration: //indent:1 exp:1
+ *                                                                          //indent:1 exp:1
+ * arrayInitIndent = 4                                                      //indent:1 exp:1
+ * basicOffset = 4                                                          //indent:1 exp:1
+ * braceAdjustment = 0                                                      //indent:1 exp:1
+ * caseIndent = 4                                                           //indent:1 exp:1
+ * forceStrictCondition = true                                              //indent:1 exp:1
+ * lineWrappingIndentation = 4                                              //indent:1 exp:1
+ * tabWidth = 4                                                             //indent:1 exp:1
+ * throwsIndent = 4                                                         //indent:1 exp:1
+ *                                                                          //indent:1 exp:1
+ */                                                                         //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;     //indent:0 exp:0
+
+class InputIndentationChainedMethodCallWrappedArguments2 {                  //indent:0 exp:0
+
+    void argumentsNotWrappedFarEnough() {                                   //indent:4 exp:4
+        new Builder()                                                       //indent:8 exp:8
+            .foo(1                                                          //indent:12 exp:12
+            + 1)                                                            //indent:12 exp:16 warn
+            .foo(1                                                          //indent:12 exp:12
+                + 1);                                                       //indent:16 exp:16
+    }                                                                       //indent:4 exp:4
+
+    private static final class Builder {                                    //indent:4 exp:4
+
+        Builder foo(int number) {                                           //indent:8 exp:8
+            return this;                                                    //indent:12 exp:12
+        }                                                                   //indent:8 exp:8
+    }                                                                       //indent:4 exp:4
+}                                                                           //indent:0 exp:0


### PR DESCRIPTION
Fixes #6020

### Problem

`MethodCallHandler.checkIndentation()` runs a line-wrapping check across the whole
chained expression, but only when the last call in the chain is wrapped
(`if (!TokenUtil.areOnSameLine(rparen, lparen))`). `LineWrappingHandler` then applies a
single flat `currentIndent = firstNodeIndent + indentLevel` to every wrapped line in that
range, including lines that continue the *argument list* of an individual link in the chain.

For the example in the issue (`lineWrappingIndentation=8`, `forceStrictCondition=true`),
the chain starts at column 8, so every wrapped line is expected at 16 — including the
`+ 1` lines, which continue `.foo(` at column 16 and therefore belong at 24:

```
[ERROR] :14:25: '+' has incorrect indentation level 24, expected level should be 16.
[ERROR] :16:25: '+' has incorrect indentation level 24, expected level should be 16.
[ERROR] :18:25: '+' has incorrect indentation level 24, expected level should be 16.
```

Lines 14/16/18 are character-identical to the block above them that passes; the only
difference is whether the final call is wrapped. The same flat base also *accepts*
those lines at 16, which is the false negative the issue reports in its third block.

### Fix

Argument continuation lines of a chain link that begins its own line are now wrapped
relative to that link's line rather than the first line of the whole expression.

Two details worth review:

- The expected value is an acceptable **set**, `{link + basicOffset,
  link + lineWrappingIndentation}`, mirroring what `MethodCallHandler.getSuggestedChildIndent`
  already builds for call arguments. A single value regressed
  `testChainedMethodCalling`, whose input indents `.ifPresentOrElse(...)` arguments by
  `basicOffset`. `MSG_ERROR_MULTI` is used when the set is multi-level, following
  `AbstractExpressionHandler.logError`.
- The search for the enclosing link stops at `SLIST`/`OBJBLOCK`, so a statement inside a
  lambda passed as an argument is not treated as a continuation of the call it is passed
  to. Without this, correctly indented chains containing block lambdas gained violations.

### Verification

Scanned all 915 files in `src/main/java` + `src/test/java` with
`Indentation` (`forceStrictCondition=true`), comparing the build before and after:

| | |
|---|---|
| violations removed (false positives) | 62 |
| violations added | 0 |

A representative removed false positive, in `MainTest.java`, is ordinary assertion code:

```java
assertWithMessage("Unexpected output log")
    .that(systemOut.getCapturedData())
    .isEqualTo("Option '-s' cannot be used with other options."
        + System.lineSeparator());
```

The `+` was reported as `incorrect indentation level 16, expected level should be 12`.

`IndentationCheckTest` passes (225 existing tests, plus the new
`testChainedMethodCallWrappedArguments`), as does the full `mvn test` run.

One case from the issue is deliberately left alone: when the last call is *not* wrapped
the chain check does not run at all, so under-indented arguments still go unreported
there. That is the separate gate in `MethodCallHandler.checkIndentation()` rather than
the flat-indent defect, and changing it would affect far more than this issue. All three
blocks in the issue's own example now behave as described there.
