### PR TITLE
Issue #21554: alphabetize Active Tools and Inactive or Old Tools tables

### DIFF
--- a/src/site/xdoc/index.xml.vm
+++ b/src/site/xdoc/index.xml.vm
@@ -557,6 +557,38 @@
                 <th>Remarks</th>
               </tr>
             <tr>
+              <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
+                Bamboo Checkstyle plug-in</a></td>
+              <td>Atlassian (formerly by Ross Rowe and Stephan Paulicke)</td>
+              <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
+                Bamboo Checkstyle plug-in Home Page</a></td>
+              <td>An add-on that will parse and record CheckStyle reports and report your
+                style violations over time.</td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://rife2.com/bld">bld</a>
+              </td>
+              <td>Erik C. Thauvin</td>
+              <td><a href="https://github.com/rife2/bld-checkstyle">Checkstyle Extension</a> for bld</td>
+              <td>An extension for checking source code in a bld project</td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://github.com/nikitasavinov/checkstyle-action#
+                  checkstyle-github-action">
+                  Checkstyle GitHub Actions
+                </a>
+              </td>
+              <td>Nikita Savinov</td>
+              <td><a href="https://github.com/marketplace/actions/run-java-checkstyle">
+              Github-action Marketplace</a></td>
+              <td>It runs checkstyle on your Pull Requests using
+                <a href="https://github.com/features/actions">github-actions</a> and
+                <a href="https://github.com/reviewdog/reviewdog">reviewdog</a>
+              </td>
+            </tr>
+            <tr>
               <td>
                 <a href="https://www.codacy.com/">Codacy</a>
               </td>
@@ -570,6 +602,28 @@
                   Provides analysis per commit and per pull request. Supports CheckStyle
                   config files.
               </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://codeclimate.com/">Code Climate</a>
+              </td>
+              <td>Sivakumar Kailasam</td>
+              <td>
+                <a href="https://github.com/sivakumar-kailasam/codeclimate-checkstyle">
+                  codeclimate-checkstyle
+                </a>
+              </td>
+              <td>Supports Checkstyle configuration files and integrates with Code
+                Climate's automated code review system.
+              </td>
+            </tr>
+            <tr>
+              <td><a href="https://github.com/nidi3/code-assert">code-assert</a></td>
+              <td>Stefan Niederhauser</td>
+              <td><a href="https://github.com/nidi3/code-assert#checkstyle-checks">
+                  code-assert</a></td>
+              <td>Assert that the java code of a project satisfies certain checks. Launch
+                  checkstyle validation from UTs</td>
             </tr>
             <tr>
               <td><a href="https://www.eclipse.org/">Eclipse/RAD/RDz</a></td>
@@ -598,31 +652,14 @@
               </td>
             </tr>
             <tr>
-              <td><a href="https://gradle.org">Gradle</a></td>
-              <td>Hans Dockter (initial author)</td>
-              <td>Checkstyle supported out of the box</td>
+              <td><a href="https://www.eclipse.org/">Eclipse/RAD/RDz</a></td>
+              <td>Jan Burkhardt</td>
               <td>
-                <a href="https://docs.gradle.org/current/userguide/checkstyle_plugin.html">
-                  Gradle Checkstyle docs
-                </a>
+                <a href="https://github.com/bjrke/JSR305CheckstylePlugin">Project Page</a>
               </td>
-            </tr>
-            <tr>
-              <td><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
-              <td>James Shiell</td>
               <td>
-                <a href="https://github.com/jshiell/checkstyle-idea">
-                  Checkstyle-idea Project Page
-                </a>
-              </td>
-              <td>Provides real-time and on-demand scanning.</td>
-            </tr>
-            <tr>
-              <td><a href="https://www.jgrasp.org/">jGRASP</a></td>
-              <td>Larry Barowski</td>
-              <td><a href="https://www.jgrasp.org/">jGRASP Home Page</a></td>
-              <td>Integrates Checkstyle for code analysis and displays
-                  results within the IDE.
+                Extension for Eclipse-CS plugin which ensures nullness annotations on
+                methods and constructors (JSR305).
               </td>
             </tr>
             <tr>
@@ -642,53 +679,54 @@
               </td>
             </tr>
             <tr>
