### PR TITLE
Issue #20590: Add NoEnumTrailingComma compact source coverage

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoEnumTrailingCommaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoEnumTrailingCommaCheckTest.java
@@ -80,6 +80,16 @@ public class NoEnumTrailingCommaCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testCompactSourceFile() throws Exception {
+        final String[] expected = {
+            "14:9: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("compact/InputNoEnumTrailingCommaCompactSourceFile.java"),
+                expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final NoEnumTrailingCommaCheck check = new NoEnumTrailingCommaCheck();
         assertWithMessage("Acceptable tokens should not be null")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksCompactSourceCoverageTest.java
@@ -187,7 +187,6 @@ public class AllChecksCompactSourceCoverageTest {
         "NestedIfDepthCheck",
         "NestedTryDepthCheck",
         "NoCodeInFileCheck",
-        "NoEnumTrailingCommaCheck",
         "NoLineWrapCheck",
         "NoWhitespaceAfterCheck",
         "NoWhitespaceBeforeCaseDefaultColonCheck",

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/noenumtrailingcomma/compact/InputNoEnumTrailingCommaCompactSourceFile.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/noenumtrailingcomma/compact/InputNoEnumTrailingCommaCompactSourceFile.java
@@ -1,0 +1,15 @@
+/*
+NoEnumTrailingComma
+
+
+*/
+
+// non-compiled with javac: Compilable with Java25
+
+void main() {
+}
+
+enum Color {
+    RED,
+    BLUE, // violation 'Enum should not contain trailing comma.'
+}


### PR DESCRIPTION
Issue: #20590

Adds Java 25 compact-source coverage for `NoEnumTrailingCommaCheck`.

The new input verifies that a trailing comma after an enum constant is reported using the default configuration. It also removes the check from the `AllChecksCompactSourceCoverageTest` suppression list.

Validation:

- `./mvnw clean -Dtest=NoEnumTrailingCommaCheckTest,AllChecksCompactSourceCoverageTest test`
- `./mvnw clean verify`