### PR TITLE
Issue #20590: Add ModifierOrder compact source coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
@@ -176,4 +176,15 @@ public class ModifierOrderCheckTest
                 expected);
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "13:8: " + getCheckMessage(MSG_MODIFIER_ORDER, "private"),
+            "20:7: " + getCheckMessage(MSG_ANNOTATION_ORDER, "@Deprecated"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("compact/InputModifierOrderCompactSourceFile.java"),
+                expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -183,7 +183,6 @@ public class AllChecksCompactSourceCoverageTest {
         "MissingOverrideOnRecordAccessorCheck",
         "MissingSwitchDefaultCheck",
         "ModifiedControlVariableCheck",
-        "ModifierOrderCheck",
         "MultipleStringLiteralsCheck",
         "MutableExceptionCheck",
         "NPathComplexityCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/compact/InputModifierOrderCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/compact/InputModifierOrderCompactSourceFile.java
@@ -1,0 +1,21 @@
+/*
+ModifierOrder
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+}
+
+// violation below ''private' modifier.*order.*JLS suggestions.'
+static private void util() {
+}
+
+@Deprecated final void annotated() {
+}
+
+// violation below ''@Deprecated' annotation modifier.*precede non-annotation modifiers.'
+final @Deprecated void wronglyAnnotated() {
+}


### PR DESCRIPTION
Issue: #20590

Adds Java 25 compact-source coverage for `ModifierOrderCheck`.

The new input verifies the default configuration reports both violation kinds on top-level members of the implicit class: a modifier out of JLS order (`static private`) and an annotation that does not precede non-annotation modifiers (`final @Deprecated`). It also removes the check from the `AllChecksCompactSourceCoverageTest` suppression list.

Validation:

- `./mvnw clean -Dtest=ModifierOrderCheckTest,AllChecksCompactSourceCoverageTest test`
- `./mvnw clean verify`
