### PR TITLE
Issue #21137: Fix modules suppressed from the default-config example :  return count

### DIFF
--- a/src/site/xdoc/checks/coding/returncount.xml
+++ b/src/site/xdoc/checks/coding/returncount.xml
@@ -20,11 +20,18 @@
             <input type="checkbox" id="toc-sub-Examples" class="toc-sub-toggle-checkbox" checked="checked"/>
             <label for="toc-sub-Examples" class="toc-sub-toggle"><a href="#ReturnCount_Examples">Examples</a><span class="toc-sub-arrow"/></label>
             <ul class="toc-sublist">
-              <li><a href="#Example1-config" class="toc-sublink">So that it doesn't allow more than three return statements per method (ignoring the <code>equals()</code> method)</a></li>
+              <li><a href="#Example1-config" class="toc-sublink">With default properties</a></li>
               <li><a href="#Example2-config" class="toc-sublink">So that it doesn't allow any return statements per void method</a></li>
-              <li><a href="#Example3-config" class="toc-sublink">So that it doesn't allow more than 2 return statements per method (ignoring the <code>equals()</code> method) and more than 1 return statements per void method</a></li>
-              <li><a href="#Example4-config" class="toc-sublink">So that it doesn't allow more than three return statements per method, ignoring the <code>signB()</code> method</a></li>
-              <li><a href="#Example5-config" class="toc-sublink">So that it doesn't allow any return statements in constructors, more than one return statement in all lambda expressions and more than two return statements in methods</a></li>
+              <li><a href="#Example3-config" class="toc-sublink">So that it doesn't allow more than three return statements per method, ignoring the <code>signB()</code> method</a></li>
+              <li><a href="#Example4-config" class="toc-sublink">So that it doesn't allow any return statements in constructors, more than one return statement in all lambda expressions and more than two return statements in methods</a></li>
+              <li><a href="#Example5-config" class="toc-sublink">So that it doesn't allow more than three return statements per method (ignoring the <code>equals()</code> method)</a></li>
+            </ul>
+          </li>
+          <li>
+            <input type="checkbox" id="toc-sub-UseCases" class="toc-sub-toggle-checkbox" checked="checked"/>
+            <label for="toc-sub-UseCases" class="toc-sub-toggle"><a href="#ReturnCount_Use_Cases">Use Cases</a><span class="toc-sub-arrow"/></label>
+            <ul class="toc-sublist">
+              <li><a href="#UseCase1-config" class="toc-sublink">Explicitly set the default values (max=2 for non-void methods, maxForVoid=1 for void methods)</a></li>
             </ul>
           </li>
           <li><a href="#ReturnCount_Example_of_Usage">Example of Usage</a></li>
@@ -120,16 +127,12 @@
 
       <subsection name="Examples" id="ReturnCount_Examples">
         <p id="Example1-config">
-          To configure the check so that it doesn't allow more than three
-          return statements per method (ignoring the <code>equals()</code>
-          method):
+          To configure the check with default properties:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
 &lt;module name="Checker"&gt;
   &lt;module name="TreeWalker"&gt;
-    &lt;module name="ReturnCount"&gt;
-      &lt;property name="max" value="3"/&gt;
-    &lt;/module&gt;
+    &lt;module name="ReturnCount"/&gt;
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
@@ -146,14 +149,14 @@ public class Example1 {
         if (x &lt; -2) { return -1; }
         return 0;
     }
-    // violation below 'max allowed for non-void methods/lambdas is 3'
+    // violation below 'max allowed for non-void methods/lambdas is 2'
     public int signB(int x) {
         if (x &lt; -2) { return -1; }
         if (x == 0) { return 0; }
         if (x &gt; 2) { return 2; }
         return 1;
     }