-              <td><a href="https://www.eclipse.org/">Eclipse/RAD/RDz</a></td>
-              <td>Jan Burkhardt</td>
-              <td>
-                <a href="https://github.com/bjrke/JSR305CheckstylePlugin">Project Page</a>
+              <td><a href="http://jdee.sourceforge.net/">Emacs JDE</a></td>
+              <td>Markus Mohnen</td>
+              <td>Part of the standard JDEE distribution -
+                <a href="https://github.com/jdee-emacs/jdee"/>
               </td>
-              <td>
-                Extension for Eclipse-CS plugin which ensures nullness annotations on
-                methods and constructors (JSR305).
-              </td>
+              <td><a href="https://github.com/jdee-emacs/jdee/blob/master/jdee-checkstyle.el">
+                  configuration could be seen at jdee-checkstyle.el</a></td>
             </tr>
             <tr>
-              <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
-                Bamboo Checkstyle plug-in</a></td>
-              <td>Atlassian (formerly by Ross Rowe and Stephan Paulicke)</td>
-              <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
-                Bamboo Checkstyle plug-in Home Page</a></td>
-              <td>An add-on that will parse and record CheckStyle reports and report your
-                style violations over time.</td>
-            </tr>
-            <tr>
+              <td><a href="https://gradle.org">Gradle</a></td>
+              <td>Hans Dockter (initial author)</td>
+              <td>Checkstyle supported out of the box</td>
               <td>
-                <a href="https://codeclimate.com/">Code Climate</a>
-              </td>
-              <td>Sivakumar Kailasam</td>
-              <td>
-                <a href="https://github.com/sivakumar-kailasam/codeclimate-checkstyle">
-                  codeclimate-checkstyle
+                <a href="https://docs.gradle.org/current/userguide/checkstyle_plugin.html">
+                  Gradle Checkstyle docs
                 </a>
               </td>
-              <td>Supports Checkstyle configuration files and integrates with Code
-                Climate's automated code review system.
-              </td>
             </tr>
             <tr>
+              <td><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
+              <td>Jakub Slawinski</td>
               <td>
-                <a href="https://github.com/nikitasavinov/checkstyle-action#
-                  checkstyle-github-action">
-                  Checkstyle GitHub Actions
+                <a href="https://plugins.jetbrains.com/plugin/4594-qaplug">QAPlug</a>
+              </td>
+              <td>Provides quality assurance features.</td>
+            </tr>
+            <tr>
+              <td><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
+              <td>James Shiell</td>
+              <td>
+                <a href="https://github.com/jshiell/checkstyle-idea">
+                  Checkstyle-idea Project Page
                 </a>
               </td>
-              <td>Nikita Savinov</td>
-              <td><a href="https://github.com/marketplace/actions/run-java-checkstyle">
-              Github-action Marketplace</a></td>
-              <td>It runs checkstyle on your Pull Requests using
-                <a href="https://github.com/features/actions">github-actions</a> and
-                <a href="https://github.com/reviewdog/reviewdog">reviewdog</a>
-              </td>
+              <td>Provides real-time and on-demand scanning.</td>
+            </tr>
+            <tr>
+              <td><a href="https://www.jarchitect.com">JArchitect</a></td>
+              <td>JArchitect Team</td>
+              <td><a href="https://www.jarchitect.com">JArchitect Home Page</a></td>
+              <td>Imports XML result files from CheckStyle.</td>
+            </tr>
+            <tr>
+              <td><a href="https://www.jedit.org/">jEdit</a></td>
+              <td>Todd Papaioannou</td>
+              <td><a href="https://plugins.jedit.org/plugins/?CheckStylePlugin">
+                  JEdit CheckStylePlugin</a></td>
+              <td/>
             </tr>
             <tr>
               <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins
@@ -701,96 +739,19 @@
               graphs.</td>
             </tr>
             <tr>
+              <td><a href="https://www.jgrasp.org/">jGRASP</a></td>
+              <td>Larry Barowski</td>
+              <td><a href="https://www.jgrasp.org/">jGRASP Home Page</a></td>
+              <td>Integrates Checkstyle for code analysis and displays
+                  results within the IDE.
+              </td>
+            </tr>
+            <tr>
               <td><a href="https://maven.apache.org/">Maven</a></td>
               <td>Vincent Massol</td>
               <td>Checkstyle supported out of the box</td>
               <td><a href="https://maven.apache.org/plugins/maven-checkstyle-plugin/checkstyle.html">
                   example report</a></td>
