### PR TITLE
Issue #13987: remove openjdk25 excludes for implicitly declared classes

### DIFF
--- a/config/projects-to-test/openjdk25-excluded.files
+++ b/config/projects-to-test/openjdk25-excluded.files
@@ -43,23 +43,6 @@
   <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]flags[\\/]NoFalseSealedError.java$"/>
 </module>
 
-<!-- until https://github.com/checkstyle/checkstyle/issues/13987 -->
-<module name="BeforeExecutionExclusionFileFilter">
-  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]diags[\\/]examples[\\/]UnnamedClass.java$"/>
-</module>
-<module name="BeforeExecutionExclusionFileFilter">
-  <property name="fileNamePattern" value="[\\/]test[\\/]jdk[\\/]java[\\/]lang[\\/]Class[\\/]UnnamedClass[\\/]Unnamed.java$"/>
-</module>
-<module name="BeforeExecutionExclusionFileFilter">
-  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]unnamedclass[\\/]SourceLevelErrorPosition.java$"/>
-</module>
-<module name="BeforeExecutionExclusionFileFilter">
-  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]processing[\\/]model[\\/]element[\\/]Anonymous.java$"/>
-</module>
-<module name="BeforeExecutionExclusionFileFilter">
-  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]unnamedclass[\\/]NestedEnum.java$"/>
-</module>
-
 <!-- Permanent suppression for string templates, see reason at https://github.com/checkstyle/checkstyle/issues/14805#issue-2248064127. -->
 <module name="BeforeExecutionExclusionFileFilter">
   <property name="fileNamePattern" value="[\\/]test[\\/]jdk[\\/]java[\\/]lang[\\/]template[\\/]StringTemplateTest.java$"/>


### PR DESCRIPTION
#13987 is fixed since 13.6.0, so the exclusion group it guarded can go. This also unblocks `check_issues`, which is red on every open PR right now because that line points at a closed issue.

Four of the five paths no longer exist in jdk25u master. The files were renamed when unnamed classes became implicitly declared classes, and the renamed ones are already excluded further down under `non-compilable`. The only one still present is `test/langtools/tools/javac/processing/model/element/Anonymous.java`. I ran it through `checks-nonjavadoc-error.xml` with 14.1.0 and it parses as a `COMPACT_COMPILATION_UNIT`, no exception, exit 0.