-    // ok below, because non-void restriction is 3
+    // ok below, because default non-void restriction is 2
     final Predicate&lt;Integer&gt; lambdaA = i -&gt; {
         if (i &gt; 5) { return true; }
         return false;
@@ -213,54 +216,6 @@ public class Example2 {
 }
 </code></pre></div><hr class="example-separator"/>
         <p id="Example3-config">
-          To configure the check so that it doesn't allow more than 2
-          return statements per method (ignoring the <code>equals()</code>
-          method) and more than 1 return statements per void method:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
-&lt;module name="Checker"&gt;
-  &lt;module name="TreeWalker"&gt;
-    &lt;module name="ReturnCount"&gt;
-      &lt;property name="max" value="2"/&gt;
-      &lt;property name="maxForVoid" value="1"/&gt;
-    &lt;/module&gt;
-  &lt;/module&gt;
-&lt;/module&gt;
-</code></pre></div>
-        <p id="Example3-code">
-            Example:
-        </p>
-        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example3 {
-    public Example3() {}
-    // ok below, because default void restriction is 1
-    public Example3(int i) { return; }
-
-    public int signA(int x) {
-        if (x &lt; -2) { return -1; }
-        return 0;
-    }
-    // violation below 'max allowed for non-void methods/lambdas is 2'
-    public int signB(int x) {
-        if (x &lt; -2) { return -1; }
-        if (x == 0) { return 0; }
-        if (x &gt; 2) { return 2; }
-        return 1;
-    }
-    // ok below, because non-void restriction is 2
-    final Predicate&lt;Integer&gt; lambdaA = i -&gt; {
-        if (i &gt; 5) { return true; }
-        return false;
-    };
-
-    final Predicate&lt;Integer&gt; lambdaB = i -&gt; { return i &gt; 5; };
-
-    public void methodA(int x) {}
-    // ok below, because default void restriction is 1
-    public void methodB(int x) { return; }
-}
-</code></pre></div><hr class="example-separator"/>
-        <p id="Example4-config">
           To configure the check so that it doesn't allow more than three
           return statements per method, ignoring the <code>signB()</code>
           method:
@@ -275,14 +230,14 @@ public class Example3 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example4-code">
+        <p id="Example3-code">
             Example:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example4 {
-    public Example4() {}
+public class Example3 {
+    public Example3() {}
     // ok below, because default void restriction is 1
-    public Example4(int i) { return; }
+    public Example3(int i) { return; }
 
     public int signA(int x) {
         if (x &lt; -2) { return -1; }
@@ -308,7 +263,7 @@ public class Example4 {
     public void methodB(int x) { return; }
 }
 </code></pre></div><hr class="example-separator"/>
-        <p id="Example5-config">
+        <p id="Example4-config">
           To configure the check so that it doesn't allow any return statements
           in constructors, more than one return statement in all lambda
           expressions and more than two return statements in methods:
@@ -331,14 +286,14 @@ public class Example4 {
   &lt;/module&gt;
 &lt;/module&gt;
 </code></pre></div>
-        <p id="Example5-code">
+        <p id="Example4-code">
             Example:
         </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
-public class Example5 {
-    public Example5() {}
+public class Example4 {
+    public Example4() {}
     // violation below 'max allowed for void methods/constructors/lambdas is 0'
-    public Example5(int i) { return; }
+    public Example4(int i) { return; }
 
     public int signA(int x) {
         if (x &lt; -2) { return -1; }
@@ -362,6 +317,103 @@ public class Example5 {
     public void methodA(int x) {}
     // ok below, because default void restriction is 1
     public void methodB(int x) { return; }
+}
+</code></pre></div><hr class="example-separator"/>
+        <p id="Example5-config">
+          To configure the check so that it doesn't allow more than three
+          return statements per method (ignoring the <code>equals()</code>
+          method):
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ReturnCount"&gt;
+      &lt;property name="max" value="3"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="Example5-code">
+            Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class Example5 {
+    public Example5() {}
+    // ok below, because default void restriction is 1
+    public Example5(int i) { return; }
+
+    public int signA(int x) {
+        if (x &lt; -2) { return -1; }
+        return 0;
+    }
+    // violation below 'max allowed for non-void methods/lambdas is 3'
+    public int signB(int x) {
+        if (x &lt; -2) { return -1; }
+        if (x == 0) { return 0; }
+        if (x &gt; 2) { return 2; }
+        return 1;
+    }
+    // ok below, because non-void restriction is 3
+    final Predicate&lt;Integer&gt; lambdaA = i -&gt; {
+        if (i &gt; 5) { return true; }
+        return false;
+    };
+
+    final Predicate&lt;Integer&gt; lambdaB = i -&gt; { return i &gt; 5; };
+
+    public void methodA(int x) {}
+    // ok below, because default void restriction is 1
+    public void methodB(int x) { return; }
+}
+</code></pre></div>
+      </subsection>
+
+      <subsection name="Use Cases" id="ReturnCount_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check to explicitly set the default values
+          (max=2 for non-void methods, maxForVoid=1 for void methods):
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-xml">
+&lt;module name="Checker"&gt;
+  &lt;module name="TreeWalker"&gt;
+    &lt;module name="ReturnCount"&gt;
+      &lt;property name="max" value="2"/&gt;
+      &lt;property name="maxForVoid" value="1"/&gt;
+    &lt;/module&gt;
+  &lt;/module&gt;
+&lt;/module&gt;
+</code></pre></div>
+        <p id="UseCase1-code">
+            Example:
+        </p>
+        <div class="wrapper"><pre class="prettyprint"><code class="language-java">
+public class UseCase1 {
+  public UseCase1() {}
+  // ok below, because default void restriction is 1
+  public UseCase1(int i) { return; }
+
+  public int signA(int x) {
+    if (x &lt; -2) { return -1; }
+    return 0;
+  }
+  // violation below 'max allowed for non-void methods/lambdas is 2'
+  public int signB(int x) {
+    if (x &lt; -2) { return -1; }
+    if (x == 0) { return 0; }
+    if (x &gt; 2) { return 2; }
+    return 1;
+  }
+  // ok below, because non-void restriction is 2
+  final Predicate&lt;Integer&gt; lambdaA = i -&gt; {
+    if (i &gt; 5) { return true; }
+    return false;
+  };
+
+  final Predicate&lt;Integer&gt; lambdaB = i -&gt; { return i &gt; 5; };
+
+  public void methodA(int x) {}
+  // ok below, because default void restriction is 1
+  public void methodB(int x) { return; }
 }
 </code></pre></div>
       </subsection>

--- a/src/site/xdoc/checks/coding/returncount.xml.template
+++ b/src/site/xdoc/checks/coding/returncount.xml.template
@@ -33,9 +33,7 @@
 
       <subsection name="Examples" id="ReturnCount_Examples">
         <p id="Example1-config">
-          To configure the check so that it doesn't allow more than three
-          return statements per method (ignoring the <code>equals()</code>
-          method):
+          To configure the check with default properties:
         </p>
         <macro name="example">
           <param name="path"
@@ -68,9 +66,9 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example3-config">
-          To configure the check so that it doesn't allow more than 2
-          return statements per method (ignoring the <code>equals()</code>
-          method) and more than 1 return statements per void method:
+          To configure the check so that it doesn't allow more than three
+          return statements per method, ignoring the <code>signB()</code>
+          method:
         </p>
         <macro name="example">
           <param name="path"
@@ -86,9 +84,9 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example4-config">
-          To configure the check so that it doesn't allow more than three
-          return statements per method, ignoring the <code>signB()</code>
-          method:
+          To configure the check so that it doesn't allow any return statements
+          in constructors, more than one return statement in all lambda
+          expressions and more than two return statements in methods:
         </p>
         <macro name="example">
           <param name="path"
@@ -104,9 +102,9 @@
           <param name="type" value="code"/>
         </macro><hr class="example-separator"/>
         <p id="Example5-config">
-          To configure the check so that it doesn't allow any return statements
-          in constructors, more than one return statement in all lambda
-          expressions and more than two return statements in methods:
+          To configure the check so that it doesn't allow more than three
+          return statements per method (ignoring the <code>equals()</code>
+          method):
         </p>
         <macro name="example">
           <param name="path"
@@ -119,6 +117,26 @@
         <macro name="example">
           <param name="path"
                  value="resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example5.java"/>
+          <param name="type" value="code"/>
+        </macro>
+      </subsection>
+
+      <subsection name="Use Cases" id="ReturnCount_Use_Cases">
+        <p id="UseCase1-config">
+          To configure the check to explicitly set the default values
+          (max=2 for non-void methods, maxForVoid=1 for void methods):
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/UseCase1.java"/>
+          <param name="type" value="config"/>
+        </macro>
+        <p id="UseCase1-code">
+            Example:
+        </p>
+        <macro name="example">
+          <param name="path"
+                 value="resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/UseCase1.java"/>
           <param name="type" value="code"/>
         </macro>
       </subsection>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsExamplesAstConsistencyTest.java
@@ -149,7 +149,6 @@ public class XdocsExamplesAstConsistencyTest {
      * Until: <a href="https://github.com/checkstyle/checkstyle/issues/21137">...</a>
      */
     private static final Set<String> EXAMPLE_DEFAULT_CONFIG_SUPPRESSED_MODULES = Set.of(
-            "checks/coding/returncount",
             "checks/descendanttoken",
             "checks/imports/importcontrol",
             "filters/severitymatchfilter",

--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckExamplesTest.java
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckExamplesTest.java
@@ -37,7 +37,7 @@ public class ReturnCountCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample1() throws Exception {
         final String[] expected = {
-            "25:5: " + getCheckMessage(MSG_KEY, 4, 3),
+            "23:5: " + getCheckMessage(MSG_KEY, 4, 2),
         };
 
         verifyWithInlineConfigParser(getPath("Example1.java"), expected);
@@ -55,17 +55,28 @@ public class ReturnCountCheckExamplesTest extends AbstractExamplesModuleTestSupp
     }
 
     @Test
-    public void testExample3() throws Exception {
+    public void testUseCase1() throws Exception {
         final String[] expected = {
-            "26:5: " + getCheckMessage(MSG_KEY, 4, 2),
+            "26:3: " + getCheckMessage(MSG_KEY, 4, 2),
         };
+
+        verifyWithInlineConfigParser(getPath("UseCase1.java"), expected);
+    }
+
+    @Test
+    public void testExample3() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verifyWithInlineConfigParser(getPath("Example3.java"), expected);
     }
 
     @Test
     public void testExample4() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "27:5: " + getCheckMessage(MSG_KEY_VOID, 1, 0),
+            "34:5: " + getCheckMessage(MSG_KEY, 4, 2),
+            "41:42: " + getCheckMessage(MSG_KEY, 2, 1),
+        };
 
         verifyWithInlineConfigParser(getPath("Example4.java"), expected);
     }
@@ -73,9 +84,7 @@ public class ReturnCountCheckExamplesTest extends AbstractExamplesModuleTestSupp
     @Test
     public void testExample5() throws Exception {
         final String[] expected = {
-            "27:5: " + getCheckMessage(MSG_KEY_VOID, 1, 0),
-            "34:5: " + getCheckMessage(MSG_KEY, 4, 2),
-            "41:42: " + getCheckMessage(MSG_KEY, 2, 1),
+            "25:5: " + getCheckMessage(MSG_KEY, 4, 3),
         };
 
         verifyWithInlineConfigParser(getPath("Example5.java"), expected);

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example1.java
@@ -1,9 +1,7 @@
 /*xml
 <module name="Checker">
   <module name="TreeWalker">
-    <module name="ReturnCount">
-      <property name="max" value="3"/>
-    </module>
+    <module name="ReturnCount"/>
   </module>
 </module>
 */
@@ -21,14 +19,14 @@ public class Example1 {
         if (x < -2) { return -1; }
         return 0;
     }
-    // violation below 'max allowed for non-void methods/lambdas is 3'
+    // violation below 'max allowed for non-void methods/lambdas is 2'
     public int signB(int x) {
         if (x < -2) { return -1; }
         if (x == 0) { return 0; }
         if (x > 2) { return 2; }
         return 1;
     }
-    // ok below, because non-void restriction is 3
+    // ok below, because default non-void restriction is 2
     final Predicate<Integer> lambdaA = i -> {
         if (i > 5) { return true; }
         return false;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example3.java
@@ -2,8 +2,8 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="ReturnCount">
-      <property name="max" value="2"/>
-      <property name="maxForVoid" value="1"/>
+      <property name="max" value="3"/>
+      <property name="format" value="^signB$"/>
     </module>
   </module>
 </module>
@@ -22,14 +22,14 @@ public class Example3 {
         if (x < -2) { return -1; }
         return 0;
     }
-    // violation below 'max allowed for non-void methods/lambdas is 2'
+    // ok below, because 'signB' is ignored by 'format'
     public int signB(int x) {
         if (x < -2) { return -1; }
         if (x == 0) { return 0; }
         if (x > 2) { return 2; }
         return 1;
     }
-    // ok below, because non-void restriction is 2
+    // ok below, because non-void restriction is 3
     final Predicate<Integer> lambdaA = i -> {
         if (i > 5) { return true; }
         return false;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example4.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example4.java
@@ -2,8 +2,16 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="ReturnCount">
-      <property name="max" value="3"/>
-      <property name="format" value="^signB$"/>
+      <property name="maxForVoid" value="0"/>
+      <property name="tokens" value="CTOR_DEF"/>
+    </module>
+    <module name="ReturnCount">
+      <property name="max" value="1"/>
+      <property name="tokens" value="LAMBDA"/>
+    </module>
+    <module name="ReturnCount">
+      <property name="max" value="2"/>
+      <property name="tokens" value="METHOD_DEF"/>
     </module>
   </module>
 </module>
@@ -15,21 +23,21 @@ import java.util.function.Predicate;
 // xdoc section - start
 public class Example4 {
     public Example4() {}
-    // ok below, because default void restriction is 1
+    // violation below 'max allowed for void methods/constructors/lambdas is 0'
     public Example4(int i) { return; }
 
     public int signA(int x) {
         if (x < -2) { return -1; }
         return 0;
     }
-    // ok below, because 'signB' is ignored by 'format'
+    // violation below 'max allowed for non-void methods/lambdas is 2'
     public int signB(int x) {
         if (x < -2) { return -1; }
         if (x == 0) { return 0; }
         if (x > 2) { return 2; }
         return 1;
     }
-    // ok below, because non-void restriction is 3
+    // violation below 'max allowed for non-void methods/lambdas is 1'
     final Predicate<Integer> lambdaA = i -> {
         if (i > 5) { return true; }
         return false;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example5.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/Example5.java
@@ -2,16 +2,7 @@
 <module name="Checker">
   <module name="TreeWalker">
     <module name="ReturnCount">
-      <property name="maxForVoid" value="0"/>
-      <property name="tokens" value="CTOR_DEF"/>
-    </module>
-    <module name="ReturnCount">
-      <property name="max" value="1"/>
-      <property name="tokens" value="LAMBDA"/>
-    </module>
-    <module name="ReturnCount">
-      <property name="max" value="2"/>
-      <property name="tokens" value="METHOD_DEF"/>
+      <property name="max" value="3"/>
     </module>
   </module>
 </module>
@@ -23,21 +14,21 @@ import java.util.function.Predicate;
 // xdoc section - start
 public class Example5 {
     public Example5() {}
-    // violation below 'max allowed for void methods/constructors/lambdas is 0'
+    // ok below, because default void restriction is 1
     public Example5(int i) { return; }
 
     public int signA(int x) {
         if (x < -2) { return -1; }
         return 0;
     }
-    // violation below 'max allowed for non-void methods/lambdas is 2'
+    // violation below 'max allowed for non-void methods/lambdas is 3'
     public int signB(int x) {
         if (x < -2) { return -1; }
         if (x == 0) { return 0; }
         if (x > 2) { return 2; }
         return 1;
     }
-    // violation below 'max allowed for non-void methods/lambdas is 1'
+    // ok below, because non-void restriction is 3
     final Predicate<Integer> lambdaA = i -> {
         if (i > 5) { return true; }
         return false;

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/UseCase1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/returncount/UseCase1.java
@@ -1,0 +1,44 @@
+/*xml
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="ReturnCount">
+      <property name="max" value="2"/>
+      <property name="maxForVoid" value="1"/>
+    </module>
+  </module>
+</module>
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.returncount;
+
+import java.util.function.Predicate;
+
+// xdoc section - start
+public class UseCase1 {
+  public UseCase1() {}
+  // ok below, because default void restriction is 1
+  public UseCase1(int i) { return; }
+
+  public int signA(int x) {
+    if (x < -2) { return -1; }
+    return 0;
+  }
+  // violation below 'max allowed for non-void methods/lambdas is 2'
+  public int signB(int x) {
+    if (x < -2) { return -1; }
+    if (x == 0) { return 0; }
+    if (x > 2) { return 2; }
+    return 1;
+  }
+  // ok below, because non-void restriction is 2
+  final Predicate<Integer> lambdaA = i -> {
+    if (i > 5) { return true; }
+    return false;
+  };
+
+  final Predicate<Integer> lambdaB = i -> { return i > 5; };
+
+  public void methodA(int x) {}
+  // ok below, because default void restriction is 1
+  public void methodB(int x) { return; }
+}
+// xdoc section - end


### PR DESCRIPTION
#21137 


| File | Configuration | Description |
|-------------|---------------|-------------------|
| Example1.java | Default (no properties) | "default properties" |
| Example2.java | maxForVoid=0 |  "doesn't allow any return statements per void method" |
| Example3.java | max=3, format=^signB$ | "doesn't allow more than three return statements per method, ignoring signB()" |
| Example4.java | Multiple instances (CTOR_DEF: maxForVoid=0, LAMBDA: max=1, METHOD_DEF: max=2) |  "doesn't allow any return statements in constructors, more than one return statement in all lambda expressions and more than two return statements in methods" |
| Example5.java | max=3 |  "doesn't allow more than three return statements per method (ignoring equals())" |
| UseCase1.java | max=2, maxForVoid=1 |  "explicitly set the default values" |


**PR Description:**

Add default-config example for ReturnCountCheck and refactor examples

**Changes:**
- Added default-config example (Example1.java) with no configured properties
- Removed "checks/coding/returncount" from `EXAMPLE_DEFAULT_CONFIG_SUPPRESSED_MODULES` in XdocsExamplesAstConsistencyTest
- Converted Example3 to a usecase (UseCase1.java) demonstrating explicit default values (max=2, maxForVoid=1)
- Renumbered examples: Example4→Example3, Example5→Example4, Example6→Example5
- Updated `ReturnCountCheckExamplesTest `with `testUseCase1 `and corrected file paths
- Updated returncount.xml.template with renumbered examples and new Use Cases subsection