-            </tr>
-            <tr>
-              <td><a href="http://tide.olympe.in/">tIDE</a></td>
-              <td>Olympe Team</td>
-              <td>Built in</td>
-              <td>Includes built-in Checkstyle support for code analysis during development.</td>
-            </tr>
-            <tr>
-              <td><a href="https://netbeans.apache.org/front/main/index.html">NetBeans</a></td>
-              <td>Petr Hejl</td>
-              <td>
-                <a href="https://www.sickboy.cz/checkstyle/">Checkstyle Beans</a>
-              </td>
-              <td>
-                  Problems with source code are displayed as annotations of
-                  the source
-              </td>
-            </tr>
-            <tr>
-              <td><a href="https://www.sonarsource.com/products/sonarqube/">SonarQube</a></td>
-              <td>Freddy Mallet (initial author)</td>
-              <td><a href="https://github.com/checkstyle/sonar-checkstyle">
-                  Checkstyle SonarQube repository</a></td>
-              <td><a href="https://sonarcloud.io/projects">Demo site of SonarQube</a></td>
-            </tr>
-            <tr>
-              <td><a href="https://www.jedit.org/">jEdit</a></td>
-              <td>Todd Papaioannou</td>
-              <td><a href="https://plugins.jedit.org/plugins/?CheckStylePlugin">
-                  JEdit CheckStylePlugin</a></td>
-              <td/>
-            </tr>
-            <tr>
-              <td><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
-              <td>Jakub Slawinski</td>
-              <td>
-                <a href="https://plugins.jetbrains.com/plugin/4594-qaplug">QAPlug</a>
-              </td>
-              <td>Provides quality assurance features.</td>
-            </tr>
-            <tr>
-              <td><a href="https://www.jarchitect.com">JArchitect</a></td>
-              <td>JArchitect Team</td>
-              <td><a href="https://www.jarchitect.com">JArchitect Home Page</a></td>
-              <td>Imports XML result files from CheckStyle.</td>
-            </tr>
-            <tr>
-              <td><a href="https://www.scala-sbt.org/">SBT</a></td>
-              <td>Andrew Johnson</td>
-              <td><a href="https://github.com/etsy/sbt-checkstyle-plugin">
-                  sbt-checkstyle-plugin Project Page</a></td>
-              <td>SBT plugin for running Checkstyle on Java source files in an SBT
-                project</td>
-            </tr>
-            <tr>
-              <td><a href="https://github.com/nidi3/code-assert">code-assert</a></td>
-              <td>Stefan Niederhauser</td>
-              <td><a href="https://github.com/nidi3/code-assert#checkstyle-checks">
-                  code-assert</a></td>
-              <td>Assert that the java code of a project satisfies certain checks. Launch
-                  checkstyle validation from UTs</td>
-            </tr>
-            <tr>
-              <td><a href="http://jdee.sourceforge.net/">Emacs JDE</a></td>
-              <td>Markus Mohnen</td>
-              <td>Part of the standard JDEE distribution -
-                <a href="https://github.com/jdee-emacs/jdee"/>
-              </td>
-              <td><a href="https://github.com/jdee-emacs/jdee/blob/master/jdee-checkstyle.el">
-                  configuration could be seen at jdee-checkstyle.el</a></td>
-            </tr>
-            <tr>
-              <td><a href="https://neovim.io/">Neovim</a></td>
-              <td>Mathias Fußenegger</td>
-              <td><a href="https://github.com/mfussenegger/nvim-lint">nvim-lint</a></td>
-              <td>An asynchronous linter plugin for Neovim complementary to the built-in Language
-                  Server Protocol support.</td>
-            </tr>
-            <tr>
-              <td><a href="https://code.visualstudio.com/">Visual Studio Code</a></td>
-              <td>Sheng Chen</td>
-              <td><a href="https://marketplace.visualstudio.com/items?
-                  itemName=shengchen.vscode-checkstyle">
-                  vscode-checkstyle</a></td>
-              <td>Checkstyle for Microsoft Visual Studio Code</td>
             </tr>
             <tr>
               <td>
@@ -804,12 +765,43 @@
                   Available as GitHub Action, other CI tools and locally</td>
             </tr>
             <tr>
