### PR TITLE
Issue #21501: Fix file extensions for paths with dotted directories

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -510,7 +510,7 @@ public final class CommonUtil {
      *         or empty string if file does not have an extension.
      */
     public static String getFileExtension(String fileNameWithExtension) {
-        final String fileName = Path.of(fileNameWithExtension).toString();
+        final String fileName = Path.of(fileNameWithExtension).toFile().getName();
         final int dotIndex = fileName.lastIndexOf('.');
         final String extension;
         if (dotIndex == -1) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
@@ -373,6 +373,26 @@ public class CommonUtilTest extends AbstractPathTestSupport {
     }
 
     @Test
+    public void testGetFileExtensionInDottedDirectory() {
+        assertWithMessage("Parent directory must not supply the file extension")
+            .that(CommonUtil.getFileExtension("config.d/filename"))
+            .isEmpty();
+        assertWithMessage("Parent directory must not change the file extension")
+            .that(CommonUtil.getFileExtension("config.d/filename.properties"))
+            .isEqualTo("properties");
+    }
+
+    @Test
+    public void testGetFileExtensionInRelativeDirectory() {
+        assertWithMessage("Current directory must not supply the file extension")
+            .that(CommonUtil.getFileExtension("./filename"))
+            .isEmpty();
+        assertWithMessage("Parent directory must not supply the file extension")
+            .that(CommonUtil.getFileExtension("../filename"))
+            .isEmpty();
+    }
+
+    @Test
     public void testIsIdentifier() {
         assertWithMessage("Should return true when valid identifier is passed")
                 .that(CommonUtil.isIdentifier("aValidIdentifier"))


### PR DESCRIPTION
Issue: #21501

Submitted following [romani's request](https://github.com/checkstyle/checkstyle/issues/21501#issuecomment-5579381186) to review the implementation in a PR.

`CommonUtil.getFileExtension("config.d/filename")` currently returns `d/filename`, even though the final filename has no extension. Extract the final filename before searching for its last dot, using the same approach as `getFileNameWithoutExtension`.

Add regression tests for dotted parent directories and current/parent-relative paths, including preservation of a real `.properties` extension. This addresses the public utility; the existing `TranslationCheck` caller already supplies a bare filename.

Validation:
- Before the production change, both new regression tests failed.
- After the change, all 74 tests in `CommonUtilTest` and `TranslationCheckTest` passed.
- After rebasing onto `d89b173`, Java 21 `mvn -B -ntp clean verify` passed: 6,790 unit/example tests (2 skipped), 1,349 integration tests, and all configured quality checks; no failures or errors.

Codex assisted with investigation, implementation, and validation.
