### PR TITLE
Issue #17170: Enable ModuleDirectiveOrder in Google style

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -886,6 +886,7 @@ mockito
 Modello
 modifiedcontrolvariable
 modifierorder
+moduledeclaration
 moduledirectiveorder
 moduleimportorder
 moduleinfo

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration/ModuleDeclarationTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration/ModuleDeclarationTest.java
@@ -1,0 +1,53 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.google.checkstyle.test.chapter3filestructure.rule35moduledeclaration;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
+
+public class ModuleDeclarationTest extends AbstractGoogleModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration";
+    }
+
+    @Test
+    public void testValid() throws Exception {
+        verifyWithWholeConfig(getNonCompilablePath("valid/module-info.java"));
+    }
+
+    @Test
+    public void testOrder() throws Exception {
+        verifyWithWholeConfig(getNonCompilablePath("order/module-info.java"));
+    }
+
+    @Test
+    public void testGrouping() throws Exception {
+        verifyWithWholeConfig(getNonCompilablePath("grouping/module-info.java"));
+    }
+
+    @Test
+    public void testSeparation() throws Exception {
+        verifyWithWholeConfig(getNonCompilablePath("separation/module-info.java"));
+    }
+
+}

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration/grouping/module-info.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration/grouping/module-info.java
@@ -1,0 +1,14 @@
+// non-compiled with javac: reference to non existent modules and packages
+
+module com.example.app {
+  requires java.base;
+
+  exports com.example.api;
+
+  requires java.sql;
+  // violation above 'All 'requires' directives should be in a single block.'
+
+  opens com.example.model;
+
+  uses com.example.api.Service;
+}

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration/order/module-info.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration/order/module-info.java
@@ -1,0 +1,14 @@
+// non-compiled with javac: reference to non existent modules and packages
+
+module com.example.app {
+  exports com.example.api;
+
+  requires java.base;
+  // violation above ''requires' directive should be before 'exports' directive.'
+
+  opens com.example.model;
+
+  uses com.example.api.Service;
+
+  provides com.example.api.Service with com.example.impl.ServiceImpl;
+}

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration/separation/module-info.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration/separation/module-info.java
@@ -1,0 +1,13 @@
+// non-compiled with javac: reference to non existent modules and packages
+
+module com.example.app {
+  requires java.base;
+  exports com.example.api;
+  // violation above ''exports' directive block should be separated .* empty line.'
+
+  opens com.example.model;
+
+  uses com.example.api.Service;
+
+  provides com.example.api.Service with com.example.impl.ServiceImpl;
+}

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration/valid/module-info.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration/valid/module-info.java
@@ -1,0 +1,17 @@
+// non-compiled with javac: reference to non existent modules and packages
+
+module com.example.app {
+  requires java.base;
+  requires transitive java.sql;
+  requires static com.example.annotations;
+
+  exports com.example.api;
+  exports com.example.internal to com.example.other;
+
+  opens com.example.model;
+  opens com.example.secrets to com.example.friend;
+
+  uses com.example.api.Service;
+
+  provides com.example.api.Service with com.example.impl.ServiceImpl;
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -23,11 +23,6 @@
   <property name="severity" value="${org.checkstyle.google.severity}" default="warning"/>
 
   <property name="fileExtensions" value="java, properties, xml"/>
-  <!-- Excludes all 'module-info.java' files              -->
-  <!-- See https://checkstyle.org/filefilters/index.html -->
-  <module name="BeforeExecutionExclusionFileFilter">
-    <property name="fileNamePattern" value="module\-info\.java$"/>
-  </module>
 
   <module name="SuppressWarningsFilter"/>
 
@@ -119,6 +114,10 @@
     <module name="NoLineWrap">
       <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
     </module>
+
+    <!-- Modules -->
+    <module name="ModuleDirectiveOrder"/>
+
     <module name="NeedBraces">
       <property name="tokens"
                value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>

--- a/src/site/xdoc/checks/modules/moduledirectiveorder.xml
+++ b/src/site/xdoc/checks/modules/moduledirectiveorder.xml
@@ -302,6 +302,10 @@ module com.example.app {
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ModuleDirectiveOrder">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ModuleDirectiveOrder">
+            Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/checks/modules/moduledirectiveorder.xml.template
+++ b/src/site/xdoc/checks/modules/moduledirectiveorder.xml.template
@@ -177,6 +177,10 @@
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ModuleDirectiveOrder">
             Checkstyle Style</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ModuleDirectiveOrder">
+            Google Style</a>
+          </li>
         </ul>
       </subsection>
 

--- a/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml
+++ b/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml
@@ -203,10 +203,6 @@
       <subsection name="Example of Usage" id="BeforeExecutionExclusionFileFilter_Example_of_Usage">
         <ul>
           <li>
-            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+BeforeExecutionExclusionFileFilter">
-              Google Style</a>
-          </li>
-          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+BeforeExecutionExclusionFileFilter">
               Sun Style</a>
           </li>

--- a/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml.template
+++ b/src/site/xdoc/filefilters/beforeexecutionexclusionfilefilter.xml.template
@@ -94,10 +94,6 @@
       <subsection name="Example of Usage" id="BeforeExecutionExclusionFileFilter_Example_of_Usage">
         <ul>
           <li>
-            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+BeforeExecutionExclusionFileFilter">
-              Google Style</a>
-          </li>
-          <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+BeforeExecutionExclusionFileFilter">
               Sun Style</a>
           </li>

--- a/src/site/xdoc/google-style.xml
+++ b/src/site/xdoc/google-style.xml
@@ -696,18 +696,17 @@
                 </td>
                 <td>
                   <span class="wrapper inline">
-                    <img
-                        src="images/ban_red.png"
-                        alt="" />
+                    <img src="images/ok_green.png" alt="" />
                   </span>
-                  Checkstyle currently does not have a Parser to support
-                  <code>module-info.java</code> file Grammar. For more information,
-                  see the discussion at:
-                  <a href="https://github.com/checkstyle/checkstyle/issues/17170#issuecomment-2944237497">
-                    #17170
-                  </a>
+                  <a href="checks/modules/moduledirectiveorder.html#ModuleDirectiveOrder">
+                    ModuleDirectiveOrder</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ModuleDirectiveOrder">
+                  config</a>)
                 </td>
-                <td/>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule35moduledeclaration">
+                    samples</a>
+                </td>
               </tr>
               <tr>
                 <td><a name="a4"/>


### PR DESCRIPTION
closes #17170 

Google Java Style Guide §3.5.1 requires module-info.java directives to be grouped by kind(requires, exports, opens, uses, provides, in that order) with exactly one blank line between blocks. Issue #17170 tracked this as unenforced, blocked on #8240 (no grammar support for module-info.java).

Both blockers were already resolved on master