### PR TITLE
Issue #20590: add AvoidNestedBlocks compact source input coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
@@ -80,4 +80,29 @@ public class AvoidNestedBlocksCheckTest
                 .isEqualTo(expected);
     }
 
+    @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "12:5: " + getCheckMessage(MSG_KEY_BLOCK_NESTED),
+            "20:17: " + getCheckMessage(MSG_KEY_BLOCK_NESTED),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("compact/InputAvoidNestedBlocksCompactSourceFile.java"),
+                expected);
+    }
+
+    @Test
+    public void testCompactSourceFileAllowInSwitchCase() throws Exception {
+        final String[] expected = {
+            "12:5: " + getCheckMessage(MSG_KEY_BLOCK_NESTED),
+            "20:17: " + getCheckMessage(MSG_KEY_BLOCK_NESTED),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath(
+                        "compact/InputAvoidNestedBlocksCompactSourceFileAllowInSwitchCase.java"),
+                expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -96,7 +96,6 @@ public class AllChecksCompactSourceCoverageTest {
         "AtclauseOrderCheck",
         "AvoidDoubleBraceInitializationCheck",
         "AvoidEscapedUnicodeCharactersCheck",
-        "AvoidNestedBlocksCheck",
         "AvoidStarImportCheck",
         "BooleanExpressionComplexityCheck",
         "CatchParameterNameCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/avoidnestedblocks/compact/InputAvoidNestedBlocksCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/avoidnestedblocks/compact/InputAvoidNestedBlocksCompactSourceFile.java
@@ -1,0 +1,28 @@
+/*
+AvoidNestedBlocks
+allowInSwitchCase = (default)false
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void helper() {
+    int a = 1;
+    { // violation 'Avoid nested blocks.'
+        a++;
+    }
+    System.out.println(a);
+}
+
+void main() {
+    switch (1) {
+        case 1: { // violation 'Avoid nested blocks.'
+            int b = 2;
+            System.out.println(b);
+        }
+        default:
+            break;
+    }
+    helper();
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/avoidnestedblocks/compact/InputAvoidNestedBlocksCompactSourceFileAllowInSwitchCase.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/avoidnestedblocks/compact/InputAvoidNestedBlocksCompactSourceFileAllowInSwitchCase.java
@@ -1,0 +1,29 @@
+/*
+AvoidNestedBlocks
+allowInSwitchCase = true
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+    int a = 1;
+    { // violation 'Avoid nested blocks.'
+        a++;
+    }
+    switch (a) {
+        case 1: {
+            int b = 2;
+            System.out.println(b);
+        }
+        case 2: { // violation 'Avoid nested blocks.'
+            int c = 3;
+            System.out.println(c);
+        }
+        break;
+        default:
+            break;
+    }
+    System.out.println(a);
+}


### PR DESCRIPTION
Issue #20590

Adds compact source file (JEP 512) input coverage for `AvoidNestedBlocks`, and removes it from `SUPPRESSED_CHECKS` in `AllChecksCompactSourceCoverageTest`.

Two inputs are added, so that the check runs once with all properties at their defaults and its only settable property is also exercised at a non-default value:

- `InputAvoidNestedBlocksCompactSourceFile.java` - `allowInSwitchCase = (default)false`
- `InputAvoidNestedBlocksCompactSourceFileAllowInSwitchCase.java` - `allowInSwitchCase = true`

The second input exercises both sides of the property. Per the check's logic, a violation is reported when the parent is an `SLIST` and `!allowInSwitchCase || hasSiblings(ast)`, so with the property enabled the lone block in `case 1:` is not reported, while the block in `case 2:` still is, because the following `break` makes it a sibling.

