### PR TITLE
Issue #14084: resolve purity violations in MultipleStringLiterals

### DIFF
--- a/config/checker-framework-suppressions/checker-purity-value-returns-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-purity-value-returns-suppressions.xml
@@ -1,16 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java</fileName>
-    <specifier>flowexpr.parse.index.too.big</specifier>
-    <message>the method has no parameter #1 (total 0 parameters)</message>
-    <lineContent>ignoreOccurrenceContext.clear();</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java</fileName>
-    <specifier>flowexpr.parse.index.too.big</specifier>
-    <message>the method has no parameter #1 (total 0 parameters)</message>
-    <lineContent>ignoreOccurrenceContext.clear();</lineContent>
-  </checkerFrameworkError>
 </suppressedErrors>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -134,7 +134,11 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
      * @since 4.4
      */
     public final void setIgnoreOccurrenceContext(String... strRep) {
-        ignoreOccurrenceContext.clear();
+        // BitSet#clear() is skipped in favor of the range overload, as the annotated
+        // JDK of Checker Framework declares a contract on the no-argument method that
+        // refers to a parameter it does not have, which the checkers report as a
+        // 'flowexpr.parse.index.too.big' violation at every call site.
+        ignoreOccurrenceContext.clear(0, ignoreOccurrenceContext.length());
         for (final String s : strRep) {
             final int type = TokenUtil.getTokenId(s);
             ignoreOccurrenceContext.set(type);


### PR DESCRIPTION
Issue: #14084

Fixes #14084

Resolves the two remaining suppressed violations of the `checker-purity-value-returns` profile, which empties its suppression file.

Both blocks were the same call, reported once by each of the profile's two processors (`PurityChecker` and `ReturnsReceiverChecker`):

```
MultipleStringLiteralsCheck.java:[137,38]
[flowexpr.parse.index.too.big] the method has no parameter #1 (total 0 parameters)
lineContent: ignoreOccurrenceContext.clear();
```

### Cause

The contract is not declared in checkstyle. The annotated JDK of Checker Framework 4.2.3 declares a contract on the no-argument `BitSet#clear()` that refers to `#1`, a parameter that overload does not have, so the checkers report the malformed flow expression at the call site. `ignoreOccurrenceContext` is the only `BitSet` in main code that `clear()` is called on, which is why this is the only place it appears; the other `clear()` calls in main code are on collections and are unaffected.

### Fix

Call the range overload `clear(int, int)` instead, which is not annotated with the malformed contract. `clear(0, length())` clears every set bit, since `length()` is the index of the highest set bit plus one, and is a no-op on an empty set, so behavior is unchanged. A comment records why the no-argument overload is avoided.

The suppression file is kept with an empty `suppressedErrors` element, matching `checker-formatter-suppressions.xml`, which is already at zero blocks.

### Verification

Ran locally on this branch:

| Command | Result |
| --- | --- |
| `mvn compile -P checker-purity-value-returns` | 0 `flowexpr` warnings (2 before the change) |
| `mvn test -Dtest=MultipleStringLiteralsCheckTest` | 10/10 pass |
| `mvn antrun:run@ant-phase-verify` | BUILD SUCCESS |