### PR TITLE
checks: quote remaining violation messages

### DIFF
--- a/src/site/xdoc/checks/coding/equalshashcode.xml
+++ b/src/site/xdoc/checks/coding/equalshashcode.xml
@@ -60,14 +60,14 @@
         <p id="Example1-code">Example:</p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 class Example1 {
-  public int hashCode() { // violation, no valid 'equals'
+  public int hashCode() { // violation 'Definition of 'hashCode()''
     return 0;
   }
   public boolean equals(String o) { return false; }
 }
 
 class ExampleNoHashCode {
-  public boolean equals(Object o) { // violation, no 'hashCode'
+  public boolean equals(Object o) { // violation 'Definition of 'equals()''
     return false;
   }
   public boolean equals(String o) { return false; }
@@ -90,13 +90,13 @@ class ExampleBothMethods2 {
 
 class ExampleNoValidHashCode {
   public static int hashCode(int i) { return 0; }
-  public boolean equals(Object o) { // violation, no valid 'hashCode'
+  public boolean equals(Object o) { // violation 'Definition of 'equals()''
     return false;
   }
 }
 
 class ExampleNoValidEquals {
-  public int hashCode() { // violation, no valid 'equals'
+  public int hashCode() { // violation 'Definition of 'hashCode()''
     return 0;
   }
   public static boolean equals(Object o, Object o2) { return false; }

--- a/src/site/xdoc/checks/coding/noclone.xml
+++ b/src/site/xdoc/checks/coding/noclone.xml
@@ -156,7 +156,7 @@ System.out.println(s2 instanceof Square); //true
         <p id="Example1-code">Example: </p>
         <div class="wrapper"><pre class="prettyprint"><code class="language-java">
 public class Example1 {
-  public Example1 clone() {return null;} // violation, overrides the clone method
+  public Example1 clone() {return null;} // violation 'Avoid using clone method.'
   public static Object clone(Object o) {return null;}
   public static Example1 clone(Example1 same) {return null;}
 }

--- a/src/site/xdoc/checks/sizes/recordcomponentnumber.xml
+++ b/src/site/xdoc/checks/sizes/recordcomponentnumber.xml
@@ -116,10 +116,10 @@ class Example1{
 class Example2{
   public record MyRecord1(int x, int y, String str) {}
 
-  public record MyRecord2(int x, int y, double d, // violation, 6 components
+  public record MyRecord2(int x, int y, double d, // violation 'components is 6'
                     String str, char c, float f) {}
 
-  record MyRecord3(int x, int y, int z, double d, // violation, 9 components
+  record MyRecord3(int x, int y, int z, double d, // violation 'components is 9'
                     String str1, String str2, char c, float f, String location) {}
 
   private record MyRecord4(int x, int y,
@@ -151,13 +151,13 @@ class Example2{
 class Example3 {
   public record MyRecord1(int x, int y, String str) {}
 
-  public record MyRecord2(int x, int y, double d, // violation, 6 components
+  public record MyRecord2(int x, int y, double d, // violation 'components is 6'
                     String str, char c, float f) {}
 
   record MyRecord3(int x, int y, int z, double d,
                     String str1, String str2, char c, float f, String location) {}
 
-  private record MyRecord4(int x, int y, // violation, 4 components
+  private record MyRecord4(int x, int y, // violation 'components is 4'
                            String str, double d) {}
 }
 </code></pre></div>

--- a/src/site/xdoc/checks/whitespace/separatorwrap.xml
+++ b/src/site/xdoc/checks/whitespace/separatorwrap.xml
@@ -130,9 +130,9 @@ class Example1 {
   }
 
   void bar(int p
-          , int q) { // violation ',' should be on the previous line
+          , int q) { // violation "',' should be on the previous line."
     if (s
-            .isEmpty()) { // violation '.' should be on the previous line
+            .isEmpty()) { // violation "'.' should be on the previous line."
     }
   }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -301,12 +301,7 @@ public final class InlineConfigParser {
      * violation messages. Remove entries here as their input files are fixed.
      * <a href="https://github.com/checkstyle/checkstyle/issues/20954">#20954</a>
      */
-    private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of(
-            "checks/coding/equalshashcode/Example1.java",
-            "checks/coding/noclone/Example1.java",
-            "checks/sizes/recordcomponentnumber/Example2.java",
-            "checks/whitespace/separatorwrap/Example1.java"
-    );
+    private static final Set<String> SUPPRESSED_VALIDATE_MESSAGE_FILES = Set.of();
 
     /**
      * Input files where default values for properties are intentionally not specified.

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode/Example1.java
@@ -8,14 +8,14 @@
 package com.puppycrawl.tools.checkstyle.checks.coding.equalshashcode;
 // xdoc section - start
 class Example1 {
-  public int hashCode() { // violation, no valid 'equals'
+  public int hashCode() { // violation 'Definition of 'hashCode()''
     return 0;
   }
   public boolean equals(String o) { return false; }
 }
 
 class ExampleNoHashCode {
-  public boolean equals(Object o) { // violation, no 'hashCode'
+  public boolean equals(Object o) { // violation 'Definition of 'equals()''
     return false;
   }
   public boolean equals(String o) { return false; }
@@ -38,13 +38,13 @@ class ExampleBothMethods2 {
 
 class ExampleNoValidHashCode {
   public static int hashCode(int i) { return 0; }
-  public boolean equals(Object o) { // violation, no valid 'hashCode'
+  public boolean equals(Object o) { // violation 'Definition of 'equals()''
     return false;
   }
 }
 
 class ExampleNoValidEquals {
-  public int hashCode() { // violation, no valid 'equals'
+  public int hashCode() { // violation 'Definition of 'hashCode()''
     return 0;
   }
   public static boolean equals(Object o, Object o2) { return false; }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/noclone/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/coding/noclone/Example1.java
@@ -9,7 +9,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding.noclone;
 
 // xdoc section - start
 public class Example1 {
-  public Example1 clone() {return null;} // violation, overrides the clone method
+  public Example1 clone() {return null;} // violation 'Avoid using clone method.'
   public static Object clone(Object o) {return null;}
   public static Example1 clone(Example1 same) {return null;}
 }

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/Example2.java
@@ -15,10 +15,10 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 class Example2{
   public record MyRecord1(int x, int y, String str) {}
 
-  public record MyRecord2(int x, int y, double d, // violation, 6 components
+  public record MyRecord2(int x, int y, double d, // violation 'components is 6'
                     String str, char c, float f) {}
 
-  record MyRecord3(int x, int y, int z, double d, // violation, 9 components
+  record MyRecord3(int x, int y, int z, double d, // violation 'components is 9'
                     String str1, String str2, char c, float f, String location) {}
 
   private record MyRecord4(int x, int y,

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/Example3.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/Example3.java
@@ -20,13 +20,13 @@ package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
 class Example3 {
   public record MyRecord1(int x, int y, String str) {}
 
-  public record MyRecord2(int x, int y, double d, // violation, 6 components
+  public record MyRecord2(int x, int y, double d, // violation 'components is 6'
                     String str, char c, float f) {}
 
   record MyRecord3(int x, int y, int z, double d,
                     String str1, String str2, char c, float f, String location) {}
 
-  private record MyRecord4(int x, int y, // violation, 4 components
+  private record MyRecord4(int x, int y, // violation 'components is 4'
                            String str, double d) {}
 }
 // xdoc section - end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/Example1.java
@@ -24,9 +24,9 @@ class Example1 {
   }
 
   void bar(int p
-          , int q) { // violation ',' should be on the previous line
+          , int q) { // violation "',' should be on the previous line."
     if (s
-            .isEmpty()) { // violation '.' should be on the previous line
+            .isEmpty()) { // violation "'.' should be on the previous line."
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace paraphrased violation comments with exact quoted Checkstyle messages for the remaining Issue #20954 examples.
- Remove the temporary SUPPRESSED_VALIDATE_MESSAGE_FILES entries.
- Keep the corresponding xdoc snippets synchronized with the validated examples.

## Validation

- mvn -q -Dtest=XdocsExampleFileTest test
- mvn -q -DskipTests compile

#20954