### PR TITLE
Issue #20919: enable jdk25 on windows appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,10 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\JDK21
       DESC: "site, without verify (JDK21)"
       CMD: "./.ci/validation.cmd site_without_verify"
+    # verify (JDK25)
+    - JAVA_HOME: C:\Program Files\Java\JDK25
+      DESC: "verify (JDK25)"
+      CMD: "./mvnw.cmd -e --no-transfer-progress verify"
 
 build_script:
   - ps: |


### PR DESCRIPTION
Reverts fdec324210cf511f174583e6c791232dd0dd1dd0. Restores the JDK25 verify job in appveyor.yml now that summer is over, as requested in #20919.