### PR TITLE
Issue #20590: Add MissingSwitchDefault compact source coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
@@ -126,4 +126,16 @@ public class MissingSwitchDefaultCheckTest
                 expected);
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "29:5: " + getCheckMessage(MSG_KEY),
+            "74:9: " + getCheckMessage(MSG_KEY),
+            "82:13: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("compact/InputMissingSwitchDefaultCompactSourceFile.java"),
+                expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -181,7 +181,6 @@ public class AllChecksCompactSourceCoverageTest {
         "MissingNullCaseInSwitchCheck",
         "MissingOverrideCheck",
         "MissingOverrideOnRecordAccessorCheck",
-        "MissingSwitchDefaultCheck",
         "ModifiedControlVariableCheck",
         "ModifierOrderCheck",
         "MultipleStringLiteralsCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/compact/InputMissingSwitchDefaultCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/compact/InputMissingSwitchDefaultCompactSourceFile.java
@@ -1,0 +1,88 @@
+/*
+MissingSwitchDefault
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+}
+
+enum Day {
+    MONDAY,
+    TUESDAY
+}
+
+sealed interface Shape permits Circle, Square { }
+
+record Circle(int radius) implements Shape { }
+
+record Square(int side) implements Shape { }
+
+int field = switch (2) {
+    case 1 -> 1;
+    default -> 0;
+};
+
+void missingDefault(int value) {
+    switch (value) { // violation 'switch without "default" clause'
+        case 1: value++; break;
+        case 2: value--; break;
+    }
+}
+
+void withDefault(int value) {
+    switch (value) {
+        case 1: value++; break;
+        case 2: value--; break;
+        default: break;
+    }
+}
+
+int switchExpression(int value) {
+    return switch (value) {
+        case 1 -> 10;
+        default -> 0;
+    };
+}
+
+void patternCaseLabel(Object obj) {
+    switch (obj) {
+        case String s -> System.out.println(s);
+        case Object o -> System.out.println(o);
+    }
+}
+
+void recordPatternCaseLabel(Shape shape) {
+    switch (shape) {
+        case Circle(int radius) -> System.out.println(radius);
+        case Square(int side) -> System.out.println(side);
+    }
+}
+
+void nullCaseLabel(Day day) {
+    switch (day) {
+        case MONDAY -> System.out.println("MONDAY");
+        case TUESDAY -> System.out.println("TUESDAY");
+        case null -> System.out.println("NULL");
+    }
+}
+
+void switchInsideIf(int value, boolean flag) {
+    if (flag)
+        switch (value) { // violation 'switch without "default" clause'
+            case 1: value++; break;
+        }
+}
+
+void nestedSwitch(int value) {
+    switch (value) {
+        case 1:
+            switch (value) { // violation 'switch without "default" clause'
+                case 2: value++; break;
+            }
+            break;
+        default: break;
+    }
+}


### PR DESCRIPTION
Issue #20590

Adds compact source file (JEP 512) input coverage for `MissingSwitchDefault` and removes it from `SUPPRESSED_CHECKS` in `AllChecksCompactSourceCoverageTest`.

The check has no settable properties, so a single input running it with the default config satisfies the coverage rules.

The input exercises each branch of `visitToken`:

- switch statement without `default` (violation)
- switch statement with `default`
- switch expression
- pattern case label
- record pattern case label
- `null` case label
- a top-level field initialized by a switch expression
- a switch directly under `if`, covering `SWITCH_STATEMENT_PARENTS`
- a nested switch

Behaviour was compared against the equivalent ordinary source: the same code wrapped in a class produces exactly the same three violations at the shifted line/columns, so there is no divergence to report and no `// until` marker is needed.
