### PR TITLE
Issue #20590: Add NoArrayTrailingComma compact source coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheckTest.java
@@ -49,6 +49,16 @@ public class NoArrayTrailingCommaCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "10:26: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("compact/InputNoArrayTrailingCommaCompactSourceFile.java"),
+                expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final NoArrayTrailingCommaCheck check = new NoArrayTrailingCommaCheck();
         assertWithMessage("Acceptable tokens should not be null")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -186,7 +186,6 @@ public class AllChecksCompactSourceCoverageTest {
         "NestedForDepthCheck",
         "NestedIfDepthCheck",
         "NestedTryDepthCheck",
-        "NoArrayTrailingCommaCheck",
         "NoCodeInFileCheck",
         "NoEnumTrailingCommaCheck",
         "NoLineWrapCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/noarraytrailingcomma/compact/InputNoArrayTrailingCommaCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/noarraytrailingcomma/compact/InputNoArrayTrailingCommaCompactSourceFile.java
@@ -1,0 +1,11 @@
+/*
+NoArrayTrailingComma
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+    int[] numbers = {1, 2,}; // violation 'Array should not contain trailing comma.'
+}


### PR DESCRIPTION
Issue: #20590

Adds Java 25 compact-source coverage for `NoArrayTrailingCommaCheck`.

The new input verifies that an array initializer with a trailing comma is reported using the default configuration. It also removes the check from the `AllChecksCompactSourceCoverageTest` suppression list.

Validation:

- `./mvnw clean -Dtest=NoArrayTrailingCommaCheckTest,AllChecksCompactSourceCoverageTest test`
- `./mvnw clean verify`