### PR TITLE
Issue #21515: ExpressionOverBlockLambda misses block lambdas used as switch-rule values

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExpressionOverBlockLambdaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExpressionOverBlockLambdaCheck.java
@@ -78,7 +78,7 @@ public class ExpressionOverBlockLambdaCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (!isSwitchRuleLambda(ast)
+        if (!isSwitchRuleArrow(ast)
                 && isSingleLineLambda(ast)) {
             final DetailAST body = ast.getLastChild();
             final DetailAST statement =
@@ -92,13 +92,14 @@ public class ExpressionOverBlockLambdaCheck extends AbstractCheck {
     }
 
     /**
-     * Checks if the lambda is a switch rule lambda.
+     * Checks if the given lambda node is the arrow token of a switch rule.
+     * Such token is the only lambda which has no children.
      *
      * @param lambda the lambda AST node
-     * @return true if the lambda is part of a switch rule
+     * @return true if the lambda is the arrow token of a switch rule
      */
-    private static boolean isSwitchRuleLambda(DetailAST lambda) {
-        return lambda.getParent().getType() == TokenTypes.SWITCH_RULE;
+    private static boolean isSwitchRuleArrow(DetailAST lambda) {
+        return !lambda.hasChildren();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ExpressionOverBlockLambdaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ExpressionOverBlockLambdaCheckTest.java
@@ -38,12 +38,14 @@ public class ExpressionOverBlockLambdaCheckTest
     @Test
     public void testSingleLineBlockLambdas() throws Exception {
         final String[] expected = {
-            "22:25: " + getCheckMessage(MSG_KEY),
-            "30:42: " + getCheckMessage(MSG_KEY),
-            "39:20: " + getCheckMessage(MSG_KEY),
-            "47:33: " + getCheckMessage(MSG_KEY),
-            "56:23: " + getCheckMessage(MSG_KEY),
-            "58:24: " + getCheckMessage(MSG_KEY),
+            "23:25: " + getCheckMessage(MSG_KEY),
+            "31:42: " + getCheckMessage(MSG_KEY),
+            "40:20: " + getCheckMessage(MSG_KEY),
+            "48:33: " + getCheckMessage(MSG_KEY),
+            "57:23: " + getCheckMessage(MSG_KEY),
+            "59:24: " + getCheckMessage(MSG_KEY),
+            "69:26: " + getCheckMessage(MSG_KEY),
+            "71:27: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputExpressionOverBlockLambdaInvalid.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/expressionoverblocklambda/InputExpressionOverBlockLambdaInvalid.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/expressionoverblocklambda/InputExpressionOverBlockLambdaInvalid.java
@@ -9,6 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.expressionoverblocklambda;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Test input for expression lambda preferred over single-line block lambda.
@@ -57,6 +58,18 @@ public class InputExpressionOverBlockLambdaInvalid {
             // violation above 'Expression lambdas are preferred over single-line block lambdas.'
             .forEach(s -> { System.out.println(s); });
         // violation above 'Expression lambdas are preferred over single-line block lambdas.'
+    }
+
+    /**
+     * Block lambda used as switch rule value.
+     */
+    public Supplier<String> testSwitchRuleLambda(int x) {
+        return switch (x) {
+            // violation below 'Expression lambdas are preferred over single-line block lambdas.'
+            case 1 -> () -> { return "one"; };
+            // violation below 'Expression lambdas are preferred over single-line block lambdas.'
+            default -> () -> { return "other"; };
+        };
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/expressionoverblocklambda/InputExpressionOverBlockLambdaValid.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/expressionoverblocklambda/InputExpressionOverBlockLambdaValid.java
@@ -9,6 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.expressionoverblocklambda;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Test input for expression lambda preferred over single-line block lambda - valid cases.
@@ -103,6 +104,17 @@ public class InputExpressionOverBlockLambdaValid {
             case 1 -> System.out.println("one");
             default -> System.out.println("other");
         }
+    }
+
+    public Supplier<String> testSwitchRuleValidCases(int x) {
+        return switch (x) {
+            case 1 -> () -> "one";
+            case 2 -> { yield () -> "two"; }
+            case 3 -> () -> {
+                return "three"; };
+            case 4 -> () -> { int y = 1; return "four" + y; };
+            default -> () -> "d";
+        };
     }
 
 }


### PR DESCRIPTION
Issue: #21515

Fixes #21515

`ExpressionOverBlockLambda` does not report violations for single-line block
lambdas used as values of switch rules.

For example:

```java
return switch (x) {
    case 1 -> () -> { return "one"; };
    default -> () -> { return "other"; };
};
```

This change reports those lambdas, adds coverage for switch-rule values, and
keeps `InputExpressionOverBlockLambdaValid.java` within the 120-line FileLength
limit used by resource checks.


Made with [Cursor](https://cursor.com)