### PR TITLE
infra: fix no-error-pmd by skipping PMD integration tests

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -332,6 +332,7 @@ no-error-pmd)
   cd pmd
   mvn -e --no-transfer-progress verify --show-version --errors --batch-mode \
                 -DskipTests \
+                -DskipITs=true \
                 -Dmaven.javadoc.skip=true \
                 -Dmaven.source.skip=true \
                 -Dpmd.skip=true \


### PR DESCRIPTION
The `no-error-pmd` job fails on `master` as well as on every PR, so it is not caused by any single change. Recent examples on `master`: CircleCI builds [1827819](https://circleci.com/gh/checkstyle/checkstyle/1827819) and [1827764](https://circleci.com/gh/checkstyle/checkstyle/1827764).

The failure is always:

```
BinaryDistributionIT.testZipFileContent:126 Missing files in archive:
  [pmd-bin-7.28.0-SNAPSHOT/sbom/pmd-7.28.0-SNAPSHOT-cyclonedx.json,
   pmd-bin-7.28.0-SNAPSHOT/sbom/pmd-7.28.0-SNAPSHOT-cyclonedx.xml]
```

### Cause

The job builds PMD with `-Dcyclonedx.skip=true`, so the SBOM is not generated:

```
--- cyclonedx:2.9.3:makeAggregateBom (default) @ pmd-dist ---
Skipping CycloneDX goal
```

PMD's `BinaryDistributionIT` unconditionally asserts that `sbom/pmd-*-cyclonedx.{json,xml}` are present in the binary distribution, so the test fails.

The job already passes `-DskipTests`, intending to skip PMD's tests, but that no longer skips integration tests. In maven-failsafe-plugin 3.6.0 (the version PMD uses) the `skipTests` parameter is deprecated in favour of `skipITs` and no longer has a property binding. The plugin descriptor exposes only:

```xml
<skip implementation="boolean" default-value="false">${maven.test.skip}</skip>
<skipITs implementation="boolean">${skipITs}</skipITs>
```

There is no `${skipTests}` binding, so `-DskipTests` silently has no effect on failsafe and the distribution ITs run anyway.

### Fix

Add `-DskipITs=true`, completing the job's existing intent to skip PMD's own tests. The job's purpose is to verify that checkstyle reports no errors on PMD's sources (`-Dcheckstyle.skip=false`, bound to the `verify` phase); PMD's distribution integration tests are unrelated to that and are not affected by this change.

Verified with a minimal project using maven-failsafe-plugin 3.6.0 and one always-failing `*IT`:

| Flags | Result |
| --- | --- |
| `-DskipTests` | `Running demo.SampleIT` -> BUILD FAILURE, exit 1 |
| `-DskipTests -DskipITs=true` | `Tests are skipped.` -> BUILD SUCCESS, exit 0 |
