### PR TITLE
Issue #21480: Convert CustomImportOrderCheckTest#testBeginTreeClear to embedded config

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -28,13 +28,12 @@ import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCh
 import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.MSG_SEPARATED_IN_GROUP;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
 
-import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.Checker;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -364,21 +363,12 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testBeginTreeClear() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(CustomImportOrderCheck.class);
-        checkConfig.addProperty("specialImportsRegExp", "com");
-        checkConfig.addProperty("separateLineBetweenGroups", "false");
-        checkConfig.addProperty("customImportOrderRules",
-            "STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS");
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        final Checker checker = createChecker(checkConfig);
-        final String fileName1 = getPath("InputCustomImportOrderImportsContainingJava.java");
-        final String fileName2 = getPath("InputCustomImportOrderNoValid.java");
-        final File[] files = {
-            new File(fileName1),
-            new File(fileName2),
-        };
-        verify(checker, files, fileName1, expected);
+        final String fileName1 = getPath("InputCustomImportOrderBeginTreeClear.java");
+        final String fileName2 = getPath("InputCustomImportOrderBeginTreeClear2.java");
+        final List<String> expectedFirstInput = Arrays.asList(CommonUtil.EMPTY_STRING_ARRAY);
+        final List<String> expectedSecondInput = Arrays.asList(CommonUtil.EMPTY_STRING_ARRAY);
+        verifyWithInlineConfigParser(fileName1, fileName2,
+                expectedFirstInput, expectedSecondInput);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderBeginTreeClear.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderBeginTreeClear.java
@@ -1,0 +1,19 @@
+/*
+CustomImportOrder
+customImportOrderRules = STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS
+standardPackageRegExp = (default)^(java|javax)\\.
+thirdPartyPackageRegExp = (default).*
+specialImportsRegExp = com
+separateLineBetweenGroups = false
+sortImportsInGroupAlphabetically = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
+
+import java.io.File;
+import javax.lang.model.SourceVersion;
+import com.google.errorprone.annotations.*;
+
+public class InputCustomImportOrderBeginTreeClear {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderBeginTreeClear2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderBeginTreeClear2.java
@@ -1,0 +1,20 @@
+/*
+CustomImportOrder
+customImportOrderRules = STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS
+standardPackageRegExp = (default)^(java|javax)\\.
+thirdPartyPackageRegExp = (default).*
+specialImportsRegExp = com
+separateLineBetweenGroups = false
+sortImportsInGroupAlphabetically = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+
+public class InputCustomImportOrderBeginTreeClear2 {
+}


### PR DESCRIPTION
Issue: #21480

created 2 new input files with headers matching testBeginTreeClear's config 

converted the test to verifyWithInlineConfigParser which points at those copies 

left the original inputs untouched for testNoValid and testImportsContainingJava to still work

CustomImportOrderCheckTest — 48/48 pass
./mvnw clean verify  -  clean

