### PR TITLE
Issue #20590: Add EqualsHashCode compact source coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheckTest.java
@@ -130,4 +130,15 @@ public class EqualsHashCodeCheckTest
             .isNotNull();
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "12:1: " + getCheckMessage(MSG_KEY_HASHCODE),
+            "18:5: " + getCheckMessage(MSG_KEY_EQUALS),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("compact/InputEqualsHashCodeCompactSourceFile.java"),
+                expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -117,7 +117,6 @@ public class AllChecksCompactSourceCoverageTest {
         "EmptyForIteratorPadCheck",
         "EmptyLineSeparatorCheck",
         "EqualsAvoidNullCheck",
-        "EqualsHashCodeCheck",
         "ExecutableStatementCountCheck",
         "ExplicitInitializationCheck",
         "FallThroughCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode/compact/InputEqualsHashCodeCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode/compact/InputEqualsHashCodeCompactSourceFile.java
@@ -1,0 +1,22 @@
+/*
+EqualsHashCode
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+}
+
+public boolean equals(Object obj) { // violation 'without .* of 'hashCode()'.'
+    return this == obj;
+}
+
+class Helper {
+
+    public int hashCode() { // violation 'without .* of 'equals()'.'
+        return 1;
+    }
+
+}


### PR DESCRIPTION
Issue: #20590

Adds Java 25 compact-source coverage for `EqualsHashCodeCheck`.

The new input verifies the default configuration reports an `equals(Object)` declared as a top-level member of the implicit class without a matching `hashCode()`, and the inverse case inside a nested class. It also removes the check from the `AllChecksCompactSourceCoverageTest` suppression list.

Validation:

- `./mvnw clean -Dtest=EqualsHashCodeCheckTest,AllChecksCompactSourceCoverageTest test`
- `./mvnw clean verify`