+              <td><a href="https://neovim.io/">Neovim</a></td>
+              <td>Mathias Fußenegger</td>
+              <td><a href="https://github.com/mfussenegger/nvim-lint">nvim-lint</a></td>
+              <td>An asynchronous linter plugin for Neovim complementary to the built-in Language
+                  Server Protocol support.</td>
+            </tr>
+            <tr>
+              <td><a href="https://netbeans.apache.org/front/main/index.html">NetBeans</a></td>
+              <td>Petr Hejl</td>
               <td>
-                <a href="https://rife2.com/bld">bld</a>
+                <a href="https://www.sickboy.cz/checkstyle/">Checkstyle Beans</a>
               </td>
-              <td>Erik C. Thauvin</td>
-              <td><a href="https://github.com/rife2/bld-checkstyle">Checkstyle Extension</a> for bld</td>
-              <td>An extension for checking source code in a bld project</td>
+              <td>
+                  Problems with source code are displayed as annotations of
+                  the source
+              </td>
+            </tr>
+            <tr>
+              <td><a href="https://www.scala-sbt.org/">SBT</a></td>
+              <td>Andrew Johnson</td>
+              <td><a href="https://github.com/etsy/sbt-checkstyle-plugin">
+                  sbt-checkstyle-plugin Project Page</a></td>
+              <td>SBT plugin for running Checkstyle on Java source files in an SBT
+                project</td>
+            </tr>
+            <tr>
+              <td><a href="https://www.sonarsource.com/products/sonarqube/">SonarQube</a></td>
+              <td>Freddy Mallet (initial author)</td>
+              <td><a href="https://github.com/checkstyle/sonar-checkstyle">
+                  Checkstyle SonarQube repository</a></td>
+              <td><a href="https://sonarcloud.io/projects">Demo site of SonarQube</a></td>
+            </tr>
+            <tr>
+              <td><a href="http://tide.olympe.in/">tIDE</a></td>
+              <td>Olympe Team</td>
+              <td>Built in</td>
+              <td>Includes built-in Checkstyle support for code analysis during development.</td>
             </tr>
             <tr>
               <td><a href="https://www.vim.org/">Vim editor</a></td>
@@ -817,6 +809,14 @@
               <td><a href="https://github.com/vim-syntastic/syntastic">Plugin syntastic</a></td>
               <td><a href="https://medium.com/@Sohjiro/setup-vim-checkstyle-java-d0dd74dca1e1">
                   how to setup.</a></td>
+            </tr>
+            <tr>
+              <td><a href="https://code.visualstudio.com/">Visual Studio Code</a></td>
+              <td>Sheng Chen</td>
+              <td><a href="https://marketplace.visualstudio.com/items?
+                  itemName=shengchen.vscode-checkstyle">
+                  vscode-checkstyle</a></td>
+              <td>Checkstyle for Microsoft Visual Studio Code</td>
             </tr>
             </table>
           </div>
@@ -832,12 +832,6 @@
                 <th>Remarks</th>
               </tr>
               <tr>
-                <td><a href="https://qalab.sourceforge.net">QALab</a></td>
-                <td>Benoit Xhenseval</td>
-                <td><a href="https://qalab.sourceforge.net">QALab Home Page</a></td>
-                <td>Supports tracking Checkstyle statistics over time.</td>
-              </tr>
-              <tr>
               <td><a href="https://netbeans.apache.org/front/main/index.html">NetBeans</a></td>
               <td>SQE Team</td>
               <td>
@@ -847,6 +841,12 @@
                   including Checkstyle integration.
               </td>
             </tr>
+              <tr>
+                <td><a href="https://qalab.sourceforge.net">QALab</a></td>
+                <td>Benoit Xhenseval</td>
+                <td><a href="https://qalab.sourceforge.net">QALab Home Page</a></td>
+                <td>Supports tracking Checkstyle statistics over time.</td>
+              </tr>
             </table>
           </div>
         </subsection>


### PR DESCRIPTION
## Description

Alphabetize the Active Tools and Inactive or Old Tools tables on the
Checkstyle homepage.

This follows the maintainer's request in #21554.

## Changes

- Alphabetized Active Tools by tool name.
- Alphabetized Inactive or Old Tools by tool name.
- Preserved the existing tool information and links.
- No functional changes.

## Testing

 ./mvnw clean verify   