### PR TITLE
Issue #20590: Add AvoidNoArgumentSuperConstructorCall compact source coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidNoArgumentSuperConstructorCallCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidNoArgumentSuperConstructorCallCheckTest.java
@@ -50,6 +50,17 @@ public class AvoidNoArgumentSuperConstructorCallCheckTest
     }
 
     @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "18:9: " + getCheckMessage(MSG_CTOR),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                        "compact/InputAvoidNoArgumentSuperConstructorCallCompactSourceFile.java"),
+                expected);
+    }
+
+    @Test
     public void testTokens() {
         final AvoidNoArgumentSuperConstructorCallCheck check =
             new AvoidNoArgumentSuperConstructorCallCheck();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -97,7 +97,6 @@ public class AllChecksCompactSourceCoverageTest {
         "AvoidDoubleBraceInitializationCheck",
         "AvoidEscapedUnicodeCharactersCheck",
         "AvoidNestedBlocksCheck",
-        "AvoidNoArgumentSuperConstructorCallCheck",
         "AvoidStarImportCheck",
         "BooleanExpressionComplexityCheck",
         "CatchParameterNameCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/avoidnoargumentsuperconstructorcall/compact/InputAvoidNoArgumentSuperConstructorCallCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/avoidnoargumentsuperconstructorcall/compact/InputAvoidNoArgumentSuperConstructorCallCompactSourceFile.java
@@ -1,0 +1,21 @@
+/*
+AvoidNoArgumentSuperConstructorCall
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+}
+
+class Parent {
+}
+
+class Child extends Parent {
+
+    Child() {
+        super(); // violation 'Unnecessary call to superclass constructor with no arguments'
+    }
+
+}


### PR DESCRIPTION
Issue: #20590

Adds Java 25 compact-source coverage for `AvoidNoArgumentSuperConstructorCallCheck`.

The new input verifies the default configuration reports an explicit no-argument `super()` call. It also removes the check from `AllChecksCompactSourceCoverageTest` suppression list.

Validation:

- `./mvnw clean -Dtest=AvoidNoArgumentSuperConstructorCallCheckTest,AllChecksCompactSourceCoverageTest test`
- `./mvnw clean verify`