### PR TITLE
Issue #12847: Compare test violations without order

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.common.truth.Correspondence;
 import com.puppycrawl.tools.checkstyle.LocalizedMessage.Utf8Control;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
@@ -241,7 +242,6 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
         final List<TestInputViolation> violationsWithoutFilters =
                 new ArrayList<>(testInputConfiguration.violations());
         violationsWithoutFilters.addAll(testInputConfiguration.filteredViolations());
-        Collections.sort(violationsWithoutFilters);
         verifyViolations(configWithoutFilters, filePath, violationsWithoutFilters);
         verify(configWithoutFilters, filePath, expectedUnfiltered);
         final DefaultConfiguration configWithFilters =
@@ -697,7 +697,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     }
 
     /**
-     * Performs verification of violation lines.
+     * Verifies violation lines and message patterns independently of their order.
      *
      * @param config parsed config.
      * @param file file path.
@@ -709,48 +709,27 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                                   List<TestInputViolation> testInputViolations)
             throws Exception {
         final List<String> actualViolations = getActualViolationsForFile(config, file);
-        final List<Integer> actualViolationLines = actualViolations.stream()
-                .map(violation -> violation.substring(0, violation.indexOf(':')))
-                .map(Integer::valueOf)
-                .toList();
-        final List<Integer> expectedViolationLines = testInputViolations.stream()
-                .map(TestInputViolation::getLineNo)
-                .toList();
-        assertWithMessage("Violation lines for %s differ.", file)
-                .that(actualViolationLines)
-                .isEqualTo(expectedViolationLines);
-        for (int index = 0; index < actualViolations.size(); index++) {
-            assertWithMessage("Actual and expected violations differ.")
-                    .that(actualViolations.get(index))
-                    .matches(testInputViolations.get(index).toRegex());
-        }
+        verifyViolations(file, testInputViolations, actualViolations);
     }
 
     /**
-     * Performs verification of violation lines.
+     * Verifies violation lines and message patterns independently of their order.
      *
      * @param file file path.
      * @param testInputViolations List of TestInputViolation objects.
      * @param actualViolations for a file
      */
-    private static void verifyViolations(String file,
-                                  List<TestInputViolation> testInputViolations,
-                                  List<String> actualViolations) {
-        final List<Integer> actualViolationLines = actualViolations.stream()
-                .map(violation -> violation.substring(0, violation.indexOf(':')))
-                .map(Integer::valueOf)
-                .toList();
-        final List<Integer> expectedViolationLines = testInputViolations.stream()
-                .map(TestInputViolation::getLineNo)
-                .toList();
-        assertWithMessage("Violation lines for %s differ.", file)
-                .that(actualViolationLines)
-                .isEqualTo(expectedViolationLines);
-        for (int index = 0; index < actualViolations.size(); index++) {
-            assertWithMessage("Actual and expected violations differ.")
-                    .that(actualViolations.get(index))
-                    .matches(testInputViolations.get(index).toRegex());
-        }
+    /* package */ static void verifyViolations(String file,
+                                               List<TestInputViolation> testInputViolations,
+                                               List<String> actualViolations) {
+        assertWithMessage("Actual and expected violations for %s differ.", file)
+                .that(actualViolations)
+                .comparingElementsUsing(Correspondence.from(
+                    (String actual, TestInputViolation expected) -> {
+                        return actual.matches(expected.toRegex());
+                    },
+                    "matches the expected violation pattern"))
+                .containsExactlyElementsIn(testInputViolations);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ModuleTestSupportTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ModuleTestSupportTest.java
@@ -1,0 +1,103 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2026 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.getExpectedThrowable;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.bdd.TestInputViolation;
+
+public class ModuleTestSupportTest {
+
+    @Test
+    public void testViolationOrder() {
+        AbstractModuleTestSupport.verifyViolations("input", List.of(
+                new TestInputViolation(12, "second"),
+                new TestInputViolation(2, "first"),
+                new TestInputViolation(12, "first")),
+                List.of("12:9: first message", "12:3: second message", "2: first message"));
+    }
+
+    @Test
+    public void testOverlappingViolationPatterns() {
+        AbstractModuleTestSupport.verifyViolations("input", List.of(
+                new TestInputViolation(3, null),
+                new TestInputViolation(3, "specific")),
+                List.of("3:1: specific message", "3:8: other message"));
+    }
+
+    @Test
+    public void testOverlappingPatternsRequireDistinctViolations() {
+        getExpectedThrowable(AssertionError.class, () -> {
+            AbstractModuleTestSupport.verifyViolations("input", List.of(
+                    new TestInputViolation(3, null),
+                    new TestInputViolation(3, "specific"),
+                    new TestInputViolation(3, "specific")),
+                    List.of("3:1: specific message", "3:8: other message",
+                            "3:9: another message"));
+        });
+    }
+
+    @Test
+    public void testDuplicateViolations() {
+        AbstractModuleTestSupport.verifyViolations("input", List.of(
+                new TestInputViolation(3, "message"),
+                new TestInputViolation(3, "message")),
+                List.of("3:1: message", "3:8: message"));
+    }
+
+    @Test
+    public void testMissingViolation() {
+        getExpectedThrowable(AssertionError.class, () -> {
+            AbstractModuleTestSupport.verifyViolations("input", List.of(
+                    new TestInputViolation(3, "message"),
+                    new TestInputViolation(3, "message")), List.of("3:1: message"));
+        });
+    }
+
+    @Test
+    public void testUnexpectedViolation() {
+        getExpectedThrowable(AssertionError.class, () -> {
+            AbstractModuleTestSupport.verifyViolations("input", List.of(
+                    new TestInputViolation(3, "message")),
+                    List.of("3:1: message", "3:8: message"));
+        });
+    }
+
+    @Test
+    public void testWrongMessage() {
+        getExpectedThrowable(AssertionError.class, () -> {
+            AbstractModuleTestSupport.verifyViolations("input", List.of(
+                    new TestInputViolation(3, "expected")), List.of("3:1: different"));
+        });
+    }
+
+    @Test
+    public void testWrongLine() {
+        getExpectedThrowable(AssertionError.class, () -> {
+            AbstractModuleTestSupport.verifyViolations("input", List.of(
+                    new TestInputViolation(3, "message")), List.of("4:1: message"));
+        });
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
@@ -368,9 +368,9 @@ public class ViolationTest {
     }
 
     private static Violation createSampleViolationWithColumn(int column) {
-        return new Violation(1, column,
+        return new Violation(1, column, 1, TokenTypes.CLASS_DEF,
                 "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
-                EMPTY_OBJECT_ARRAY, "module", Violation.class, null);
+                EMPTY_OBJECT_ARRAY, SeverityLevel.ERROR, "module", Violation.class, null);
     }
 
 }


### PR DESCRIPTION
Fixes #12847

`AbstractModuleTestSupport` previously compared expected and actual violations by list position. Tests with multiple violations on the same line therefore had to understand and reproduce the internal event ordering.

Compare the two collections through their existing violation-message patterns without requiring the lists to have the same order. The comparison remains one-to-one, so missing, unexpected, duplicate, wrong-line, and wrong-message violations still fail.

Validation:

- Full test suites and coverage passed during `./mvnw -ntp clean verify`.
- `./mvnw -ntp verify -DskipTests` passed on the final commit, including Checkstyle and PMD validation.
- Main test suite: 6,810 tests, no failures or errors, two skipped.
- Integration test suite: 1,358 tests, no failures, errors, or skips.
- Eight focused matcher tests cover unordered violations, overlapping patterns, one-to-one matching, duplicate counts, and incorrect lines/messages.
