### PR TITLE
Add SeparatorWrap check for Sun Style 4.2 Wrapping Lines

### DIFF
--- a/src/it/java/com/sun/checkstyle/test/chapter4indentation/rule42wrappinglines/SeparatorWrapTest.java
+++ b/src/it/java/com/sun/checkstyle/test/chapter4indentation/rule42wrappinglines/SeparatorWrapTest.java
@@ -1,0 +1,38 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.sun.checkstyle.test.chapter4indentation.rule42wrappinglines;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.checkstyle.test.base.AbstractSunModuleTestSupport;
+
+public class SeparatorWrapTest extends AbstractSunModuleTestSupport {
+
+    @Override
+    public String getPackageLocation() {
+        return "com/sun/checkstyle/test/chapter4indentation/rule42wrappinglines";
+    }
+
+    @Test
+    public void testSeparatorWrap() throws Exception {
+        verifyWithWholeConfig(getPath("InputSeparatorWrap.java"));
+    }
+
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule42wrappinglines/InputSeparatorWrap.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule42wrappinglines/InputSeparatorWrap.java
@@ -1,0 +1,26 @@
+package com.sun.checkstyle.test.chapter4indentation.rule42wrappinglines;
+
+/** Test cases for comma wrapping. */
+public final class InputSeparatorWrap {
+
+    /** Tests correct comma wrapping. */
+    void goodCase() {
+        foo(
+            "first",
+            "second",
+            "third");
+    }
+
+    /** Tests incorrect comma wrapping. */
+    void badCase() {
+        foo(
+            "first",
+            "second"
+            , "third"); // violation '',' is preceded with whitespace.'
+                 // violation '',' should be on the previous line.'
+    }
+
+    private static void foo(final String... values) {
+    }
+
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule42wrappinglines/package-info.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule42wrappinglines/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Test inputs for the wrapping lines check in Sun style.
+ */
+package com.sun.checkstyle.test.chapter4indentation.rule42wrappinglines;

--- a/src/main/resources/sun_checks.xml
+++ b/src/main/resources/sun_checks.xml
@@ -149,6 +149,7 @@
     <module name="NoWhitespaceAfter"/>
     <module name="NoWhitespaceBefore"/>
     <module name="OperatorWrap"/>
+    <module name="SeparatorWrap"/>
     <module name="ParenPad"/>
     <module name="TypecastParenPad"/>
     <module name="WhitespaceAfter">

--- a/src/site/xdoc/sun-style.xml
+++ b/src/site/xdoc/sun-style.xml
@@ -352,8 +352,18 @@
                     4.2 Wrapping Lines
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_blue.png" alt="" />
+                  </span>
+                  <a href="checks/whitespace/separatorwrap.html#SeparatorWrap">SeparatorWrap</a>
+                  (<a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A%2A%2A%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SeparatorWrap">
+                    config</a>)
+                </td>
+                <td>
+                  <a href="https://github.com/checkstyle/checkstyle/tree/master/src/it/resources/com/sun/checkstyle/test/chapter4indentation/rule42wrappinglines">
+                    samples</a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
## Description

Add `SeparatorWrap` to the Sun checks configuration for the
"4.2 Wrapping Lines" rule.

This covers the Sun Style requirement:

> Break after a comma.

The coverage page is updated to reflect partial coverage of section 4.2.

## Changes

- Added `SeparatorWrap` to `sun_checks.xml`
- Added Sun Style 4.2 integration test input and test class
- Added coverage entry for `SeparatorWrap`

## Testing

The integration test input was validated directly against the
Sun checks configuration and produces the two expected violations:
- `NoWhitespaceBefore`
- `SeparatorWrap`

The full Maven test lifecycle could not be completed locally because
the repository's JaCoCo offline instrumentation fails with
`org/jacoco/agent/rt/internal_bac9136/Offline`.

Related issue: #21528