### PR TITLE
Issue #20590: Add NoClone compact source coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheckTest.java
@@ -64,4 +64,15 @@ public class NoCloneCheckTest
             .isNotNull();
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "12:1: " + getCheckMessage(MSG_KEY),
+            "19:5: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("compact/InputNoCloneCompactSourceFile.java"),
+                expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -191,7 +191,6 @@ public class AllChecksCompactSourceCoverageTest {
         "NestedIfDepthCheck",
         "NestedTryDepthCheck",
         "NoArrayTrailingCommaCheck",
-        "NoCloneCheck",
         "NoCodeInFileCheck",
         "NoEnumTrailingCommaCheck",
         "NoLineWrapCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/noclone/compact/InputNoCloneCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/noclone/compact/InputNoCloneCompactSourceFile.java
@@ -1,0 +1,23 @@
+/*
+NoClone
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+}
+
+public Object clone() { // violation 'Avoid using clone method.'
+    return this;
+}
+
+class Helper implements Cloneable {
+
+    // violation below 'Avoid using clone method.'
+    public Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
+
+}


### PR DESCRIPTION
Issue: #20590

Adds Java 25 compact-source coverage for `NoCloneCheck`.

The new input verifies the default configuration reports a `clone()` method declared as a top-level member of the implicit class, as well as one declared inside a nested class. It also removes the check from the `AllChecksCompactSourceCoverageTest` suppression list.

Validation:

- `./mvnw clean -Dtest=NoCloneCheckTest,AllChecksCompactSourceCoverageTest test`
- `./mvnw clean verify`
